### PR TITLE
fix(backend): preserve device when rolling publish back to draft

### DIFF
--- a/src/backend/src/agentclaw/community/core/service_bot/services/bot_publish_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/bot_publish_service.py
@@ -1190,14 +1190,10 @@ class BotPublishService(PublishDraftRestoreMixin, PublishRollbackMixin):
                 f"[offline_publish] Publish status updated to draft: publish_id={publish_id}"
             )
 
-        # Step 5: both verify cancellation and online offline must tear down the
-        # corresponding runtime.  Merely changing VALIDATING -> DRAFT leaves the
-        # verify container alive and makes a later staging publish race a stale
-        # runtime.  The durable destroy task is idempotent for both stages.
+        # Step 5: rolling a validating publish back to draft must not destroy
+        # the existing verify runtime. The draft can be published again using
+        # the same device, so leave the binding and container intact.
         if stage == PublishStage.VERIFY.value:
-            publish_flow_service.enqueue_offline_destroy(
-                publish_id=publish_id, stage=stage, operator="system"
-            )
             result["message"] = f"验证环境已下线，发布单已回退到草稿状态: publish_id={publish_id}"
 
             logger.info(

--- a/src/backend/tests/community/core/service_bot/services/test_bot_publish_service.py
+++ b/src/backend/tests/community/core/service_bot/services/test_bot_publish_service.py
@@ -651,10 +651,8 @@ class TestOfflinePublish:
         mock_repo.update_status.assert_called_once_with(
             1, PublishStatus.DRAFT, PublishStatus.VALIDATING
         )
-        # 取消预发既回退状态，也用持久任务销毁 verify 运行时。
-        mock_publish_flow_service.enqueue_offline_destroy.assert_called_once_with(
-            publish_id=1, stage=PublishStage.VERIFY, operator="system"
-        )
+        # 回退草稿只更新发布单状态，不销毁现有 verify 运行时。
+        mock_publish_flow_service.enqueue_offline_destroy.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_offline_publish_not_found(self):


### PR DESCRIPTION
## Problem
当服务 Bot 处于预发校验（VALIDATING）状态时，调用 offline 回退草稿会进入 VERIFY 分支。原逻辑会创建 `service_bot.publish.destroy` 任务，进而调用 BaaS stop，导致 Teclaw 预发设备被停止/删除。这样回退到草稿后，后续再次发布无法复用原有设备。

## Solution
- 调整 `BotPublishService.offline_publish` 的 VERIFY 分支：仅将发布单从 `VALIDATING` 回退为 `DRAFT`。
- 不再为 VERIFY 阶段入队 `enqueue_offline_destroy`，保留现有 Teclaw 设备及 binding。
- 更新单测，明确验证回退草稿不会创建销毁任务。
- ONLINE 下线流程保持不变，仍按原有销毁逻辑处理。

## Validation
- `uv run pytest tests/community/core/service_bot/services/test_bot_publish_service.py -k "offline_publish_with_validating_status or offline_publish_success_with_non_terminal_records or offline_publish_success_without_non_terminal_records" -q`
- 结果：3 passed, 126 deselected
- `git diff --check` 通过

## Compatibility and risk
- 仅改变 VALIDATING/VERIFY 回退草稿行为；SUCCESS/ONLINE 下线行为不变。
- 不涉及数据库结构、接口契约或迁移脚本。
- 回滚本 PR 即可恢复 VERIFY 回退时的销毁任务行为。

## Spec
- OCB 研发需求澄清与 PR 提交规范：Yuque 文档 `ntaobfrt6in13shl`

## Related issues
- 回退草稿时保留 Teclaw 预发设备，避免调用 BaaS stop。