### PR TITLE
ci(singlebox-coverage): skip the unused debug BCS build in the coverage run

### DIFF
--- a/scripts/ci/singlebox_coverage.sh
+++ b/scripts/ci/singlebox_coverage.sh
@@ -208,7 +208,13 @@ run_real_singlebox() {
   }
   trap cleanup_real_singlebox EXIT
   bcs_e2e_mock_start "$coverage_root/mock-services"
-  env OCB_SKIP_GIT_HOOKS=1 SINGLEBOX_MODEL_CONFIG_MODE="$model_config_mode" \
+  # BCS_SKIP_DEBUG_BUILD=1: `setup all` would otherwise compile the
+  # non-instrumented bcs/bcs-cli/bcs-admin into src/bcs/target/debug, a full
+  # cargo build (~2 minutes in CI) that nothing in this run uses. The
+  # `--with-bcs-coverage start all` below builds the instrumented binaries
+  # under src/bcs/target/cov-e2e and exports BCS_BIN/BCS_CLI_BIN; the BCS e2e
+  # reads the same instrumented bcs-cli.
+  env OCB_SKIP_GIT_HOOKS=1 BCS_SKIP_DEBUG_BUILD=1 SINGLEBOX_MODEL_CONFIG_MODE="$model_config_mode" \
     STANDALONE_OPENCLAW_ROOT="$coverage_standalone_root" \
     STANDALONE_RUNTIME_DIR="$coverage_standalone_runtime" \
     bash "$repo_root/scripts/singlebox.sh" --standalone setup all

--- a/scripts/modules/bcs.sh
+++ b/scripts/modules/bcs.sh
@@ -929,7 +929,14 @@ bcs_setup() {
 
     build_bcs_panel_asset || return 1
 
-    if bcs_binaries_stale; then
+    # The coverage stack (--with-bcs-coverage) builds and runs its own
+    # LLVM-instrumented bcs/bcs-cli under target/cov-e2e and exports
+    # BCS_BIN/BCS_CLI_BIN, so the target/debug binaries built here would go
+    # unused. Callers that only start that stack set BCS_SKIP_DEBUG_BUILD=1
+    # to save a full cargo build (~2 minutes in CI).
+    if [ "${BCS_SKIP_DEBUG_BUILD:-0}" = "1" ]; then
+        log_info "Skipping BCS debug build (BCS_SKIP_DEBUG_BUILD=1)"
+    elif bcs_binaries_stale; then
         log_info "BCS build needed: ${BCS_BUILD_REASON}"
         build_bcs || return 1
         build_bcs_panel_asset || return 1

--- a/scripts/test_singlebox_bcs_prereqs.sh
+++ b/scripts/test_singlebox_bcs_prereqs.sh
@@ -68,7 +68,28 @@ test_cargo_hint_when_cargo_is_not_installed() {
   grep -F "rustup.rs" <<<"$message" >/dev/null || fail "rustup hint missing"
 }
 
+test_setup_skips_debug_build_when_requested() {
+  setup_env
+
+  # shellcheck source=/dev/null
+  source "$MODULE"
+
+  check_directory_exists() { return 0; }
+  build_bcs_panel_asset() { return 0; }
+  bcs_binaries_stale() { BCS_BUILD_REASON="stale for test"; return 0; }
+  build_bcs() { printf 'BUILD_BCS_CALLED\n'; return 0; }
+
+  output="$(BCS_SKIP_DEBUG_BUILD=1 bcs_setup)"
+  grep -F "BUILD_BCS_CALLED" <<<"$output" >/dev/null && fail "BCS_SKIP_DEBUG_BUILD=1 should not run the debug cargo build"
+  grep -F "Skipping BCS debug build" <<<"$output" >/dev/null || fail "skip message missing"
+  grep -F "BCS setup complete" <<<"$output" >/dev/null || fail "setup should still complete when the build is skipped"
+
+  output="$(BCS_SKIP_DEBUG_BUILD=0 bcs_setup)"
+  grep -F "BUILD_BCS_CALLED" <<<"$output" >/dev/null || fail "stale binaries should still trigger the debug cargo build by default"
+}
+
 test_cargo_hint_when_rustup_cargo_exists_outside_path
 test_cargo_hint_when_cargo_is_not_installed
+test_setup_skips_debug_build_when_requested
 
 printf 'PASS: singlebox BCS prereq tests\n'

--- a/scripts/test_singlebox_coverage_gate.sh
+++ b/scripts/test_singlebox_coverage_gate.sh
@@ -97,6 +97,10 @@ case "${STANDALONE_RUNTIME_DIR:-}" in
   *) echo "singlebox coverage should use an isolated standalone runtime dir" >&2; exit 14 ;;
 esac
 printf '%s\n' "$*" >> "${SINGLEBOX_STUB_LOG:?}"
+if [ "$*" = "--standalone setup all" ] && [ "${BCS_SKIP_DEBUG_BUILD:-}" != "1" ]; then
+  echo "singlebox coverage setup should skip the unused non-instrumented BCS build" >&2
+  exit 17
+fi
 if [ "$*" = "--standalone --with-bcs-coverage start all" ]; then
   mkdir -p "${SINGLEBOX_COVERAGE_DIR:?}/backend" "${SINGLEBOX_COVERAGE_DIR:?}/baas"
   printf '%s\n' '{}' > "${SINGLEBOX_COVERAGE_DIR}/backend/.coverage.fake"


### PR DESCRIPTION
## Problem

"Singlebox Coverage" is the slowest PR check (15 to 18 minutes on the last 20 PR runs). Timing the job log of run 33643686453 (job 100292863449, 17m15s) shows the coverage script compiles BCS **twice**:

| Phase inside `Run singlebox coverage` (14m46s) | Time |
| --- | --- |
| `setup all` → `cargo build -p bcs -p bcs-cli -p bcs-admin` into `src/bcs/target/debug` | **2m19s** |
| `--with-bcs-coverage start all` → instrumented `cargo build --workspace` into `target/cov-e2e/llvm-cov-target` | 2m01s |
| service startup | 2m19s |
| backend acceptance pytest | 2m37s |
| BCS e2e + aggregate | 1m54s |
| Python coverage reports | 1m23s |

Nothing in the coverage run uses the `target/debug` binaries: `start_bcs_binary` launches `BCS_BIN`, the bots prereqs and the BCS e2e resolve `BCS_CLI_BIN`, both exported by `prepare_bcs_coverage_bin`, and `bcs-admin` is never invoked. The first build is pure waste.

## Solution

- `bcs_setup` honours a new `BCS_SKIP_DEBUG_BUILD=1` and logs that it skipped the debug build; the default stale-rebuild path is unchanged for every other caller.
- `scripts/ci/singlebox_coverage.sh` sets it on its `setup all` call, with a comment explaining why. The instrumented build keeps `BCS_COVERAGE_FORCE_REBUILD=1`, so coverage still reflects the pushed source.

Rejected alternative: listing services explicitly instead of `setup all` in the coverage script. That drifts from `SETUP_ORDER` in `all.sh` and changes the "one standalone stack" entrypoint pre-push and CI share; an explicit flag on the one wasted step is smaller.

## Validation

- `bash scripts/test_singlebox_bcs_prereqs.sh` → PASS. New case asserts `BCS_SKIP_DEBUG_BUILD=1` skips `build_bcs` and that stale binaries still rebuild by default.
- `bash scripts/test_singlebox_coverage_gate.sh` → PASS. The `singlebox.sh` stub now fails `setup all` if the flag is missing.
- `bash -n` on the changed scripts.

**Before/after, GitHub step timings.** Baseline is job 100292863449 (dev, run 33643686453); after is this PR's own run [33648763063](https://github.com/inclusionAI/Avernet/actions/runs/33648763063), job 100310068634, green, all gates unchanged (BCS line 41.6%, endpoints 150/150, CLI 52/52).

| | Baseline | This PR | Delta |
| --- | --- | --- | --- |
| Job total | 17m15s | 14m50s | **−2m25s** |
| `Run singlebox coverage` step | 14m46s | 12m50s | **−1m56s** |
| `setup all` debug cargo build | 2m19s | skipped (0s) | −2m19s |
| instrumented `cargo build --workspace` | 2m01s | 2m36s | +35s |
| service startup, acceptance, e2e, reports | unchanged within noise | | |

Compile lines in the log: 957 → 504 (one workspace build instead of two). The instrumented build is ~35s slower because it now also performs the crates.io download that the debug build used to absorb; a `~/.cargo/registry` cache keyed on `src/bcs/Cargo.lock` (as in `e2e-tests.yml`) recovers that and is a separate, workflow-only change.

## Compatibility and risk

Gates unchanged: `SINGLEBOX_COVERAGE_BCS_LINE_MIN=40`, `METHOD_MIN=36`, and the `verify_singlebox_coverage_artifacts.py` thresholds are untouched. Rollback is dropping the env var from the coverage script. Local pre-push runs through the same script and simply stops refreshing `target/debug` as a side effect of the coverage gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YPdg69PH5W61u5L5MknbPG