### PR TITLE
fix(bot-run): inject eval_session_log into BotRunRequestExecutor

### DIFF
--- a/src/baas/src/secbaas/community/bootstrap/_core_services.py
+++ b/src/baas/src/secbaas/community/bootstrap/_core_services.py
@@ -662,6 +662,7 @@ class CoreServiceContainer(containers.DeclarativeContainer):
         chunk_repository=bot_run_queue_chunk_repository,
         cache_plugin=cache_plugin,
         api_key_repository=api_gateway_repo,
+        eval_session_log=eval_session_log,
     )
 
     serializing_executor = providers.Singleton(

--- a/src/baas/src/secbaas/community/core/service/bot_run/_executor.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_executor.py
@@ -255,6 +255,7 @@ class BotRunRequestExecutor:
         chunk_repository: BotRunQueueChunkRepository,
         cache_plugin: CachePlugin,
         api_key_repository: APIKeyRepository,
+        eval_session_log: Any | None = None,
         stream_flush_interval_seconds: float = 0.2,
         stream_flush_max_content_bytes: int = 65536,
     ) -> None:
@@ -264,6 +265,7 @@ class BotRunRequestExecutor:
         self._chunk_repository = chunk_repository
         self._cache_plugin = cache_plugin
         self._api_key_repository = api_key_repository
+        self._eval_session_log = eval_session_log
         self._stream_flush_interval = stream_flush_interval_seconds
         # 单条 chunk content 的字节上界：超过阈值时提前 flush，避免在 ZDAS tracer
         # 等非参数化内联 SQL 路径下因单条 payload 过大触发 1064 转义断裂。
@@ -292,7 +294,9 @@ class BotRunRequestExecutor:
             if metadata.get("timeout")
             else queue_meta.get("timeout")
         )
-        chat_metadata = build_chat_metadata(metadata, run.run_id)
+        chat_metadata = build_chat_metadata(
+            metadata, run.run_id, eval_session_log=self._eval_session_log
+        )
 
         context = _rebuild_context(
             run.api_key_prefix, self._api_key_repository, metadata
@@ -328,6 +332,22 @@ class BotRunRequestExecutor:
             request_type,
             stream,
         )
+
+        # eval 对话 session 日志与保护性校验 — 委托 Plugin（与 Runner 路径对称）
+        eval_id = metadata.get("eval_id")
+        if eval_id:
+            logger.info(
+                "[BotRunExecutor] eval chat session: eval_id=%s, bot_id=%s",
+                eval_id,
+                run.bot_id,
+            )
+            if self._eval_session_log is not None:
+                self._eval_session_log.log_eval_session(
+                    eval_id=eval_id,
+                    bot_id=run.bot_id,
+                    session_id=session_id,
+                    method="execute",
+                )
 
         try:
             if request_type == "inject":

--- a/src/baas/tests/unit/core/service/bot_run/test_bot_run_executor.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_bot_run_executor.py
@@ -1295,3 +1295,141 @@ async def test_executor_handles_missing_attachments_in_meta():
     # Verify repo state updates still called normally
     repo.update_status.assert_called_once_with("r1", "RUNNING")
     repo.update_result.assert_called_once()
+
+
+# ----------------------------- eval_session_log 注入 -----------------------------
+
+
+async def test_executor_eval_session_log_enriches_chat_metadata():
+    """eval_session_log 非空时，build_chat_metadata 传入 eval_session_log，enrich_chat_metadata 被调用。"""
+    repo = MagicMock()
+    plugin = MagicMock()
+    selector = MagicMock()
+
+    repo.get_by_run_id.return_value = _run(
+        run_id="r-eval",
+        bot_id="bot-1:ent",
+        metadata={
+            "app_id": "a",
+            "app_type": "T",
+            "tenant": "t",
+            "request_type": "chat",
+            "eval_id": "eval-abc",
+            "default_tag": "eval",
+        },
+    )
+    plugin.get_binding = AsyncMock(return_value=_binding_data())
+
+    bot_svc = MagicMock()
+    bot_svc.send_message = AsyncMock(
+        return_value=BotResponse(content="eval response", usage=None)
+    )
+    selector.select.return_value = bot_svc
+
+    # 构造 mock eval_session_log
+    eval_log = MagicMock()
+    eval_log.enrich_chat_metadata.return_value = {
+        "biz_task_id": "r-eval",
+        "biz_scene": "eval:eval",
+        "eval_observed": "true",
+        "eval_run_id": "eval-abc",
+    }
+
+    executor = BotRunRequestExecutor(
+        repo, plugin, selector, MagicMock(), MagicMock(), _api_key_repo(),
+        eval_session_log=eval_log,
+    )
+    await executor.execute(
+        _queue_rec(run_id="r-eval", bot_id="bot-1:ent", session_id="sess-eval")
+    )
+
+    # enrich_chat_metadata 应被调用
+    eval_log.enrich_chat_metadata.assert_called_once()
+
+    # log_eval_session 应被调用
+    eval_log.log_eval_session.assert_called_once_with(
+        eval_id="eval-abc",
+        bot_id="bot-1:ent",
+        session_id="sess-eval",
+        method="execute",
+    )
+
+    # chat_metadata 传入 send_message 应包含 eval 观测字段
+    call_kwargs = bot_svc.send_message.call_args.kwargs
+    assert call_kwargs["chat_metadata"]["eval_observed"] == "true"
+    assert call_kwargs["chat_metadata"]["eval_run_id"] == "eval-abc"
+
+
+async def test_executor_eval_session_log_none_compatible():
+    """eval_session_log 为 None（向后兼容），不报错，send_message 正常执行。"""
+    repo = MagicMock()
+    plugin = MagicMock()
+    selector = MagicMock()
+
+    repo.get_by_run_id.return_value = _run(
+        run_id="r-no-eval",
+        bot_id="bot-1:ent",
+        metadata={
+            "app_id": "a",
+            "app_type": "T",
+            "tenant": "t",
+            "request_type": "chat",
+        },
+    )
+    plugin.get_binding = AsyncMock(return_value=_binding_data())
+
+    bot_svc = MagicMock()
+    bot_svc.send_message = AsyncMock(
+        return_value=BotResponse(content="normal response", usage=None)
+    )
+    selector.select.return_value = bot_svc
+
+    executor = BotRunRequestExecutor(
+        repo, plugin, selector, MagicMock(), MagicMock(), _api_key_repo(),
+        eval_session_log=None,
+    )
+    await executor.execute(
+        _queue_rec(run_id="r-no-eval", bot_id="bot-1:ent", session_id="sess-normal")
+    )
+
+    bot_svc.send_message.assert_awaited_once()
+    # chat_metadata 不含 eval 观测字段
+    call_kwargs = bot_svc.send_message.call_args.kwargs
+    assert "eval_observed" not in call_kwargs.get("chat_metadata", {})
+
+
+async def test_executor_eval_id_present_without_eval_log_only_logs():
+    """eval_id 存在但 eval_session_log 为 None 时，log_eval_session 不调用，也不抛异常。"""
+    repo = MagicMock()
+    plugin = MagicMock()
+    selector = MagicMock()
+
+    repo.get_by_run_id.return_value = _run(
+        run_id="r-eval-no-log",
+        bot_id="bot-1:ent",
+        metadata={
+            "app_id": "a",
+            "app_type": "T",
+            "tenant": "t",
+            "request_type": "chat",
+            "eval_id": "eval-xyz",
+        },
+    )
+    plugin.get_binding = AsyncMock(return_value=_binding_data())
+
+    bot_svc = MagicMock()
+    bot_svc.send_message = AsyncMock(
+        return_value=BotResponse(content="ok", usage=None)
+    )
+    selector.select.return_value = bot_svc
+
+    executor = BotRunRequestExecutor(
+        repo, plugin, selector, MagicMock(), MagicMock(), _api_key_repo(),
+        eval_session_log=None,
+    )
+    await executor.execute(
+        _queue_rec(run_id="r-eval-no-log", bot_id="bot-1:ent", session_id="sess-x")
+    )
+
+    # 不应抛异常，send_message 仍正常执行
+    bot_svc.send_message.assert_awaited_once()


### PR DESCRIPTION
## Problem

队列 Worker 执行路径（`BotRunRequestExecutor`）缺少 `eval_session_log` 依赖注入，导致 eval 消息走 Executor 路径时：

1. `build_chat_metadata` 未传入 `eval_session_log`，`chat_metadata` 缺少 `eval_observed`/`eval_run_id` 观测字段，下游消费方无法通过这些字段识别评测消息
2. `log_eval_session` 不被调用，评测会话可追踪性受损
3. 系统日志出现告警：`build_chat_metadata: eval_session_log not injected, skipping eval metadata enrichment`

对比 Runner 路径（`BotRunner`）已正确注入 `eval_session_log`，两条路径行为不一致。

## Solution

在 `BotRunRequestExecutor` 中补齐 `eval_session_log` 注入，与 `BotRunner` 路径对称：

1. **`_executor.py` 构造函数**：增加 `eval_session_log: Any | None = None` 参数，默认 `None` 保证向后兼容
2. **`_executor.py` `build_chat_metadata` 调用**：传入 `eval_session_log=self._eval_session_log`
3. **`_executor.py` `execute` 方法**：增加 `eval_id` 检查和 `log_eval_session` 调用（与 Runner 的 `deliver_message`/`deliver_message_stream` 对称）
4. **`_core_services.py` DI 注册**：补充 `eval_session_log=eval_session_log`（与 `bot_runner` L644 的做法一致）

拒绝的方案：
- 在 `build_chat_metadata` 内部从 metadata 反推 eval 上下文 → 违反 Plugin 架构，eval 观测逻辑应委托 `EvalSessionLogProtocol`

## Validation

- 新增 3 个单元测试，全部通过：
  - `test_executor_eval_session_log_enriches_chat_metadata` — `eval_session_log` 非空时 `enrich_chat_metadata` 和 `log_eval_session` 均被调用，`chat_metadata` 含 eval 观测字段
  - `test_executor_eval_session_log_none_compatible` — `eval_session_log=None`（向后兼容）不报错，正常执行
  - `test_executor_eval_id_present_without_eval_log_only_logs` — `eval_id` 存在但 `eval_session_log=None` 时不抛异常
- 全量 executor 测试 43 个用例全部通过
- ruff format + ruff check 通过

## Compatibility and risk

**对生产消息无影响**：
- 生产消息不含 `eval_id`，新增的 `if eval_id:` 和 `if eval_session_log is not None:` 分支均不进入
- `RealEvalSessionLog.enrich_chat_metadata` 在 `chat_metadata` 无 `eval_id`/`default_tag` 时直接返回原 metadata，行为与修复前一致
- 构造函数参数默认 `None`，现有无此参数的调用方无需改动

**回滚路径**：单次 revert 即可，无 schema/config/migration 变更。

## Related issues

修复文档：`fixing_executor_eval_session_log_not_injected.md`