### PR TITLE
chore(skill-center): instrument MCP projection timing

### DIFF
--- a/src/backend/src/agentclaw/community/core/skill_center/services/bot_runtime_projector.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/bot_runtime_projector.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import time
 from collections.abc import Mapping, Sequence
-import time
 
 from injector import inject
 
@@ -356,13 +355,19 @@ class BotRuntimeProjector(BotRuntimeProjectorProtocol):
         # Resolved here, with the other pre-flight checks, because it can fail:
         # doing it at the Passport call would abort after the device allow-list
         # was already written, and compensation would hit the same failure.
+        started_at = time.perf_counter()
         identity_modes = self._resolve_mcp_identity_modes(
             bot=bot, bot_id=bot_id, engine=engine
+        )
+        self._log_plan_timing(
+            stage="resolve_mcp_identity_modes", bot_id=bot_id, engine=engine,
+            started_at=started_at, outcome="success", mcp_count=len(identity_modes),
         )
         # The legacy SkillSet service remains the authority for effective
         # System Defaults during Phase 1. It resolves template presets and
         # applies ac_default_skillset_mcp_exclusion.
         try:
+            started_at = time.perf_counter()
             effective_mcp_entries = service.collect_bot_active_mcps(
                 entity_id=str(bot.get("entity_id") or owner_id),
                 bot_id=bot_id,
@@ -372,25 +377,47 @@ class BotRuntimeProjector(BotRuntimeProjectorProtocol):
                 strict_policy_context=True,
             )
         except Exception as exc:
+            self._log_plan_timing(
+                stage="collect_effective_mcps", bot_id=bot_id, engine=engine,
+                started_at=started_at, outcome="error",
+            )
             raise SkillSetRuntimeReconcileError() from exc
+        self._log_plan_timing(
+            stage="collect_effective_mcps", bot_id=bot_id, engine=engine,
+            started_at=started_at, outcome="success", mcp_count=len(effective_mcp_entries),
+        )
         effective_default_mcp_codes = frozenset(
             str(item.get("server_code") or item.get("serverCode") or "").strip()
             for item in effective_mcp_entries
             if item.get("server_code") or item.get("serverCode")
         )
         try:
+            started_at = time.perf_counter()
             # Passport is the authority for the effective Default CLI scope.
             effective_cli_items = self._passport.query_passport_clis(bot_id, owner_id)
         except Exception as exc:
+            self._log_plan_timing(
+                stage="query_passport_clis", bot_id=bot_id, engine=engine,
+                started_at=started_at, outcome="error",
+            )
             raise SkillSetRuntimeReconcileError() from exc
+        self._log_plan_timing(
+            stage="query_passport_clis", bot_id=bot_id, engine=engine,
+            started_at=started_at, outcome="success", cli_count=len(effective_cli_items),
+        )
+        started_at = time.perf_counter()
+        installed_mcp_codes = frozenset(
+            self._repository.list_installed_mcps(bot_id=bot_id, owner_id=owner_id)
+        )
+        self._log_plan_timing(
+            stage="read_installed_mcps", bot_id=bot_id, engine=engine,
+            started_at=started_at, outcome="success", mcp_count=len(installed_mcp_codes),
+        )
+        started_at = time.perf_counter()
         projection = RuntimeProjectionResolver().resolve(
             RuntimeDesiredState(
                 skills=skill_plan.projection.skill_assets,
-                installed_mcp_server_codes=frozenset(
-                    self._repository.list_installed_mcps(
-                        bot_id=bot_id, owner_id=owner_id
-                    )
-                ),
+                installed_mcp_server_codes=installed_mcp_codes,
                 system_default_mcp_server_codes=effective_default_mcp_codes,
                 system_default_cli_commands=tuple(
                     str(item["cli_code"])
@@ -398,6 +425,10 @@ class BotRuntimeProjector(BotRuntimeProjectorProtocol):
                     if item.get("cli_code")
                 ),
             )
+        )
+        self._log_plan_timing(
+            stage="resolve_effective_capabilities", bot_id=bot_id, engine=engine,
+            started_at=started_at, outcome="success", mcp_count=len(projection.mcp_server_codes),
         )
 
         return ResolvedCapabilityPlan(

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
@@ -3,6 +3,7 @@
 Migrated from: services/openclawserver/server/services/skill_set_service.py
 """
 import asyncio
+import time
 import zlib
 from datetime import datetime
 from pathlib import Path
@@ -1699,32 +1700,53 @@ class SkillSetService:
                 "SkillSetServiceFactory"
             )
         effective_engine = engine_type if engine_type is not None else self.engine_type
+        started_at = time.perf_counter()
         effective_ext_info = self._get_default_capabilities_ext_info(
             effective_engine,
             bot_id,
             strict=strict_policy_context,
         )
+        self._log_effective_mcp_timing(
+            stage="default_ext_info", bot_id=bot_id, engine_type=effective_engine,
+            started_at=started_at, has_value=effective_ext_info is not None,
+        )
+        started_at = time.perf_counter()
         effective_template_type = self._get_default_capabilities_template_type(
             bot_id,
             strict=strict_policy_context,
         )
+        self._log_effective_mcp_timing(
+            stage="default_template_type", bot_id=bot_id, engine_type=effective_engine,
+            started_at=started_at, has_value=effective_template_type is not None,
+        )
+        started_at = time.perf_counter()
         active_skill_sets = self._get_all_active_skill_sets_with_default_fallback(
             user_id=entity_id,
             bolt_id=bot_id,
             engine_type=effective_engine,
+        )
+        self._log_effective_mcp_timing(
+            stage="active_skill_sets", bot_id=bot_id, engine_type=effective_engine,
+            started_at=started_at, item_count=len(active_skill_sets),
         )
 
         # This Bot's exclusions silence a Default member entirely — the row
         # half too: ``get_set_mcp_servers`` filters only the static default
         # codes, and the flush already treats an exclusion as the Default
         # Set's per-Bot deactivation.
+        started_at = time.perf_counter()
         excluded_codes = set(self.skill_set_repo.get_all_excluded_mcps(user_id, bot_id))
+        self._log_effective_mcp_timing(
+            stage="default_mcp_exclusions", bot_id=bot_id, engine_type=effective_engine,
+            started_at=started_at, item_count=len(excluded_codes),
+        )
 
         # Each phase appends entries and marks their codes in
         # ``seen_server_codes``, so a later phase never duplicates an earlier
         # one; ordering is the union's precedence (rows, policy, installed).
         active_mcps: List[dict] = []
         seen_server_codes: set = set()
+        started_at = time.perf_counter()
         active_mcps.extend(
             self._default_set_mcp_rows(
                 active_skill_sets,
@@ -1737,6 +1759,11 @@ class SkillSetService:
                 seen_server_codes=seen_server_codes,
             )
         )
+        self._log_effective_mcp_timing(
+            stage="default_set_mcp_rows", bot_id=bot_id, engine_type=effective_engine,
+            started_at=started_at, item_count=len(active_mcps),
+        )
+        started_at = time.perf_counter()
         active_mcps.extend(
             self._default_policy_mcp_entries(
                 engine_type=effective_engine,
@@ -1746,16 +1773,40 @@ class SkillSetService:
                 seen_server_codes=seen_server_codes,
             )
         )
+        self._log_effective_mcp_timing(
+            stage="default_policy_mcp_entries", bot_id=bot_id,
+            engine_type=effective_engine, started_at=started_at,
+            item_count=len(active_mcps),
+        )
+        started_at = time.perf_counter()
+        active_skill_assets = self._active_skill_assets(
+            entity_id=entity_id, bot_id=bot_id, user_id=user_id
+        )
+        self._log_effective_mcp_timing(
+            stage="active_skill_assets", bot_id=bot_id, engine_type=effective_engine,
+            started_at=started_at, item_count=len(active_skill_assets),
+        )
+        started_at = time.perf_counter()
+        installed_mcp_codes = self._installed_mcp_codes(
+            entity_id=entity_id, bot_id=bot_id, user_id=user_id
+        )
+        self._log_effective_mcp_timing(
+            stage="installed_mcp_codes", bot_id=bot_id, engine_type=effective_engine,
+            started_at=started_at, item_count=len(installed_mcp_codes),
+        )
+        started_at = time.perf_counter()
         effective_non_default_codes = resolve_effective_mcp_server_codes(
             RuntimeDesiredState(
-                skills=self._active_skill_assets(
-                    entity_id=entity_id, bot_id=bot_id, user_id=user_id
-                ),
-                installed_mcp_server_codes=self._installed_mcp_codes(
-                    entity_id=entity_id, bot_id=bot_id, user_id=user_id
-                ),
+                skills=active_skill_assets,
+                installed_mcp_server_codes=installed_mcp_codes,
             )
         )
+        self._log_effective_mcp_timing(
+            stage="resolve_non_default_codes", bot_id=bot_id,
+            engine_type=effective_engine, started_at=started_at,
+            item_count=len(effective_non_default_codes),
+        )
+        started_at = time.perf_counter()
         active_mcps.extend(
             self._non_default_effective_mcp_entries(
                 effective_codes=effective_non_default_codes,
@@ -1763,12 +1814,38 @@ class SkillSetService:
                 seen_server_codes=seen_server_codes,
             )
         )
+        self._log_effective_mcp_timing(
+            stage="non_default_mcp_entries", bot_id=bot_id,
+            engine_type=effective_engine, started_at=started_at,
+            item_count=len(active_mcps),
+        )
 
         logger.info(
             f"[collect_bot_active_mcps] bot_id={bot_id}, engine_type={effective_engine}, "
             f"total_mcps={len(active_mcps)}, codes={[m.get('server_code') for m in active_mcps]}"
         )
         return active_mcps
+
+    @staticmethod
+    def _log_effective_mcp_timing(
+        *,
+        stage: str,
+        bot_id: str,
+        engine_type: str | None,
+        started_at: float,
+        item_count: int | None = None,
+        has_value: bool | None = None,
+    ) -> None:
+        logger.info(
+            "[collect_bot_active_mcps] timing stage=%s bot_id=%s engine_type=%s "
+            "duration_ms=%s item_count=%s has_value=%s",
+            stage,
+            bot_id,
+            engine_type,
+            round((time.perf_counter() - started_at) * 1000),
+            item_count,
+            has_value,
+        )
 
     def _default_set_mcp_rows(
         self,

--- a/src/backend/tests/community/core/skill_center/services/test_skill_set_service.py
+++ b/src/backend/tests/community/core/skill_center/services/test_skill_set_service.py
@@ -1,4 +1,5 @@
 """Tests for agentclaw.community.core.services.skill_set_service.SkillSetService."""
+import logging
 from unittest.mock import patch, MagicMock, AsyncMock
 
 import pytest
@@ -259,7 +260,7 @@ class TestGetSetMcpServers:
 class TestCollectBotActiveMcps:
     """collect_bot_active_mcps filters out user-excluded default MCPs."""
 
-    def test_collect_excludes_user_excluded_default_mcps(self):
+    def test_collect_excludes_user_excluded_default_mcps(self, caplog):
         from agentclaw.community.core.skill_center.services.skill_set_service import SkillSetService
         mock_repo = MagicMock()
         mock_repo.get_all_active_skill_sets.return_value = [
@@ -287,12 +288,28 @@ class TestCollectBotActiveMcps:
         svc.skill_set_repo = mock_repo
         svc.bot_id = "default"
 
+        caplog.set_level(logging.INFO)
         with patch.object(svc, "get_set_mcp_servers") as mock_get_mcps:
             mock_get_mcps.return_value = []
             result = svc.collect_bot_active_mcps("entity1", "default", "user1", "staff")
 
         codes = {r["server_code"] for r in result}
         assert "mcp.ant.antprocessai.anttaskmcp" not in codes
+        messages = [record.getMessage() for record in caplog.records]
+        for stage in (
+            "default_ext_info",
+            "active_skill_sets",
+            "default_mcp_exclusions",
+            "active_skill_assets",
+            "installed_mcp_codes",
+            "resolve_non_default_codes",
+        ):
+            assert any(
+                "[collect_bot_active_mcps] timing" in message
+                and f"stage={stage}" in message
+                and "duration_ms=" in message
+                for message in messages
+            )
 
     def test_get_bot_mcp_codes_for_env_uses_only_explicit_env_repository_reads(self):
         from agentclaw.community.core.skill_center.services.skill_set_service import (

--- a/src/backend/tests/community/core/skill_center/test_bot_runtime_projector_timing.py
+++ b/src/backend/tests/community/core/skill_center/test_bot_runtime_projector_timing.py
@@ -83,7 +83,15 @@ def test_runtime_projector_logs_skill_and_mcp_plan_timing(caplog) -> None:
 
     assert isinstance(plan, ResolvedCapabilityPlan)
     messages = [record.getMessage() for record in caplog.records]
-    for stage in ("build_skill_plan", "build_mcp_plan"):
+    for stage in (
+        "build_skill_plan",
+        "build_mcp_plan",
+        "resolve_mcp_identity_modes",
+        "collect_effective_mcps",
+        "query_passport_clis",
+        "read_installed_mcps",
+        "resolve_effective_capabilities",
+    ):
         assert any(
             "[BotRuntimeProjector] timing" in message
             and f"stage={stage}" in message


### PR DESCRIPTION
## Problem

Desktop Bot MCP add operations synchronously rebuild effective MCP state and project it to BaaS/Passport. Existing logs expose only broad projection duration, so the dominant Effective MCP computation cannot be attributed safely.

## Solution

- Add duration and cardinality logs for Default-policy resolution, exclusions, active Skills, installed MCPs, and non-default MCP enrichment.
- Add Projector sub-stage timings for identity, effective MCP collection, Passport CLI reads, Installation MCP reads, and final capability resolution.
- Preserve every query, write, ordering, and runtime call; this PR is observability-only.

## Validation

- uv run ruff check src/agentclaw/community/core/skill_center/services/skill_set_service.py src/agentclaw/community/core/skill_center/services/bot_runtime_projector.py tests/community/core/skill_center/test_bot_runtime_projector_timing.py tests/community/core/skill_center/services/test_skill_set_service.py
- uv run pytest -q tests/community/core/skill_center/test_bot_runtime_projector_timing.py tests/community/core/skill_center/services/test_skill_set_service.py (32 passed)
- uv run pytest -q tests/community/architecture/test_module_boundaries.py (3 passed)

## Compatibility and risk

No API, DDL, cache, or runtime-delivery behavior changes. Added INFO logs only.