### PR TITLE
ci(singlebox-coverage): cache dependencies and stop compiling tools in CI

### DIFF
--- a/.github/workflows/singlebox-coverage.yml
+++ b/.github/workflows/singlebox-coverage.yml
@@ -106,6 +106,14 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "22"
+          # Cache ~/.npm keyed on the committed lockfiles. `npm ci` for the
+          # frontend (2153 packages, ~44s) and the BCS panel asset then
+          # resolve tarballs from the cache; the openclaw global install and
+          # the lockfile-less BCN plugin build share the same tarball cache.
+          cache: npm
+          cache-dependency-path: |
+            src/frontend/package-lock.json
+            src/bcs/assets/panel/package-lock.json
 
       - name: Install Rust toolchain
         if: steps.changes.outputs.skip != 'true'
@@ -114,38 +122,76 @@ jobs:
           rustup default stable
           rustup component add llvm-tools
           echo "${HOME}/.cargo/bin" >> "${GITHUB_PATH}"
-          cargo install cargo-llvm-cov --locked
           rustc --version
           cargo --version
-          cargo llvm-cov --version
+
+      - name: Install cargo-llvm-cov
+        if: steps.changes.outputs.skip != 'true'
+        # Prebuilt release binary into ~/.cargo/bin. `cargo install
+        # cargo-llvm-cov --locked` compiled it from source on every run
+        # (~55s of the 61s toolchain step); the download takes seconds.
+        # No version pin, so this tracks the latest release exactly like
+        # `cargo install` did.
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Show cargo-llvm-cov version
+        if: steps.changes.outputs.skip != 'true'
+        run: cargo llvm-cov --version
 
       - name: Install system dependencies
         if: steps.changes.outputs.skip != 'true'
+        # ubuntu-latest already ships gcc/make, curl, git, jq, libsqlite3-dev,
+        # libssl-dev, lsof, pkg-config, and procps; listing them here only
+        # pulled in package upgrades. protobuf-compiler (protoc, needed by
+        # the BCS build) is the one package the image lacks.
         run: |
           sudo apt-get update
-          sudo apt-get install -y \
-            build-essential \
-            curl \
-            git \
-            jq \
-            libsqlite3-dev \
-            libssl-dev \
-            lsof \
-            pkg-config \
-            procps \
-            protobuf-compiler
+          sudo apt-get install -y --no-install-recommends protobuf-compiler
 
-      - name: Install Python tooling
+      - name: Install uv
         if: steps.changes.outputs.skip != 'true'
-        run: |
-          python -m pip install --upgrade pip uv
-          uv --version
+        # Same setup as unit-tests.yml. The cache holds uv's wheel/sdist-build
+        # cache (~/.cache/uv), keyed on the lockfiles of every project the
+        # coverage stack syncs, so `uv sync` links from cache instead of
+        # re-downloading (and rebuilding jieba from sdist) on every run.
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            src/backend/uv.lock
+            src/baas/uv.lock
+            src/bcsfuse/uv.lock
+            src/engine/uv.lock
+
+      - name: Show uv version
+        if: steps.changes.outputs.skip != 'true'
+        run: uv --version
 
       - name: Install OpenClaw CLI
         if: steps.changes.outputs.skip != 'true'
         run: |
           npm install -g openclaw@2026.6.1
           openclaw --version || true
+
+      - name: Cache Cargo registry and git
+        if: steps.changes.outputs.skip != 'true'
+        uses: actions/cache@v4
+        with:
+          # Registry/git fetch only. NOT src/bcs/target: the instrumented
+          # build under target/cov-e2e/llvm-cov-target is force-rebuilt every
+          # run (BCS_COVERAGE_FORCE_REBUILD=1) so coverage always reflects
+          # the pushed source; caching those artifacts would risk stale
+          # coverage across commits (same reasoning as e2e-tests.yml).
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-singlebox-${{ hashFiles('src/bcs/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-singlebox-
+            ${{ runner.os }}-cargo-e2e-
+            ${{ runner.os }}-cargo-
 
       - name: Validate shell scripts
         if: steps.changes.outputs.skip != 'true'


### PR DESCRIPTION
## Problem

"Singlebox Coverage" is the slowest PR check (15 to 18 minutes). The workflow had no cache step and compiled or downloaded the same tooling on every run. Timing job 100292863449 (17m15s) attributes the setup cost:

| Item | Cost per run |
| --- | --- |
| `cargo install cargo-llvm-cov --locked` compiled from source | ~55s of the 61s toolchain step |
| uv syncs of backend, engine, BaaS, bcsfuse (incl. building jieba from sdist) | ~42s |
| crates.io download before the instrumented build (on the critical path since #1837 removed the debug build) | ~35s |
| frontend `npm ci` (2153 pkgs) + BCN plugin install (2051 pkgs) + global openclaw install | ~44s + ~23s + ~15s |
| apt upgrading nine packages already on ubuntu-24.04 | part of 27s |

## Solution

One commit touching only `.github/workflows/singlebox-coverage.yml`:

- Install cargo-llvm-cov as a prebuilt release binary via `taiki-e/install-action@v2` (same floating-latest semantics as `cargo install`).
- Install uv via `astral-sh/setup-uv@v5` with its cache enabled, keyed on the four synced lockfiles, as `unit-tests.yml` already does.
- Cache `~/.cargo/registry` and `~/.cargo/git` keyed on `src/bcs/Cargo.lock`. Deliberately not `src/bcs/target`: the instrumented build under `target/cov-e2e` is force-rebuilt every run so coverage reflects the pushed source (same reasoning as `e2e-tests.yml`).
- Enable setup-node's `~/.npm` cache keyed on the frontend and BCS panel lockfiles.
- apt installs only `protobuf-compiler`, the one package the runner image lacks.

## Validation

- YAML parses; each edit was also validated as a standalone patch against dev.
- This PR's own run [33711046797](https://github.com/inclusionAI/Avernet/actions/runs/33711046797) (job 100510386525): green, `Verify singlebox coverage artifacts` passed, BCS debug build skipped, all gates unchanged.

Step timings, baseline = job 100292863449 on dev before #1837/#1838; comparable = #1837's run 33648763063 (same dev minus this change):

| | Baseline | #1837 run | This PR (cache-cold) |
| --- | --- | --- | --- |
| Install Rust toolchain + cargo-llvm-cov | 61s | 68s | **5s** |
| Install system dependencies (apt) | 27s | 13s | 19s (0 upgraded, 3 new) |
| Install uv / Python tooling | 6s | 3s | 2s |
| `Run singlebox coverage` step | 14m46s | 12m50s | **12m08s** |
| Job total | 17m15s | 14m50s | **13m32s** |

This first run missed all three caches (npm, uv, cargo) and saved them at the end, so the npm, uv, and cargo items have not paid off yet: instrumented build 2m40s, frontend `npm ci` 54s, BCN 31s, openclaw 17s, all in line with the cold baseline. The next run on this branch or on dev restores them; expected further saving ~35s (cargo) + ~20-40s (npm) + up to ~30s (uv), bringing the job to roughly 11 to 12 minutes.

## Compatibility and risk

No gate or threshold changes: `SINGLEBOX_COVERAGE_BCS_LINE_MIN=40`, `METHOD_MIN=36`, and the `verify_singlebox_coverage_artifacts.py` arguments are untouched. Two new third-party actions (`taiki-e/install-action`, `astral-sh/setup-uv`); the latter is already used by `unit-tests.yml`. Caches are keyed on lockfiles and never include build artifacts of `src/bcs`. Rollback is reverting the single commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YPdg69PH5W61u5L5MknbPG