### PR TITLE
fix(resources): preserve legacy preview query behavior

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/resources/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/resources/router.py
@@ -46,7 +46,7 @@ from urllib.parse import quote
 
 import httpx
 from fastapi import APIRouter, Body, HTTPException, Query, Request, Response
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, JSONResponse
 from starlette.background import BackgroundTask
 
 from agentclaw.community.api.resource_service import ResourceServiceFactoryProtocol
@@ -263,7 +263,7 @@ async def list_resources(
     ] = None,
     bot_repo: BotRepository = Injected(BotRepository),
     file_svc: ResourceFileService = Injected(ResourceFileService),
-) -> Envelope[Page[FileEntry]]:
+) -> Envelope[Page[FileEntry]] | Response:
     """List a directory of the bot's workspace.
 
     Entries come from the **workspace**, never from records. That is what makes
@@ -280,6 +280,20 @@ async def list_resources(
     response, not the work. Requesting a later page costs exactly what the
     first one costs.
     """
+    # A deployed pre-contract client still sends ``action=preview`` to this
+    # list URL. Keep that request shape as an adapter-only compatibility shim:
+    # it is not part of the public schema, and must never reach ``list_dir`` on
+    # a file path. Returning a concrete response deliberately leaves the
+    # documented list response model intact.
+    if request.query_params.get("action") == "preview":
+        preview = envelope(
+            await _preview_resource(
+                file_svc, bot_id=bot_id, owner_id=owner_id, bot_repo=bot_repo, path=path
+            ),
+            request,
+        )
+        return JSONResponse(content=preview.model_dump(mode="json"))
+
     safe = _safe_path(path)
     listed = await _list_dir_or_empty(
         file_svc, bot_id=bot_id, owner_id=owner_id, bot_repo=bot_repo, path=safe
@@ -586,6 +600,31 @@ async def _read_file_or_404(
     return content
 
 
+async def _preview_resource(
+    file_svc: ResourceFileService,
+    *,
+    bot_id: str,
+    owner_id: str,
+    bot_repo: BotRepository,
+    path: str,
+) -> Preview:
+    """Build one text preview for either public preview route."""
+    content = await _read_file_or_404(
+        file_svc, bot_id=bot_id, owner_id=owner_id, bot_repo=bot_repo, path=path
+    )
+    if len(content) > _PREVIEW_MAX_BYTES:
+        raise FileTooLargeError(
+            f"File too large for preview (max {_PREVIEW_MAX_BYTES} bytes)"
+        )
+    return Preview(
+        path=_safe_path(path),
+        content_type="application/octet-stream",
+        # ``replace`` rather than raising: a preview of a mostly-text file
+        # with a stray byte is useful; a 500 is not.
+        content=content.decode("utf-8", errors="replace"),
+    )
+
+
 @router.get(
     "/download",
     responses={
@@ -696,20 +735,13 @@ async def preview_file(
     Capped at 1 MB (legacy parity) — over that is a 413, not a truncated preview,
     so a caller is never handed a prefix it might mistake for the whole file.
     """
-    content = await _read_file_or_404(
-        file_svc, bot_id=bot_id, owner_id=owner_id, bot_repo=bot_repo, path=path
-    )
-    if len(content) > _PREVIEW_MAX_BYTES:
-        raise FileTooLargeError(
-            f"File too large for preview (max {_PREVIEW_MAX_BYTES} bytes)"
-        )
     return envelope(
-        Preview(
-            path=_safe_path(path),
-            content_type="application/octet-stream",
-            # ``replace`` rather than raising: a preview of a mostly-text file
-            # with a stray byte is useful; a 500 is not.
-            content=content.decode("utf-8", errors="replace"),
+        await _preview_resource(
+            file_svc,
+            bot_id=bot_id,
+            owner_id=owner_id,
+            bot_repo=bot_repo,
+            path=path,
         ),
         request,
     )

--- a/src/backend/tests/community/adapters/http/openapi_v1/resources/test_resources_handlers.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/resources/test_resources_handlers.py
@@ -64,7 +64,7 @@ def _request_scope() -> dict:
     }
 
 
-def _request_without_trace() -> Request:
+def _request_without_trace(query_string: bytes = b"") -> Request:
     """A request whose tracer middleware did not run — ``state.trace_id`` unset.
 
     ``responses._trace_id`` reads ``request.state.trace_id`` and falls back to
@@ -73,7 +73,9 @@ def _request_without_trace() -> Request:
     ``fastapi.Request`` (not a ``SimpleNamespace``) so ``@envelope_errors``'
     ``_find_request`` recognises it on the error path.
     """
-    return Request(_request_scope())
+    scope = _request_scope()
+    scope["query_string"] = query_string
+    return Request(scope)
 
 
 def _request_with_trace(trace_id: str) -> Request:
@@ -354,6 +356,33 @@ async def test_list_returns_workspace_entries():
     assert by_name["docs"].type == OpenapiType.FOLDER
     # A folder has no size to report, whatever the listing carried.
     assert by_name["docs"].size is None
+
+
+@pytest.mark.asyncio
+async def test_legacy_list_preview_action_reads_the_file_instead_of_listing_it():
+    """``action=preview`` is a file operation, not a list on a file path."""
+
+    class _PreviewOnlyFileService(_StubReadFileService):
+        async def list_dir(self, **_kw) -> List[dict]:
+            raise AssertionError("preview must not call list_dir")
+
+    file_svc = _PreviewOnlyFileService({"test.txt": b"hello"})
+    response = await list_resources(
+        page=PageParams(),
+        owner_id="u1",
+        bot_id="bot-x",
+        path="test.txt",
+        type=None,
+        bot_repo=_StubBotRepo(),
+        file_svc=file_svc,
+        request=_request_without_trace(b"action=preview"),
+    )
+
+    assert isinstance(response, Response)
+    body = json.loads(response.body)
+    assert body["data"]["path"] == "test.txt"
+    assert body["data"]["content"] == "hello"
+    assert file_svc.read_paths == ["test.txt"]
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/community/core/bot_config_surface/test_no_handler_only_checks.py
+++ b/src/backend/tests/community/core/bot_config_surface/test_no_handler_only_checks.py
@@ -41,6 +41,7 @@ CLASSIFIED: dict[str, dict[str, str]] = {
             "the other providers answer alike. Transport-shaped, not policy"
         ),
         "_read_file_or_404": "adapter: maps device errors onto this surface's 404/413",
+        "_preview_resource": "adapter: serializes shared preview bytes for two HTTP handlers",
     },
     f"{_PREFIX}.skills.router": {
         "_require_addressed_bot": "MOVED — binding to core.require_addressed_bot",

--- a/src/backend/tests/community/endpoints/test_openapi_resources.py
+++ b/src/backend/tests/community/endpoints/test_openapi_resources.py
@@ -296,6 +296,23 @@ for _method, _path, _input, _status, _body in _HAPPY_CASES:
     )(lambda: None)
 
 
+endpoint_test(
+    method="GET",
+    path=_BASE_PATH,
+    scenario="legacy_preview_action",
+    input=CaseInput(
+        path_params=_PATH_PARAMS,
+        query_params=_query(path=_EXISTING_PATH, action="preview"),
+        headers=_HEADERS,
+    ),
+    seed=_seed_happy_services,
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={"data": {"path": _EXISTING_PATH, "content": "hello world"}},
+    ),
+)(lambda: None)
+
+
 # The refusal every user-scoped operation on this surface owes: ``user_id``
 # names someone other than the caller the principal authenticated.
 # ``require_user_id`` raises ahead of the handler, so no workspace is seeded —


### PR DESCRIPTION
## Problem

已部署的旧调用 `GET /openapi/v1/bots/{bot_id}/resources?path=<file>&action=preview` 被误送到目录列举，BaaS 对文件路径返回 400，最终冒泡为 500。

## Solution

在 HTTP adapter 为该既有 query 形态增加兼容分流，复用既有预览读取与错误处理逻辑，确保不会对文件调用 `list_dir`。公开 OpenAPI、Gateway schema 与文档均未修改；默认目录列表行为不变。

## Validation

- 资源 handler、架构分类、现代/旧地址及兼容 query 端点用例：84 passed。
- Ruff：通过。
- 全量 Backend：首次运行 16535 passed、59 skipped；发现的两项本改动引入测试失败已修复并针对性重跑通过。

## Compatibility and risk

不改变公开契约；仅保留已部署调用的服务端兼容行为。回滚仅需移除 adapter 兼容分支。