### PR TITLE
fix(w6): make tree replacement, addressing and admission hold against the real write chain

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/README.md
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/README.md
@@ -516,7 +516,8 @@ consumes:
   - "MAX_SCRIPT_BYTES (core.bot_startup_script) — script.body IS the #926 startup script, so it takes that cap rather than a second one"
   - "TokenVault (core.bot_management) — enc:v1: AES-GCM reversible encryption for the credential secret; the master key comes from the SecretResolver, and the fail-closed profiles refuse writes without one"
   - "SourceCredentialRepositoryProtocol (core.repository) — persistence for the credential table"
-  - "ALLOWED_EXTENSIONS / MAX_FILE_SIZE (core.resources.services.file_service) — the workspace file surface's admission rules, re-asked in the `resources` materialiser's resolve so an undeliverable entry fails with the tree still standing (W6)"
+  - "ALLOWED_EXTENSIONS / MAX_FILE_SIZE (core.resources.services.file_service) — the workspace file surface's admission rule, re-asked in the `resources` materialiser's resolve by delegating to the one `admission_refusal` predicate so an undeliverable entry fails with the tree still standing (W6)"
+  - "resolve_bot_engine (core.bot_management.engines.registry) — the pure runtime-engine routing policy (claude_code + a non-normalCC template ⇒ aicoding) the `resources` materialiser applies when addressing a bot's workspace, the same rule the resources router resolves through before it composes {bot_dir}/{engine}/workspace (W6)"
 consumed_by:
   - "adapters/http/openapi_v1/bots — the public read/replace/clear/capabilities surface"
   - "the apply orchestration (`apply/`, W4 #1472 + W5 #1473) — di/modules/manifest_fetch_module.py constructor-injects the transport_allowlist and the content store root (read via the W2/W11 pure parsers over config_module's seam) and holds the one EntryFetcher over the fetcher, the store, and W3's credentials"
@@ -524,6 +525,7 @@ consumed_by:
 internal_dependencies:
   - agentclaw.community.core.base
   - agentclaw.community.core.bot_startup_script
+  - agentclaw.community.core.bot_management.engines.registry  # the pure runtime-engine routing policy the resources materialiser addresses workspaces through, the router's own rule (W6)
   - agentclaw.community.core.bot_management.token_vault
   - agentclaw.community.core.mcp.mcp_auth_service_protocol  # the permission check DirectActivationService also consults
   - agentclaw.community.core.repository

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/resources.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/resources.py
@@ -74,6 +74,12 @@ from agentclaw.community.core.bot_config_manifest.fetch.unpack import (
     UnpackError,
     unpack_archive,
 )
+from agentclaw.community.core.bot_config_manifest.schema._support import (
+    relative_path_refusal,
+)
+from agentclaw.community.core.bot_config_manifest.schema.entries import (
+    VALID_UNPACK,
+)
 from agentclaw.community.core.workspace.constants import DEFAULT_ENGINE_TYPE
 
 #: Schema §5 states the two resource forms' fetch widths separately —
@@ -132,15 +138,30 @@ class ResourcesMaterialiser(Materialiser):
         """
         intents: list[Intent] = []
         failures: list[ResolveFailure] = []
+        # The PUT layer refuses a duplicate resource path (one owner per
+        # path); the belt re-asks it — two entries at one path would
+        # otherwise converge to whatever wrote last, a no-rule answer.
+        seen: set[str] = set()
         for index, entry in enumerate(entries):
             path = entry.get("path") if isinstance(entry, dict) else None
             failed = self._entry_failure(entry, path, index)
             if failed is not None:
                 failures.append(failed)
                 continue
+            assert isinstance(path, str)  # _entry_failure passed it
+            if path in seen:
+                failures.append(
+                    ResolveFailure(
+                        path,
+                        "a resources path is declared more than once "
+                        "in this category",
+                    )
+                )
+                continue
+            seen.add(path)
             if isinstance(path, str) and path.endswith("/"):
                 unpack_kind = entry.get("unpack")
-                if unpack_kind not in ("zip", "tar.gz"):
+                if unpack_kind not in VALID_UNPACK:
                     failures.append(
                         ResolveFailure(
                             path,
@@ -329,14 +350,18 @@ class ResourcesMaterialiser(Materialiser):
         A stored document can predate a rule, or have skipped the validator
         (a hand-built apply in W8's lifecycle points) — this is the half the
         path-safety question needs answered at *apply* time, not only at
-        write time.
+        write time. The rule itself is the schema's own pure predicate
+        (:func:`relative_path_refusal`), not a re-derivation: the belt must
+        refuse exactly what the PUT layer refuses — "~", drive letters,
+        quoted characters and all — or it is a second, weaker rule.
         """
         if not isinstance(path, str) or not path:
             return ResolveFailure(
                 f"[{index}]", "a resources entry must declare a 'path'"
             )
-        if path.startswith("/") or ".." in path.split("/") or "\x00" in path:
-            return ResolveFailure(path, "path must be workspace-relative")
+        refusal = relative_path_refusal(path, what="path")
+        if refusal is not None:
+            return ResolveFailure(path, refusal[1])
         return None
 
     def _check_nesting(

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/resources.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/resources.py
@@ -31,18 +31,20 @@ Three invariants, all from the W6 work item:
 
 Two v1 narrows, stated here rather than discovered:
 
-- **The write chain's admission rules are re-asked in ``resolve``**
-  (extension allow-list, size cap — the same constants the service
-  enforces), so an undeliverable member fails its category with the tree
-  still standing rather than one delete ago. What is *not* re-asked is the
-  HTTP surface's read-only policy (dotfiles, reserved roots): a manifest
-  declaring ``.env`` is the owner's declaration, deliberately broader than
-  the console router's guard — that is the platform's contract with apply,
-  not an oversight.
+- **The write chain's admission predicate is re-asked in ``resolve``**
+  — the same :func:`admission_refusal` ``upload_file`` raises (extension
+  allow-list, size cap), so an undeliverable member fails its category
+  with the tree still standing rather than one delete ago. What is *not*
+  re-asked is the HTTP surface's read-only policy (dotfiles, reserved
+  roots): a manifest declaring ``.env`` is the owner's declaration,
+  deliberately broader than the console router's guard — that is the
+  platform's contract with apply, not an oversight.
 - **``plan`` probes ``exists`` per member** for the report's label alone.
   A 5000-member tree therefore costs 5000 more device round trips than a
-  single probe would — accepted for v1's tree sizes, and the first place to
-  look if apply latency ever outruns the lock TTL on large archives.
+  single probe would (plus one re-probe per declared tree, on the rare
+  path where a tree delete answers ``False``) — accepted for v1's tree
+  sizes, and the first place to look if apply latency ever outruns the
+  lock TTL on large archives. Follow-up, not fixed here.
 """
 from __future__ import annotations
 

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/resources.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/resources.py
@@ -163,7 +163,10 @@ class ResourcesMaterialiser(Materialiser):
             seen.add(path)
             if isinstance(path, str) and path.endswith("/"):
                 unpack_kind = entry.get("unpack")
-                if unpack_kind not in VALID_UNPACK:
+                # Str first: ``VALID_UNPACK`` is a frozenset, and an
+                # unhashable ``unpack`` (a YAML list) would raise on the
+                # membership test where the belt owes a clean refusal.
+                if not isinstance(unpack_kind, str) or unpack_kind not in VALID_UNPACK:
                     failures.append(
                         ResolveFailure(
                             path,

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/resources.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/resources.py
@@ -23,7 +23,11 @@ Three invariants, all from the W6 work item:
   drifted tree would survive that. v1 takes the recommended option (1):
   every apply rewrites every member. ``plan`` therefore classifies for the
   report only (created / updated), never "unchanged", and the category is
-  never ``is_noop``.
+  never ``is_noop``. The declared-tree replacement rides the plan's
+  ``removals`` channel — the engine's "an overwrite removes something with
+  no declared entry to attach to" — so the dry-run projection and the real
+  write report one shape, and a dirs-only archive's destructive replace
+  still audits through ``removed``.
 
 Two v1 narrows, stated here rather than discovered:
 
@@ -84,6 +88,24 @@ from agentclaw.community.core.bot_config_manifest.fetch.limits import (
 
 _FETCH_CATEGORY_FILE = FetchCategory.RESOURCES_FILE.value
 _FETCH_CATEGORY_ARCHIVE = FetchCategory.RESOURCES_ARCHIVE.value
+
+
+class _DeclaredTree:
+    """The declared-tree marker intent's value — an explicit object, never
+    ``None``.
+
+    ``None`` is ``Intent.value``'s dataclass *default*, so keying the tree
+    marker on it would let any future intent constructed without an
+    explicit value silently promise a whole-tree deletion at write time.
+    An instance of a module-private class cannot be produced by accident.
+    """
+
+    __slots__ = ()
+
+
+#: The single marker instance: ``Intent.value`` for a declared directory,
+#: identity the declared path with its trailing slash.
+_DECLARED_TREE = _DeclaredTree()
 
 
 class ResourcesMaterialiser(Materialiser):
@@ -160,13 +182,12 @@ class ResourcesMaterialiser(Materialiser):
                 if isinstance(members, str):
                     failures.append(ResolveFailure(path, members))
                     continue
-                # The directory sentinel: identity=path, value=None. It rides
-                # first in the intent list so plan marks the tree for
-                # replacement and write deletes it before members upload.
-                # The gate on every member, before the sentinel that
-                # promises the tree: one undeliverable member must abort
-                # the category with the tree still standing, not delete it
-                # for a partial delivery that every re-apply would repeat.
+                # The declared-tree marker intent rides first so plan routes
+                # the tree into ``removals`` and write replaces it before
+                # members upload. The gate on every member comes before the
+                # marker that promises the tree: one undeliverable member
+                # must abort the category with the tree still standing, not
+                # delete it for a partial delivery every re-apply repeats.
                 bad = next(
                     (
                         (path + rel, refused)
@@ -179,9 +200,7 @@ class ResourcesMaterialiser(Materialiser):
                 if bad is not None:
                     failures.append(ResolveFailure(bad[0], bad[1]))
                     continue
-                intents.append(
-                    Intent(identity=path, value=None, note=fetched.fallback_reason)
-                )
+                intents.append(Intent(identity=path, value=_DECLARED_TREE))
                 for rel, data in members:
                     intents.append(
                         Intent(
@@ -345,14 +364,21 @@ class ResourcesMaterialiser(Materialiser):
         """Classify for the report. Never ``unchanged`` — v1 replaces on
         every apply (the work item's recommended option (1)), so classifying
         anything as unchanged would be a claim the write stage does not
-        honour. ``exists`` is consulted only for the created/updated label,
-        and the directory sentinels classify within the same vocabulary:
-        the orchestrator's dry-run projection feeds every planned outcome
-        through :class:`EntryOutcome`, which a bespoke label would crash.
+        honour. ``exists`` is consulted only for the members' created/updated
+        labels.
+
+        The declared trees do not classify at all — they go to the plan's
+        ``removals`` channel, the engine's own answer for "an overwrite
+        removes something with no declared entry to attach to". That is
+        what keeps the dry-run projection and the real write in one shape
+        (both take ``plan.removals`` verbatim), and what gives a
+        dirs-only archive's destructive replace its audit row.
         """
         entity_type, entity_id = _coords(ctx)
         planned: list[PlannedEntry] = []
         for intent in intents:
+            if intent.value is _DECLARED_TREE:
+                continue
             present = await self._resources.exists(
                 entity_type=entity_type,
                 entity_id=entity_id,
@@ -366,7 +392,10 @@ class ResourcesMaterialiser(Materialiser):
                     outcome="updated" if present else "created",
                 )
             )
-        return CategoryPlan(entries=tuple(planned), removals=())
+        removals = tuple(
+            intent.identity for intent in intents if intent.value is _DECLARED_TREE
+        )
+        return CategoryPlan(entries=tuple(planned), removals=removals)
 
     async def write(
         self, ctx: ApplyContext, plan: CategoryPlan
@@ -381,33 +410,57 @@ class ResourcesMaterialiser(Materialiser):
         """
         entity_type, entity_id = _coords(ctx)
         results: list[EntryResult] = []
-        # 1) Directory sentinels first — one delete per declared tree. A
-        # tree's replace removes everything under ``path``, including files
-        # the new archive no longer ships and hand-added ones (the
-        # ownership rule). Sentinels produce no EntryResult: an ownership
+        # 1) Declared trees first — one delete per tree, from the plan's
+        # removals. A tree's replace removes everything under ``path``,
+        # including files the new archive no longer ships and hand-added
+        # ones (the ownership rule). Tree deletes are addressed at the path
+        # *minus* the declaring slash: the write chain branches file-vs-tree
+        # on the path's shape, and "wrap/" reads as a file named "" to that
+        # branch. Tree deletes produce no EntryResult: an ownership
         # action, not an entry — but a *failed* one fails its members, in
         # the stage's composed words (never the exception's: a transport
         # error can quote a header, a header can carry a token).
         failed_trees: list[str] = []
-        for planned in plan.entries:
-            if planned.intent.value is not None:
-                continue
+        for tree in plan.removals:
+            target = tree.rstrip("/")
             try:
-                await self._resources.delete(
+                ok = await self._resources.delete(
                     entity_type=entity_type,
                     entity_id=entity_id,
                     bot_id=ctx.bot_id,
                     engine_type=ctx.engine_type,
-                    path=planned.intent.identity,
+                    path=target,
                 )
             except Exception:  # noqa: BLE001 — surfaced per member, not as text
-                failed_trees.append(planned.intent.identity)
-        # 2) then each member file, in declaration order
+                failed_trees.append(tree)
+                continue
+            if ok:
+                continue
+            # ``False`` is ambiguous in the write chain's own contract: it
+            # is both "nothing was deleted" (a first apply onto an absent
+            # tree — fine) and the transports' *only* failure signal (every
+            # device filesystem catches its own errors and returns False
+            # rather than raising). Presence re-probes tell them apart: a
+            # tree that is still there was not deleted and never will be,
+            # and delivery over an unreplaced tree would report success.
+            try:
+                still_present = await self._resources.exists(
+                    entity_type=entity_type,
+                    entity_id=entity_id,
+                    bot_id=ctx.bot_id,
+                    engine_type=ctx.engine_type,
+                    path=target,
+                )
+            except Exception:  # noqa: BLE001 — pessimistic default below
+                still_present = True
+            if still_present:
+                failed_trees.append(tree)
+        # 2) then each member file, in declaration order. Containment is
+        # matched against the *declared* form (with the slash) so a tree
+        # "wrap/" cannot claim "wrap-old/x.txt" as its member.
         for planned in plan.entries:
             identity = planned.intent.identity
             data = planned.intent.value
-            if data is None:
-                continue
             if any(identity.startswith(tree) for tree in failed_trees):
                 results.append(
                     EntryResult(

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/resources.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/resources.py
@@ -543,38 +543,25 @@ class ResourcesMaterialiser(Materialiser):
 
 
 def _delivery_refusal(identity: str, data: bytes) -> str | None:
-    """The write chain's own admission rules, asked before the first delete.
+    """The write chain's own admission predicate, asked before the first delete.
 
-    ``ResourceFileService.upload_file`` refuses extensions outside its
-    allow-list (no ``.sh``, no extensionless files) and content over its
-    size cap. A refusal that first lands on the write side would arrive
-    *after* the sentinel deleted the declared tree — a deterministically
-    half-written tree on every re-apply. So the materialiser re-asks the
-    same rules in ``resolve``, where failing costs nothing: the constants
-    are imported at call time so this module's importers still pull no
-    service graph, and the fake-driven tests cannot drift from the real
-    gate because both read the same constants.
+    ``admission_refusal`` (beside the constants in the file-service module)
+    is the one rule both surfaces ask: ``upload_file`` raises it, and this
+    gate asks it in ``resolve`` so a refusal that would first land on the
+    write side never does — write-side refusals arrive *after* the declared
+    tree is deleted, a deterministically half-written tree on every
+    re-apply. The import stays at call time so this module's importers pull
+    no service graph.
 
     Inline ``content`` is the other reason the gate lives here: it never
     goes through the fetch funnel's caps, so this is the only line an
     oversized inline entry meets.
     """
     from agentclaw.community.core.resources.services.file_service import (
-        ALLOWED_EXTENSIONS,
-        MAX_FILE_SIZE,
+        admission_refusal,
     )
 
-    if Path(identity.rpartition("/")[2]).suffix.lower() not in ALLOWED_EXTENSIONS:
-        return (
-            "the workspace file surface does not allow this file type; "
-            f"allowed extensions: {', '.join(sorted(ALLOWED_EXTENSIONS))}"
-        )
-    if len(data) > MAX_FILE_SIZE:
-        return (
-            "content exceeds the workspace file surface's size cap "
-            f"({MAX_FILE_SIZE // (1024 * 1024)}MB)"
-        )
-    return None
+    return admission_refusal(identity.rpartition("/")[2], data)
 
 
 def _coords(ctx: ApplyContext) -> tuple[str, str, str]:

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/resources.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/resources.py
@@ -74,6 +74,7 @@ from agentclaw.community.core.bot_config_manifest.fetch.unpack import (
     UnpackError,
     unpack_archive,
 )
+from agentclaw.community.core.workspace.constants import DEFAULT_ENGINE_TYPE
 
 #: Schema §5 states the two resource forms' fetch widths separately —
 #: ``resources_file`` (100MB) and ``resources_archive`` (200MB) — and the
@@ -384,7 +385,7 @@ class ResourcesMaterialiser(Materialiser):
         (both take ``plan.removals`` verbatim), and what gives a
         dirs-only archive's destructive replace its audit row.
         """
-        entity_type, entity_id = _coords(ctx)
+        entity_type, entity_id, engine = _coords(ctx)
         planned: list[PlannedEntry] = []
         for intent in intents:
             if intent.value is _DECLARED_TREE:
@@ -393,7 +394,7 @@ class ResourcesMaterialiser(Materialiser):
                 entity_type=entity_type,
                 entity_id=entity_id,
                 bot_id=ctx.bot_id,
-                engine_type=ctx.engine_type,
+                engine_type=engine,
                 path=intent.identity,
             )
             planned.append(
@@ -418,7 +419,7 @@ class ResourcesMaterialiser(Materialiser):
         the source of truth, no rollback is attempted. The platform-side
         unpack already kept a bad archive from reaching this far.
         """
-        entity_type, entity_id = _coords(ctx)
+        entity_type, entity_id, engine = _coords(ctx)
         results: list[EntryResult] = []
         # 1) Declared trees first — one delete per tree, from the plan's
         # removals. A tree's replace removes everything under ``path``,
@@ -438,7 +439,7 @@ class ResourcesMaterialiser(Materialiser):
                     entity_type=entity_type,
                     entity_id=entity_id,
                     bot_id=ctx.bot_id,
-                    engine_type=ctx.engine_type,
+                    engine_type=engine,
                     path=target,
                 )
             except Exception:  # noqa: BLE001 — surfaced per member, not as text
@@ -458,7 +459,7 @@ class ResourcesMaterialiser(Materialiser):
                     entity_type=entity_type,
                     entity_id=entity_id,
                     bot_id=ctx.bot_id,
-                    engine_type=ctx.engine_type,
+                    engine_type=engine,
                     path=target,
                 )
             except Exception:  # noqa: BLE001 — pessimistic default below
@@ -487,7 +488,7 @@ class ResourcesMaterialiser(Materialiser):
                     entity_type=entity_type,
                     entity_id=entity_id,
                     bot_id=ctx.bot_id,
-                    engine_type=ctx.engine_type,
+                    engine_type=engine,
                     target_dir=target_dir,
                     filename=filename,
                     data=data,
@@ -551,8 +552,8 @@ def _delivery_refusal(identity: str, data: bytes) -> str | None:
     return None
 
 
-def _coords(ctx: ApplyContext) -> tuple[str, str]:
-    """The entity pair every resource write uses, the router's own way.
+def _coords(ctx: ApplyContext) -> tuple[str, str, str]:
+    """The entity pair — and the routed engine — every resource write uses.
 
     The entity is the bot's owner — the address the resources router's
     ``_resolve_params`` resolves and ``resource_coords_from_record`` derives
@@ -561,14 +562,28 @@ def _coords(ctx: ApplyContext) -> tuple[str, str]:
     happens to share the name. ``entity_type`` is ``"staff"``, the
     personal-bot surface's fixed type.
 
-    The engine halves of the address come from ``ctx.engine_type``, resolved
-    once per apply rather than re-resolved here (the context's own rule: a
-    single resolution cannot disagree with itself midway through an apply).
-    ``resource_coords_from_record`` is therefore not called — it would
+    The engine half routes the same way the router does before it composes
+    ``{bot_dir}/{engine}/workspace``: the runtime routing policy
+    (``claude_code`` + a non-``normalCC`` template ⇒ ``aicoding``) read
+    off the bot record. ``ctx.engine_type`` is the *raw* ``active_engine``
+    and the capability vocabulary — redefining it would silently change
+    script/`${BOT_ENGINE_TYPE}` substitution — so the routing is applied
+    here, over ``ctx.bot`` (carried on the context precisely so a
+    materialiser can read engine/template facts off it, its docstring
+    records). ``resolve_bot_engine`` is pure over that dict; the import
+    stays at call time for the same no-service-graph reason as the
+    admission constants (a module-scope import would pull the engine
+    registry's strategy graph into every importer). ``resource_coords_from_record``
+    is the twin derivation for repo-carrying callers; calling it here would
     re-resolve the engine through a bot repository this materialiser does
-    not carry, for a value the pipeline already holds.
+    not carry, for a value the carried record already answers.
     """
-    return "staff", ctx.owner_id
+    from agentclaw.community.core.bot_management.engines.registry import (
+        resolve_bot_engine,
+    )
+
+    engine = resolve_bot_engine(ctx.bot) or ctx.engine_type or DEFAULT_ENGINE_TYPE
+    return "staff", ctx.owner_id, engine
 
 
 __all__ = ["ResourcesMaterialiser"]

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/resources.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/resources.py
@@ -198,7 +198,17 @@ class ResourcesMaterialiser(Materialiser):
                     None,
                 )
                 if bad is not None:
-                    failures.append(ResolveFailure(bad[0], bad[1]))
+                    # The failure keys to the *declared* entry's identity —
+                    # the orchestrator's abort mapping blames declared rows,
+                    # and a member-keyed failure would match nothing, sinking
+                    # the reason (which member, which admission rule) out of
+                    # the report. The member is named in the reason instead.
+                    failures.append(
+                        ResolveFailure(
+                            path,
+                            f"archive member {bad[0]!r}: {bad[1]}",
+                        )
+                    )
                     continue
                 intents.append(Intent(identity=path, value=_DECLARED_TREE))
                 for rel, data in members:

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/resource_port.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/resource_port.py
@@ -23,8 +23,16 @@ from typing import Any, Protocol, runtime_checkable
 class ManifestResourcePort(Protocol):
     """The three methods the ``resources`` materialiser reaches, as a type key.
 
-    Signatures mirror the real service's keyword-only contract, so a drift
-    there is caught by the materialiser's fake-driven tests first.
+    The declared keyword-only parameters are *apply's own call surface* —
+    exactly and only what the materialiser passes, every one present on the
+    real ``ResourceFileService`` method with the same declared default. The
+    real service is a deliberate keyword **superset** (``preserve_structure``
+    is the console router's folder-upload vocabulary; ``publish_id`` /
+    ``device_uuid`` address a bound instance): a superset satisfies a
+    structurally-checked protocol, so the port stays narrow on purpose. A
+    ``runtime_checkable`` isinstance only checks method *presence* — the
+    reflection test in the materialiser's suite is what pins the mirror
+    against drift (alongside the fake, which copies these shapes).
     """
 
     @abstractmethod
@@ -38,7 +46,6 @@ class ManifestResourcePort(Protocol):
         target_dir: str,
         filename: str,
         data: bytes,
-        preserve_structure: bool = False,
     ) -> dict[str, Any]: ...
 
     @abstractmethod
@@ -56,6 +63,7 @@ class ManifestResourcePort(Protocol):
     async def exists(
         self,
         *,
+        entity_type: str = "staff",
         entity_id: str,
         bot_id: str,
         engine_type: str,

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/schema/_support.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/schema/_support.py
@@ -169,41 +169,54 @@ def check_digest(ctx: Context, location: str, value: Any) -> None:
         )
 
 
-def check_relative_path(
-    ctx: Context, location: str, value: Any, *, what: str
-) -> bool:
-    """Refuse an absolute path, a ``..`` segment, or exotic characters.
+def relative_path_refusal(
+    value: Any, *, what: str = "path"
+) -> tuple[str, str] | None:
+    """The workspace-relative path rule, pure (no ``Context``, no I/O).
 
-    Returns True when the value is usable by later rules (nesting, basenames).
+    Returns ``(code, message)`` for a value the workspace cannot accept, or
+    ``None`` when it is usable by later rules (nesting, basenames). Re-asked
+    from outside the PUT layer — the apply-time belt (a stored document can
+    predate the validator) — as *the* rule rather than a re-derivation, so
+    the two sides cannot drift.
 
     ``..`` is checked **per segment**, not as a substring: a directory named
     ``..config`` is legitimate and contains the two characters. A substring test
     would refuse it while still admitting nothing more.
     """
     if not isinstance(value, str) or not value:
-        ctx.add(location, "invalid_path", f"{what} must be a non-empty string")
-        return False
+        return "invalid_path", f"{what} must be a non-empty string"
     if value.startswith("/") or (len(value) > 1 and value[1] == ":"):
-        ctx.add(location, "absolute_path", f"{what} must be workspace-relative, not absolute")
-        return False
+        return (
+            "absolute_path",
+            f"{what} must be workspace-relative, not absolute",
+        )
     if value.startswith("~"):
-        ctx.add(location, "absolute_path", f"{what} must not start with '~'")
-        return False
+        return "absolute_path", f"{what} must not start with '~'"
     segments = value.split("/")
     if any(segment == ".." for segment in segments):
-        ctx.add(
-            location,
-            "path_traversal",
-            f"{what} must not contain a '..' segment",
-        )
-        return False
+        return "path_traversal", f"{what} must not contain a '..' segment"
     if not _PATH_CHARS_RE.match(value):
-        ctx.add(
-            location,
+        return (
             "invalid_path",
             f"{what} may only contain letters, digits, '.', '_', '-', '/' and "
             "${...} placeholders",
         )
+    return None
+
+
+def check_relative_path(
+    ctx: Context, location: str, value: Any, *, what: str
+) -> bool:
+    """Refuse an absolute path, a ``..`` segment, or exotic characters.
+
+    Returns True when the value is usable by later rules (nesting, basenames).
+    The rule itself lives in :func:`relative_path_refusal` — pure, shared —
+    so this wrapper only contributes the ``Context`` reporting.
+    """
+    refusal = relative_path_refusal(value, what=what)
+    if refusal is not None:
+        ctx.add(location, refusal[0], refusal[1])
         return False
     # Placeholders inside the value are *not* checked here. Every string this
     # function sees is also swept by the walker that scans a whole entry (or a

--- a/src/backend/src/agentclaw/community/core/resources/services/file_service.py
+++ b/src/backend/src/agentclaw/community/core/resources/services/file_service.py
@@ -28,6 +28,28 @@ ALLOWED_EXTENSIONS = {
 }
 
 
+def admission_refusal(basename: str, data: bytes) -> Optional[str]:
+    """The workspace file surface's admission rule — the one predicate.
+
+    Read by both enforcement sites: ``ResourceFileService.upload_file``
+    raises it as ``ValueError``; the manifest apply flow asks it in its
+    resolve stage (before the first destructive delete) and reports the
+    answer. One rule, both sides — the reason it lives here, beside the
+    constants it reads at call time.
+
+    ``basename`` is judged alone (the caller strips any directory part);
+    ``data`` is the exact bytes about to be written.
+    """
+    if Path(basename).suffix.lower() not in ALLOWED_EXTENSIONS:
+        return (
+            "File type not allowed. Allowed: "
+            f"{', '.join(sorted(ALLOWED_EXTENSIONS))}"
+        )
+    if len(data) > MAX_FILE_SIZE:
+        return f"File too large. Max size: {MAX_FILE_SIZE / 1024 / 1024}MB"
+    return None
+
+
 class FileNode:
     """Represents a file or directory node in the tree."""
     def __init__(self, name: str, path: str, is_dir: bool = False, size: int = 0,

--- a/src/backend/src/agentclaw/community/core/services/resource_file_service.py
+++ b/src/backend/src/agentclaw/community/core/services/resource_file_service.py
@@ -51,9 +51,8 @@ from agentclaw.community.core.devices.services.device_context_resolver import (
     DeviceContextResolver,
 )
 from agentclaw.community.core.resources.services.file_service import (
-    ALLOWED_EXTENSIONS,
-    MAX_FILE_SIZE,
     FileNode,
+    admission_refusal,
 )
 from agentclaw.community.core.repository.protocols.publishing import BotPublishRepositoryProtocol
 from agentclaw.community.core.workspace.constants import SUPPORTED_ENGINE_TYPES
@@ -593,12 +592,13 @@ class ResourceFileService:
             raise ValueError("Filename is required")
 
         basename = filename.rsplit("/", 1)[-1]
-        if Path(basename).suffix.lower() not in ALLOWED_EXTENSIONS:
-            raise ValueError(
-                f"File type not allowed. Allowed: {', '.join(sorted(ALLOWED_EXTENSIONS))}"
-            )
-        if len(data) > MAX_FILE_SIZE:
-            raise ValueError(f"File too large. Max size: {MAX_FILE_SIZE / 1024 / 1024}MB")
+        # The admission rule is the one predicate beside the constants
+        # (``core/resources/services/file_service.admission_refusal``) — the
+        # same question the manifest apply flow asks in its resolve stage,
+        # so the two surfaces cannot drift from each other.
+        refusal = admission_refusal(basename, data)
+        if refusal is not None:
+            raise ValueError(refusal)
 
         if preserve_structure and "/" in filename:
             safe = "/".join(

--- a/src/backend/tests/community/core/bot_config_manifest/apply/_fakes.py
+++ b/src/backend/tests/community/core/bot_config_manifest/apply/_fakes.py
@@ -658,10 +658,26 @@ def make_context(
     bot_type: str = "personal",
     apply_id: str | None = None,
     source_session=None,
+    bot: dict[str, Any] | None = None,
 ) -> ApplyContext:
-    """An ``ApplyContext`` with real capabilities resolved for a baas bot;
+    """An ``ApplyContext`` with real capabilities resolved for a baas bot.
+
     ``source_session`` carries the W7 per-apply named-source state when a
-    test drives the ``from``/git pipeline."""
+    test drives the ``from``/git pipeline. ``bot`` overlays the default
+    record — e.g. ``bot={"template_type": "applicationCoding"}`` for the
+    runtime-routing cases: the bot record is what the engine-provisioning
+    routing policy reads, and ``bot_type`` / ``engine_type`` stay the
+    *capability* vocabulary while the materialiser derives the workspace
+    address from the record.
+    """
+    record = {
+        "bot_id": bot_id,
+        "owner_id": owner_id,
+        "entity_id": entity_id,
+        "active_engine": engine_type,
+        "bot_type": bot_type,
+    }
+    record.update(bot or {})
     return ApplyContext(
         bot_id=bot_id,
         owner_id=owner_id,
@@ -673,13 +689,7 @@ def make_context(
         bot_type=bot_type,
         apply_id=apply_id,
         source_session=source_session,
-        bot={
-            "bot_id": bot_id,
-            "owner_id": owner_id,
-            "entity_id": entity_id,
-            "active_engine": engine_type,
-            "bot_type": bot_type,
-        },
+        bot=record,
         capabilities=resolve_capabilities(
             active_engine=engine_type,
             bot_type=bot_type,

--- a/src/backend/tests/community/core/bot_config_manifest/apply/_fakes.py
+++ b/src/backend/tests/community/core/bot_config_manifest/apply/_fakes.py
@@ -705,8 +705,10 @@ class FakeResourceFileService:
     (its dispatcher covers the arca / baas / teclaw transports uniformly), so
     the fake needs only the three entry points the materialiser calls:
     ``upload_file``, ``delete`` — plus ``exists`` for the plan stage's
-    classification. Signatures mirror the real service's, so a drift shows up
-    as a TypeError in these tests before it shows up mid-apply in production.
+    classification. Signatures mirror the port's apply-side surface (every
+    parameter the materialiser passes; the router-only extras such as
+    ``preserve_structure`` are deliberately absent), so a drift shows up as a
+    TypeError in these tests before it shows up mid-apply in production.
 
     ``delete`` removes from the presence set as well — the real service's
     contract — because the plan stage classifies by ``exists`` and would
@@ -746,7 +748,6 @@ class FakeResourceFileService:
         target_dir: str,
         filename: str,
         data: bytes,
-        preserve_structure: bool = False,
     ) -> dict[str, Any]:
         self.upload_calls.append(
             {

--- a/src/backend/tests/community/core/bot_config_manifest/apply/_fakes.py
+++ b/src/backend/tests/community/core/bot_config_manifest/apply/_fakes.py
@@ -700,10 +700,19 @@ class FakeResourceFileService:
 
     ``delete`` removes from the presence set as well — the real service's
     contract — because the plan stage classifies by ``exists`` and would
-    otherwise call a deleted path "unchanged".
+    otherwise call a deleted path "unchanged". Deleting a directory removes
+    the whole subtree from presence (the real chain's ``delete_tree``
+    branch); a path named in ``fail_deletes`` answers a silent ``False``
+    with presence untouched — the real transports' contract, which catch
+    their own errors and return ``False`` rather than raise, so a refused
+    ``rmtree`` is only distinguishable by re-probing presence.
     """
 
-    def __init__(self, exists_paths: set[str] | None = None) -> None:
+    def __init__(
+        self,
+        exists_paths: set[str] | None = None,
+        fail_deletes: set[str] | None = None,
+    ) -> None:
         self.writes: dict[tuple[str, str], bytes] = {}
         self.deleted: list[str] = []
         # Full addressing of every call, so a test can pin *how* the write
@@ -712,6 +721,7 @@ class FakeResourceFileService:
         self.delete_calls: list[dict[str, Any]] = []
         self.exists_probes: list[dict[str, Any]] = []
         self._exists = set(exists_paths or ())
+        self._fail_deletes = set(fail_deletes or ())
 
     def record_present(self, *paths: str) -> None:
         self._exists.update(paths)
@@ -760,8 +770,16 @@ class FakeResourceFileService:
                 "path": path,
             }
         )
+        if path in self._fail_deletes:
+            # Silent refusal: the transport answered, nothing was removed,
+            # presence still reports the tree — an exists re-probe sees it.
+            return False
         self.deleted.append(path)
-        self._exists.discard(path)
+        self._exists = {
+            p
+            for p in self._exists
+            if p != path and not p.startswith(f"{path}/")
+        }
         return True
 
     async def exists(

--- a/src/backend/tests/community/core/bot_config_manifest/apply/test_resources_materialiser.py
+++ b/src/backend/tests/community/core/bot_config_manifest/apply/test_resources_materialiser.py
@@ -1202,3 +1202,49 @@ def test_refusals_quote_the_write_chains_own_words():
     resolved = _run(m.resolve(ctx, [{"path": "data/run.sh", "content": "#"}]))
     assert not resolved.ok
     assert resolved.failures[0].reason.startswith("File type not allowed")
+
+
+# --- the port the wiring keys on (F7) ---
+
+
+def test_the_port_mirrors_the_apply_side_call_surface():
+    """The port is apply's call surface, exactly — and a keyword subset of
+    the real service.
+
+    A ``@runtime_checkable`` isinstance checks method *presence* only, so
+    nothing else notices a signature drift; pinned here by reflection:
+    every parameter the port declares must exist on the real
+    ``ResourceFileService`` method with the same declared default (the
+    fake mirrors the port in turn). The port is deliberately *narrower*
+    than the real service — ``preserve_structure`` and ``publish_id`` /
+    ``device_uuid`` are the router's vocabulary, not apply's.
+    """
+    import inspect
+
+    from agentclaw.community.core.bot_config_manifest.apply.resource_port import (
+        ManifestResourcePort,
+    )
+    from agentclaw.community.core.services.resource_file_service import (
+        ResourceFileService,
+    )
+
+    def _kwparams(func) -> dict[str, Any]:
+        return {
+            name: param.default
+            for name, param in inspect.signature(func).parameters.items()
+            if param.kind == inspect.Parameter.KEYWORD_ONLY
+        }
+
+    for method in ("upload_file", "delete", "exists"):
+        port_params = _kwparams(getattr(ManifestResourcePort, method))
+        real_params = _kwparams(getattr(ResourceFileService, method))
+        # Every port parameter exists on the real service...
+        assert set(port_params) <= set(real_params), (method, port_params)
+        # ...with the same declared default where the port declares one.
+        for name, default in port_params.items():
+            assert real_params[name] == default, (method, name)
+        # ...and every parameter the port declares is one apply passes.
+        assert "preserve_structure" not in port_params, method
+        # The one divergence the apply side must not reintroduce: ``exists``
+        # is addressed like ``delete`` and ``upload_file``, entity and all.
+        assert "entity_type" in _kwparams(ManifestResourcePort.exists)

--- a/src/backend/tests/community/core/bot_config_manifest/apply/test_resources_materialiser.py
+++ b/src/backend/tests/community/core/bot_config_manifest/apply/test_resources_materialiser.py
@@ -796,7 +796,9 @@ def test_inline_content_over_the_size_cap_fails_at_resolve(
         m.resolve(ctx, [{"path": "data/big.md", "content": "x" * 32}])
     )
     assert not resolved.ok
-    assert "size cap" in resolved.failures[0].reason.lower()
+    # The write chain's own words — the gate delegates to the same
+    # predicate ``upload_file`` enforces, so the refusal texts agree.
+    assert "too large" in resolved.failures[0].reason.lower()
 
 
 def test_strip_components_of_the_wrong_type_is_a_resolve_failure():
@@ -1185,3 +1187,18 @@ def test_an_unknown_unpack_kind_is_refused():
     )
     assert not resolved.ok
     assert "zip|tar.gz" in resolved.failures[0].reason
+
+
+def test_refusals_quote_the_write_chains_own_words():
+    """The resolve gate's verdict is the write chain's own text`` —`
+
+    delegated to the one predicate (``file_service.admission_refusal``)
+    rather than restated, the two surfaces cannot drift into disagreeing
+    about what they admit.
+    """
+    svc = FakeResourceFileService()
+    m = ResourcesMaterialiser(svc, _StubEntryFetcher())
+    ctx = make_context(engine_type="claude_code")
+    resolved = _run(m.resolve(ctx, [{"path": "data/run.sh", "content": "#"}]))
+    assert not resolved.ok
+    assert resolved.failures[0].reason.startswith("File type not allowed")

--- a/src/backend/tests/community/core/bot_config_manifest/apply/test_resources_materialiser.py
+++ b/src/backend/tests/community/core/bot_config_manifest/apply/test_resources_materialiser.py
@@ -1248,3 +1248,29 @@ def test_the_port_mirrors_the_apply_side_call_surface():
         # The one divergence the apply side must not reintroduce: ``exists``
         # is addressed like ``delete`` and ``upload_file``, entity and all.
         assert "entity_type" in _kwparams(ManifestResourcePort.exists)
+
+
+def test_an_unhashable_unpack_kind_is_refused_not_raised():
+    """The membership check is against a frozenset (``VALID_UNPACK``); an
+    unhashable ``unpack`` (a YAML list, from a validator-bypassing document)
+    must still get the belt's clean refusal — a raw ``TypeError`` would
+    leave the category's failure text to the orchestrator's exception
+    path instead of the stage's own words.
+    """
+    svc = FakeResourceFileService()
+    m = ResourcesMaterialiser(svc, _StubEntryFetcher(_tgz({"a.md": b"x"})))
+    ctx = make_context(engine_type="claude_code")
+    resolved = _run(
+        m.resolve(
+            ctx,
+            [
+                {
+                    "path": "wrap/",
+                    "unpack": ["zip"],
+                    "source": "https://x/t.tgz",
+                }
+            ],
+        )
+    )
+    assert not resolved.ok
+    assert "zip|tar.gz" in resolved.failures[0].reason

--- a/src/backend/tests/community/core/bot_config_manifest/apply/test_resources_materialiser.py
+++ b/src/backend/tests/community/core/bot_config_manifest/apply/test_resources_materialiser.py
@@ -746,9 +746,11 @@ def test_write_carries_the_note_onto_the_report_row():
 def test_an_archive_member_the_chain_would_refuse_fails_at_resolve():
     """``upload_file`` refuses extensions outside its allow-list (no ``.sh``,
     no extensionless files). That refusal must land in ``resolve`` — before
-    the sentinel deletes the declared tree — or the category reaches write
-    with a member that deterministically fails *after* the destructive
-    delete, on every re-apply.
+    the tree marker promises the declared tree — or the category reaches
+    write with a member that deterministically fails *after* the
+    destructive delete, on every re-apply. The failure is keyed to the
+    *declared* entry's identity with the member named in the reason, so
+    the orchestrator's abort mapping can blame the declared row.
     """
     archive = _tgz({"a.md": b"ok", "run.sh": b"#!/bin/sh\n"})
     svc = FakeResourceFileService(exists_paths={"tools/old.md"})
@@ -763,7 +765,9 @@ def test_an_archive_member_the_chain_would_refuse_fails_at_resolve():
     # The whole category aborts (§3.2): one undeliverable member means the
     # tree is NOT deleted for a partial delivery.
     assert not resolved.ok
-    assert resolved.failures[0].identity == "tools/run.sh"
+    assert resolved.failures[0].identity == "tools/"
+    # The reason names the offending member inside the declared entry.
+    assert "tools/run.sh" in resolved.failures[0].reason
     assert "file type" in resolved.failures[0].reason.lower()
 
 
@@ -995,3 +999,52 @@ def test_an_empty_archive_still_audits_the_tree_removal():
     # The tree was deleted for real, and nothing was delivered.
     assert svc.deleted == ["gone"]
     assert svc.writes == {}
+
+
+def test_a_refused_member_blames_the_declared_entry_in_the_report():
+    """F3: the report must say which member was undeliverable and why.
+
+    The orchestrator's abort mapping keys failure reasons onto *declared*
+    entry identities — a member-keyed failure matches nothing and both
+    declared rows answer a generic "another entry could not be
+    materialized", leaving the author to guess which of the archive's
+    members violated the write chain's admission and in what way.
+    """
+    archive = _tgz({"a.md": b"ok", "run.sh": b"#!/bin/sh\n"})
+    svc = FakeResourceFileService(exists_paths={"tools/old.md"})
+    engine = _resources_engine(svc, _StubEntryFetcher(archive))
+    ctx = make_context(engine_type="claude_code")
+
+    report = _run(
+        engine.apply(
+            ctx,
+            {
+                "schema_version": 1,
+                "manifest": {
+                    "resources": [
+                        {
+                            "path": "tools/",
+                            "unpack": "tar.gz",
+                            "source": "https://x/t.tgz",
+                        },
+                        {"path": "notes/r.md", "content": "# rules"},
+                    ]
+                },
+            },
+            apply_id="a1", trigger="explicit",
+            started_at=datetime.now(), dry_run=False,
+        )
+    )
+
+    rows = {(e.identity, e.outcome.value): e for e in report.entries}
+    (identity, outcome), row = next(
+        item for item in rows.items() if item[0][0] == "tools/"
+    )
+    assert outcome == "failed"
+    assert "run.sh" in (row.reason or "")
+    assert "file type" in (row.reason or "").lower()
+    # The blameless neighbour keeps the generic skip wording.
+    assert rows[("notes/r.md", "skipped")].reason is not None
+    # Nothing was written and the tree still stands.
+    assert svc.writes == {}
+    assert svc.deleted == []

--- a/src/backend/tests/community/core/bot_config_manifest/apply/test_resources_materialiser.py
+++ b/src/backend/tests/community/core/bot_config_manifest/apply/test_resources_materialiser.py
@@ -15,6 +15,7 @@ Pins, by the work item's acceptance criteria:
 from __future__ import annotations
 
 import asyncio
+from datetime import datetime
 from typing import Any
 
 from agentclaw.community.core.bot_config_manifest.apply.entry_fetch import (
@@ -22,10 +23,31 @@ from agentclaw.community.core.bot_config_manifest.apply.entry_fetch import (
     FetchedEntry,
 )
 from agentclaw.community.core.bot_config_manifest.apply.materialisers.resources import (
+    _DECLARED_TREE,
     ResourcesMaterialiser,
 )
+from agentclaw.community.core.bot_config_manifest.apply.orchestrator import (
+    ApplyOrchestrator,
+)
+from agentclaw.community.core.bot_config_manifest.apply.registry import (
+    build_materialisers,
+)
 
-from ._fakes import FakeResourceFileService, build_skill_tgz, make_context
+from ._fakes import (
+    FakeActivationService,
+    FakeCapabilityReader,
+    FakeCredentials,
+    FakeGuardedFetcher,
+    FakeIdentityService,
+    FakeManifestContent,
+    FakeMcpAuth,
+    FakeResourceFileService,
+    FakeSkillUploadService,
+    FakeStartupScriptService,
+    build_skill_tgz,
+    make_context,
+    real_validator,
+)
 
 
 def _run(coro):
@@ -212,15 +234,16 @@ def test_dir_entry_expands_members_under_path():
     )
     assert resolved.ok, [f.reason for f in resolved.failures]
     got = {i.identity: i.value for i in resolved.intents}
-    # The "wrap/" entry is the directory sentinel (value=None, the
-    # tree-replacement marker), riding first so write deletes the tree
-    # before any member uploads.
+    # The "wrap/" entry is the declared-tree marker: an explicit object,
+    # never ``None`` (the dataclass default) — a future intent constructed
+    # without an explicit value must not silently promise a tree deletion.
     assert got == {
-        "wrap/": None,
+        "wrap/": _DECLARED_TREE,
         "wrap/a.txt": b"AAA",
         "wrap/sub/b.txt": b"BBB",
     }
     assert resolved.intents[0].identity == "wrap/"
+    assert resolved.intents[0].value is _DECLARED_TREE
 
 
 def test_bad_archive_is_a_resolve_failure_and_nothing_reaches_the_bot():
@@ -330,16 +353,19 @@ def test_plan_addresses_the_bot_owner_not_the_manifest_storage_key():
     ]
 
 
-def test_plan_classifies_the_directory_sentinel_within_the_report_vocabulary():
-    """The sentinel classifies like any entry — the vocabulary stays the enum's.
+def test_declared_trees_report_as_removals_not_member_rows():
+    """A declared tree's replacement rides the plan's removals channel.
 
-    A bespoke outcome ("replaced") would crash the orchestrator's dry-run
-    projection, which feeds every planned outcome through
-    ``EntryOutcome(...)``; write recognises the sentinel by its ``value is
-    None``, not by the label.
+    The old encoding put the tree in ``entries`` as a ``value=None``
+    sentence-turn — so the dry-run projection emitted a report row for it
+    while the real write skipped it (two shapes for one document), and an
+    empty archive's destructive delete left no audit row at all. The
+    removals channel is the engine's own answer for "an overwrite removes
+    something with no declared entry to attach to": the tree reports under
+    the category's ``removed``, the member files classify as entries.
     """
     archive = _tgz({"a.txt": b"AAA"})
-    svc = FakeResourceFileService(exists_paths={"established/"})
+    svc = FakeResourceFileService(exists_paths={"established/a.txt"})
     m = ResourcesMaterialiser(svc, _StubEntryFetcher(archive))
     ctx = make_context(engine_type="claude_code")
     resolved = _run(
@@ -362,15 +388,17 @@ def test_plan_classifies_the_directory_sentinel_within_the_report_vocabulary():
     assert resolved.ok, [f.reason for f in resolved.failures]
     plan = _run(m.plan(ctx, resolved.intents))
     by_id = {p.intent.identity: p.outcome for p in plan.entries}
-    # Presence is probed per identity: only the "established/" tree root was
-    # seeded present, so its member — a fresh upload under a replaced tree —
-    # classifies as created, exactly as a first apply of the member would.
+    # Members only: presence is probed per member file; a fresh upload under
+    # a replaced tree classifies as created, exactly as a first apply would.
     assert by_id == {
-        "established/": "updated",
-        "established/a.txt": "created",
-        "fresh/": "created",
+        "established/a.txt": "updated",
         "fresh/a.txt": "created",
     }
+    # Presence probes never ask about the tree roots — they have no label.
+    assert all(not p["path"].endswith("/") for p in svc.exists_probes)
+    # The declared trees, in declaration order, as removals.
+    assert plan.removals == ("established/", "fresh/")
+    assert not plan.is_noop
 
 
 # --- write: delivery through the one write chain (Task 5) ---
@@ -396,15 +424,89 @@ def test_write_replaces_the_tree_then_uploads_every_member():
     # One delete per declared tree, first: the replace removes everything
     # under "wrap/" — including files the new archive no longer ships and
     # hand-added ones (the ownership rule).
-    assert svc.deleted == ["wrap/"]
+    assert svc.deleted == ["wrap"]
     assert svc.writes == {
         ("wrap", "a.txt"): b"AAA",
         ("wrap/sub", "b.txt"): b"BBB",
     }
-    # The sentinel is an ownership action, not an entry: only its member
-    # files report.
+    # The tree replacement is an ownership action, not an entry: only its
+    # member files report.
     assert [r.identity for r in results] == ["wrap/a.txt", "wrap/sub/b.txt"]
     assert all(r.outcome.value == "created" for r in results)
+    # The tree is in the plan's removals — the audit row for the replace.
+    assert plan.removals == ("wrap/",)
+
+
+def test_write_deletes_the_declared_tree_without_the_trailing_slash():
+    """F1: the write chain's file/dir branching keys on the path's shape.
+
+    ``ResourceFileService._is_dir`` rpartitions ``path`` and looks the leaf
+    up in the parent listing — for "wrap/" that leaf is the empty string and
+    never matches, so the delete is routed to the single-file remove API
+    ("not recursive" by that service's own docstring) and every transport
+    under it swallows the refusal as ``False``. The materialiser must
+    therefore hand the write chain the tree path *minus* the declaring
+    slash, which routes to the recursive branch.
+    """
+    svc = FakeResourceFileService(exists_paths={"wrap/old.txt"})
+    archive = _tgz({"a.txt": b"AAA"})
+    m = ResourcesMaterialiser(svc, _StubEntryFetcher(archive))
+    ctx = make_context(engine_type="claude_code")
+    _write_through(
+        m, ctx, [{"path": "wrap/", "unpack": "tar.gz", "source": "https://x/t"}]
+    )
+    assert [c["path"] for c in svc.delete_calls] == ["wrap"]
+
+
+def test_a_silently_failed_tree_delete_fails_its_members():
+    """F1's second half: the transports refuse by returning ``False``, not
+    by raising — all three device filesystems catch their own errors — so a
+    write stage that only caught exceptions would see a refused rmtree as
+    success and upload the new members over a tree that was never
+    replaced, reporting ``created``. A ``False`` delete with the tree still
+    present (re-probed) must fail the tree's members instead.
+    """
+    svc = FakeResourceFileService(
+        exists_paths={"tools"}, fail_deletes={"tools"}
+    )
+    archive = _tgz({"a.md": b"A"})
+    m = ResourcesMaterialiser(svc, _StubEntryFetcher(archive))
+    ctx = make_context(engine_type="claude_code")
+    plan, results = _write_through(
+        m,
+        ctx,
+        [
+            {"path": "tools/", "unpack": "tar.gz", "source": "https://x/t.tgz"},
+            {"path": "notes/r.md", "content": "# rules"},
+        ],
+    )
+    by_id = {r.identity: r for r in results}
+    assert by_id["tools/a.md"].outcome.value == "failed"
+    assert by_id["tools/a.md"].reason == "directory tree replacement failed"
+    # Nothing from the failed tree was uploaded; the sibling outside it
+    # still converged.
+    assert ("tools", "a.md") not in svc.writes
+    assert by_id["notes/r.md"].outcome.value == "created"
+    assert plan.removals == ("tools/",)
+
+
+def test_a_failed_delete_of_an_absent_tree_is_not_a_failure():
+    """``delete`` returns ``False`` when nothing was deleted — the real
+    service's own contract — which is the *normal* answer for a first
+    apply onto a tree that does not exist yet. The failure detection must
+    re-probe presence, not read ``False`` as refusal.
+    """
+    svc = FakeResourceFileService(fail_deletes={"tools"})
+    archive = _tgz({"a.md": b"A"})
+    m = ResourcesMaterialiser(svc, _StubEntryFetcher(archive))
+    ctx = make_context(engine_type="claude_code")
+    plan, results = _write_through(
+        m,
+        ctx,
+        [{"path": "tools/", "unpack": "tar.gz", "source": "https://x/t.tgz"}],
+    )
+    assert [r.outcome.value for r in results] == ["created"]
+    assert svc.writes == {("tools", "a.md"): b"A"}
 
 
 def test_write_addresses_the_bot_owner():
@@ -427,7 +529,7 @@ def test_write_addresses_the_bot_owner():
             "entity_id": "u_owner",
             "bot_id": "b_1",
             "engine_type": "claude_code",
-            "path": "wrap/",
+            "path": "wrap",
         }
     ]
     assert svc.upload_calls == [
@@ -460,7 +562,7 @@ def test_write_is_player_setup_convergent():
             [{"path": "wrap/", "unpack": "tar.gz", "source": "https://x/t.tgz"}],
         )
     assert svc.writes == {("wrap", "a.txt"): b"AAA"}
-    assert svc.deleted == ["wrap/", "wrap/"]
+    assert svc.deleted == ["wrap", "wrap"]
 
 
 def test_write_failure_yields_failed_entry_per_member():
@@ -726,7 +828,7 @@ def test_a_failed_tree_replacement_fails_its_members_in_composed_words():
 
     class _BuggyTreeDelete(FakeResourceFileService):
         async def delete(self, **kwargs):
-            if kwargs["path"] == "tools/":
+            if kwargs["path"] == "tools":
                 raise RuntimeError("rmtree quoted a header with a token")
             return await super().delete(**kwargs)
 
@@ -753,3 +855,143 @@ def test_a_failed_tree_replacement_fails_its_members_in_composed_words():
     assert all("token" not in (r.reason or "") for r in results)
     # the sibling entry outside the failed tree was still delivered
     assert by_id["notes/r.md"].outcome.value == "created"
+
+
+# --- report shape: the tree channel, end to end (review F4) ---
+
+
+def _resources_engine(svc, fetcher):
+    """An orchestrator over the real registry, resources wired to the rig."""
+    return ApplyOrchestrator(
+        build_materialisers(
+            script_service=FakeStartupScriptService(),
+            activation_service=FakeActivationService(),
+            mcp_auth_service=FakeMcpAuth(),
+            identity_service=FakeIdentityService(),
+            upload_service=FakeSkillUploadService(),
+            capability_reader=FakeCapabilityReader(),
+            package_validator=real_validator(),
+            entry_fetcher=fetcher,
+            resource_service=svc,
+        )
+    )
+
+
+_DOCUMENT = {
+    "schema_version": 1,
+    "manifest": {
+        "resources": [
+            {
+                "path": "wrap/",
+                "unpack": "tar.gz",
+                "source": "https://x/t.tgz",
+            },
+            {"path": "notes/r.md", "content": "# rules"},
+        ]
+    },
+}
+
+
+def test_dry_run_and_apply_report_the_same_resources_shape():
+    """F4: preview and execution must answer in one shape.
+
+    The old encoding put the declared tree in ``entries`` (the dry-run
+    projection emits one row per planned entry) while the real write
+    skipped it — one document, two report shapes, and any caller diffing
+    preview against execution saw a row vanish. With the tree in
+    ``removals`` both paths take the same plan and report the same rows
+    plus the same ``removed``.
+    """
+    archive = _tgz({"a.txt": b"AAA"})
+    svc = FakeResourceFileService()
+    engine = _resources_engine(svc, _StubEntryFetcher(archive))
+    ctx = make_context(engine_type="claude_code")
+
+    dry = _run(
+        engine.apply(
+            ctx, _DOCUMENT, apply_id="a1", trigger="explicit",
+            started_at=datetime.now(), dry_run=True,
+        )
+    )
+    real = _run(
+        engine.apply(
+            ctx, _DOCUMENT, apply_id="a2", trigger="explicit",
+            started_at=datetime.now(), dry_run=False,
+        )
+    )
+
+    for report in (dry, real):
+        resources = next(
+            c for c in report.categories if c.construct.value == "resources"
+        )
+        assert resources.removals == ("wrap/",)
+    dry_rows = {e.identity: e.outcome.value for e in dry.entries}
+    real_rows = {e.identity: e.outcome.value for e in real.entries}
+    assert dry_rows == {"notes/r.md": "created", "wrap/a.txt": "created"}
+    assert real_rows == {"notes/r.md": "created", "wrap/a.txt": "created"}
+    # The preview wrote nothing; the execution delivered.
+    assert svc.writes == {("notes", "r.md"): b"# rules", ("wrap", "a.txt"): b"AAA"}
+    assert svc.deleted == ["wrap"]
+
+
+def test_an_empty_archive_still_audits_the_tree_removal():
+    """F4's tail case: a dirs-only (or empty) archive replaces the declared
+    tree with nothing. The old encoding deleted the whole tree while
+    emitting zero report rows — a destructive operation with no audit
+    trail. The removals channel makes the replace visible as ``removed``
+    in both shapes.
+    """
+    archive = _tgz({})
+    svc = FakeResourceFileService(exists_paths={"gone/old.md"})
+    engine = _resources_engine(svc, _StubEntryFetcher(archive))
+    ctx = make_context(engine_type="claude_code")
+
+    dry = _run(
+        engine.apply(
+            ctx,
+            {
+                "schema_version": 1,
+                "manifest": {
+                    "resources": [
+                        {
+                            "path": "gone/",
+                            "unpack": "tar.gz",
+                            "source": "https://x/empty.tgz",
+                        }
+                    ]
+                },
+            },
+            apply_id="a1", trigger="explicit",
+            started_at=datetime.now(), dry_run=True,
+        )
+    )
+    real = _run(
+        engine.apply(
+            ctx,
+            {
+                "schema_version": 1,
+                "manifest": {
+                    "resources": [
+                        {
+                            "path": "gone/",
+                            "unpack": "tar.gz",
+                            "source": "https://x/empty.tgz",
+                        }
+                    ]
+                },
+            },
+            apply_id="a2", trigger="explicit",
+            started_at=datetime.now(), dry_run=False,
+        )
+    )
+
+    for report in (dry, real):
+        resources = next(
+            c for c in report.categories if c.construct.value == "resources"
+        )
+        assert resources.removals == ("gone/",)
+        assert resources.as_dict()["removed"] == ["gone/"]
+    assert [e.identity for e in real.entries] == []
+    # The tree was deleted for real, and nothing was delivered.
+    assert svc.deleted == ["gone"]
+    assert svc.writes == {}

--- a/src/backend/tests/community/core/bot_config_manifest/apply/test_resources_materialiser.py
+++ b/src/backend/tests/community/core/bot_config_manifest/apply/test_resources_materialiser.py
@@ -1048,3 +1048,70 @@ def test_a_refused_member_blames_the_declared_entry_in_the_report():
     # Nothing was written and the tree still stands.
     assert svc.writes == {}
     assert svc.deleted == []
+
+
+# --- the write address's engine half: the runtime routing (F2) ---
+
+
+def test_routed_bots_address_the_runtime_engine_workspace():
+    """F2: the workspace address routes the engine the router's way.
+
+    The resources router resolves the engine through the runtime routing
+    policy (``claude_code`` + a non-``normalCC`` template ⇒ ``aicoding``)
+    before composing ``{bot_dir}/{engine}/workspace``; a raw
+    ``active_engine`` would deliver the files into a tree neither the
+    resources console nor the bot reads while the report says SUCCEEDED.
+    """
+    archive = _tgz({"a.txt": b"A"})
+    svc = FakeResourceFileService()
+    m = ResourcesMaterialiser(svc, _StubEntryFetcher(archive))
+    ctx = make_context(
+        engine_type="claude_code", bot={"template_type": "applicationCoding"}
+    )
+    _write_through(
+        m, ctx, [{"path": "wrap/", "unpack": "tar.gz", "source": "https://x/t"}]
+    )
+    assert svc.delete_calls[0]["engine_type"] == "aicoding"
+    assert all(c["engine_type"] == "aicoding" for c in svc.upload_calls)
+    assert all(p["engine_type"] == "aicoding" for p in svc.exists_probes)
+
+
+def test_unrouted_bots_keep_the_active_engine():
+    """The control cases: no template, the ``normalCC`` template, and a
+    plain non-claude_code engine all keep the address on the active engine
+    — the routing policy must be the only thing that moves the address."""
+    archive = _tgz({"a.txt": b"A"})
+    cases = [
+        {},  # fake default: claude_code, no template_type
+        {"template_type": "normalCC"},
+    ]
+    for overlay in cases:
+        svc = FakeResourceFileService()
+        m = ResourcesMaterialiser(svc, _StubEntryFetcher(archive))
+        ctx = make_context(engine_type="claude_code", bot=overlay)
+        _write_through(
+            m, ctx, [{"path": "wrap/", "unpack": "tar.gz", "source": "https://x/t"}]
+        )
+        assert svc.delete_calls[0]["engine_type"] == "claude_code"
+
+    svc = FakeResourceFileService()
+    m = ResourcesMaterialiser(svc, _StubEntryFetcher(archive))
+    ctx = make_context(engine_type="openclaw")
+    _write_through(
+        m, ctx, [{"path": "wrap/", "unpack": "tar.gz", "source": "https://x/t"}]
+    )
+    assert svc.delete_calls[0]["engine_type"] == "openclaw"
+
+
+def test_an_engineless_bot_record_falls_back_to_the_context_engine():
+    """A record without a readable engine (``active_engine`` None) falls
+    back to ``ctx.engine_type`` — never an empty string, which the path
+    factory would compose into the bot root instead of an engine dir."""
+    archive = _tgz({"a.txt": b"A"})
+    svc = FakeResourceFileService()
+    m = ResourcesMaterialiser(svc, _StubEntryFetcher(archive))
+    ctx = make_context(engine_type="openclaw", bot={"active_engine": None})
+    _write_through(
+        m, ctx, [{"path": "wrap/", "unpack": "tar.gz", "source": "https://x/t"}]
+    )
+    assert svc.delete_calls[0]["engine_type"] == "openclaw"

--- a/src/backend/tests/community/core/bot_config_manifest/apply/test_resources_materialiser.py
+++ b/src/backend/tests/community/core/bot_config_manifest/apply/test_resources_materialiser.py
@@ -1115,3 +1115,73 @@ def test_an_engineless_bot_record_falls_back_to_the_context_engine():
         m, ctx, [{"path": "wrap/", "unpack": "tar.gz", "source": "https://x/t"}]
     )
     assert svc.delete_calls[0]["engine_type"] == "openclaw"
+
+
+# --- the apply-time path belt re-asks the schema's own rule (F6) ---
+
+
+def test_a_tilde_path_is_refused_at_resolve():
+    """A document that predates the validator carries the PUT layer's
+    refusals into apply: "~" is an absolute-ish path in exactly the way
+    "/" is, and the old belt (only "/", ".." segments) let it through to
+    the write chain."""
+    svc = FakeResourceFileService()
+    m = ResourcesMaterialiser(svc, _StubEntryFetcher())
+    ctx = make_context(engine_type="claude_code")
+    resolved = _run(m.resolve(ctx, [{"path": "~/x.md", "content": "x"}]))
+    assert not resolved.ok
+    assert resolved.failures[0].identity == "~/x.md"
+    assert "~" in resolved.failures[0].reason
+
+
+def test_a_windows_drive_path_is_refused_at_resolve():
+    svc = FakeResourceFileService()
+    m = ResourcesMaterialiser(svc, _StubEntryFetcher())
+    ctx = make_context(engine_type="claude_code")
+    resolved = _run(m.resolve(ctx, [{"path": "C:evil.md", "content": "x"}]))
+    assert not resolved.ok
+    assert "workspace-relative" in resolved.failures[0].reason
+
+
+def test_duplicate_declared_paths_abort_the_category():
+    """The schema refuses a duplicate resource path at PUT; the belt must
+    re-ask it, or two entries at one path produce two intents with one
+    identity, two report rows, and a last-write-wins order no rule defines."""
+    svc = FakeResourceFileService()
+    m = ResourcesMaterialiser(svc, _StubEntryFetcher())
+    ctx = make_context(engine_type="claude_code")
+    resolved = _run(
+        m.resolve(
+            ctx,
+            [
+                {"path": "data/a.md", "content": "first"},
+                {"path": "data/a.md", "source": "https://x/a"},
+            ],
+        )
+    )
+    assert not resolved.ok
+    # The mcp/siblings' "seen" refusal convention: the duplicate is blamed
+    # and the category aborts (§3.2) — the intents resolved before the
+    # refusal are never consumed, the orchestrator aborts on ``not ok``
+    # without looking at them. Nothing writable survives the apply.
+    assert any("more than once" in f.reason for f in resolved.failures)
+
+
+def test_an_unknown_unpack_kind_is_refused():
+    svc = FakeResourceFileService()
+    m = ResourcesMaterialiser(svc, _StubEntryFetcher(_tgz({"a.md": b"x"})))
+    ctx = make_context(engine_type="claude_code")
+    resolved = _run(
+        m.resolve(
+            ctx,
+            [
+                {
+                    "path": "wrap/",
+                    "unpack": "tgz",
+                    "source": "https://x/t.tgz",
+                }
+            ],
+        )
+    )
+    assert not resolved.ok
+    assert "zip|tar.gz" in resolved.failures[0].reason

--- a/src/backend/tests/community/core/bot_config_manifest/test_manifest_schema.py
+++ b/src/backend/tests/community/core/bot_config_manifest/test_manifest_schema.py
@@ -838,3 +838,37 @@ manifest:
       source: "{boundary}"
 """
     )
+
+
+def test_relative_path_refusal_is_the_one_rule_both_sides_ask():
+    """The PUT-time predicate, pure, exposed for the apply-time belt.
+
+    The resources materialiser re-asks this rule at apply time (a stored
+    document can predate the validator); sharing one function is what
+    keeps the belt from being a weaker copy of the schema's rule.
+    """
+    from agentclaw.community.core.bot_config_manifest.schema._support import (
+        relative_path_refusal,
+    )
+
+    refused = [
+        ("/etc/passwd", "absolute_path"),
+        ("~/.ssh/id", "absolute_path"),
+        ("C:evil.md", "absolute_path"),
+        ("../../etc/passwd", "path_traversal"),
+        ("data/../../etc", "path_traversal"),
+        ("a\\b.md", "invalid_path"),
+        ("a b.md", "invalid_path"),
+        ("", "invalid_path"),
+    ]
+    for value, code in refused:
+        refusal = relative_path_refusal(value)
+        assert refusal is not None, value
+        assert refusal[0] == code, (value, refusal)
+        assert refusal[1]
+    # A non-string is the belt's own business (declared by the index) — the
+    # predicate refuses it as invalid rather than assuming str.
+    assert relative_path_refusal(123)[0] == "invalid_path"
+    # The legitimate shapes, including the per-segment '..' reading.
+    for value in ("data/..config", "data/a.md", "top/sub/b.txt", "${BASE}/k.md"):
+        assert relative_path_refusal(value) is None, value

--- a/src/backend/tests/community/core/resources/test_file_service.py
+++ b/src/backend/tests/community/core/resources/test_file_service.py
@@ -88,3 +88,43 @@ class TestGetFilePathDeviceFs:
 
         result = await service.get_file_path("nope.txt")
         assert result is None
+
+
+class TestAdmissionRefusal:
+    """The one predicate both the write chain and the apply-time gate ask.
+
+    Lives beside the constants it reads so the two call surfaces
+    (``ResourceFileService.upload_file`` raises it; the manifest
+    materialiser's resolve gate returns it) cannot drift from each other —
+    each reading its own copy would be the drift, silently re-creating the
+    half-written-tree bug the gate exists to prevent.
+    """
+
+    def test_an_allowed_extension_passes(self):
+        from agentclaw.community.core.resources.services import file_service
+
+        assert file_service.admission_refusal("a.md", b"body") is None
+
+    def test_a_refused_extension_names_the_rule(self):
+        from agentclaw.community.core.resources.services import file_service
+
+        refusal = file_service.admission_refusal("run.sh", b"#!/bin/sh\n")
+        assert refusal is not None and refusal.startswith("File type not allowed.")
+        assert file_service.admission_refusal("LICENSE", b"MIT").startswith(
+            "File type not allowed."
+        )
+
+    def test_an_oversized_body_names_the_rule(self, monkeypatch):
+        from agentclaw.community.core.resources.services import file_service
+
+        monkeypatch.setattr(file_service, "MAX_FILE_SIZE", 16)
+        refusal = file_service.admission_refusal("a.md", b"x" * 17)
+        assert refusal is not None and refusal.startswith("File too large.")
+
+    def test_the_extension_is_judged_on_the_basename(self):
+        from agentclaw.community.core.resources.services import file_service
+
+        # A path-shaped name must not dodge the allow-list via its directory.
+        assert file_service.admission_refusal("run.sh", b"").startswith(
+            "File type not allowed."
+        )

--- a/src/backend/tests/community/core/resources/test_resource_file_service.py
+++ b/src/backend/tests/community/core/resources/test_resource_file_service.py
@@ -412,21 +412,24 @@ async def test_upload_empty_filename_raises():
 @pytest.mark.asyncio
 async def test_upload_too_large_raises(monkeypatch):
     # The real ceiling is 500MB. Materialising ``b"x" * (500MB + 1)`` to trip the
-    # ``len(data) > MAX_FILE_SIZE`` check cost ~11.6s of allocation alone — the
-    # single slowest non-retry test in the suite. Shrink the ceiling instead: the
-    # guard being asserted compares a length against this module global, so a
-    # 16-byte limit exercises exactly the same branch.
-    # ``resource_file_service`` binds the constant into its own namespace with
-    # ``from ... import MAX_FILE_SIZE``, so that is the name the guard reads.
-    from agentclaw.community.core.services import resource_file_service
+    # size check cost ~11.6s of allocation alone — the single slowest
+    # non-retry test in the suite. Shrink the ceiling instead: the predicate
+    # compares a length against this module global, so a 16-byte bound
+    # exercises exactly the same branch.
+    # The admission rule now lives in ``file_service.admission_refusal`` and
+    # reads *its own* module's globals at call time — patching
+    # ``resource_file_service.MAX_FILE_SIZE`` (the old from-import binding)
+    # gated nothing once the service delegated, which is how this test
+    # proved the move: it went red first, then the target moved here.
+    from agentclaw.community.core.resources.services import file_service
 
-    monkeypatch.setattr(resource_file_service, "MAX_FILE_SIZE", 16)
+    monkeypatch.setattr(file_service, "MAX_FILE_SIZE", 16)
 
     svc, _ = _svc(provider="arca", device_fs=MagicMock())
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="File too large"):
         await svc.upload_file(
             **_COORDS, target_dir="", filename="big.csv",
-            data=b"x" * (resource_file_service.MAX_FILE_SIZE + 1),
+            data=b"x" * (file_service.MAX_FILE_SIZE + 1),
         )
 
 

--- a/src/backend/tests/community/endpoints/test_openapi_config_manifest_apply.py
+++ b/src/backend/tests/community/endpoints/test_openapi_config_manifest_apply.py
@@ -573,8 +573,10 @@ def _resources_reached_the_write_chain(_response, world) -> None:
         ("tools/sub", "b.py"): b"y = 2\n",
     }
     # The declared directory tree is replaced in full, delete first — the
-    # ownership rule, including files the new archive no longer ships.
-    assert _seed_bot_with_resource_manifest.deletes == ["tools/"]
+    # ownership rule, including files the new archive no longer ships. The
+    # tree is addressed without the declaring slash: the write chain's
+    # file-vs-tree branching keys on the path's shape.
+    assert _seed_bot_with_resource_manifest.deletes == ["tools"]
 
 
 @endpoint_test(


### PR DESCRIPTION
## Problem

W6（#1821）合入后对其做了一次 8 视角复审 + 双向源码验证，确认 7 个问题——三个是**生产上报表 SUCCEEDED 但行为错误**的静默失败：

- **F1（阻断）** 目录 sentinel 带尾斜杠传入 `delete`，`_is_dir` 对 `"wrap/"` 的 leaf 永远是空串 → 删除被路由进**非递归** `delete_file` 分支；三个引擎传输层都 catch 自身错误 return `False`，write 又只捕异常不查 bool——**整树替换在 teclaw/baas 上从未发生**，手工添加与已退役文件全部幸存。
- **F2（阻断）** 写侧寻址用原始 `active_engine`，而资源路由器在组合 `{bot_dir}/{engine}/workspace` 前走 runtime 路由（claude_code+非normalCC ⇒ aicoding）——文件落进**谁都不读的目录**。
- **F3（高）** 归档成员的 admission 拒绝以成员身份构造 failure，orchestrator 按声明身份匹配不上——**具体拒绝理由（哪个成员/哪条规则）在报表里消失**。
- **F4（高）**声明树用 `Intent.value=None` 当删除标记（None 恰是 dataclass 默认值）且 dry-run/real 报表形状不一致、空归档毁树零审计行。
- **F5/F6/F7（中/低）** admission 规则第三份手抄、path belt 弱于 schema（漏 `~`/盘符/重复 path）、`ManifestResourcePort` 出生即与真实签名漂移。

422 个测试本地全绿、e2e 通过——因为 fake 复刻的是 materialiser 而非 `ResourceFileService`，这正是三个阻断项的遮蔽机制。

## Solution

每项修复一个 commit，行为全部由新测试先钉后改：

- **树替换走 removals 通道**：声明树改显式标记对象（`_DECLARED_TREE`，非 value-None 默认值），plan 归入 `CategoryPlan.removals`（identity/skills 先例）；write 以 rstrip 后的路径删除、`False` 用 `exists` 复核区分"树本来不在"与"删不下去"。dry-run 与 real 同形；空归档有 `removed` 审计行。
- **成员拒绝归声明条目**：failure 身份=声明 path，reason 嵌成员名——报表可见"该改哪行"。
- **runtime 引擎路由**：`_coords` 三元组，`resolve_bot_engine(ctx.bot)`（纯函数）or `ctx.engine_type` or 默认——与路由器同一规则；改 ctx.engine_type 会非中立地联动 script/`${BOT_ENGINE_TYPE}`，故 resources-local。
- **一条 admission 规则**：`file_service.admission_refusal` 谓词，`upload_file` 与 materialiser gate 同源委托（迁移证明：旧 monkeypatch 目标先红后迁）。
- **一条 path 规则**：schema `_support.relative_path_refusal`（(code, reason)，code 语义保留），belt 与 PUT 同宽；补重复 path 拒绝；`VALID_UNPACK` 源头替换字面量。
- **端口回归调用面**：`exists` 补 `entity_type`、`upload_file` 去 `preserve_structure`，inspect.signature 反射测试钉住镜像。

## Validation

- `uv run pytest tests/community/core/bot_config_manifest` — 443 passed（复审后净增 24 个行为钉）
- resources 面套件 727 passed；manifest endpoint runner 90 cases passed
- `bash src/backend/scripts/ci_test.sh --base origin/dev` — **gate passed**：100% case pass rate，88.43% line coverage，**96.77% changed-line coverage**（≥80%）
- 逐 commit 批量终审（10 项设计风险逐一验证，结论 no defects；其 sub-threshold 项已补修：frozenset 对 unhashable `unpack` 的 TypeError 转干净拒绝）
- rebase 于合入后的 dev（W7 已入），`make_context` 与 W7 `source_session` 参数共存

## Follow-up（未修，按明示决策）

plan 阶段 per-member `exists` 探测的效率/锁 TTL 交集（5000 成员树≈5000 次额外往返 + 每树一次失败复核）——PR 原文的 v1 缩窄声明保留在 module docstring，listing 化分类（mcp.py 先例，需绕过 list_dir 的隐藏文件过滤）留待后续 wave。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
