### PR TITLE
docs(skill-center): hand off terminal offline copy flow

### DIFF
--- a/src/backend/specs/2026-08-20-skill-capability-upgrade/frontend-api.md
+++ b/src/backend/specs/2026-08-20-skill-capability-upgrade/frontend-api.md
@@ -126,7 +126,7 @@ permissions.publish_draft=true
 | 权限管理 | P2-GRT-001..005 |
 | 编辑锁 | P2-LSE-001..004 |
 | 发布影响、发布和轮询 | P2-PUB-001..005 |
-| 下线影响和下线 | P2-OFF-001..002 |
+| 下线影响、下线与 Version Copy | P2-OFF-001..003 |
 | 市场搜索 | P2-MKT-001..003 |
 | 引用 SC Public Skill | P2-REF-001..003 |
 
@@ -142,7 +142,7 @@ GET /openapi/v1/bots/spaces/{space_id}/skills?keyword=&page=1&page_size=20
 
 1. 首次进入请求第 1 页；搜索输入防抖后重新从第 1 页请求；
 2. Backend 对 name/description 做不区分大小写过滤后分页；
-3. Offline Skill 仍在工坊列表中，供 Owner/Manager 继续修改；
+3. Offline Skill 仍在工坊列表中，供 Owner/Manager 查看历史 Version 并复制为独立新 Skill；原 Skill 不可继续修改；
 4. 不在列表额外请求全部 Grants、Versions、文件树或影响面。
 
 卡片字段：
@@ -341,7 +341,7 @@ DELETE .../draft?expected_revision_id=rev-2&fencing_token=7
 - `deleted_scope=SKILL`：首次从未发布，且除终态 FAILED Attempt 外无外部事实，整个 Skill
   及其失败 Attempt 被删除。
 
-FROZEN 时不显示删除按钮。Offline Skill 不再允许升级；产品显示“复制”，以最后 Published Vn
+FROZEN 时不显示删除按钮。Offline Skill 不再允许升级；产品在历史 Version 行显示“复制”，以用户选择的精确 Published Vn
 创建独立新 Skill 的 V1 Draft。
 删除 Team Draft 会同时使当前 Lease/fencing token 失效，前端必须停止 Lease 轮询并退出编辑态。
 
@@ -446,7 +446,7 @@ Attempt。普通 FAILED 需要修改 Draft 后新建 Attempt。RESULT_UNKNOWN �
 - HTTP 202：恢复任务已重新入队，继续轮询同一 Attempt；
 - HTTP 200：Attempt 已经成功，无需创建任务，直接刷新 detail/list。
 
-## 10. 下线与重新发布
+## 10. 下线与 Version Copy
 
 先调用：
 
@@ -491,6 +491,18 @@ Artifact 无法读取，未发现明确引用，已继续下线”，但不得�
 普通错误 `data=null` 的 route-specific 例外。
 
 产品文案不能写成“Vn 变回草稿”；准确语义是“Skill Offline，保留历史 Vn；复制后产生独立新 Skill”。
+
+复制入口在历史 Version 行：
+
+```http
+POST /openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/versions/{version}/copy?user_id={actor_id}
+Idempotency-Key: <uuid>
+```
+
+仅 `lifecycle_status=OFFLINE` 且 `actor.permissions.copy_offline_skill=true` 时展示。成功 HTTP 201 返回独立新
+Skill 的 Detail（新 `skill_id`、新 `skill_uuid`、`DRAFT_ONLY`、V1 `EDITING` Draft），跳转到该新 Skill 编辑页。
+在线源 Skill 调 Copy 返回 `409 code=409316`（`SKILL_NOT_OFFLINE`）；不要与原 Skill Offline 时其他写操作返回的
+`409312 SKILL_OFFLINE` 混淆。
 
 ## 11. 添加 Skill 弹窗的四个产品来源
 
@@ -729,7 +741,7 @@ Center Skill 的技术合同支持所有实际存在的 Bot Type × Engine 组�
 
 - 按 Operation ID 建 API client，不自行改路径。
 - 覆盖未知 additive 字段、200/201/202、403、404、409、422、423、503。
-- 模拟 Published V1 + Draft V2、Offline + Draft、RESULT_UNKNOWN、Reference 部分成功。
+- 模拟 Published V1 + Draft V2、Offline + `draft=null`、Offline Version Copy、RESULT_UNKNOWN、Reference 部分成功。
 - 不把候选 API 当成已发布 Gateway 路由。
 
 ### 16.2 Backend 路由落地后
@@ -740,11 +752,11 @@ Center Skill 的技术合同支持所有实际存在的 Bot Type × Engine 组�
 - Team 编辑覆盖 acquire、takeover、旧 token 保存失败。
 - 发布覆盖影响提示、轮询、恢复和页面刷新。
 - Reference 覆盖 20 项、部分成功、Set 删除和 inactive/active Set。
-- Offline 覆盖每类 blocker 与重新发布恢复。
+- Offline 覆盖每类 blocker、非阻断 `UNKNOWN_ARTIFACT` warning 与 Version Copy。
 
 ### 16.3 正式切流前
 
 - Swagger 中每个标记已实现的 Operation 都真实可调用，无 501/stub。
 - Phase 1 Local/Repo/SkillSet/MCP 回归通过。
 - 前端不依赖旧 `status/draft_status/can_edit/retire_skill`。
-- 产品文案使用“发布前影响”“Offline 后创建下一版 Draft”“新建 SkillSet 默认 active”。
+- 产品文案使用“发布前影响”“Offline 保留历史 Version、复制为新 Skill”“新建 SkillSet 默认 active”。

--- a/src/backend/specs/2026-08-20-skill-capability-upgrade/frontend-offline-terminal-copy-handoff.md
+++ b/src/backend/specs/2026-08-20-skill-capability-upgrade/frontend-offline-terminal-copy-handoff.md
@@ -1,0 +1,166 @@
+# 前端 Handoff：Skill 终态下线与 Version Copy
+
+> 适用基线：`REL20260901`，已合入 #1825。
+>
+> 本文只说明本次前端需要适配的 **终态下线（Offline）** 和 **从历史 Version 复制新 Skill**。精确字段、必填项和 HTTP 状态以部署环境 Gateway 的 `/openapi.json` 为准。
+
+## 1. 产品语义变更
+
+旧交互是“下线 Vn 后，原 Skill 自动产生 Vn+1 Draft，未来还能在原 Skill 上重新发布”。
+
+现在改为：
+
+```text
+Published Skill
+  └─ 下线成功
+       └─ 原 Skill = OFFLINE（保留所有已发布历史 Version）
+            ├─ 不创建 Vn+1 Draft
+            ├─ 不可编辑 / 升级 / 发布 / 再次消费
+            └─ 可从任一 Published Vn 复制
+                 └─ 新 skill_id + 新 skill_uuid + 独立 V1 Draft
+                      └─ 后续发布时创建独立的 Skill Center Skill
+```
+
+前端不要把 Offline 理解为“退回草稿”或“暂时不可用”。它是 TeamClaw 本地的终态：不会调用 Skill Center 下线，Skill Center 外部页面可能仍可见。
+
+## 2. 列表与详情的状态渲染
+
+使用 `lifecycle_status` 作为页面主状态，不能由是否存在 Draft 推断。
+
+| Detail/List 事实 | 产品展示和可用动作 |
+| --- | --- |
+| `PUBLISHED`，`draft=null` | 已发布；可进入升级、下线检查。 |
+| `PUBLISHED`，`draft.status=EDITING` | 已发布 · 有待发布修改；继续编辑/发布/删除本次 Draft。 |
+| `PUBLISHED`，`draft.status=FROZEN` 或有 `active_publication` | 发布中/物化中；按 Publication 状态展示并轮询。 |
+| `OFFLINE`，`draft=null` | 已下线；仅展示历史 Version、详情和“复制为新 Skill”。不要展示编辑、升级、发布、删除 Draft、Lease 获取或 Lease 轮询。 |
+
+Offline Detail 的关键形态：
+
+```json
+{
+  "skill_id": "1123989",
+  "skill_uuid": "old-skill-uuid",
+  "lifecycle_status": "OFFLINE",
+  "latest_published_version": {"version": 2, "sc_version_number": "2.0.0"},
+  "draft": null,
+  "active_publication": null,
+  "lease_summary": null,
+  "offline_at": "2026-09-02T12:00:00Z",
+  "offline_by": "168944",
+  "actor": {
+    "permissions": {"copy_offline_skill": true}
+  }
+}
+```
+
+`actor.permissions.copy_offline_skill` 只表示当前调用者具备 Owner/Manager ACL 资格；仍必须同时判断 `lifecycle_status=OFFLINE` 和用户选择的 Version 存在。后端会再次校验。
+
+## 3. 下线流程
+
+### 3.1 用户点击“下线”
+
+先查询影响面：
+
+```http
+GET /openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/offline-impact?page=1&page_size=20&user_id={actor_id}
+```
+
+响应中的 `blocked=true` 时，展示 `items` 与 `counts`，禁用确认下线：
+
+| `items[].kind` | 用户要处理的事实 |
+| --- | --- |
+| `DRAFT` | 先删除或完成现有 Draft。 |
+| `PUBLICATION` | 等待或处理进行中的/结果未知的发布。 |
+| `MEMBERSHIP` | 从普通或 Default SkillSet 移除。 |
+| `INSTALLATION` | 移除 Bot 的有效安装。 |
+| `SERVICE_ARTIFACT` | 删除/退役仍可 restart、scale、rollback 的 Service Bot 版本。 |
+
+`warnings[].kind=UNKNOWN_ARTIFACT` 是“历史 Artifact 无法读取”的诊断信息，**不阻断**下线。可以提示用户，但不能据此禁用确认按钮。
+
+`blocked=false` 后调用：
+
+```http
+POST /openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/offline?user_id={actor_id}
+```
+
+无 request body、无 `Idempotency-Key`、无 `fencing_token`。成功示例：
+
+```json
+{
+  "code": 200000,
+  "message": "OK",
+  "data": {
+    "changed": true,
+    "lifecycle_status": "OFFLINE",
+    "offline_at": "2026-09-02T12:00:00Z"
+  },
+  "request_id": "trace-id"
+}
+```
+
+若已是 Offline，仍返回 200，但 `changed=false`。POST 在事务内会重新检查影响面，因此即便预检为 `blocked=false`，仍可能返回 409。
+
+### 3.2 下线成功后的前端收敛
+
+1. 停止该 Skill 的 Draft Lease 轮询；不要再请求 `/draft/lease`。该路由在无 Draft 时会正常返回 404。
+2. 清空当前编辑器内存态、Draft Revision、fencing token、Publication 轮询状态。
+3. 重新 GET Detail 和当前列表页；以服务端返回的 `OFFLINE` 为准。
+4. 跳转/保留在“历史 Version”视图，提供“复制为新 Skill”而不是“继续编辑/重新发布”。
+
+## 4. Version Copy 流程
+
+复制只允许 Offline 原 Skill 的 **精确 Published Version**。产品应先请求历史版本列表，让用户选 Vn；不能默认使用名称或 latest 指针代替 Version。
+
+```http
+POST /openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/versions/{version}/copy?user_id={actor_id}
+Idempotency-Key: {uuid-for-this-copy-intent}
+```
+
+- 不传 body。
+- `version` 是业务版本号，例如 `1`、`2`，不是 `sc_version_number`。
+- 同一次点击、网络重试、页面恢复必须复用相同 `Idempotency-Key`；再次点击“复制”才生成新 Key。
+- 成功返回 HTTP `201` 和完整 `SpaceSkillDetail`。新 Detail 必须被视为一个新资产：新 `skill_id`、新 `skill_uuid`、`lifecycle_status=DRAFT_ONLY`、`draft.target_version=1`、`draft.status=EDITING`、`draft.source_kind=PUBLISHED_VERSION`、`source=COPY`。
+
+成功后：跳转到返回的新 `skill_id` 的编辑页。Team Space 需要先获取 Draft Lease，才可保存文件：
+
+```text
+GET/PUT .../draft/lease
+→ 获得 fencing_token
+→ PUT Draft 文件（expected_revision_id + fencing_token）
+```
+
+复制不复用原 Skill 的 `skill_uuid` 或任何 Skill Center 身份；前端无需生成或传递 UUID。新副本后续发布时，Backend 使用它的新 UUID 创建独立的 Skill Center Skill。
+
+## 5. 必须处理的错误
+
+响应统一为 Envelope。请记录 HTTP status、顶层 `code` 和 `request_id`；后端错误符号只用于本文可读性，不是 response 新字段。
+
+| 场景 | HTTP / `code` | 前端处理 |
+| --- | --- | --- |
+| 下线时出现新 blocker | `409 / 409313` `SKILL_OFFLINE_BLOCKED`；`data` 是最新 OfflineImpact | 用本次响应的 `data` 刷新阻断弹窗，不继续下线。 |
+| 原 Skill 已 Offline，却调用升级/编辑/发布/新增消费 | `409 / 409312` `SKILL_OFFLINE` | 刷新 Detail，展示终态 Offline；引导到 Version Copy。 |
+| 在线 Skill 点击 Copy | `409 / 409316` `SKILL_NOT_OFFLINE` | 刷新 Detail；提示“需先完成下线才能复制”。不要误展示为“Skill 已下线”。 |
+| Version 不存在或不是 Published | `404 / 404204` `DRAFT_NOT_FOUND` | 刷新版本列表，提示用户选择有效的已发布 Version。 |
+| 非 Owner/Manager 或不是 Space Member | `403` | 隐藏/禁用操作，并以服务端结果为准。 |
+| Copy 幂等键被用于另一份 Skill/Version | `409 / 409305` `IDEMPOTENCY_KEY_REUSED` | 不自动换 Key 重试；视为客户端关联错误。 |
+
+## 6. 前端改造清单
+
+- [ ] API model 增加 `actor.permissions.copy_offline_skill`。
+- [ ] `SpaceSkillDetail.source` 接受新增枚举 `COPY`。
+- [ ] Draft `source_kind` 接受 `PUBLISHED_VERSION`。
+- [ ] Offline 页面不假设存在 Vn+1 Draft；允许 `draft=null`、`lease_summary=null`。
+- [ ] 下线成功后停止 Lease/编辑/发布轮询，并刷新 Detail/List。
+- [ ] 历史 Version 行增加“复制为新 Skill”；调用精确 Version Copy endpoint 并使用 Idempotency-Key。
+- [ ] Copy 201 后以响应中的新 Skill Detail 建立页面状态并跳转，不覆盖原 Offline Skill。
+- [ ] `UNKNOWN_ARTIFACT` 仅为 warning，不阻断下线。
+- [ ] 按本文错误码展示准确文案，特别区分 `SKILL_OFFLINE` 与 `SKILL_NOT_OFFLINE`。
+
+## 7. 最小联调用例
+
+1. Published V1、无引用：impact `blocked=false` → Offline 200 → Detail 为 `OFFLINE + draft=null`。
+2. Offline 后刷新页面：不再调用 Draft/Lease 接口，历史 Version 仍可读。
+3. Offline V1 Copy：201 返回不同 `skill_id/skill_uuid` 的 `DRAFT_ONLY V1`；原 Skill 仍为 Offline。
+4. 在线 Skill Copy：409 `409316`，不是 `409312`。
+5. 有 Membership/Installation/Service Artifact 任一 blocker：Offline 409 `409313`，列表展示最新 blocker。
+6. 有 `UNKNOWN_ARTIFACT` warning 且无明确 blocker：Offline 仍 200。

--- a/src/backend/specs/2026-08-20-skill-capability-upgrade/phase2-openapi-contract.md
+++ b/src/backend/specs/2026-08-20-skill-capability-upgrade/phase2-openapi-contract.md
@@ -211,6 +211,7 @@ Work Order 的列表、详情和审批复用既有 `/openapi/v1/bots/work-orders
       "delete_draft": true,
       "create_upgrade_draft": true,
       "offline_skill": true,
+      "copy_offline_skill": true,
       "manage_grants": true,
       "transfer_owner": true,
       "request_edit_access": false,
@@ -247,7 +248,7 @@ Detail 包含 `SpaceSkillSummary` 的全部字段，并展开：
 | `draft` | `DraftDetail|null` | 当前 Draft 的完整来源、Revision 与 metadata |
 | `latest_published_version` | `SkillVersionSummary|null` | 最新 Ready Version |
 | `active_publication` | `PublicationAttemptSummary|null` | 当前发布进度 |
-| `source` | `FOLDER|GIT` | Identity 首次创建来源 |
+| `source` | `FOLDER|GIT|COPY` | Identity 首次创建来源 |
 | `offline_at/offline_by` | `string|null` | TeamClaw 本地下线事实 |
 
 `DraftDetail`：

--- a/src/backend/specs/2026-08-20-skill-capability-upgrade/spec.md
+++ b/src/backend/specs/2026-08-20-skill-capability-upgrade/spec.md
@@ -651,6 +651,7 @@ publish_draft
 delete_draft
 create_upgrade_draft
 offline_skill
+copy_offline_skill
 manage_grants
 transfer_owner
 request_edit_access
@@ -805,7 +806,7 @@ Owner 审批，旧 Owner 不得继续审批。
 | GET | `/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/publications/{attempt_id}` | Attempt 详情 |
 | POST | `/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/publications/{attempt_id}/retry` | 恢复同一 Attempt；按最新阶段分流，不要求新幂等键 |
 | GET | `/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/offline-impact` | 下线影响检查 |
-| POST | `/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/offline` | 本地隐藏 Published Skill，并创建下一版 Draft |
+| POST | `/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/offline` | 本地终态隐藏 Published Skill，保留历史 Version，不创建 Draft |
 | POST | `/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/versions/{version}/copy` | 复制已下线 Skill 的精确 Vn 为独立新 Skill V1 Draft |
 
 发布事务：
@@ -863,7 +864,7 @@ Latest 是发布成功后的 Best-Effort 异步刷新，不参与发布成功门
 acknowledgement token。预览到 PUBLISHED 之间事实可能变化，Track Latest 必须在发布成功后按
 最新 Installation/迁移期候选重新发现并由 Reader 复核，禁止信任前端预览列表。
 
-#### 12.1 Offline、重新发布与血缘
+#### 12.1 Offline、Version Copy 与血缘
 
 产品“下线”是 TeamClaw-local 的终态 Offline，不是永久 Retirement，也不把历史 Published
 Version 改回 Draft。无 blocker 时，Offline 仅写 `offline_at/offline_by`，保留不可变 Published
@@ -871,7 +872,7 @@ Vn；原 Skill 不再创建 Draft、升级或重新发布。用户需要继续�
 独立新 Skill 的 V1 Draft；发布新副本会在同一 SC Team 创建独立 SC Skill，绝不复用原 SC 身份。
 
 Offline 期间从 TeamClaw 市场和 consumable 列表隐藏，禁止新的 Direct activation、Membership
-和其他 Bot 消费；Owner/Manager 仍可查看历史、编辑 Draft 和发布。它不调用 Skill Center
+和其他 Bot 消费；Owner/Manager 仍可查看历史并复制精确 Published Version，但原 Skill 不可编辑、升级或发布。它不调用 Skill Center
 删除/关闭/下线，因此 SC 外部页面可能持续可见。永久 Retirement、SC 全局下线和单 Version
 offline 均不在本期范围。
 

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/spaces/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/spaces/schemas.py
@@ -409,7 +409,7 @@ class SkillDraftSourceKind(_DocumentedEnum):
     __descriptions__ = {
         "FOLDER": "Created from a browser folder upload.",
         "GIT": "Created or refreshed from a frozen Git snapshot.",
-        "PUBLISHED_VERSION": "Copied from the latest exact Published Version.",
+        "PUBLISHED_VERSION": "Copied from a selected exact Published Version.",
     }
 
 

--- a/src/gateway/configs/schemas/bots.openapi.json
+++ b/src/gateway/configs/schemas/bots.openapi.json
@@ -19792,7 +19792,7 @@
         "x-enum-descriptions": [
           "Created from a browser folder upload.",
           "Created or refreshed from a frozen Git snapshot.",
-          "Copied from the latest exact Published Version."
+          "Copied from a selected exact Published Version."
         ],
         "x-enum-varnames": [
           "FOLDER",


### PR DESCRIPTION
## Summary
- add a frontend handoff for terminal Offline and exact Version Copy
- align the Phase 2 frontend guide and contract matrix with #1825
- clarify that PUBLISHED_VERSION is the selected exact Published Version

## Verification
- `DEPLOY_PROFILE=test uv run pytest -q tests/community/adapters/http/openapi_v1/test_schema_docs.py tests/community/adapters/http/openapi_v1/test_explicit_user_id.py tests/community/architecture/test_no_oversized_modules.py`
- `DEPLOY_PROFILE=test uv run ruff check src/agentclaw/community/adapters/http/openapi_v1/spaces/schemas.py`
- regenerated `src/gateway/configs/schemas/bots.openapi.json` via `scripts/dump_openapi.py`