### PR TITLE
test(backend): cut CI suite time by fixing collection and sharing the public router in openapi_v1 tests

### DIFF
--- a/src/backend/tests/community/adapters/http/openapi_v1/bot_public/test_bot_public_router.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/bot_public/test_bot_public_router.py
@@ -11,7 +11,6 @@ from fastapi.testclient import TestClient
 from fastapi_injector import attach_injector
 from injector import Injector, Module
 
-from agentclaw.community.adapters.http.openapi_v1 import build_public_router
 from agentclaw.community.adapters.http.openapi_v1.dependencies import require_principal
 from agentclaw.community.api.bot_discover_service import BotDiscoverServiceProtocol
 from agentclaw.community.api.bot_public_service import BotPublicServiceProtocol
@@ -27,7 +26,7 @@ from agentclaw.community.core.gateway_principal.models import (
     UserPrincipal,
 )
 from agentclaw.community.core.gateway_principal.verifier import VerifiedCaller
-from tests.community.adapters.http.openapi_v1.conftest import mount_public_error_handlers
+from tests.community.adapters.http.openapi_v1.conftest import mount_public_error_handlers, public_router
 
 _SEARCH_PATH = "/openapi/v1/bots/catalog/search"
 _DISCOVER_PATH = "/openapi/v1/bots/catalog/discover"
@@ -110,7 +109,7 @@ def app(services: tuple[_PublicService, _DiscoverService]) -> FastAPI:
             binder.bind(BotDiscoverServiceProtocol, to=discover_service)
 
     app = FastAPI()
-    app.include_router(build_public_router())
+    app.include_router(public_router())
     app.dependency_overrides[require_principal] = lambda: VerifiedCaller(
         principals=(
             UserPrincipal(subject=GatewayUser(id="caller-1", username="caller-1")),

--- a/src/backend/tests/community/adapters/http/openapi_v1/conftest.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/conftest.py
@@ -1,11 +1,14 @@
 """Shared assembled-application fixtures for OpenAPI v1 adapter tests."""
 
+import copy
+import functools
 from urllib.parse import parse_qsl, urlsplit, urlunsplit
 
-from fastapi import FastAPI
+from fastapi import APIRouter, FastAPI
 from fastapi.exceptions import RequestValidationError
 from fastapi.testclient import TestClient
 
+from agentclaw.community.adapters.http.openapi_v1 import build_public_router
 from agentclaw.community.adapters.http.openapi_v1.errors import (
     BotAccessRefusedError,
     BotEditLockError,
@@ -16,6 +19,52 @@ from agentclaw.community.adapters.http.openapi_v1.errors import (
 from agentclaw.community.adapters.http.openapi_v1.principal import USER_ID_QUERY
 from tests.community.framework.fixtures import app_with_testing_modules  # noqa: F401
 from tests.community.framework.fixtures import world  # noqa: F401
+
+
+# ── The assembled public surface, built once per process ───────────────────
+#
+# ``build_public_router()`` runs ``assert_every_route_authorized`` over the whole
+# surface, which resolves the dependant of every effective route (~300 routes,
+# ~2.5s), and ``app.openapi()`` on the result generates a ~230-path document
+# (~3.5s more). Tests that only *mount* the surface, or only *read* its document,
+# do not need a fresh copy of either: the router is assembled from module-level
+# handlers and is never mutated by those tests, and the document is a pure
+# function of the router. Building both per test made this package the single
+# most expensive one in the suite (~1400s of test time under xdist).
+#
+# A test that adds routes to the router under test, or mounts a different
+# surface, must keep calling ``build_public_router()`` itself.
+
+
+@functools.cache
+def _shared_public_router() -> APIRouter:
+    return build_public_router()
+
+
+def public_router() -> APIRouter:
+    """The assembled ``/openapi/v1/bots`` router, shared read-only across tests.
+
+    Mount it into a fresh ``FastAPI()`` per test as before; ``include_router``
+    keeps the router itself untouched, and overrides, middleware and exception
+    handlers live on the app.
+    """
+    return _shared_public_router()
+
+
+@functools.cache
+def _shared_public_document() -> dict:
+    app = FastAPI()
+    app.include_router(public_router())
+    return app.openapi()
+
+
+def public_document() -> dict:
+    """The generated OpenAPI document of :func:`public_router`, a deep copy per call.
+
+    Equivalent to ``FastAPI().include_router(build_public_router())`` followed by
+    ``.openapi()``; the copy lets a test edit what it reads without leaking.
+    """
+    return copy.deepcopy(_shared_public_document())
 
 
 def user_scoped_client(app: FastAPI, user_id: str, **kwargs) -> TestClient:

--- a/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_engine_restart.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_engine_restart.py
@@ -53,13 +53,9 @@ def test_restart_on_a_bot_not_owned_by_caller_does_not_reach_the_device(client, 
 
 def test_restart_does_not_publish_a_made_up_legacy_address():
     """A new bot-first operation has no component-first contract to retire."""
-    from fastapi import FastAPI
+    from tests.community.adapters.http.openapi_v1.conftest import public_document
 
-    from agentclaw.community.adapters.http.openapi_v1 import build_public_router
-
-    app = FastAPI()
-    app.include_router(build_public_router())
-    paths = app.openapi()["paths"]
+    paths = public_document()["paths"]
 
     assert "/openapi/v1/bots/{bot_id}/engine/restart" in paths
     assert "/openapi/v1/bots/engine/{bot_id}/restart" not in paths

--- a/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_routing.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_routing.py
@@ -2,14 +2,13 @@
 
 from __future__ import annotations
 
-from fastapi import FastAPI
 from fastapi.routing import APIRoute
 
 from agentclaw.community.adapters.http.openapi_v1 import (
     _ENGINE_RUNTIME_GROUPS,
     PUBLIC_API_PREFIX,
-    build_public_router,
 )
+from tests.community.adapters.http.openapi_v1.conftest import public_document
 
 #: sessions 10 + session files 6 + engine 4 + models 2 + nodes 1 + approvals 3 + connection 1
 _EXPECTED_ROUTE_COUNT = 27
@@ -52,9 +51,7 @@ def _document() -> dict:
     the thing external callers actually receive, which makes it the better
     subject for a contract assertion.
     """
-    app = FastAPI()
-    app.include_router(build_public_router())
-    return app.openapi()
+    return public_document()
 
 
 def _schema_path(path: str) -> str:

--- a/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_stage_addressing.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_stage_addressing.py
@@ -19,7 +19,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.routing import APIRoute
 
-from agentclaw.community.adapters.http.openapi_v1 import build_public_router
+from tests.community.adapters.http.openapi_v1.conftest import public_document
 from agentclaw.community.adapters.http.openapi_v1.engine_runtime.enums import (
     RuntimeStage,
 )
@@ -344,9 +344,7 @@ def test_a_dead_stage_is_the_fixed_409(client, relay):
 def _schema() -> dict:
     # Cached: four document tests read the same generated description, and
     # assembling the whole public surface per test quadruples the cost.
-    app = FastAPI()
-    app.include_router(build_public_router())
-    return app.openapi()
+    return public_document()
 
 
 def _operations(schema: dict):

--- a/src/backend/tests/community/adapters/http/openapi_v1/resources/test_resources_handlers.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/resources/test_resources_handlers.py
@@ -16,7 +16,7 @@ import httpx
 import pytest
 from fastapi import HTTPException, Request, Response
 
-from agentclaw.community.adapters.http.openapi_v1 import build_public_router
+from tests.community.adapters.http.openapi_v1.conftest import public_router
 from agentclaw.community.adapters.http.openapi_v1.errors import MissingPrincipalError
 from agentclaw.community.adapters.http.openapi_v1.principal import require_user_id
 from agentclaw.community.adapters.http.openapi_v1.contracts import (
@@ -707,7 +707,7 @@ async def test_no_handler_can_fall_back_to_a_bot_derived_owner():
     """
     mounted = [
         route
-        for route in _api_routes(build_public_router())
+        for route in _api_routes(public_router())
         if route.path.startswith("/openapi/v1/bots/{bot_id}/resources")
     ]
     # 7 routes. The count is a tripwire — a resources route added without the

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_admission_inventory.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_admission_inventory.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 
 import pytest
 
-from agentclaw.community.adapters.http.openapi_v1 import build_public_router
+from tests.community.adapters.http.openapi_v1.conftest import public_router
 from agentclaw.community.adapters.http.openapi_v1.deprecated import (
     LEGACY_ROUTES,
     SELF_CHECKED_ROUTES,
@@ -69,7 +69,7 @@ def _effective_routes():
     the test would pass while the wiring was absent. Reading the effective
     contexts is what makes this check about the assembled surface.
     """
-    router = build_public_router()
+    router = public_router()
     found = []
     for route in getattr(router, "routes", []):
         if hasattr(route, "effective_route_contexts"):

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_app_only_refusals.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_app_only_refusals.py
@@ -24,7 +24,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from agentclaw.community.adapters.http.middleware import AvernetTenantMiddleware
-from agentclaw.community.adapters.http.openapi_v1 import build_public_router
+from tests.community.adapters.http.openapi_v1.conftest import public_router
 from agentclaw.community.adapters.http.openapi_v1.admission import (
     ADMISSION,
     AdmissionMode,
@@ -106,7 +106,7 @@ def client():
 
     app = FastAPI()
     app.add_middleware(AvernetTenantMiddleware)
-    app.include_router(build_public_router())
+    app.include_router(public_router())
     app.add_exception_handler(Exception, _unhandled_exception_handler)
     return TestClient(app, raise_server_exceptions=False)
 

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_bots_endpoints.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_bots_endpoints.py
@@ -1807,13 +1807,9 @@ def test_the_write_contract_does_not_promise_starts_that_never_recompose(
     """
     # Asserted on the *published* description, not the docstring: that string is
     # what a caller reads, and it is what promised more than the feature does.
-    from fastapi import FastAPI
+    from tests.community.adapters.http.openapi_v1.conftest import public_document
 
-    from agentclaw.community.adapters.http.openapi_v1 import build_public_router
-
-    app = FastAPI()
-    app.include_router(build_public_router())
-    ops = app.openapi()["paths"]["/openapi/v1/bots/{bot_id}/startup-script"]
+    ops = public_document()["paths"]["/openapi/v1/bots/{bot_id}/startup-script"]
 
     put_doc = ops["put"]["description"]
     assert "composes" in put_doc

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_deprecation_headers.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_deprecation_headers.py
@@ -19,7 +19,7 @@ from email.utils import parsedate_to_datetime
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from agentclaw.community.adapters.http.openapi_v1 import build_public_router
+from tests.community.adapters.http.openapi_v1.conftest import public_document, public_router
 
 from .conftest import mount_public_error_handlers
 from agentclaw.community.adapters.http.openapi_v1.deprecated import LEGACY_ROUTES
@@ -32,9 +32,7 @@ from agentclaw.community.adapters.http.openapi_v1.middleware import (
 
 
 def _document() -> dict:
-    app = FastAPI()
-    app.include_router(build_public_router())
-    return app.openapi()
+    return public_document()
 
 
 #: ``LEGACY_ROUTES`` holds route paths, which keep Starlette's ``:path``
@@ -83,7 +81,7 @@ def test_every_legacy_address_answers_with_both_headers() -> None:
     thing a test of the registration alone would miss.
     """
     app = FastAPI()
-    app.include_router(build_public_router())
+    app.include_router(public_router())
     app.add_middleware(DeprecationHeaderMiddleware)
     mount_public_error_handlers(app)
     client = TestClient(app)
@@ -111,7 +109,7 @@ def test_the_two_headers_use_their_own_spellings() -> None:
     so neither can drift into the other's format.
     """
     app = FastAPI()
-    app.include_router(build_public_router())
+    app.include_router(public_router())
     app.add_middleware(DeprecationHeaderMiddleware)
     mount_public_error_handlers(app)
     method, path = sorted(LEGACY_ROUTES)[0]
@@ -221,7 +219,7 @@ def test_a_browser_can_actually_read_the_headers_cross_origin() -> None:
             return None
 
     app = FastAPI()
-    app.include_router(build_public_router())
+    app.include_router(public_router())
     mount_public_error_handlers(app)
     # The real installer, with the two plugins stubbed: what is under test is
     # the CORS registration it performs, and re-creating that here would be the

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_explicit_user_id.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_explicit_user_id.py
@@ -29,8 +29,8 @@ from fastapi.testclient import TestClient
 
 from agentclaw.community.adapters.http.openapi_v1 import (
     PUBLIC_API_PREFIX,
-    build_public_router,
 )
+from tests.community.adapters.http.openapi_v1.conftest import public_document
 from agentclaw.community.adapters.http.openapi_v1.contracts import (
     ERROR_RESPONSES,
     USER_SCOPED_ERROR_RESPONSES,
@@ -443,9 +443,7 @@ _BOT_ID_PLACEMENT = {"path": 154, "query": 1, "none": 101}
 
 
 def _schema() -> dict:
-    app = FastAPI()
-    app.include_router(build_public_router())
-    return app.openapi()
+    return public_document()
 
 
 def _current_operations(schema: dict):

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_legacy_parity.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_legacy_parity.py
@@ -42,7 +42,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from agentclaw.community.adapters.http.openapi_v1 import build_public_router
+from tests.community.adapters.http.openapi_v1.conftest import public_router
 from agentclaw.community.adapters.http.openapi_v1.deprecated import LEGACY_ROUTES
 
 from .conftest import mount_public_error_handlers
@@ -50,7 +50,7 @@ from .conftest import mount_public_error_handlers
 
 def _client() -> TestClient:
     app = FastAPI()
-    app.include_router(build_public_router())
+    app.include_router(public_router())
     mount_public_error_handlers(app)
     return TestClient(app)
 

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_loadtest_endpoints.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_loadtest_endpoints.py
@@ -29,8 +29,8 @@ from starlette.websockets import WebSocketDisconnect
 
 from agentclaw.community.adapters.http.openapi_v1 import (
     PUBLIC_API_PREFIX,
-    build_public_router,
 )
+from tests.community.adapters.http.openapi_v1.conftest import public_router
 from agentclaw.community.adapters.http.openapi_v1.dependencies import (
     PRINCIPAL_HEADER,
     require_principal,
@@ -64,7 +64,7 @@ def client() -> TestClient:
     ``@envelope_errors`` never sees it.
     """
     app = FastAPI()
-    app.include_router(build_public_router())
+    app.include_router(public_router())
     return TestClient(mount_public_error_handlers(app))
 
 
@@ -213,7 +213,7 @@ def _routes():
             else:
                 walk(route)
 
-    walk(build_public_router())
+    walk(public_router())
     return found
 
 

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_no_duplicate_request_fields.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_no_duplicate_request_fields.py
@@ -29,7 +29,7 @@ from typing import Any
 from fastapi import FastAPI
 from fastapi.dependencies.utils import get_flat_params
 
-from agentclaw.community.adapters.http.openapi_v1 import build_public_router
+from tests.community.adapters.http.openapi_v1.conftest import public_document, public_router
 
 #: Every place a request field can be declared. ``path`` is read off the address
 #: template rather than the parameter list, so a path parameter counts even for a
@@ -39,12 +39,12 @@ _LOCATIONS = ("path", "query", "header", "cookie", "body")
 
 def _app() -> FastAPI:
     app = FastAPI()
-    app.include_router(build_public_router())
+    app.include_router(public_router())
     return app
 
 
 def _document() -> dict[str, Any]:
-    return _app().openapi()
+    return public_document()
 
 
 def _body_fields(

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_openapi_error_schema.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_openapi_error_schema.py
@@ -13,9 +13,8 @@ as a change to the mapping itself.
 
 from __future__ import annotations
 
-from fastapi import FastAPI
 
-from agentclaw.community.adapters.http.openapi_v1 import build_public_router
+from tests.community.adapters.http.openapi_v1.conftest import public_document
 from agentclaw.community.adapters.http.openapi_v1.contracts import ERROR_RESPONSES
 
 _ERROR_REF = "#/components/schemas/ErrorEnvelope"
@@ -31,9 +30,7 @@ _DOCUMENTED_DATA_BEARING_ERRORS = {
 
 
 def _schema() -> dict:
-    app = FastAPI()
-    app.include_router(build_public_router())
-    return app.openapi()
+    return public_document()
 
 
 def _json_ref(operation: dict, status: str) -> str | None:

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_org_user_identity.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_org_user_identity.py
@@ -22,7 +22,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from agentclaw.community.adapters.http.middleware import AvernetTenantMiddleware
-from agentclaw.community.adapters.http.openapi_v1 import build_public_router
+from tests.community.adapters.http.openapi_v1.conftest import public_router
 from agentclaw.community.adapters.http.openapi_v1.dependencies import PRINCIPAL_HEADER
 from agentclaw.community.plugin_api.secret_resolver import SecretResolver
 from agentclaw.community.utils.avernet_tenant import DEFAULT_AVERNET_TENANT
@@ -106,7 +106,7 @@ def client():
 
     app = FastAPI()
     app.add_middleware(AvernetTenantMiddleware)
-    app.include_router(build_public_router())
+    app.include_router(public_router())
     app.add_exception_handler(Exception, _unhandled_exception_handler)
     return TestClient(app, raise_server_exceptions=False)
 

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_path_convention.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_path_convention.py
@@ -20,12 +20,11 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-from fastapi import FastAPI
 
 from agentclaw.community.adapters.http.openapi_v1 import (
     PUBLIC_API_PREFIX,
-    build_public_router,
 )
+from tests.community.adapters.http.openapi_v1.conftest import public_document
 
 _BASE = f"{PUBLIC_API_PREFIX}/bots"
 
@@ -44,9 +43,7 @@ _UNROUTED_ANCHOR = "<!-- reserved-component-names-unrouted -->"
 
 
 def _document() -> dict:
-    app = FastAPI()
-    app.include_router(build_public_router())
-    return app.openapi()
+    return public_document()
 
 
 def _paths() -> list[str]:

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_principal_seam.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_principal_seam.py
@@ -26,7 +26,7 @@ from fastapi import Depends, FastAPI, Request
 from fastapi.testclient import TestClient
 
 from agentclaw.community.adapters.http.middleware import AvernetTenantMiddleware
-from agentclaw.community.adapters.http.openapi_v1 import build_public_router
+from tests.community.adapters.http.openapi_v1.conftest import public_router
 from agentclaw.community.adapters.http.openapi_v1.dependencies import (
     PRINCIPAL_HEADER,
     Principal,
@@ -367,7 +367,7 @@ def test_public_routes_require_principal():
     internal tenant's data for an unauthenticated caller, so this is checked
     rather than remembered.
     """
-    api_routes = _api_routes(build_public_router())
+    api_routes = _api_routes(public_router())
     assert api_routes, "no public routes found — the guard would pass vacuously"
 
     missing = [
@@ -382,7 +382,7 @@ def test_public_routes_require_principal():
 def test_bot_logs_routes_require_user_and_app_principal():
     bot_logs_routes = [
         route
-        for route in _api_routes(build_public_router())
+        for route in _api_routes(public_router())
         if route.path.startswith("/openapi/v1/bots/logs")
     ]
     assert bot_logs_routes, "no Bot Logs routes found"
@@ -410,7 +410,7 @@ def test_granting_a_bot_authorization_requires_user_and_app_principal():
     """
     routes = [
         route
-        for route in _api_routes(build_public_router())
+        for route in _api_routes(public_router())
         if route.path == _AUTHORIZED_APPS_PREFIX and "POST" in route.methods
     ]
     assert routes, "no grant route found"
@@ -433,7 +433,7 @@ def test_application_view_requires_user_and_app_principal():
     """
     routes = [
         route
-        for route in _api_routes(build_public_router())
+        for route in _api_routes(public_router())
         if route.path == _AUTHORIZED_BOTS_PATH
     ]
     assert routes, "no application-view route found"
@@ -456,7 +456,7 @@ def test_listing_and_withdrawing_authorizations_need_only_the_owner():
     """
     owner_only = [
         route
-        for route in _api_routes(build_public_router())
+        for route in _api_routes(public_router())
         if route.path.startswith(_AUTHORIZED_APPS_PREFIX)
         and ("GET" in route.methods or "DELETE" in route.methods)
     ]

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_schema_docs.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_schema_docs.py
@@ -16,17 +16,14 @@ published.
 
 from __future__ import annotations
 
-from fastapi import FastAPI
 
-from agentclaw.community.adapters.http.openapi_v1 import build_public_router
+from tests.community.adapters.http.openapi_v1.conftest import public_document
 
 _METHODS = {"get", "put", "post", "delete", "patch", "options", "head", "trace"}
 
 
 def _document() -> dict:
-    app = FastAPI()
-    app.include_router(build_public_router())
-    return app.openapi()
+    return public_document()
 
 
 def _operations(document: dict):

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_self_checked_routes_refuse.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_self_checked_routes_refuse.py
@@ -42,7 +42,7 @@ from fastapi import FastAPI
 from fastapi_injector import attach_injector
 from injector import Injector, Module
 
-from agentclaw.community.adapters.http.openapi_v1 import build_public_router
+from tests.community.adapters.http.openapi_v1.conftest import public_router
 from agentclaw.community.adapters.http.openapi_v1.admission import (
     HARNESS_SCOPED_OPERATIONS,
     SKILL_SCOPED_OPERATIONS,
@@ -243,7 +243,7 @@ def _make_client(services, grant_service):
                 binder.bind(protocol, to=services)
 
     app = FastAPI()
-    app.include_router(build_public_router())
+    app.include_router(public_router())
     app.dependency_overrides[require_principal] = _app_caller
     attach_injector(app, Injector([_M()]))
     mount_public_error_handlers(app)

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_skills_shared_bot_grant.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_skills_shared_bot_grant.py
@@ -26,7 +26,7 @@ from fastapi import FastAPI
 from fastapi_injector import attach_injector
 from injector import Injector, Module
 
-from agentclaw.community.adapters.http.openapi_v1 import build_public_router
+from tests.community.adapters.http.openapi_v1.conftest import public_router
 from agentclaw.community.adapters.http.openapi_v1.dependencies import require_principal
 from agentclaw.community.api.bot_app_grant_service import BotAppGrantServiceProtocol
 from agentclaw.community.api.local_skill_delete_service import (
@@ -203,7 +203,7 @@ def client():
     # The assembled router, not a hand-mounted subset: what is under test is
     # partly *how* the group is mounted, so a fixture that mounted it its own
     # way could not see the defect this file was written for.
-    app.include_router(build_public_router())
+    app.include_router(public_router())
     app.dependency_overrides[require_principal] = _app_caller
     attach_injector(app, Injector([_M()]))
     mount_public_error_handlers(app)

--- a/src/backend/tests/community/framework/registry.py
+++ b/src/backend/tests/community/framework/registry.py
@@ -14,7 +14,7 @@ decorator kwargs to declare the case.
 """
 from __future__ import annotations
 
-import inspect
+import sys
 from typing import Callable, Mapping, Tuple
 
 from tests.community.framework.case import (
@@ -42,10 +42,17 @@ def _caller_location(depth: int = 2) -> str:
 
     Used purely for diagnostics — pinpointing duplicate registrations.
     Best-effort: falls back to ``"<unknown>"`` if introspection fails.
+
+    Reads the frame directly instead of ``inspect.stack()``: the latter
+    materialises a ``FrameInfo`` (with source-line lookup) for **every** frame
+    on the stack, and scans ``sys.modules`` per frame to resolve each file.
+    During collection the stack is deep and thousands of modules are loaded,
+    so that cost ~0.1–0.25s per call — ~1300 registrations made the endpoint
+    conftest take minutes to import in every xdist worker.
     """
     try:
-        frame = inspect.stack()[depth]
-        return f"{frame.filename}:{frame.lineno}"
+        frame = sys._getframe(depth)
+        return f"{frame.f_code.co_filename}:{frame.f_lineno}"
     except Exception:  # pragma: no cover — diagnostic-only
         return "<unknown>"
 


### PR DESCRIPTION
## Problem

The backend unit-test job takes ~13 min on GitHub (the pytest step alone was 13m20s on the latest `dev` run), even though it already runs under xdist with 4 workers. Profiling the suite locally under the same flags (`-n 4 --dist loadfile`, sysmon coverage) showed two fixed costs dominating, neither of which is "the tests being slow":

1. **Collection took ~108s per worker.** `tests/community/framework/registry.py::_caller_location` called `inspect.stack()` for every `@endpoint_test` registration. `inspect.stack()` materialises a `FrameInfo` with source lookup for *every* frame on the stack and scans `sys.modules` for each; during conftest load the stack is deep and thousands of modules are loaded, so each call cost 0.1–0.25s, times ~1300 registrations, in every worker before a single test ran. cProfile: 321s of a 335s (CPU-contended) collection was in that one helper.
2. **`tests/community/adapters/http/openapi_v1` accounted for ~1440s of the ~2300s total test time.** `build_public_router()` runs `assert_every_route_authorized` over the whole surface (resolves the dependant of every effective route, ~2.5s), and `app.openapi()` on the result generates a ~230-path document (~3.5s). Most tests in that package rebuilt both per test — `test_legacy_parity` did it in each of 45 parametrized cases.

## Solution

- `registry.py`: read the caller frame with `sys._getframe(depth)` instead of `inspect.stack()`. Same `file:line` diagnostic string, O(1).
- `openapi_v1/conftest.py`: add `public_router()` (the assembled router, built once per process, mounted read-only into each test's own `FastAPI()`) and `public_document()` (the generated document, built once, deep-copied per call). Switched every call site that only mounts the surface or only reads its document. `test_authorization_inventory` extends the router under test, so it keeps calling `build_public_router()` itself.

No production code is touched. A test's `dependency_overrides`, middleware and exception handlers all live on the per-test app, so sharing the router changes nothing a test can observe.

## Validation

Local, Python 3.12, 4 cores, same flags as `scripts/ci_test.sh` (`-n 4 --dist loadfile`, `COVERAGE_CORE=sysmon`, `--cov`):

| Measurement | Before | After |
| --- | --- | --- |
| Collection (`--collect-only`, one process, uncontended) | 107.6s | 6.2s |
| `tests/community/adapters/http` summed test time | 1442s | 432s |
| Full `tests/community` summed test time | 2302s | 1127s |
| Full `tests/community` pytest wall time | 778s (12m58s) | 343s (5m43s) |

Both full runs: 16755 collected, 16691 passed, 62 skipped, and the same 2 failures in `test_bot_build_service_skill_artifact.py`, which come from `rsync` not being installed in my sandbox (present before the change, and CI runners have rsync).

Also ran `tests/community/architecture` and `tests/community/framework` (383 passed), which include the registry's own duplicate-registration tests.

On GitHub, the "Run unit tests with coverage" step of the Backend unit tests job went from 13m20s (baseline run 33638382405 on `dev`) to 9m16s (run 33643686523 on this branch), all green.

## Compatibility and risk (optional)

Test-only. Rollback is a revert. If a future openapi_v1 test needs to mutate the router, it should call `build_public_router()` directly rather than `public_router()`; the conftest docstring says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Qbn1XrftTJuCJn7uQJ2sM