### PR TITLE
feat(skill-center): make offline terminal and copy versions

### DIFF
--- a/src/backend/specs/2026-08-20-skill-capability-upgrade/frontend-api.md
+++ b/src/backend/specs/2026-08-20-skill-capability-upgrade/frontend-api.md
@@ -93,7 +93,7 @@ Attempt/Reference 这种持久异步资源会在 `data` 内返回自己的 `erro
 | Attempt `PREPARING/SC_SUBMITTING/WAITING_SC` | 发布中 |
 | Attempt `MATERIALIZING` | 物化中 |
 | Attempt `RESULT_UNKNOWN` | 发布结果确认中 |
-| `OFFLINE` | 已下线 · 可继续编辑 |
+| `OFFLINE` | 已下线 · 保留历史版本，可复制为新 Skill |
 
 `SUCCEEDED/FAILED` 是历史 Attempt 终态，详情页可展示；列表 `active_publication` 只内联非终态。
 
@@ -341,7 +341,8 @@ DELETE .../draft?expected_revision_id=rev-2&fencing_token=7
 - `deleted_scope=SKILL`：首次从未发布，且除终态 FAILED Attempt 外无外部事实，整个 Skill
   及其失败 Attempt 被删除。
 
-FROZEN 时不显示删除按钮。Offline Skill 放弃 Vn+1 Draft 后仍保持 Offline，可再次点击升级。
+FROZEN 时不显示删除按钮。Offline Skill 不再允许升级；产品显示“复制”，以最后 Published Vn
+创建独立新 Skill 的 V1 Draft。
 删除 Team Draft 会同时使当前 Lease/fencing token 失效，前端必须停止 Lease 轮询并退出编辑态。
 
 ### 7.3 查看历史版本
@@ -479,10 +480,9 @@ Backend 会重新检查，所以仍可能返回 `SKILL_OFFLINE_BLOCKED`。成功
 
 - 历史 Published Vn 保持不可变；
 - TeamClaw 市场和 consumable 隐藏；
-- 创建 Vn+1 EDITING Draft；
 - 不调用 SC 外部下线；
-- Owner/Manager 可继续编辑；
-- 发布 Vn+1 成功后恢复 PUBLISHED。
+- 原 Skill 不可继续编辑、升级或发布；
+- 产品可调用 Version Copy 创建独立新 Skill 的 V1 Draft。
 
 `data.warnings` 是不计入 `total`、`counts` 或 `items` 的诊断信息；产品可以提示“部分历史
 Artifact 无法读取，未发现明确引用，已继续下线”，但不得把 warning 当成 blocker。
@@ -490,7 +490,7 @@ Artifact 无法读取，未发现明确引用，已继续下线”，但不得�
 409 `code=409313` 的 `data` 会带回最新 OfflineImpact/counts，前端直接用它刷新阻断弹窗；这是
 普通错误 `data=null` 的 route-specific 例外。
 
-产品文案不能写成“Vn 变回草稿”；准确语义是“Skill Offline，同时创建 Vn+1 Draft”。
+产品文案不能写成“Vn 变回草稿”；准确语义是“Skill Offline，保留历史 Vn；复制后产生独立新 Skill”。
 
 ## 11. 添加 Skill 弹窗的四个产品来源
 

--- a/src/backend/specs/2026-08-20-skill-capability-upgrade/phase2-openapi-contract.md
+++ b/src/backend/specs/2026-08-20-skill-capability-upgrade/phase2-openapi-contract.md
@@ -172,7 +172,8 @@ Work Order 的列表、详情和审批复用既有 `/openapi/v1/bots/work-orders
 | P2-PUB-004 | GET | `.../publications/{attempt_id}` | 轮询/恢复 Attempt | 200 | 读取 | NEW |
 | P2-PUB-005 | POST | `.../publications/{attempt_id}/retry` | 恢复同一 Attempt | 202/200 | attempt_id | NEW |
 | P2-OFF-001 | GET | `/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/offline-impact` | 下线前阻断检查 | 200 | 读取 | NEW |
-| P2-OFF-002 | POST | `/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/offline` | 本地 Offline 并创建 Vn+1 Draft | 200 | 是 | NEW |
+| P2-OFF-002 | POST | `/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/offline` | 本地 Offline，保留历史 Vn | 200 | 是 | NEW |
+| P2-OFF-003 | POST | `/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/versions/{version}/copy` | 复制 Offline Skill 精确 Vn 为新 Skill V1 Draft | 201 | Header Key | NEW |
 
 ### 3.5 SC Public 异步 Reference
 
@@ -553,12 +554,12 @@ Blocker kind：`DRAFT | PUBLICATION | MEMBERSHIP | INSTALLATION | SERVICE_ARTIFA
 {
   "changed": true,
   "lifecycle_status": "OFFLINE",
-  "draft": {"target_version": 3, "status": "EDITING", "revision_id": "rev-3"}
+  "offline_at": "2026-09-02T12:00:00Z"
 }
 ```
 
-已有 Offline+Draft 时 `changed=false`。没有 force/管理员绕过；不调用 SC 下线。新 Version 发布成功
-后自动恢复 PUBLISHED。
+已 Offline 时 `changed=false`。没有 force/管理员绕过；不调用 SC 下线。原 Skill 不创建 Vn+1 Draft
+或恢复上线；复制精确 Vn 会创建新 UUID 的独立 V1 Draft，之后发布为新的 SC Skill。
 
 命令事务内重查发现 blocker 时返回 HTTP 409、`code=409313`，且 `data` 使用与 P2-OFF-001
 相同的最新 `OfflineImpact`；前端不得继续使用调用 POST 前缓存的 counts。

--- a/src/backend/specs/2026-08-20-skill-capability-upgrade/spec.md
+++ b/src/backend/specs/2026-08-20-skill-capability-upgrade/spec.md
@@ -100,7 +100,7 @@ artifact。本文先冻结待实现合同；实现完成后生成的 OpenAPI JSO
 50. 作为 SkillCenter Public 用户，我希望一次选择多个 Skill 后获得可跨刷新恢复的异步引用进度，且只有物化完成后才加入 SkillSet。
 51. 作为发布者，我希望发布前看到可能受 Track Latest 影响的 Bot，但该预览不阻断发布，发布成功后由后端重新计算真实候选。
 52. 作为发布者，我希望自动重试耗尽后可以针对同一个 Attempt 恢复准备、查询 SC 结果或重试物化，而不会重复发布。
-53. 作为 Skill Owner/Manager，我希望下线前看到完整血缘；无引用时保留历史 Published Vn、创建 Vn+1 Draft，并允许修改后重新发布。
+53. 作为 Skill Owner/Manager，我希望下线前看到完整血缘；无引用时保留历史 Published Vn 并下线该资产，必要时复制 Vn 为独立新 Skill。
 
 ## Implementation Decisions
 
@@ -806,6 +806,7 @@ Owner 审批，旧 Owner 不得继续审批。
 | POST | `/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/publications/{attempt_id}/retry` | 恢复同一 Attempt；按最新阶段分流，不要求新幂等键 |
 | GET | `/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/offline-impact` | 下线影响检查 |
 | POST | `/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/offline` | 本地隐藏 Published Skill，并创建下一版 Draft |
+| POST | `/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/versions/{version}/copy` | 复制已下线 Skill 的精确 Vn 为独立新 Skill V1 Draft |
 
 发布事务：
 
@@ -864,10 +865,10 @@ acknowledgement token。预览到 PUBLISHED 之间事实可能变化，Track Lat
 
 #### 12.1 Offline、重新发布与血缘
 
-产品“下线”是 TeamClaw-local、可恢复的 Offline，不是永久 Retirement，也不把历史 Published
-Version 改回 Draft。无 blocker 时，Offline 保留不可变 Published Vn，并基于 Vn 创建 Vn+1
-EDITING Draft；用户修改后发布 Vn+1，成功事务清空 `offline_at/offline_by`，恢复 PUBLISHED
-可见性。重新上线必须产生新 Version，禁止覆盖或重新发布旧 Vn。
+产品“下线”是 TeamClaw-local 的终态 Offline，不是永久 Retirement，也不把历史 Published
+Version 改回 Draft。无 blocker 时，Offline 仅写 `offline_at/offline_by`，保留不可变 Published
+Vn；原 Skill 不再创建 Draft、升级或重新发布。用户需要继续创作时，复制精确 Vn 为新 UUID、
+独立新 Skill 的 V1 Draft；发布新副本会在同一 SC Team 创建独立 SC Skill，绝不复用原 SC 身份。
 
 Offline 期间从 TeamClaw 市场和 consumable 列表隐藏，禁止新的 Direct activation、Membership
 和其他 Bot 消费；Owner/Manager 仍可查看历史、编辑 Draft 和发布。它不调用 Skill Center
@@ -895,16 +896,10 @@ Service Artifact 血缘不建新索引表、不 backfill。唯一 `ServiceArtifa
 仅把存活 Service Bot 的 SUCCESS/UPGRADED/RELEASED/VALIDATING 等仍可重放记录作为 blocker；
 Service Bot 仅下线仍可能重新上线，因此仍阻断，必须彻底删除/退役该 Service Bot 才释放血缘。
 
-Offline Application Service 复用 Upgrade Draft 的 exact source 规则：先做只读 impact 预检，
-从 TC Canonical Store 读取 Published Vn（失败时从 SC exact version 修复）并写新 immutable Draft
-Revision，再在一个 DB 事务中锁 Skill、重查 blocker、写 `offline_at/offline_by` 与 Vn+1 Draft
-facts。DB 失败或并发 blocker 出现时清理新 Revision；不存在“已下线但没有 Draft”的半状态。
-
-POST 已 Offline 且 Vn+1 Draft 存在时幂等 `changed=false`。存在 blocker 返回
+Offline Application Service 先做只读 impact 预检，再在一个 DB 事务中锁 Skill、重查 blocker、
+仅写 `offline_at/offline_by`。POST 已 Offline 时幂等 `changed=false`。存在 blocker 返回
 `409 SKILL_OFFLINE_BLOCKED` 与最新 counts。Offline 与新增引用共享 Skill row lock 和
-`offline_at IS NULL` 不变量；Offline 期间新引用返回 `SKILL_OFFLINE`。若用户主动放弃 Offline
-Draft，Skill 仍保持 Offline，可再次调用 `draft/upgrade` 重新创建下一版 Draft；只有新 Version
-PUBLISHED 才恢复上线。
+`offline_at IS NULL` 不变量；Offline 期间新引用和原 Skill 的 `draft/upgrade` 返回 `SKILL_OFFLINE`。
 
 ### 13. Skill Center 映射与精确版本物化
 
@@ -1298,7 +1293,7 @@ Phase 2 必测：
 - 文件型 manifest v1 additive center_skills、共享 Center mount、排除完整 Corpus、exact symlink
   校验；Teclaw v4 additive Store 与真实 Consumer/offload/re-inline。
 - Offline 覆盖 Draft/Attempt、inactive/default Membership、Installation、inline/offloaded
-  replayable Artifact 与 UNKNOWN_ARTIFACT；无 force、无 SC 下线；成功创建 Vn+1 Draft并可重新发布。
+  replayable Artifact；无 force、无 SC 下线；成功保留原 Vn 为 OFFLINE，精确 Version Copy 创建独立 V1 Draft。
 - Local/Repo/Center 并存、Mapping v2/v3、所有实际 Bot/Engine 走共享合同而无静态拒绝分支。
 
 Phase 2 完成定义：产品主流程 E2E、SC pre 联调、多引擎矩阵、Service Artifact

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/admission.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/admission.py
@@ -597,6 +597,7 @@ ADMISSION: dict[tuple[str, str], AdmissionMode] = {
     ("GET", "/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/versions/{version}"): AdmissionMode.USER_GATED,
     ("GET", "/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/versions/{version}/files"): AdmissionMode.USER_GATED,
     ("GET", "/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/versions/{version}/files/{path:path}"): AdmissionMode.USER_GATED,
+    ("POST", "/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/versions/{version}/copy"): AdmissionMode.REFUSED,
     ("GET", "/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/draft/files"): AdmissionMode.USER_GATED,
     ("GET", "/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/draft/files/{path:path}"): AdmissionMode.USER_GATED,
     ("PUT", "/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/draft/files/{path:path}"): AdmissionMode.REFUSED,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/authorization.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/authorization.py
@@ -489,6 +489,8 @@ AUTHORIZATION: dict[tuple[str, str], Authorization] = {
         NoCheck("Space membership and exact Canonical Version visibility, adjudicated by the Version service"),
     ("GET", "/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/versions/{version}/files/{path:path}"):
         NoCheck("Space membership and exact Canonical file visibility, adjudicated by the Version service"),
+    ("POST", "/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/versions/{version}/copy"):
+        NoCheck("Skill Owner or Manager, Offline state, exact Version and idempotency, adjudicated by the Skill service"),
     ("GET", "/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/draft/files"):
         NoCheck("Space membership and Draft visibility, adjudicated by the Skill service"),
     ("GET", "/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/draft/files/{path:path}"):

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/errors_space.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/errors_space.py
@@ -36,6 +36,7 @@ class SpaceErrorCode(IntEnum):
     PUBLICATION_TASK_UNAVAILABLE = 503203
     SKILL_OFFLINE = 409312
     SKILL_OFFLINE_BLOCKED = 409313
+    SKILL_NOT_OFFLINE = 409316
 
 
 class SpacePublicErrorMessage(StrEnum):
@@ -71,3 +72,4 @@ class SpacePublicErrorMessage(StrEnum):
     PUBLICATION_TASK_UNAVAILABLE = "Publication task is unavailable"
     SKILL_OFFLINE = "Skill is offline"
     SKILL_OFFLINE_BLOCKED = "Skill Offline is blocked"
+    SKILL_NOT_OFFLINE = "Skill must be offline before it can be copied"

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/errors_space_skill.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/errors_space_skill.py
@@ -15,6 +15,7 @@ from agentclaw.community.core.skill_center.errors import (
     SkillNameChangedError,
     SkillOfflineBlockedError,
     SkillOfflineError,
+    SkillNotOfflineError,
     SpaceSkillIdempotencyConflictError,
     DraftEditLeaseConflictError,
     DraftEditLeaseForbiddenError,
@@ -128,6 +129,7 @@ SPACE_SKILL_HTTP_ERRORS = {
         SpacePublicErrorMessage.PUBLICATION_TASK_UNAVAILABLE,
     ),
     SkillOfflineError: (409, SpacePublicErrorMessage.SKILL_OFFLINE),
+    SkillNotOfflineError: (409, SpacePublicErrorMessage.SKILL_NOT_OFFLINE),
     SkillOfflineBlockedError: (
         409,
         SpacePublicErrorMessage.SKILL_OFFLINE_BLOCKED,
@@ -170,5 +172,6 @@ SPACE_SKILL_ERROR_CODES = {
     PublicationRequiresNewAttemptError: SpaceErrorCode.PUBLICATION_REQUIRES_NEW_ATTEMPT,
     PublicationTaskUnavailableError: SpaceErrorCode.PUBLICATION_TASK_UNAVAILABLE,
     SkillOfflineError: SpaceErrorCode.SKILL_OFFLINE,
+    SkillNotOfflineError: SpaceErrorCode.SKILL_NOT_OFFLINE,
     SkillOfflineBlockedError: SpaceErrorCode.SKILL_OFFLINE_BLOCKED,
 }

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/spaces/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/spaces/schemas.py
@@ -83,7 +83,7 @@ class SkillActorPermissions(BaseModel):
         description="Actor may request creation of an upgrade Draft."
     )
     offline_skill: bool = Field(
-        description="Actor may request terminal TeamClaw-local Skill Offline."
+        description="Actor may request terminal local Skill Offline."
     )
     copy_offline_skill: bool = Field(
         default=False,
@@ -563,7 +563,7 @@ class SpaceSkillDetail(SpaceSkillSummary):
         description="Original Space Skill creation source."
     )
     offline_at: datetime | None = Field(
-        default=None, description="UTC terminal TeamClaw-local Offline time, or null."
+        default=None, description="UTC terminal local Offline time, or null."
     )
     offline_by: str | None = Field(
         default=None, description="Actor that placed the Skill Offline, or null."
@@ -624,7 +624,7 @@ class SkillOfflineImpact(BaseModel):
 
 
 class SkillOfflineResult(BaseModel):
-    """Terminal TeamClaw-local Offline result for the existing Skill."""
+    """Terminal local Offline result for the existing Skill."""
 
     changed: bool = Field(
         description="Whether this request newly moved the Skill Offline."
@@ -632,7 +632,9 @@ class SkillOfflineResult(BaseModel):
     lifecycle_status: Literal["OFFLINE"] = Field(
         description="Current recoverable lifecycle state."
     )
-    offline_at: datetime = Field(description="UTC time at which Offline was recorded.")
+    offline_at: datetime | None = Field(
+        default=None, description="UTC time at which Offline was recorded."
+    )
 
 
 class ImportSpaceSkillFromGitRequest(BaseModel):

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/spaces/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/spaces/schemas.py
@@ -738,8 +738,6 @@ SpaceSkillFolderUpload = create_model(
         ),
     ),
 )
-
-
 class AddSpaceMemberRequest(BaseModel):
     """Request for adding a user to a Space."""
 

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/spaces/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/spaces/schemas.py
@@ -83,7 +83,11 @@ class SkillActorPermissions(BaseModel):
         description="Actor may request creation of an upgrade Draft."
     )
     offline_skill: bool = Field(
-        description="Actor may request recoverable Skill Offline."
+        description="Actor may request terminal TeamClaw-local Skill Offline."
+    )
+    copy_offline_skill: bool = Field(
+        default=False,
+        description="Actor may copy an Offline Skill's exact Published Version."
     )
     manage_grants: bool = Field(description="Actor may add or remove MANAGER Grants.")
     transfer_owner: bool = Field(description="Actor may request OWNER transfer.")
@@ -379,7 +383,7 @@ class SkillLifecycleStatus(_DocumentedEnum):
     __descriptions__ = {
         "DRAFT_ONLY": "The Skill has a Draft but no Published Version.",
         "PUBLISHED": "The Skill has at least one Published Version and is online.",
-        "OFFLINE": "The Skill is recoverably offline but remains editable.",
+        "OFFLINE": "The Skill is offline, retains its Published history, and is not editable.",
     }
 
 
@@ -555,11 +559,11 @@ class SpaceSkillDetail(SpaceSkillSummary):
     draft: SkillDraftDetail | None = Field(
         default=None, description="Complete current Draft facts, or null."
     )
-    source: Literal["FOLDER", "GIT"] = Field(
+    source: Literal["FOLDER", "GIT", "COPY"] = Field(
         description="Original Space Skill creation source."
     )
     offline_at: datetime | None = Field(
-        default=None, description="UTC recoverable Offline time, or null."
+        default=None, description="UTC terminal TeamClaw-local Offline time, or null."
     )
     offline_by: str | None = Field(
         default=None, description="Actor that placed the Skill Offline, or null."
@@ -620,7 +624,7 @@ class SkillOfflineImpact(BaseModel):
 
 
 class SkillOfflineResult(BaseModel):
-    """Recoverable Offline state and the editable next-version Draft."""
+    """Terminal TeamClaw-local Offline result for the existing Skill."""
 
     changed: bool = Field(
         description="Whether this request newly moved the Skill Offline."
@@ -628,9 +632,7 @@ class SkillOfflineResult(BaseModel):
     lifecycle_status: Literal["OFFLINE"] = Field(
         description="Current recoverable lifecycle state."
     )
-    draft: SkillDraftSummary = Field(
-        description="Editable Vn+1 Draft retained for recovery publication."
-    )
+    offline_at: datetime = Field(description="UTC time at which Offline was recorded.")
 
 
 class ImportSpaceSkillFromGitRequest(BaseModel):

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/spaces/skill_routes.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/spaces/skill_routes.py
@@ -452,6 +452,42 @@ async def get_space_skill_offline_impact(
 
 
 @router.post(
+    "/{space_id}/skills/{skill_id}/versions/{version}/copy",
+    status_code=201,
+    response_model=Envelope[SpaceSkillDetail],
+    dependencies=_REFUSES_APP_ONLY,
+)
+@envelope_errors
+async def copy_offline_space_skill_version(
+    space_id: SpaceIdPath,
+    skill_id: SkillIdPath,
+    version: VersionPath,
+    request: Request,
+    user_id: UserIdDep,
+    idempotency_key: IdempotencyKeyHeader,
+    commands: SpaceSkillApplicationServiceProtocol = Injected(
+        SpaceSkillApplicationServiceProtocol
+    ),
+    queries: SpaceSkillQueryServiceProtocol = Injected(SpaceSkillQueryServiceProtocol),
+) -> Envelope[SpaceSkillDetail]:
+    outcome = await run_in_threadpool(
+        commands.copy_published_version,
+        space_id=space_id,
+        skill_id=skill_id,
+        version_ordinal=version,
+        actor_id=user_id,
+        request_id=idempotency_key,
+    )
+    detail = await run_in_threadpool(
+        queries.get_space_skill,
+        space_id=space_id,
+        skill_id=outcome.skill_id,
+        actor_id=user_id,
+    )
+    return created(_space_skill_detail(detail), request)
+
+
+@router.post(
     "/{space_id}/skills/{skill_id}/offline",
     response_model=Envelope[SkillOfflineResult],
     dependencies=_REFUSES_APP_ONLY,

--- a/src/backend/src/agentclaw/community/api/space_skill_offline_service.py
+++ b/src/backend/src/agentclaw/community/api/space_skill_offline_service.py
@@ -2,6 +2,7 @@
 
 from agentclaw.community.core.skill_center.space_skill_offline_service_protocol import (
     OfflineBlockerKind,
+    OfflineDraft,
     OfflineImpact,
     OfflineImpactItem,
     SpaceSkillOfflineResult,
@@ -11,6 +12,7 @@ from agentclaw.community.core.skill_center.space_skill_offline_service_protocol 
 
 __all__ = [
     "OfflineBlockerKind",
+    "OfflineDraft",
     "OfflineImpact",
     "OfflineImpactItem",
     "SpaceSkillOfflineResult",

--- a/src/backend/src/agentclaw/community/api/space_skill_offline_service.py
+++ b/src/backend/src/agentclaw/community/api/space_skill_offline_service.py
@@ -2,7 +2,6 @@
 
 from agentclaw.community.core.skill_center.space_skill_offline_service_protocol import (
     OfflineBlockerKind,
-    OfflineDraft,
     OfflineImpact,
     OfflineImpactItem,
     SpaceSkillOfflineResult,
@@ -12,7 +11,6 @@ from agentclaw.community.core.skill_center.space_skill_offline_service_protocol 
 
 __all__ = [
     "OfflineBlockerKind",
-    "OfflineDraft",
     "OfflineImpact",
     "OfflineImpactItem",
     "SpaceSkillOfflineResult",

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill_version.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill_version.py
@@ -98,6 +98,22 @@ class SkillVersionRepository(
             )
             return self._record(row) if row is not None else None
 
+    def get_published_by_ordinal(
+        self, *, env: str, skill_id: int, version_ordinal: int
+    ) -> SkillVersionRecord | None:
+        with self._db.orm_session() as session:
+            row = (
+                session.query(SkillVersion)
+                .filter(
+                    SkillVersion.skill_id == skill_id,
+                    SkillVersion.version_ordinal == version_ordinal,
+                    SkillVersion.env == env,
+                    SkillVersion.status == "PUBLISHED",
+                )
+                .one_or_none()
+            )
+            return self._record(row) if row is not None else None
+
     def get_materialization_target(
         self, *, env: str, skill_id: int, skill_version_id: int
     ) -> MaterializingSkillVersion | None:
@@ -177,24 +193,6 @@ class SkillVersionRepository(
                 version.status = "PUBLISHED"
                 skill.description = description
                 skill.status = "PUBLISHED"
-                # Only a real new publication of a Space-owned Skill restores
-                # TeamClaw visibility. An idempotent replay of an already
-                # PUBLISHED Version must never clear a later Offline fact, and
-                # SC Public Reference/Sync has no Space ownership to restore.
-                owns_space = (
-                    session.query(SkillSpaceBinding.id)
-                    .filter(
-                        SkillSpaceBinding.skill_id == skill_id,
-                        SkillSpaceBinding.env == env,
-                    )
-                    .one_or_none()
-                )
-                if (
-                    owns_space is not None
-                    and version.publication_attempt_id is not None
-                ):
-                    skill.offline_at = None
-                    skill.offline_by = None
                 session.flush()
             else:
                 raise RuntimeError("Skill Version is not MATERIALIZING")

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/space_skill_draft.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/space_skill_draft.py
@@ -39,6 +39,7 @@ from agentclaw.community.core.skill_center.errors import (
     DraftRevisionConflictError,
     SpaceSkillIdempotencyConflictError,
     SpaceSkillGrantForbiddenError,
+    SkillOfflineError,
 )
 from agentclaw.community.core.spaces.repository.models import SpaceModel
 from agentclaw.community.core.work_orders.repository.models import WorkOrderModel
@@ -171,6 +172,7 @@ class SpaceSkillDraftRepository(SpaceSkillDraftRepositoryProtocol):
                 "name": row[0].name,
                 "space_type": row[1].space_type,
                 "sc_team_id": row[1].sc_team_id,
+                "offline_at": row[0].offline_at,
             }
 
     def get_upgrade_by_request_id(
@@ -280,6 +282,8 @@ class SpaceSkillDraftRepository(SpaceSkillDraftRepositoryProtocol):
         )
         if grant is None:
             raise SpaceSkillGrantForbiddenError("owner or manager required")
+        if skill.offline_at is not None:
+            raise SkillOfflineError("offline Skill cannot create an upgrade Draft")
         request = (
             session.query(SkillDraftUpgradeRequest)
             .filter(

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/space_skill_offline.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/space_skill_offline.py
@@ -39,7 +39,6 @@ from agentclaw.community.core.repository.implementations.skill_center.skill_vers
 )
 from agentclaw.community.core.skill_center.errors import (
     DraftNotFoundError,
-    DraftRevisionConflictError,
 )
 from agentclaw.community.core.spaces.repository.models import SpaceModel
 from agentclaw.community.plugin_api.database import DatabasePlugin
@@ -73,10 +72,6 @@ class SpaceSkillOfflineRepository(SpaceSkillOfflineRepositoryProtocol):
         space_id: int,
         skill_id: int,
         actor_id: str,
-        expected_version_id: int,
-        target_version: int,
-        new_locator: str,
-        new_description: str | None,
         env: str,
         guard: Callable[[OfflineInspection], None],
     ) -> OfflineCommit:
@@ -89,40 +84,21 @@ class SpaceSkillOfflineRepository(SpaceSkillOfflineRepositoryProtocol):
                 env=env,
                 lock=True,
             )
-            identity = inspection.identity
             skill = session.query(Skill).filter(Skill.id == skill_id).one()
-            if (
-                skill.offline_at is not None
-                and skill.draft_status is not None
-                and skill.zip_url
-                and skill.draft_target_version is not None
-            ):
+            if skill.offline_at is not None:
                 return OfflineCommit(
                     changed=False,
-                    target_version=int(skill.draft_target_version),
-                    status=str(skill.draft_status),
-                    locator=str(skill.zip_url),
+                    offline_at=skill.offline_at,
                 )
 
             guard(inspection)
-            if identity.latest_version_id != expected_version_id:
-                raise DraftRevisionConflictError("latest Published Version changed")
-            if target_version != identity.latest_version_ordinal + 1:
-                raise DraftRevisionConflictError("Offline Draft target changed")
-
-            skill.offline_at = datetime.now(timezone.utc).replace(tzinfo=None)
+            offline_at = datetime.now(timezone.utc).replace(tzinfo=None)
+            skill.offline_at = offline_at
             skill.offline_by = actor_id
-            skill.zip_url = new_locator
-            skill.draft_target_version = target_version
-            skill.draft_status = "EDITING"
-            skill.draft_description = new_description
-            skill.draft_source_kind = "PUBLISHED_VERSION"
             session.flush()
             return OfflineCommit(
                 changed=True,
-                target_version=target_version,
-                status="EDITING",
-                locator=new_locator,
+                offline_at=offline_at,
             )
 
     def _inspection(

--- a/src/backend/src/agentclaw/community/core/repository/protocols/skill_center.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/skill_center.py
@@ -330,6 +330,13 @@ class SkillVersionRepositoryProtocol(Protocol):
         """Return the addressed PUBLISHED row, never MATERIALIZING."""
         ...
 
+    @abstractmethod
+    def get_published_by_ordinal(
+        self, *, env: str, skill_id: int, version_ordinal: int
+    ) -> SkillVersionRecord | None:
+        """Return one exact PUBLISHED business Version for Copy."""
+        ...
+
 
 @runtime_checkable
 class SkillVersionMaterializationRepositoryProtocol(Protocol):

--- a/src/backend/src/agentclaw/community/core/repository/protocols/skill_center_types.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/skill_center_types.py
@@ -168,6 +168,7 @@ class SkillUpgradeIdentityRecord(TypedDict):
     name: str
     space_type: Literal["PERSONAL", "TEAM"]
     sc_team_id: int | None
+    offline_at: datetime | None
 
 
 class DraftUpgradeRecord(TypedDict):
@@ -214,7 +215,7 @@ class SpaceSkillReadRecord(TypedDict):
     lease_holder_display_name: str | None
     gmt_created: datetime
     gmt_modified: datetime
-    source_type: Literal["FOLDER", "GIT"]
+    source_type: Literal["FOLDER", "GIT", "COPY"]
     draft_target_version: int | None
     draft_description: str | None
     draft_locator: str | None

--- a/src/backend/src/agentclaw/community/core/repository/protocols/space_skill_offline.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/space_skill_offline.py
@@ -27,10 +27,6 @@ class SpaceSkillOfflineRepositoryProtocol(Protocol):
         space_id: int,
         skill_id: int,
         actor_id: str,
-        expected_version_id: int,
-        target_version: int,
-        new_locator: str,
-        new_description: str | None,
         env: str,
         guard: Callable[[OfflineInspection], None],
     ) -> OfflineCommit: ...

--- a/src/backend/src/agentclaw/community/core/repository/space_skill_offline_types.py
+++ b/src/backend/src/agentclaw/community/core/repository/space_skill_offline_types.py
@@ -54,9 +54,7 @@ class OfflineInspection:
 @dataclass(frozen=True, slots=True)
 class OfflineCommit:
     changed: bool
-    target_version: int
-    status: str
-    locator: str
+    offline_at: datetime
 
 
 __all__ = [

--- a/src/backend/src/agentclaw/community/core/skill_center/errors.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/errors.py
@@ -7,6 +7,10 @@ class SkillOfflineError(Exception):
     """A new consumption write addressed a recoverably Offline Skill."""
 
 
+class SkillNotOfflineError(Exception):
+    """A Version Copy command requires the source Skill to be Offline."""
+
+
 class SkillOfflineBlockedError(Exception):
     """Offline could not prove that every destructive blocker is absent."""
 

--- a/src/backend/src/agentclaw/community/core/skill_center/services/published_version_draft.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/published_version_draft.py
@@ -64,9 +64,27 @@ class PublishedVersionDraftBuilder:
         self._tenant_provider = tenant_provider
 
     def prepare(self, *, identity, latest) -> PreparedPublishedVersionDraft:
+        package = self.read_exact_package(identity=identity, version=latest)
+        target_version = int(latest["version_ordinal"]) + 1
+        revision = DraftRevisionIdentity(
+            tenant=self._tenant_provider(),
+            env=self._env_provider(),
+            skill_uuid=identity["skill_uuid"],
+            target_version=target_version,
+            revision_id=str(uuid4()),
+        )
+        ref = self._draft_store.write_revision(revision, package)
+        return PreparedPublishedVersionDraft(
+            expected_version_id=int(latest["id"]),
+            target_version=target_version,
+            description=package.description,
+            ref=ref,
+        )
+
+    def read_exact_package(self, *, identity, version):
         exact_identity = CanonicalCenterVersionIdentity(
             skill_uuid=identity["skill_uuid"],
-            sc_version_number=latest["sc_version_number"],
+            sc_version_number=version["sc_version_number"],
         )
         exact_ref = CanonicalCenterVersionRef(exact_identity)
         try:
@@ -83,21 +101,7 @@ class PublishedVersionDraftBuilder:
         )
         if package.name != identity["name"]:
             raise SkillNameChangedError("SKILL.md name is immutable")
-        target_version = int(latest["version_ordinal"]) + 1
-        revision = DraftRevisionIdentity(
-            tenant=self._tenant_provider(),
-            env=self._env_provider(),
-            skill_uuid=identity["skill_uuid"],
-            target_version=target_version,
-            revision_id=str(uuid4()),
-        )
-        ref = self._draft_store.write_revision(revision, package)
-        return PreparedPublishedVersionDraft(
-            expected_version_id=int(latest["id"]),
-            target_version=target_version,
-            description=package.description,
-            ref=ref,
-        )
+        return package
 
     def discard(self, prepared: PreparedPublishedVersionDraft) -> None:
         try:

--- a/src/backend/src/agentclaw/community/core/skill_center/services/space_skill_application_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/space_skill_application_service.py
@@ -29,6 +29,7 @@ from agentclaw.community.core.skill_center.errors import (
     DraftNotFoundError,
     DraftSourceNotRefreshableError,
     SkillOfflineError,
+    SkillNotOfflineError,
     SkillNameChangedError,
     SpaceSkillIdempotencyConflictError,
 )
@@ -378,7 +379,7 @@ class SpaceSkillApplicationService(SpaceSkillApplicationServiceProtocol):
             env=self._env_provider(),
         )
         if identity.get("offline_at") is None:
-            raise SkillOfflineError("only an offline Skill can be copied")
+            raise SkillNotOfflineError("only an offline Skill can be copied")
         request_hash = hashlib.sha256(
             f"COPY\\0{space_id}\\0{skill_id}\\0{version_ordinal}".encode("ascii")
         ).hexdigest()

--- a/src/backend/src/agentclaw/community/core/skill_center/services/space_skill_application_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/space_skill_application_service.py
@@ -28,6 +28,7 @@ from agentclaw.community.core.skill_center.errors import (
     DraftFrozenError,
     DraftNotFoundError,
     DraftSourceNotRefreshableError,
+    SkillOfflineError,
     SkillNameChangedError,
     SpaceSkillIdempotencyConflictError,
 )
@@ -318,6 +319,8 @@ class SpaceSkillApplicationService(SpaceSkillApplicationServiceProtocol):
             actor_id=actor_id,
             env=self._env_provider(),
         )
+        if identity.get("offline_at") is not None:
+            raise SkillOfflineError("offline Skill cannot create an upgrade Draft")
         replay = self._draft_repository.get_upgrade_by_request_id(
             request_id=request_id, env=self._env_provider()
         )
@@ -356,6 +359,55 @@ class SpaceSkillApplicationService(SpaceSkillApplicationServiceProtocol):
         if not result["created"]:
             self._published_drafts.discard(prepared)
         return self._draft_result(result["draft"])
+
+    def copy_published_version(
+        self,
+        *,
+        space_id: int,
+        skill_id: int,
+        version_ordinal: int,
+        actor_id: str,
+        request_id: str,
+    ) -> SpaceSkillCreationOutcome:
+        self._access.require_space_member(space_id=space_id, user_id=actor_id)
+        request_id = self._request_id(request_id)
+        identity = self._draft_repository.get_skill_for_upgrade(
+            space_id=space_id,
+            skill_id=skill_id,
+            actor_id=actor_id,
+            env=self._env_provider(),
+        )
+        if identity.get("offline_at") is None:
+            raise SkillOfflineError("only an offline Skill can be copied")
+        request_hash = hashlib.sha256(
+            f"COPY\\0{space_id}\\0{skill_id}\\0{version_ordinal}".encode("ascii")
+        ).hexdigest()
+        replay = self._creation_replay(
+            space_id=space_id, request_id=request_id, request_hash=request_hash
+        )
+        if replay is not None:
+            return replay
+        version = self._versions.get_published_by_ordinal(
+            env=self._env_provider(),
+            skill_id=skill_id,
+            version_ordinal=version_ordinal,
+        )
+        if version is None:
+            raise DraftNotFoundError("Published Version not found")
+        package = self._published_drafts.read_exact_package(
+            identity=identity, version=version
+        )
+        return self._persist_creation(
+            space_id=space_id,
+            actor_id=actor_id,
+            request_id=request_id,
+            request_hash=request_hash,
+            package=package,
+            source_data={
+                "draft_source_kind": "PUBLISHED_VERSION",
+                "source_type": "COPY",
+            },
+        )
 
     @staticmethod
     def _draft_result(record) -> DraftMutationResult:

--- a/src/backend/src/agentclaw/community/core/skill_center/services/space_skill_grant_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/space_skill_grant_service.py
@@ -40,6 +40,7 @@ def space_skill_actor_permissions(
         "delete_draft": can_edit,
         "create_upgrade_draft": can_edit,
         "offline_skill": can_edit,
+        "copy_offline_skill": can_edit,
         "manage_grants": is_owner,
         "transfer_owner": is_owner or is_admin,
         "request_edit_access": can_request,

--- a/src/backend/src/agentclaw/community/core/skill_center/services/space_skill_offline_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/space_skill_offline_service.py
@@ -10,7 +10,6 @@ from agentclaw.community.core.service_bot.service_artifact_lineage_reader_protoc
 )
 from agentclaw.community.core.skill_center.space_skill_offline_service_protocol import (
     OfflineBlockerKind,
-    OfflineDraft,
     OfflineImpact,
     OfflineImpactItem,
     SpaceSkillOfflineResult,
@@ -23,13 +22,9 @@ from agentclaw.community.core.repository.space_skill_offline_types import (
 from agentclaw.community.core.repository.protocols.space_skill_offline import (
     SpaceSkillOfflineRepositoryProtocol,
 )
-from agentclaw.community.core.skill_center.draft_content import DraftRevisionRef
 from agentclaw.community.core.skill_center.errors import (
     SkillOfflineBlockedError,
     SpaceSkillGrantForbiddenError,
-)
-from agentclaw.community.core.skill_center.services.published_version_draft import (
-    PublishedVersionDraftBuilder,
 )
 from agentclaw.community.core.spaces.protocols import SpaceAccessServiceProtocol
 
@@ -51,16 +46,12 @@ class SpaceSkillOfflineService(SpaceSkillOfflineServiceProtocol):
         access: SpaceAccessServiceProtocol,
         repository: SpaceSkillOfflineRepositoryProtocol,
         lineage: ServiceArtifactLineageReaderProtocol,
-        drafts: PublishedVersionDraftBuilder,
         env_provider: Callable[[], str],
-        tenant_provider: Callable[[], str],
     ) -> None:
         self._access = access
         self._repository = repository
         self._lineage = lineage
-        self._drafts = drafts
         self._env_provider = env_provider
-        self._tenant_provider = tenant_provider
 
     def impact(
         self,
@@ -83,58 +74,21 @@ class SpaceSkillOfflineService(SpaceSkillOfflineServiceProtocol):
             space_id=space_id, skill_id=skill_id, actor_id=actor_id
         )
         identity = inspection.identity
-        if (
-            identity.offline_at is not None
-            and identity.draft_status is not None
-            and identity.draft_locator
-            and identity.draft_target_version is not None
-        ):
-            return self._result(
-                changed=False,
-                target_version=identity.draft_target_version,
-                status=identity.draft_status,
-                locator=identity.draft_locator,
-            )
+        if identity.offline_at is not None:
+            return self._result(changed=False, offline_at=identity.offline_at)
         if inspection.blockers:
             raise SkillOfflineBlockedError(
                 self._impact(inspection, page=1, page_size=20)
             )
 
-        prepared = self._drafts.prepare(
-            identity={
-                "skill_uuid": identity.skill_uuid,
-                "name": identity.name,
-                "sc_team_id": identity.sc_team_id,
-            },
-            latest={
-                "id": identity.latest_version_id,
-                "version_ordinal": identity.latest_version_ordinal,
-                "sc_version_number": identity.sc_version_number,
-            },
+        committed = self._repository.commit(
+            space_id=space_id,
+            skill_id=skill_id,
+            actor_id=actor_id,
+            env=self._env_provider(),
+            guard=self._guard_locked_offline,
         )
-        try:
-            committed = self._repository.commit(
-                space_id=space_id,
-                skill_id=skill_id,
-                actor_id=actor_id,
-                expected_version_id=prepared.expected_version_id,
-                target_version=prepared.target_version,
-                new_locator=prepared.ref.locator,
-                new_description=prepared.description,
-                env=self._env_provider(),
-                guard=self._guard_locked_offline,
-            )
-        except Exception:
-            self._drafts.discard(prepared)
-            raise
-        if not committed.changed:
-            self._drafts.discard(prepared)
-        return self._result(
-            changed=committed.changed,
-            target_version=committed.target_version,
-            status=committed.status,
-            locator=committed.locator,
-        )
+        return self._result(changed=committed.changed, offline_at=committed.offline_at)
 
     def _inspect(
         self, *, space_id: int, skill_id: int, actor_id: str
@@ -270,22 +224,11 @@ class SpaceSkillOfflineService(SpaceSkillOfflineServiceProtocol):
             warnings=inspection.warnings,
         )
 
-    def _result(
-        self, *, changed: bool, target_version: int, status: str, locator: str
-    ) -> SpaceSkillOfflineResult:
-        ref = DraftRevisionRef.from_locator(
-            tenant=self._tenant_provider(),
-            env=self._env_provider(),
-            locator=locator,
-        )
+    def _result(self, *, changed: bool, offline_at) -> SpaceSkillOfflineResult:
         return SpaceSkillOfflineResult(
             changed=changed,
             lifecycle_status="OFFLINE",
-            draft=OfflineDraft(
-                target_version=target_version,
-                status=status,
-                revision_id=ref.revision_id,
-            ),
+            offline_at=offline_at,
         )
 
 

--- a/src/backend/src/agentclaw/community/core/skill_center/services/space_skill_offline_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/space_skill_offline_service.py
@@ -47,6 +47,8 @@ class SpaceSkillOfflineService(SpaceSkillOfflineServiceProtocol):
         repository: SpaceSkillOfflineRepositoryProtocol,
         lineage: ServiceArtifactLineageReaderProtocol,
         env_provider: Callable[[], str],
+        drafts=None,
+        tenant_provider: Callable[[], str] | None = None,
     ) -> None:
         self._access = access
         self._repository = repository

--- a/src/backend/src/agentclaw/community/core/skill_center/space_skill_application_service_protocol.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/space_skill_application_service_protocol.py
@@ -121,6 +121,17 @@ class SpaceSkillApplicationServiceProtocol(Protocol):
     ) -> DraftMutationResult: ...
 
     @abstractmethod
+    def copy_published_version(
+        self,
+        *,
+        space_id: int,
+        skill_id: int,
+        version_ordinal: int,
+        actor_id: str,
+        request_id: str,
+    ) -> SpaceSkillCreationOutcome: ...
+
+    @abstractmethod
     def create_from_git(
         self,
         *,

--- a/src/backend/src/agentclaw/community/core/skill_center/space_skill_offline_service_protocol.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/space_skill_offline_service_protocol.py
@@ -35,10 +35,20 @@ class OfflineImpact:
 
 
 @dataclass(frozen=True, slots=True)
+class OfflineDraft:
+    """Deprecated in-process compatibility record; Offline no longer creates it."""
+
+    target_version: int
+    status: str
+    revision_id: str
+
+
+@dataclass(frozen=True, slots=True)
 class SpaceSkillOfflineResult:
     changed: bool
     lifecycle_status: str
-    offline_at: datetime
+    offline_at: datetime | None = None
+    draft: OfflineDraft | None = None
 
 
 @runtime_checkable
@@ -62,6 +72,7 @@ class SpaceSkillOfflineServiceProtocol(Protocol):
 
 __all__ = [
     "OfflineBlockerKind",
+    "OfflineDraft",
     "OfflineImpact",
     "OfflineImpactItem",
     "SpaceSkillOfflineResult",

--- a/src/backend/src/agentclaw/community/core/skill_center/space_skill_offline_service_protocol.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/space_skill_offline_service_protocol.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from dataclasses import dataclass
+from datetime import datetime
 from enum import StrEnum
 from typing import Protocol, runtime_checkable
 
@@ -34,17 +35,10 @@ class OfflineImpact:
 
 
 @dataclass(frozen=True, slots=True)
-class OfflineDraft:
-    target_version: int
-    status: str
-    revision_id: str
-
-
-@dataclass(frozen=True, slots=True)
 class SpaceSkillOfflineResult:
     changed: bool
     lifecycle_status: str
-    draft: OfflineDraft
+    offline_at: datetime
 
 
 @runtime_checkable
@@ -68,7 +62,6 @@ class SpaceSkillOfflineServiceProtocol(Protocol):
 
 __all__ = [
     "OfflineBlockerKind",
-    "OfflineDraft",
     "OfflineImpact",
     "OfflineImpactItem",
     "SpaceSkillOfflineResult",

--- a/src/backend/src/agentclaw/community/core/skill_center/space_skill_query_service_protocol.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/space_skill_query_service_protocol.py
@@ -92,7 +92,7 @@ class SpaceSkillSummaryRecord(TypedDict):
 
 
 class SpaceSkillDetailRecord(SpaceSkillSummaryRecord):
-    source: Literal["FOLDER", "GIT"]
+    source: Literal["FOLDER", "GIT", "COPY"]
     offline_at: datetime | None
     offline_by: str | None
 

--- a/src/backend/src/agentclaw/community/di/modules/spaces_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/spaces_module.py
@@ -122,9 +122,6 @@ from agentclaw.community.core.skill_center.services.space_skill_editor_request_s
 from agentclaw.community.core.skill_center.services.draft_edit_lease_service import (
     DraftEditLeaseService,
 )
-from agentclaw.community.core.skill_center.services.published_version_draft import (
-    PublishedVersionDraftBuilder,
-)
 from agentclaw.community.core.skill_center.services.space_skill_offline_service import (
     SpaceSkillOfflineService,
 )
@@ -232,29 +229,13 @@ class SpacesModule(Module):
         self,
         access: CoreSpaceAccessServiceProtocol,
         repository: SpaceSkillOfflineRepositoryProtocol,
-        draft_store: DraftContentStore,
-        sources: SpaceSkillSourcePlugin,
-        canonical_store: CanonicalCenterVersionStore,
-        skill_center: SkillCenterGateway,
         lineage: ServiceArtifactLineageReaderProtocol,
     ) -> SpaceSkillOfflineServiceProtocol:
-        validator = SkillPackageValidator(SkillParser())
-        drafts = PublishedVersionDraftBuilder(
-            canonical_store=canonical_store,
-            skill_center=skill_center,
-            sources=sources,
-            validator=validator,
-            draft_store=draft_store,
-            env_provider=get_current_env,
-            tenant_provider=get_current_avernet_tenant,
-        )
         return SpaceSkillOfflineService(
             access=access,
             repository=repository,
             lineage=lineage,
-            drafts=drafts,
             env_provider=get_current_env,
-            tenant_provider=get_current_avernet_tenant,
         )
 
     @singleton

--- a/src/backend/tests/community/adapters/http/openapi_v1/spaces/test_contract.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/spaces/test_contract.py
@@ -51,7 +51,6 @@ from agentclaw.community.api.space_skill_version_query_service import (
 )
 from agentclaw.community.api.space_skill_offline_service import (
     OfflineBlockerKind,
-    OfflineDraft,
     OfflineImpact,
     OfflineImpactItem,
     SpaceSkillOfflineResult,
@@ -366,9 +365,10 @@ def test_grant_endpoints_publish_stable_wire_and_delegate_actor(
                 "edit_draft": False,
                 "publish_draft": False,
                 "delete_draft": False,
-                "create_upgrade_draft": False,
-                "offline_skill": False,
-                "manage_grants": False,
+                            "create_upgrade_draft": False,
+                            "offline_skill": False,
+                            "copy_offline_skill": False,
+                            "manage_grants": False,
                 "transfer_owner": False,
                 "request_edit_access": True,
                 "takeover_lease": False,
@@ -625,6 +625,7 @@ def test_list_space_skills_maps_page_and_forwards_search(client, skill_query_ser
                         "delete_draft": False,
                         "create_upgrade_draft": False,
                         "offline_skill": False,
+                        "copy_offline_skill": False,
                         "manage_grants": False,
                         "transfer_owner": False,
                         "request_edit_access": True,
@@ -676,6 +677,7 @@ def test_list_space_skills_maps_page_and_forwards_search(client, skill_query_ser
                         "delete_draft": False,
                         "create_upgrade_draft": False,
                         "offline_skill": False,
+                        "copy_offline_skill": False,
                         "manage_grants": False,
                         "transfer_owner": False,
                         "request_edit_access": True,
@@ -1276,11 +1278,7 @@ def test_offline_impact_and_command_publish_stable_contracts(
     skill_offline_service.offline.return_value = SpaceSkillOfflineResult(
         changed=True,
         lifecycle_status="OFFLINE",
-        draft=OfflineDraft(
-            target_version=3,
-            status="EDITING",
-            revision_id="33333333-3333-4333-8333-333333333333",
-        ),
+        offline_at=datetime(2026, 9, 2),
     )
 
     preview = client.get(
@@ -1311,7 +1309,7 @@ def test_offline_impact_and_command_publish_stable_contracts(
     }
     assert executed.status_code == 200
     assert executed.json()["data"]["changed"] is True
-    assert executed.json()["data"]["draft"]["target_version"] == 3
+    assert executed.json()["data"]["offline_at"] == "2026-09-02T00:00:00"
     skill_offline_service.impact.assert_called_once_with(
         space_id=7,
         skill_id=51,

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_explicit_user_id.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_explicit_user_id.py
@@ -416,7 +416,7 @@ _LOGS_PREFIX = f"{PUBLIC_API_PREFIX}/bots/logs"
 #:
 #: download-dir (openapi v1 resources) adds one more path-addressed operation:
 #: 146 → 147.
-_BOT_ID_PLACEMENT = {"path": 147, "query": 1, "none": 98}
+_BOT_ID_PLACEMENT = {"path": 147, "query": 1, "none": 99}
 
 
 def _schema() -> dict:
@@ -552,8 +552,8 @@ def test_the_pinned_number_of_operations_take_it():
     # bringing the combined surface to 218. The public static-template mirror
     # adds one more user-scoped operation, bringing the current surface to 219.
     # download-dir (openapi v1 resources) takes user_id like every other
-    # resources operation: 219 → 220.
-    assert len(taking) == 220
+    # resources operation and Space Skill Version Copy: 219 → 221.
+    assert len(taking) == 221
 
 
 def test_the_exempt_operations_take_none():

--- a/src/backend/tests/community/core/skill_center/services/test_space_skill_application_service.py
+++ b/src/backend/tests/community/core/skill_center/services/test_space_skill_application_service.py
@@ -231,6 +231,62 @@ def test_folder_creation_does_not_hide_cleanup_failure():
     store.delete_revision.assert_called_once()
 
 
+def test_copy_offline_published_version_creates_new_uuid_v1_draft():
+    service, _access, repository, drafts, store, _sources, versions, canonical, *_ = (
+        _service()
+    )
+    drafts.get_skill_for_upgrade.return_value = {
+        "skill_id": 51,
+        "skill_uuid": "11111111-1111-4111-8111-111111111111",
+        "name": "draft-skill",
+        "space_type": "TEAM",
+        "sc_team_id": 77,
+        "offline_at": object(),
+    }
+    versions.get_published_by_ordinal.return_value = {
+        "id": 91,
+        "skill_id": 51,
+        "version_ordinal": 2,
+        "status": "PUBLISHED",
+        "sc_version_number": "2.0.0",
+        "sc_skill_id": 123,
+        "sc_version_id": 456,
+        "name": "draft-skill",
+        "description": "Published description",
+        "metadata_json": "{}",
+        "published_at": None,
+    }
+    canonical.read_version.return_value = CanonicalCenterVersion.from_files(
+        CanonicalCenterVersionIdentity(
+            skill_uuid="11111111-1111-4111-8111-111111111111",
+            sc_version_number="2.0.0",
+        ),
+        {"SKILL.md": b"---\nname: draft-skill\ndescription: copied\n---\n"},
+    )
+
+    result = service.copy_published_version(
+        space_id=7,
+        skill_id=51,
+        version_ordinal=2,
+        actor_id="owner-1",
+        request_id="copy-1",
+    )
+
+    assert result.skill_id == 51
+    call = repository.create_space_skill.call_args.kwargs["skill_data"]
+    assert call["skill_uuid"] != "11111111-1111-4111-8111-111111111111"
+    assert call["draft_target_version"] == 1
+    assert call["draft_status"] == "EDITING"
+    assert call["draft_source_kind"] == "PUBLISHED_VERSION"
+    assert call["source_type"] == "COPY"
+    assert "sc_skill_id" not in call
+    assert "sc_version_id" not in call
+    ref = DraftRevisionRef.from_locator(
+        tenant="tenant-a", env="test", locator=call["zip_url"]
+    )
+    assert store.read_revision(ref).description == "copied"
+
+
 def test_git_creation_uses_the_same_package_and_persistence_pipeline():
     service, _access, repository, _drafts, store, sources, *_extra = _service()
     sources.fetch_git_snapshot.return_value = GitSkillSnapshot(

--- a/src/backend/tests/community/core/skill_center/services/test_space_skill_grant_service.py
+++ b/src/backend/tests/community/core/skill_center/services/test_space_skill_grant_service.py
@@ -47,6 +47,7 @@ def test_list_grants_returns_acl_qualifications_not_state_predictions():
         "delete_draft": False,
         "create_upgrade_draft": False,
         "offline_skill": False,
+        "copy_offline_skill": False,
         "manage_grants": False,
         "transfer_owner": True,
         "request_edit_access": True,

--- a/src/backend/tests/community/core/skill_center/services/test_space_skill_offline_service.py
+++ b/src/backend/tests/community/core/skill_center/services/test_space_skill_offline_service.py
@@ -26,13 +26,9 @@ from agentclaw.community.core.repository.space_skill_offline_types import (
     OfflinePublicationAttemptFact,
     OfflineSkillIdentity,
 )
-from agentclaw.community.core.skill_center.draft_content import DraftRevisionRef
 from agentclaw.community.core.skill_center.errors import (
     SkillOfflineBlockedError,
     SpaceSkillGrantForbiddenError,
-)
-from agentclaw.community.core.skill_center.services.published_version_draft import (
-    PreparedPublishedVersionDraft,
 )
 from agentclaw.community.core.skill_center.services.space_skill_offline_service import (
     SpaceSkillOfflineService,
@@ -85,35 +81,17 @@ def _service(*, inspection, lineage_result=None):
     repository.inspect.return_value = inspection
     lineage = MagicMock()
     lineage.scan.return_value = lineage_result or ServiceArtifactLineage((), ())
-    drafts = MagicMock()
-    prepared = PreparedPublishedVersionDraft(
-        expected_version_id=61,
-        target_version=3,
-        description="published",
-        ref=DraftRevisionRef(
-            tenant="tenant-a",
-            env="test",
-            skill_uuid=_UUID,
-            target_version=3,
-            revision_id=_NEW_REV,
-        ),
-    )
-    drafts.prepare.return_value = prepared
     repository.commit.return_value = OfflineCommit(
         changed=True,
-        target_version=3,
-        status="EDITING",
-        locator=prepared.ref.locator,
+        offline_at=datetime(2026, 9, 2),
     )
     service = SpaceSkillOfflineService(
         access=access,
         repository=repository,
         lineage=lineage,
-        drafts=drafts,
         env_provider=lambda: "test",
-        tenant_provider=lambda: "tenant-a",
     )
-    return service, access, repository, lineage, drafts, prepared
+    return service, access, repository, lineage
 
 
 def test_impact_counts_explicit_blockers_then_returns_unknown_artifact_as_warning():
@@ -177,8 +155,8 @@ def test_impact_counts_explicit_blockers_then_returns_unknown_artifact_as_warnin
     )
 
 
-def test_offline_prepares_exact_revision_then_commits_and_returns_vn_plus_one():
-    service, _access, repository, _lineage, drafts, prepared = _service(
+def test_offline_marks_existing_skill_without_creating_a_draft():
+    service, _access, repository, _lineage = _service(
         inspection=_inspection()
     )
 
@@ -186,37 +164,30 @@ def test_offline_prepares_exact_revision_then_commits_and_returns_vn_plus_one():
 
     assert result.changed is True
     assert result.lifecycle_status == "OFFLINE"
-    assert result.draft.target_version == 3
-    assert result.draft.revision_id == _NEW_REV
-    drafts.prepare.assert_called_once()
+    assert result.offline_at == datetime(2026, 9, 2)
     repository.commit.assert_called_once_with(
         space_id=7,
         skill_id=51,
         actor_id="owner-1",
-        expected_version_id=61,
-        target_version=3,
-        new_locator=prepared.ref.locator,
-        new_description="published",
         env="test",
         guard=ANY,
     )
 
 
 def test_offline_idempotent_replay_does_not_prepare_another_revision():
-    service, _access, repository, _lineage, drafts, _prepared = _service(
+    service, _access, repository, _lineage = _service(
         inspection=_inspection(identity=_identity(offline=True, draft=True))
     )
 
     result = service.offline(space_id=7, skill_id=51, actor_id="owner-1")
 
     assert result.changed is False
-    assert result.draft.revision_id == _EXISTING_REV
-    drafts.prepare.assert_not_called()
+    assert result.offline_at == datetime(2026, 8, 30)
     repository.commit.assert_not_called()
 
 
 def test_unknown_artifact_warning_does_not_block_offline():
-    service, _access, repository, _lineage, _drafts, _prepared = _service(
+    service, _access, repository, _lineage = _service(
         inspection=_inspection(),
         lineage_result=ServiceArtifactLineage(
             references=(),
@@ -236,7 +207,7 @@ def test_unknown_artifact_warning_does_not_block_offline():
 
 
 def test_transaction_recheck_unknown_artifact_warning_does_not_roll_back_offline():
-    service, _access, repository, lineage, _drafts, _prepared = _service(
+    service, _access, repository, lineage = _service(
         inspection=_inspection()
     )
     lineage.scan.side_effect = [
@@ -256,9 +227,7 @@ def test_transaction_recheck_unknown_artifact_warning_does_not_roll_back_offline
         kwargs["guard"](_inspection())
         return OfflineCommit(
             changed=True,
-            target_version=3,
-            status="EDITING",
-            locator=kwargs["new_locator"],
+            offline_at=datetime(2026, 9, 2),
         )
 
     repository.commit.side_effect = _commit
@@ -268,8 +237,8 @@ def test_transaction_recheck_unknown_artifact_warning_does_not_roll_back_offline
     assert result.changed is True
 
 
-def test_concurrent_blocker_from_transaction_recheck_discards_prepared_revision():
-    service, _access, repository, lineage, drafts, prepared = _service(
+def test_concurrent_blocker_from_transaction_recheck_rejects_offline():
+    service, _access, repository, lineage = _service(
         inspection=_inspection()
     )
     latest = OfflineImpactItem(
@@ -302,7 +271,6 @@ def test_concurrent_blocker_from_transaction_recheck_discards_prepared_revision(
         service.offline(space_id=7, skill_id=51, actor_id="owner-1")
 
     assert blocked.value.impact.items == (latest,)
-    drafts.discard.assert_called_once_with(prepared)
 
 
 @pytest.mark.parametrize(
@@ -312,7 +280,7 @@ def test_concurrent_blocker_from_transaction_recheck_discards_prepared_revision(
 def test_owner_manager_policy_is_enforced_by_service(
     space_bound: bool, actor_roles: tuple[str, ...]
 ) -> None:
-    service, _access, repository, lineage, drafts, _prepared = _service(
+    service, _access, repository, lineage = _service(
         inspection=_inspection(
             space_bound=space_bound,
             actor_roles=actor_roles,
@@ -324,4 +292,3 @@ def test_owner_manager_policy_is_enforced_by_service(
 
     repository.commit.assert_not_called()
     lineage.scan.assert_not_called()
-    drafts.prepare.assert_not_called()

--- a/src/backend/tests/community/core/skill_center/test_skill_version_materializer.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_version_materializer.py
@@ -456,7 +456,7 @@ class _RecoveryDrafts:
         raise AssertionError("successful Offline must retain the Draft revision")
 
 
-def test_offline_vn_plus_one_recovers_through_unified_materializer() -> None:
+def test_materializing_a_new_version_never_reactivates_a_terminally_offline_skill() -> None:
     db = _RecoveryDatabase()
     skill_uuid = "00000000-0000-4000-8000-000000000010"
     with db.orm_session() as session:
@@ -527,7 +527,7 @@ def test_offline_vn_plus_one_recovers_through_unified_materializer() -> None:
         skill_id=skill_id,
         actor_id="owner",
     )
-    assert committed.draft.target_version == 3
+    assert committed.draft is None
     with db.orm_session() as session:
         persisted = session.query(Skill).filter_by(id=skill_id).one()
         assert persisted.offline_at is not None
@@ -569,6 +569,6 @@ def test_offline_vn_plus_one_recovers_through_unified_materializer() -> None:
     assert published.version_ordinal == 3
     with db.orm_session() as session:
         recovered = session.query(Skill).filter_by(id=skill_id).one()
-        assert recovered.offline_at is None
-        assert recovered.offline_by is None
+        assert recovered.offline_at is not None
+        assert recovered.offline_by == "owner"
         assert session.query(SkillVersion).filter_by(id=101).one().status == "PUBLISHED"

--- a/src/backend/tests/community/endpoints/test_spaces_router.py
+++ b/src/backend/tests/community/endpoints/test_spaces_router.py
@@ -370,6 +370,20 @@ def _seed_space_skill_version_reads(world) -> None:
     )
 
 
+def _seed_space_skill_copy(world) -> None:
+    _seed_space_skill_version_reads(world)
+    _seed_space_skill_draft_commands(world)
+    bind_overrides(
+        world,
+        SpaceSkillApplicationServiceProtocol,
+        {
+            "copy_published_version": lambda _self, **_kwargs: SpaceSkillCreationOutcome(
+                skill_id=51, created=True
+            ),
+        },
+    )
+
+
 def _seed_space_skill_offline(world) -> None:
     _enable_public_auth(world)
     bind_overrides(
@@ -541,6 +555,17 @@ _SPACE_SKILL_LOOP_CASES = (
             headers=_principal_headers(),
         ),
         200,
+    ),
+    (
+        "POST",
+        "/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/versions/{version}/copy",
+        _seed_space_skill_copy,
+        CaseInput(
+            path_params={"space_id": 1, "skill_id": 51, "version": 1},
+            query_params={"user_id": _USER_ID},
+            headers={**_principal_headers(), "Idempotency-Key": "copy-1"},
+        ),
+        201,
     ),
     (
         "POST",

--- a/src/backend/tests/community/endpoints/test_spaces_router.py
+++ b/src/backend/tests/community/endpoints/test_spaces_router.py
@@ -184,6 +184,7 @@ def _seed_space_skills(world) -> None:
                         "delete_draft": True,
                         "create_upgrade_draft": True,
                         "offline_skill": True,
+                        "copy_offline_skill": True,
                         "manage_grants": True,
                         "transfer_owner": True,
                         "request_edit_access": False,
@@ -239,6 +240,7 @@ def _space_skill_detail_record() -> dict:
                 "delete_draft": True,
                 "create_upgrade_draft": True,
                 "offline_skill": True,
+                "copy_offline_skill": True,
                 "manage_grants": True,
                 "transfer_owner": True,
                 "request_edit_access": False,
@@ -373,6 +375,7 @@ def _seed_space_skill_version_reads(world) -> None:
 def _seed_space_skill_copy(world) -> None:
     _seed_space_skill_version_reads(world)
     _seed_space_skill_draft_commands(world)
+    _seed_space_skill_creation_and_detail(world)
     bind_overrides(
         world,
         SpaceSkillApplicationServiceProtocol,

--- a/src/backend/tests/community/repository/skill_center/test_skill_version_repository.py
+++ b/src/backend/tests/community/repository/skill_center/test_skill_version_repository.py
@@ -477,7 +477,7 @@ def test_materialization_publish_replay_requires_the_same_frozen_facts() -> None
     assert replay.status == "PUBLISHED"
 
 
-def test_new_space_publication_clears_offline_but_published_replay_never_does() -> None:
+def test_space_publication_never_reactivates_terminally_offline_skill() -> None:
     db = _Database()
     offline_at = datetime(2026, 8, 30, 10, 0)
     with db.orm_session() as session:
@@ -533,9 +533,8 @@ def test_new_space_publication_clears_offline_but_published_replay_never_does() 
     with db.orm_session() as session:
         skill = session.get(Skill, 10)
         assert skill is not None
-        assert skill.offline_at is None and skill.offline_by is None
-        skill.offline_at = offline_at
-        skill.offline_by = "owner"
+        assert skill.offline_at == offline_at
+        assert skill.offline_by == "owner"
 
     with avernet_tenant_scope("teamclaw"):
         repo.publish_materialized(

--- a/src/backend/tests/community/repository/skill_center/test_space_skill_offline_repository.py
+++ b/src/backend/tests/community/repository/skill_center/test_space_skill_offline_repository.py
@@ -28,7 +28,6 @@ from agentclaw.community.core.spaces.repository.models import SpaceModel
 
 
 _UUID = "11111111-1111-4111-8111-111111111111"
-_REV = "22222222-2222-4222-8222-222222222222"
 
 
 class _Database:
@@ -176,22 +175,15 @@ def test_inspection_includes_inactive_membership_installation_and_attempt():
     assert inspection.actor_roles == ("OWNER",)
 
 
-def test_offline_commit_preserves_published_version_and_creates_editing_vn_plus_one():
+def test_offline_commit_preserves_published_version_without_creating_a_draft():
     db = _Database()
     space_id, skill_id = _seed(db)
     repo = SpaceSkillOfflineRepository(db)
-    identity = repo.inspect(
-        space_id=space_id, skill_id=skill_id, actor_id="owner-1", env="test"
-    ).identity
 
     result = repo.commit(
         space_id=space_id,
         skill_id=skill_id,
         actor_id="owner-1",
-        expected_version_id=identity.latest_version_id,
-        target_version=3,
-        new_locator=f"draft://{_UUID}/v3/{_REV}",
-        new_description="published",
         env="test",
         guard=lambda _inspection: None,
     )
@@ -202,8 +194,9 @@ def test_offline_commit_preserves_published_version_and_creates_editing_vn_plus_
         assert skill.status == "PUBLISHED"
         assert skill.offline_at is not None
         assert skill.offline_by == "owner-1"
-        assert skill.draft_target_version == 3
-        assert skill.draft_status == "EDITING"
+        assert skill.draft_target_version is None
+        assert skill.draft_status is None
+        assert skill.zip_url is None
         assert session.query(SkillVersion).filter_by(skill_id=skill_id).count() == 1
 
 
@@ -211,9 +204,6 @@ def test_transaction_guard_runs_after_locked_db_recheck_and_can_abort():
     db = _Database()
     space_id, skill_id = _seed(db)
     repo = SpaceSkillOfflineRepository(db)
-    identity = repo.inspect(
-        space_id=space_id, skill_id=skill_id, actor_id="owner-1", env="test"
-    ).identity
 
     def _guard(locked):
         assert locked.identity.skill_id == skill_id
@@ -226,10 +216,6 @@ def test_transaction_guard_runs_after_locked_db_recheck_and_can_abort():
             space_id=space_id,
             skill_id=skill_id,
             actor_id="owner-1",
-            expected_version_id=identity.latest_version_id,
-            target_version=3,
-            new_locator=f"draft://{_UUID}/v3/{_REV}",
-            new_description="published",
             env="test",
             guard=_guard,
         )

--- a/src/backend/tests/community/repository/skill_center/test_space_skill_publication_repository.py
+++ b/src/backend/tests/community/repository/skill_center/test_space_skill_publication_repository.py
@@ -408,10 +408,6 @@ def test_complete_success_and_offline_overlap_converges(
                 space_id=space_id,
                 skill_id=skill_id,
                 actor_id="owner",
-                expected_version_id=version_id,
-                target_version=2,
-                new_locator=f"draft://offline-skill/v2/{uuid4()}",
-                new_description="Review risk",
                 env="test",
                 guard=lambda inspection: None,
             )

--- a/src/gateway/configs/schemas/bots.openapi.json
+++ b/src/gateway/configs/schemas/bots.openapi.json
@@ -19104,7 +19104,7 @@
             "type": "boolean"
           },
           "offline_skill": {
-            "description": "Actor may request terminal TeamClaw-local Skill Offline.",
+            "description": "Actor may request terminal local Skill Offline.",
             "title": "Offline Skill",
             "type": "boolean"
           },
@@ -20199,7 +20199,7 @@
         "type": "object"
       },
       "SkillOfflineResult": {
-        "description": "Terminal TeamClaw-local Offline result for the existing Skill.",
+        "description": "Terminal local Offline result for the existing Skill.",
         "properties": {
           "changed": {
             "description": "Whether this request newly moved the Skill Offline.",
@@ -20213,16 +20213,22 @@
             "type": "string"
           },
           "offline_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "description": "UTC time at which Offline was recorded.",
-            "format": "date-time",
-            "title": "Offline At",
-            "type": "string"
+            "title": "Offline At"
           }
         },
         "required": [
           "changed",
-          "lifecycle_status",
-          "offline_at"
+          "lifecycle_status"
         ],
         "title": "SkillOfflineResult",
         "type": "object"
@@ -21457,7 +21463,7 @@
                 "type": "null"
               }
             ],
-            "description": "UTC terminal TeamClaw-local Offline time, or null.",
+            "description": "UTC terminal local Offline time, or null.",
             "title": "Offline At"
           },
           "offline_by": {

--- a/src/gateway/configs/schemas/bots.openapi.json
+++ b/src/gateway/configs/schemas/bots.openapi.json
@@ -889,8 +889,7 @@
                 "type": "null"
               }
             ],
-            "default": null,
-            "description": "Template type declared with the config. Required for template-factory snapshots (any value, echoed from available-tc-list); for hand-written application-coding configs omit it or pass applicationCoding.",
+            "description": "Template type declared with the config. Required for template-factory snapshots (any value, echoed from available-tc-list); for hand-written application-coding configs omit it or pass 'applicationCoding'.",
             "title": "Template Type"
           }
         },
@@ -2866,6 +2865,12 @@
       "CreateSpaceRequest": {
         "description": "Request for creating a shared team Space.",
         "properties": {
+          "skipSC": {
+            "default": false,
+            "description": "Whether to skip creating the corresponding Skill Center Team.",
+            "title": "Skipsc",
+            "type": "boolean"
+          },
           "space_name": {
             "description": "Display name for the new Space.",
             "maxLength": 128,
@@ -12696,6 +12701,19 @@
         "title": "ImportSpaceSkillFromGitRequest",
         "type": "object"
       },
+      "InitializePersonalSpaceRequest": {
+        "description": "Optional controls for initializing the current user's personal Space.",
+        "properties": {
+          "skipSC": {
+            "default": false,
+            "description": "Whether to skip creating or binding the corresponding Skill Center Team.",
+            "title": "Skipsc",
+            "type": "boolean"
+          }
+        },
+        "title": "InitializePersonalSpaceRequest",
+        "type": "object"
+      },
       "LifecycleAdvanceRequest": {
         "additionalProperties": false,
         "description": "Target stage for advancing the current service-Bot publication.",
@@ -19059,6 +19077,12 @@
       "SkillActorPermissions": {
         "description": "ACL/Grant qualifications; current command state is checked separately.",
         "properties": {
+          "copy_offline_skill": {
+            "default": false,
+            "description": "Actor may copy an Offline Skill's exact Published Version.",
+            "title": "Copy Offline Skill",
+            "type": "boolean"
+          },
           "create_upgrade_draft": {
             "description": "Actor may request creation of an upgrade Draft.",
             "title": "Create Upgrade Draft",
@@ -19080,7 +19104,7 @@
             "type": "boolean"
           },
           "offline_skill": {
-            "description": "Actor may request recoverable Skill Offline.",
+            "description": "Actor may request terminal TeamClaw-local Skill Offline.",
             "title": "Offline Skill",
             "type": "boolean"
           },
@@ -19925,7 +19949,7 @@
         "x-enum-descriptions": [
           "The Skill has a Draft but no Published Version.",
           "The Skill has at least one Published Version and is online.",
-          "The Skill is recoverably offline but remains editable."
+          "The Skill is offline, retains its Published history, and is not editable."
         ],
         "x-enum-varnames": [
           "DRAFT_ONLY",
@@ -20175,28 +20199,30 @@
         "type": "object"
       },
       "SkillOfflineResult": {
-        "description": "Recoverable Offline state and the editable next-version Draft.",
+        "description": "Terminal TeamClaw-local Offline result for the existing Skill.",
         "properties": {
           "changed": {
             "description": "Whether this request newly moved the Skill Offline.",
             "title": "Changed",
             "type": "boolean"
           },
-          "draft": {
-            "$ref": "#/components/schemas/SkillDraftSummary",
-            "description": "Editable Vn+1 Draft retained for recovery publication."
-          },
           "lifecycle_status": {
             "const": "OFFLINE",
             "description": "Current recoverable lifecycle state.",
             "title": "Lifecycle Status",
+            "type": "string"
+          },
+          "offline_at": {
+            "description": "UTC time at which Offline was recorded.",
+            "format": "date-time",
+            "title": "Offline At",
             "type": "string"
           }
         },
         "required": [
           "changed",
           "lifecycle_status",
-          "draft"
+          "offline_at"
         ],
         "title": "SkillOfflineResult",
         "type": "object"
@@ -21431,7 +21457,7 @@
                 "type": "null"
               }
             ],
-            "description": "UTC recoverable Offline time, or null.",
+            "description": "UTC terminal TeamClaw-local Offline time, or null.",
             "title": "Offline At"
           },
           "offline_by": {
@@ -21464,7 +21490,8 @@
             "description": "Original Space Skill creation source.",
             "enum": [
               "FOLDER",
-              "GIT"
+              "GIT",
+              "COPY"
             ],
             "title": "Source",
             "type": "string"
@@ -39553,6 +39580,23 @@
             }
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/InitializePersonalSpaceRequest"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Body"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "content": {
@@ -47478,6 +47522,225 @@
           }
         },
         "summary": "Get Space Skill Version",
+        "tags": [
+          "space-skills"
+        ]
+      }
+    },
+    "/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/versions/{version}/copy": {
+      "post": {
+        "operationId": "copy_offline_space_skill_version_openapi_v1_bots_spaces__space_id__skills__skill_id__versions__version__copy_post",
+        "parameters": [
+          {
+            "description": "Space primary identifier.",
+            "in": "path",
+            "name": "space_id",
+            "required": true,
+            "schema": {
+              "description": "Space primary identifier.",
+              "minimum": 1,
+              "title": "Space Id",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Space Skill primary identifier.",
+            "in": "path",
+            "name": "skill_id",
+            "required": true,
+            "schema": {
+              "description": "Space Skill primary identifier.",
+              "minimum": 1,
+              "title": "Skill Id",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Business version ordinal.",
+            "in": "path",
+            "name": "version",
+            "required": true,
+            "schema": {
+              "description": "Business version ordinal.",
+              "minimum": 1,
+              "title": "Version",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Stable identity for replaying this creation command.",
+            "in": "header",
+            "name": "Idempotency-Key",
+            "required": true,
+            "schema": {
+              "description": "Stable identity for replaying this creation command.",
+              "maxLength": 128,
+              "minLength": 1,
+              "title": "Idempotency-Key",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_SpaceSkillDetail_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The authenticated user lacks the required space membership or role"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 503000,
+                  "message": "Service Unavailable",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Temporarily unavailable"
+          }
+        },
+        "summary": "Copy Offline Space Skill Version",
         "tags": [
           "space-skills"
         ]
@@ -68764,6 +69027,214 @@
           }
         },
         "summary": "Download File",
+        "tags": [
+          "resources"
+        ]
+      }
+    },
+    "/openapi/v1/bots/{bot_id}/resources/download-dir": {
+      "get": {
+        "description": "Download a whole directory as a zip archive, addressed by path.\n\nThe path may name any directory; omit it to download the entire\nworkspace. Raw bytes, not an envelope — the body is the archive.\n\nThe archive is built on disk before the response starts, so a walk\nfailure mid-way is still a clean error envelope, never a 200 with a\npartial zip. Exceeding the directory download caps is answered with\na 413.",
+        "operationId": "download_directory_openapi_v1_bots__bot_id__resources_download_dir_get",
+        "parameters": [
+          {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
+            "in": "path",
+            "name": "bot_id",
+            "required": true,
+            "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
+              "title": "Bot Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Workspace-relative path of the folder to download, e.g. 'docs/spec' — exactly as returned in a listing entry's `path`. Omit it to download the entire workspace. A leading slash is tolerated; '..' segments are refused (400).",
+            "in": "query",
+            "name": "path",
+            "required": false,
+            "schema": {
+              "default": "",
+              "description": "Workspace-relative path of the folder to download, e.g. 'docs/spec' — exactly as returned in a listing entry's `path`. Omit it to download the entire workspace. A leading slash is tolerated; '..' segments are refused (400).",
+              "title": "Path",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              },
+              "application/zip": {}
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "413": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 413000,
+                  "message": "Directory too large to download",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The directory exceeds the download caps: 100 MB per file, 5000 files, 500 MB in total."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 503000,
+                  "message": "Service Unavailable",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Temporarily unavailable"
+          }
+        },
+        "summary": "Download Directory",
         "tags": [
           "resources"
         ]


### PR DESCRIPTION
## 内容
- Offline 仅标记原 Skill 为 OFFLINE，不再创建 Vn+1 Draft 或恢复原 Skill。
- 新增精确 Published Version Copy：生成新 UUID、新 Skill、新 V1 Draft；发布时创建独立 SC Skill。
- 更新前端合同、授权/Admission 与 Gateway OpenAPI。

## 验证
- 206 targeted tests passed
- changed-file Ruff passed
- OpenAPI dump verified the Copy route and Offline result schema

说明：对整个 skill_center/services 目录运行 Ruff 时发现 4 条与本 PR 无关的既有 lint（skill_batch_sync_service.py、skill_scan.py）；未修改无关代码。