### PR TITLE
ci(singlebox-coverage): render backend and BaaS coverage reports concurrently

### DIFF
--- a/scripts/ci/singlebox_coverage.sh
+++ b/scripts/ci/singlebox_coverage.sh
@@ -232,8 +232,21 @@ run_real_singlebox() {
   flush_coverage_processes
   cleanup_real_singlebox
   trap - EXIT
-  combine_python_coverage "backend" "$repo_root/src/backend" "$coverage_root/raw/backend" || backend_coverage_status=$?
-  combine_python_coverage "baas" "$repo_root/src/baas" "$coverage_root/raw/baas" || baas_coverage_status=$?
+  # Backend and BaaS coverage are independent (separate project dirs, data
+  # files, and report paths), so render them concurrently. Each writes to its
+  # own log that is replayed afterwards so the output stays readable.
+  local backend_report_log="$coverage_root/backend-report.log"
+  local baas_report_log="$coverage_root/baas-report.log"
+  local backend_report_pid baas_report_pid
+  combine_python_coverage "backend" "$repo_root/src/backend" "$coverage_root/raw/backend" \
+    > "$backend_report_log" 2>&1 &
+  backend_report_pid=$!
+  combine_python_coverage "baas" "$repo_root/src/baas" "$coverage_root/raw/baas" \
+    > "$baas_report_log" 2>&1 &
+  baas_report_pid=$!
+  wait "$backend_report_pid" || backend_coverage_status=$?
+  wait "$baas_report_pid" || baas_coverage_status=$?
+  cat "$backend_report_log" "$baas_report_log"
   write_summary_artifacts "$acceptance_status" "$bcs_e2e_status" || summary_status=$?
   write_module_artifacts || module_status=$?
   verify_required_artifacts || artifact_status=$?
@@ -350,9 +363,31 @@ combine_python_coverage() {
   (
     cd "$component_dir"
     COVERAGE_FILE="$combined_file" uv run coverage combine "${coverage_files[@]}"
-    COVERAGE_FILE="$combined_file" uv run coverage json -i -o "$json_report"
-    COVERAGE_FILE="$combined_file" uv run coverage html -i -d "$html_dir"
-    COVERAGE_FILE="$combined_file" uv run coverage report -i > "$text_report"
+    # The JSON, HTML, and text reports only read the combined data file, so
+    # render them concurrently; the HTML report alone takes ~30s for backend.
+    local json_pid html_pid text_pid
+    local json_status=0 html_status=0 text_status=0
+    COVERAGE_FILE="$combined_file" uv run coverage json -i -o "$json_report" &
+    json_pid=$!
+    COVERAGE_FILE="$combined_file" uv run coverage html -i -d "$html_dir" &
+    html_pid=$!
+    COVERAGE_FILE="$combined_file" uv run coverage report -i > "$text_report" &
+    text_pid=$!
+    wait "$json_pid" || json_status=$?
+    wait "$html_pid" || html_status=$?
+    wait "$text_pid" || text_status=$?
+    if [ "$json_status" -ne 0 ]; then
+      echo "${component} coverage json report failed with exit code $json_status" >&2
+      exit "$json_status"
+    fi
+    if [ "$html_status" -ne 0 ]; then
+      echo "${component} coverage html report failed with exit code $html_status" >&2
+      exit "$html_status"
+    fi
+    if [ "$text_status" -ne 0 ]; then
+      echo "${component} coverage text report failed with exit code $text_status" >&2
+      exit "$text_status"
+    fi
   )
 }
 


### PR DESCRIPTION
## Problem

"Singlebox Coverage" is the slowest PR check (15 to 18 minutes). In the job log of run 33643686453 (job 100292863449), after the stack is stopped the script spends **1m23s** writing Python coverage reports strictly sequentially:

| Step | Time |
| --- | --- |
| backend `coverage combine` + `coverage json` | 22s |
| backend `coverage html` | 30s |
| backend `coverage report` | ~5s |
| baas `coverage combine` | 11s |
| baas `coverage json` | 6s |
| baas `coverage html` | 9s |

The runner has 4 cores and each `coverage` invocation is single-threaded.

## Solution

In `scripts/ci/singlebox_coverage.sh`:

- Run `combine_python_coverage backend` and `combine_python_coverage baas` concurrently. They use separate project directories, raw data dirs, combined files, and report paths, so they share nothing.
- Inside each component, after `coverage combine`, render the json, html, and text reports concurrently. They only read the combined data file. Each renderer's exit status is checked and reported individually.
- Each component's output goes to its own log under the coverage root and is replayed once both finish, so the job log stays readable.

## Validation

- `bash scripts/test_singlebox_coverage_gate.sh` → PASS (all report artifacts still produced, exit-code propagation cases still pass).
- `bash -n scripts/ci/singlebox_coverage.sh`.

**Before/after, GitHub step timings.** Baseline is job 100292863449 (dev); after is this PR's own run [33648794887](https://github.com/inclusionAI/Avernet/actions/runs/33648794887), job 100310184270, green, all gates unchanged.

| | Baseline | This PR | Delta |
| --- | --- | --- | --- |
| Report phase (BAAS stop → `gate passed`) | 1m23s | 54s | **−29s** |
| `Run singlebox coverage` step | 14m46s | 14m41s | −5s |
| Job total | 17m15s | 16m40s | −35s |

The step-level delta is smaller than the phase delta because this run's runner was slower elsewhere: the two cargo builds took 2m57s + ~3m50s versus 2m19s + 2m01s on the baseline runner, which is noise this PR does not touch. The report phase itself, which is the only thing this PR changes, went from 83s to 54s; its critical path is now backend `combine` followed by the ~30s backend HTML render.

## Compatibility and risk

No report content, path, or threshold changes; `verify_singlebox_coverage_artifacts.py` reads the same files. Gates `SINGLEBOX_COVERAGE_BCS_LINE_MIN=40` / `METHOD_MIN=36` untouched. Rollback is restoring the sequential calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YPdg69PH5W61u5L5MknbPG