### PR TITLE
feat(backend): carry a session working directory from OpenAPI to the engine

### DIFF
--- a/src/backend/docs/openapi-v1/engine-surface.md
+++ b/src/backend/docs/openapi-v1/engine-surface.md
@@ -112,7 +112,7 @@ the `Envelope[T]` / `Page[T]` shapes from `openapi_v1/contracts.py`.
 | Method | Public path | Engine route | Notes |
 |---|---|---|---|
 | GET | `…/{bot_id}/sessions` | `GET /api/sessions` | `agent_id`, `session_key`, paged → `Envelope[SessionPage]` |
-| POST | `…/{bot_id}/sessions` | `POST /api/sessions` | `201 Envelope[Session]` |
+| POST | `…/{bot_id}/sessions` | `POST /api/sessions` | body is `title`/`model`/`cwd` — see below → `201 Envelope[Session]` |
 | GET | `…/{bot_id}/sessions/{session_id}` | `GET /api/sessions/{session_id}` | `Envelope[Session]` |
 | DELETE | `…/{bot_id}/sessions/{session_id}` | `DELETE /api/sessions/{session_id}` | `Envelope[Deleted]` |
 | GET | `…/{bot_id}/sessions/{session_id}/messages` | `GET …/messages` | paged → `Envelope[MessagePage]` |
@@ -155,6 +155,16 @@ Two things about this group are not the shape a reader would assume:
   discards it without saying so, which would make the same request succeed and
   do nothing depending on which engine the bot runs. A caller still sending it
   gets a 422 rather than a silent no-op. _Decided 2026-07-30._
+- **`POST` accepts a `cwd`, and `PATCH` still does not.** The engine's session
+  API takes a working directory on the create request and binds the session to
+  it before any turn runs, so the public create forwards it — omitting the key
+  entirely when the caller left it unset, which is how the engine is asked for
+  its own default. This is not a reversal of the ruling above: what that ruling
+  rejected is a directory that succeeds and does nothing, and on create the
+  created session reports back the `cwd` that took effect (empty from an engine
+  that models no working directory), so the answer says which happened.
+  Rebinding an *established* session's directory is the operation that would
+  still be silently dropped, and it keeps its 422. _Decided 2026-09-03._
 
 ### engine (4) — engine `/api/engine`
 

--- a/src/backend/docs/openapi-v1/engine-surface.md
+++ b/src/backend/docs/openapi-v1/engine-surface.md
@@ -165,6 +165,18 @@ Two things about this group are not the shape a reader would assume:
   that models no working directory), so the answer says which happened.
   Rebinding an *established* session's directory is the operation that would
   still be silently dropped, and it keeps its 422. _Decided 2026-09-03._
+- **The device polices the `cwd`, not the backend.** A session's directory is
+  where an agent runs, and on the `claude_code` engine that agent runs with
+  permissions bypassed — so the value is held to the device's own configured
+  workspace roots (`AICODING_CWD_ALLOW_ROOTS` / `CONTAINER_WORKSPACE_BASE`),
+  canonicalised first so `..` cannot walk out. That check lives on the engine
+  because the roots are the device's configuration, not the backend's; Backend
+  owning a copy would be the engine-filesystem-path coupling `AGENTS.md`
+  forbids. A refused directory currently surfaces as the group's generic `502`
+  rather than a `400`, because the relay maps every engine 4xx that is not 404
+  or 501 to `EngineUpstreamError` — the request is safely refused, but the
+  status under-describes it. Narrowing that mapping is a separate change.
+  _Decided 2026-09-03._
 
 ### engine (4) — engine `/api/engine`
 

--- a/src/backend/docs/openapi-v1/engine-surface.zh-CN.md
+++ b/src/backend/docs/openapi-v1/engine-surface.zh-CN.md
@@ -125,6 +125,14 @@ C1 的权威清单是 `src/frontend/src/requestConfig.ts:189-205` 里的 proxypa
   创建路径上，返回的会话会报出实际生效的 `cwd`（不建模工作目录的引擎报空），
   所以应答说得清到底发生了哪一种。真正会被静默丢弃的是给*已建立*的会话改绑目录，
   那仍然是 422。_2026-09-03 决定。_
+- **`cwd` 由设备侧把关，不由 Backend 把关。** 会话目录就是 agent 的运行目录，而
+  `claude_code` 引擎下的 agent 以 bypassPermissions 运行——因此该值会被约束到设备
+  自己配置的工作区根（`AICODING_CWD_ALLOW_ROOTS` / `CONTAINER_WORKSPACE_BASE`），
+  且先做规范化，`..` 无法越界。这道闸放在 engine 侧：允许根属于设备配置而非
+  Backend 配置，Backend 再存一份就成了 `AGENTS.md` 明令禁止的"把引擎文件系统路径
+  写进 Backend"。目前被拒绝的目录在公共面上表现为该组通用的 `502` 而不是 `400`
+  —— relay 把除 404/501 之外的 engine 4xx 一律映射为 `EngineUpstreamError`；请求
+  被安全拒绝，但状态码描述不足。收窄该映射属于另一个改动。_2026-09-03 决定。_
 
 ### engine（4）—— engine `/api/engine`
 

--- a/src/backend/docs/openapi-v1/engine-surface.zh-CN.md
+++ b/src/backend/docs/openapi-v1/engine-surface.zh-CN.md
@@ -92,7 +92,7 @@ C1 的权威清单是 `src/frontend/src/requestConfig.ts:189-205` 里的 proxypa
 | 方法 | 公共路径 | engine 路由 | 说明 |
 |---|---|---|---|
 | GET | `…/{bot_id}/sessions` | `GET /api/sessions` | `agent_id`、`session_key`、分页 → `Envelope[SessionPage]` |
-| POST | `…/{bot_id}/sessions` | `POST /api/sessions` | `201 Envelope[Session]` |
+| POST | `…/{bot_id}/sessions` | `POST /api/sessions` | 请求体为 `title`/`model`/`cwd`，见下 → `201 Envelope[Session]` |
 | GET | `…/{bot_id}/sessions/{session_id}` | `GET /api/sessions/{session_id}` | `Envelope[Session]` |
 | DELETE | `…/{bot_id}/sessions/{session_id}` | `DELETE /api/sessions/{session_id}` | `Envelope[Deleted]` |
 | GET | `…/{bot_id}/sessions/{session_id}/messages` | `GET …/messages` | 分页 → `Envelope[MessagePage]` |
@@ -118,6 +118,13 @@ C1 的权威清单是 `src/frontend/src/requestConfig.ts:189-205` 里的 proxypa
   中一个会应用它、另一个不声不响地丢弃，那会让同一个请求"成功但什么也没做"，
   取决于该 bot 跑的是哪个引擎。仍然发送它的调用方会拿到 422，而不是一个静默的
   空操作。_2026-07-30 决定。_
+- **`POST` 接受 `cwd`，`PATCH` 仍然不接受。** engine 的 session API 在创建请求上
+  接收工作目录，并在任何一轮对话开始前把会话绑定到它，因此公共创建路由会转发该
+  字段 —— 调用方没填时整个键都不发送，这正是"请引擎用自己的默认值"的表达方式。
+  这不是对上一条裁定的翻案：那条裁定否决的是"成功但什么也没做"的工作目录，而在
+  创建路径上，返回的会话会报出实际生效的 `cwd`（不建模工作目录的引擎报空），
+  所以应答说得清到底发生了哪一种。真正会被静默丢弃的是给*已建立*的会话改绑目录，
+  那仍然是 422。_2026-09-03 决定。_
 
 ### engine（4）—— engine `/api/engine`
 

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/sessions/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/sessions/router.py
@@ -303,6 +303,7 @@ async def create_session(
         body={
             "title": body.title,
             "model": body.model,
+            **({"cwd": body.cwd} if body.cwd is not None else {}),
             # The verified caller (never accepted from the body), so on a
             # shared bot a session records the operator who created it.
             "user_id": user_id,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/sessions/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/sessions/schemas.py
@@ -149,10 +149,13 @@ class SessionCreate(BaseModel):
     # engine's to choose.
     cwd: str | None = Field(
         default=None,
-        description="Optional working directory for the session on the bot's "
-        "device. Left unset, the bot's engine picks its own default. A bot "
-        "whose engine does not model a working directory ignores this and "
-        "reports `cwd` empty on the created session.",
+        description="Optional absolute working directory for the session on the "
+        "bot's device. Left unset, the bot's engine picks its own default. The "
+        "device holds this to its own configured workspace roots and refuses "
+        "anything outside them, so a path the bot is not allowed to run in "
+        "fails the request rather than being silently relocated. A bot whose "
+        "engine does not model a working directory ignores this and reports "
+        "`cwd` empty on the created session.",
     )
 
 

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/sessions/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/sessions/schemas.py
@@ -117,9 +117,7 @@ class SessionCreate(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    # Only fields every engine on this surface actually persists — the same
-    # ruling `cwd` got on SessionUpdate, for the same reason. An agent was
-    # offered here and withdrawn: these local engines build
+    # An agent was offered here and withdrawn: these local engines build
     # `session:{uuid}:user:{user_id}` / related local session keys and do not send
     # the agent through this request body, while `openclaw` also builds
     # `session:{uuid}:user:{user_id}` and never sends the agent at all,
@@ -133,6 +131,29 @@ class SessionCreate(BaseModel):
     model: str | None = Field(
         default=None, description="Optional model for the session."
     )
+    # Published on create — and only on create — because that is the one
+    # operation the engine's session API carries it through: the create request
+    # reaches the engine's own `cwd` field, which seeds the working directory a
+    # session is bound to before any turn runs. The engine that models no
+    # working directory reports it back empty on `Session.cwd`, which is what
+    # the read field already documents, so a caller can tell what took effect
+    # rather than being told a request applied when it did not. `PATCH` still
+    # rejects it: rebinding an established session's directory is not the same
+    # operation, and the field keeps its 422 there.
+    #
+    # The handler omits the key entirely rather than forwarding a null when this
+    # is unset: the engine binds a session to its own default directory on a
+    # create that carries no `cwd`, and an explicit null would have to travel
+    # through a relay body and an engine request model that both read "absent"
+    # as that fallback. Sending only what was asked for keeps the fallback the
+    # engine's to choose.
+    cwd: str | None = Field(
+        default=None,
+        description="Optional working directory for the session on the bot's "
+        "device. Left unset, the bot's engine picks its own default. A bot "
+        "whose engine does not model a working directory ignores this and "
+        "reports `cwd` empty on the created session.",
+    )
 
 
 class SessionUpdate(BaseModel):
@@ -145,7 +166,11 @@ class SessionUpdate(BaseModel):
     # applies it and the other discards it without saying so, which would have
     # made the same request succeed and do nothing depending on which engine the
     # bot runs. `extra="forbid"` means a caller still sending `cwd` gets a 422
-    # rather than a silent no-op.
+    # rather than a silent no-op. `SessionCreate` publishes `cwd` and this does
+    # not: creating is where the engine's session API takes a directory to bind
+    # the session to, and the created session reports back the value that took
+    # effect. Rebinding one afterwards is the operation that silently does
+    # nothing on an engine modelling no working directory, so it stays a 422.
     title: str | None = Field(default=None, description="New session title.")
     model: str | None = Field(default=None, description="New model.")
 

--- a/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_sessions.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_sessions.py
@@ -226,6 +226,41 @@ def test_create_does_not_forward_an_agent_field(client, relay):
     assert "agent_id" not in relay.calls[0]["body"]
 
 
+def test_create_forwards_the_working_directory_to_the_engine(client, relay):
+    """The engine binds a session to its directory on the create request, before
+    any turn runs, so a caller's ``cwd`` has to travel with the create itself —
+    there is no later operation on this surface that could set it."""
+    relay.bots[(BOT, OWNER)] = relay.bots[(BOT, OWNER)].__class__(
+        bot_id=BOT, bot_type="personal", active_engine="claude_code", owner_id=OWNER,
+    )
+    relay.results = [EngineResult(data=ENGINE_SESSION)]
+
+    resp = client.post(_base(), json={"title": "T", "cwd": "/workspace/report"})
+
+    assert resp.status_code == 201, resp.json()
+    assert relay.calls[0]["body"]["cwd"] == "/workspace/report"
+    # What the engine reports back, not what was asked for: an engine that
+    # models no working directory answers with an empty one, and that is how a
+    # caller tells the request applied from a request that was ignored.
+    assert resp.json()["data"]["cwd"] == ENGINE_SESSION["cwd"]
+
+
+def test_create_omits_a_working_directory_the_caller_did_not_send(client, relay):
+    """Absent means "the engine picks its own default". Forwarding an explicit
+    null would make the backend the one choosing that fallback, and an engine
+    distinguishing a blank directory from an absent one would bind the wrong
+    one."""
+    relay.bots[(BOT, OWNER)] = relay.bots[(BOT, OWNER)].__class__(
+        bot_id=BOT, bot_type="personal", active_engine="claude_code", owner_id=OWNER,
+    )
+    relay.results = [EngineResult(data=ENGINE_SESSION)]
+
+    resp = client.post(_base(), json={"title": "T"})
+
+    assert resp.status_code == 201, resp.json()
+    assert "cwd" not in relay.calls[0]["body"]
+
+
 def test_get_session_uses_the_id_verbatim(client, relay):
     """Colons are legal in a path segment; no encoding scheme is applied."""
     relay.results = [EngineResult(data=ENGINE_SESSION)]

--- a/src/engine/src/engine/community/api/session/router.py
+++ b/src/engine/src/engine/community/api/session/router.py
@@ -25,6 +25,7 @@ from engine.community.core.session.models import (
     SessionListRequest,
     SessionUpdateRequest,
 )
+from engine.community.core.aicoding.workspace_service import WorkspaceService
 from engine.community.core.session_favorite import get_session_favorite_repository
 from engine.community.shared.utils import decode_session_key
 
@@ -44,6 +45,30 @@ def _get_session_api(engine: Optional[str] = None):
             f"Unsupported engine type: {engine}. Only '{manager.engine}' is supported."
         )
     return manager.session
+
+
+def _validated_cwd(cwd: Optional[str]) -> Optional[str]:
+    """Canonicalise a caller-supplied ``cwd`` and hold it to the allowed roots.
+
+    ``cwd`` reaches the ``claude_code`` relay as the directory a session is bound
+    to, and that session runs with ``permissionMode: bypassPermissions``. The
+    relay's own ``validateDirPath`` only asks whether the path is absolute and
+    is an existing directory — ``/etc`` satisfies both — so without this gate a
+    caller of the create/update routes could bind the agent anywhere on the
+    device it can read. Every other caller-supplied ``cwd`` on this engine is
+    already held to ``AICODING_CWD_ALLOW_ROOTS`` /
+    ``CONTAINER_WORKSPACE_BASE``; these two routes are brought under the same
+    rule rather than being given a weaker one.
+
+    Prefix-and-format only (:meth:`_validate_cwd_prefix`), not
+    :meth:`validate_cwd`: existence is the relay's to enforce at bind time, and
+    requiring it here would reject a directory the engine process cannot stat
+    but the relay can. ``ValueError`` is the caller's error — the routes turn it
+    into a 400 *before* their ``except Exception`` can bury it as a 500.
+    """
+    if not cwd:
+        return cwd
+    return WorkspaceService._validate_cwd_prefix(cwd)
 
 
 def _fmt_dt(dt) -> str:
@@ -145,13 +170,20 @@ async def list_sessions(
 @router.post("")
 async def create_session(body: CreateSessionBody) -> ApiResponse:
     warning = check_capability(Capability.SESSION_CREATE)
+    # Outside the try: this route's ``except Exception`` maps everything to 500,
+    # which would turn a rejected cwd into a server error instead of a 400.
+    try:
+        cwd = _validated_cwd(body.cwd)
+    except ValueError as e:
+        log.warning("[create_session] cwd 拒绝: %s", e)
+        raise HTTPException(status_code=400, detail=str(e)) from e
     try:
         api = _get_session_api(body.engine)
         log.info(f"[create_session] 收到请求: title={body.title}, user_id={body.user_id}, agent_id={body.agent_id}, model={body.model}, runtime={body.runtime}, cwd={body.cwd}, engine={body.engine}, uuid={body.uuid}")
         session = await api.create(SessionCreateRequest(
             title=body.title, user_id=body.user_id or "default", agent_id=body.agent_id, model=body.model,
             runtime=body.runtime,
-            cwd=body.cwd,
+            cwd=cwd,
             uuid=body.uuid,
             extInfo=body.extInfo,
             payload=body.payload,
@@ -301,9 +333,17 @@ async def update_session(
             parsed_ext_info = json.loads(ext_info)
         except (json.JSONDecodeError, TypeError):
             raise HTTPException(status_code=400, detail="ext_info must be valid JSON")
-    log.info(f"[update_session] 收到请求: session_id={session_id}, title={title}, model={model}, runtime={runtime}, permission_mode={permission_mode}, engine={engine}")
+    log.info(f"[update_session] 收到请求: session_id={session_id}, title={title}, model={model}, runtime={runtime}, cwd={cwd}, permission_mode={permission_mode}, engine={engine}")
     warning = check_capability(Capability.SESSION_UPDATE)
     session_id = decode_session_key(session_id)
+    # Same gate as create, and for the same reason: the public create route
+    # reaches this one for a friend bot, whose requested fields are applied
+    # through /update rather than the create body.
+    try:
+        cwd = _validated_cwd(cwd)
+    except ValueError as e:
+        log.warning("[update_session] cwd 拒绝: %s", e)
+        raise HTTPException(status_code=400, detail=str(e)) from e
 
     try:
         api = _get_session_api(engine)

--- a/src/engine/src/engine/community/api/session/router.py
+++ b/src/engine/src/engine/community/api/session/router.py
@@ -147,10 +147,11 @@ async def create_session(body: CreateSessionBody) -> ApiResponse:
     warning = check_capability(Capability.SESSION_CREATE)
     try:
         api = _get_session_api(body.engine)
-        log.info(f"[create_session] 收到请求: title={body.title}, user_id={body.user_id}, agent_id={body.agent_id}, model={body.model}, runtime={body.runtime}, engine={body.engine}, uuid={body.uuid}")
+        log.info(f"[create_session] 收到请求: title={body.title}, user_id={body.user_id}, agent_id={body.agent_id}, model={body.model}, runtime={body.runtime}, cwd={body.cwd}, engine={body.engine}, uuid={body.uuid}")
         session = await api.create(SessionCreateRequest(
             title=body.title, user_id=body.user_id or "default", agent_id=body.agent_id, model=body.model,
             runtime=body.runtime,
+            cwd=body.cwd,
             uuid=body.uuid,
             extInfo=body.extInfo,
             payload=body.payload,

--- a/src/engine/src/engine/community/api/session/schemas.py
+++ b/src/engine/src/engine/community/api/session/schemas.py
@@ -18,6 +18,9 @@ class CreateSessionBody(BaseModel):
     agent_id: Optional[str] = None
     model: Optional[str] = None
     runtime: Optional[str] = None
+    # 工作目录：省略时由引擎自行决定默认值（claude_code 引擎在 relay 侧回落到
+    # DEFAULT_CWD）。不暴露工作目录概念的引擎会忽略该字段。
+    cwd: Optional[str] = None
     engine: Optional[str] = None
     uuid: Optional[str] = None
     extInfo: Optional[dict[str, Any]] = None

--- a/src/engine/src/engine/community/api/tests/test_session_router.py
+++ b/src/engine/src/engine/community/api/tests/test_session_router.py
@@ -79,6 +79,17 @@ def mock_favorite_repository():
 
 
 @pytest.fixture()
+def allow_root(tmp_path, monkeypatch) -> str:
+    """A real directory admitted by ``AICODING_CWD_ALLOW_ROOTS``.
+
+    The allow roots are read from the environment on every call, so a temp dir
+    keeps these tests off the container's hardcoded default workspace base.
+    """
+    monkeypatch.setenv("AICODING_CWD_ALLOW_ROOTS", str(tmp_path))
+    return str(tmp_path)
+
+
+@pytest.fixture()
 def client(mock_session_api, mock_favorite_repository) -> TestClient:
     app = FastAPI()
     app.include_router(router)
@@ -201,14 +212,47 @@ class TestCreateSession:
         assert resp.status_code == 200
         assert "runtime" not in resp.json()["data"]
 
-    def test_cwd_forwarded_to_create_request(self, client, mock_session_api):
+    def test_cwd_forwarded_to_create_request(self, client, mock_session_api, allow_root):
         resp = client.post("/api/sessions", json={
             "title": "Report",
-            "cwd": "/home/admin/workspace",
+            "cwd": f"{allow_root}/report",
         })
         assert resp.status_code == 200
         req = mock_session_api.create.call_args[0][0]
-        assert req.cwd == "/home/admin/workspace"
+        assert req.cwd == f"{allow_root}/report"
+
+    def test_cwd_outside_the_allowed_roots_is_rejected(self, client, mock_session_api):
+        """``cwd`` binds the claude_code relay's working directory, and that
+        session runs with ``permissionMode: bypassPermissions``. The relay only
+        checks absolute/exists/is-a-directory, so ``/etc`` would sail through —
+        the allowed-roots gate is the only thing standing between a caller of
+        this route and an agent bound outside the workspace."""
+        resp = client.post("/api/sessions", json={"cwd": "/etc"})
+        assert resp.status_code == 400, resp.json()
+        assert "not allowed" in resp.json()["detail"]
+        # Never reached the engine: rejected before any session was created.
+        mock_session_api.create.assert_not_called()
+
+    def test_cwd_traversal_out_of_an_allowed_root_is_rejected(
+        self, client, mock_session_api, allow_root
+    ):
+        """Canonicalised before the prefix test, so ``..`` cannot walk out."""
+        resp = client.post("/api/sessions", json={"cwd": f"{allow_root}/../../etc"})
+        assert resp.status_code == 400, resp.json()
+        mock_session_api.create.assert_not_called()
+
+    def test_relative_cwd_is_rejected(self, client, mock_session_api):
+        resp = client.post("/api/sessions", json={"cwd": "relative/dir"})
+        assert resp.status_code == 400, resp.json()
+        mock_session_api.create.assert_not_called()
+
+    def test_cwd_is_canonicalised_before_forwarding(
+        self, client, mock_session_api, allow_root
+    ):
+        resp = client.post("/api/sessions", json={"cwd": f"{allow_root}/a/./b/"})
+        assert resp.status_code == 200, resp.json()
+        req = mock_session_api.create.call_args[0][0]
+        assert req.cwd == f"{allow_root}/a/b"
 
     def test_cwd_defaults_to_none(self, client, mock_session_api):
         """Absent leaves the working directory to the engine: the claude_code
@@ -218,11 +262,38 @@ class TestCreateSession:
         req = mock_session_api.create.call_args[0][0]
         assert req.cwd is None
 
-    def test_cwd_in_response(self, client, mock_session_api):
-        mock_session_api.create.return_value = _make_session(cwd="/home/admin/workspace")
-        resp = client.post("/api/sessions", json={"cwd": "/home/admin/workspace"})
+    def test_cwd_in_response(self, client, mock_session_api, allow_root):
+        mock_session_api.create.return_value = _make_session(cwd=allow_root)
+        resp = client.post("/api/sessions", json={"cwd": allow_root})
         assert resp.status_code == 200
-        assert resp.json()["data"]["cwd"] == "/home/admin/workspace"
+        assert resp.json()["data"]["cwd"] == allow_root
+
+
+class TestUpdateSessionCwdGate:
+    """``POST /api/sessions/{id}/update`` takes ``cwd`` as a query parameter, and
+    the public create route reaches it for a friend bot (Expert Chat applies the
+    requested fields through /update), so it needs the same gate as create."""
+
+    def test_cwd_outside_the_allowed_roots_is_rejected(self, client, mock_session_api):
+        resp = client.post("/api/sessions/sess-1/update", params={"cwd": "/etc"})
+        assert resp.status_code == 400, resp.json()
+        assert "not allowed" in resp.json()["detail"]
+        mock_session_api.update.assert_not_called()
+
+    def test_allowed_cwd_is_forwarded(self, client, mock_session_api, allow_root):
+        resp = client.post(
+            "/api/sessions/sess-1/update", params={"cwd": f"{allow_root}/report"}
+        )
+        assert resp.status_code == 200, resp.json()
+        req = mock_session_api.update.call_args[0][0]
+        assert req.cwd == f"{allow_root}/report"
+
+    def test_omitted_cwd_stays_none(self, client, mock_session_api):
+        resp = client.post("/api/sessions/sess-1/update", params={"title": "T"})
+        assert resp.status_code == 200, resp.json()
+        req = mock_session_api.update.call_args[0][0]
+        assert req.cwd is None
+
 
 # ── GET /api/sessions/{session_id} ───────────────────────────────────────────
 
@@ -399,17 +470,22 @@ class TestUpdateSession:
         assert req.title is None
         assert req.model is None
 
-    def test_all_query_params_forwarded(self, client, mock_session_api):
+    def test_all_query_params_forwarded(self, client, mock_session_api, allow_root):
+        # ``cwd`` must sit inside the allowed roots: this route now holds a
+        # caller-supplied working directory to ``AICODING_CWD_ALLOW_ROOTS``
+        # before forwarding it (see TestUpdateSessionCwdGate). What this test
+        # asserts — that every query parameter reaches the request — is
+        # unchanged.
         resp = client.post(
             "/api/sessions/sess-1/update"
-            "?title=Chat&model=GLM-5&cwd=/tmp/work"
+            f"?title=Chat&model=GLM-5&cwd={allow_root}/work"
             "&user_id=u-1&agent_id=a-1&permission_mode=ask"
         )
         assert resp.status_code == 200
         req = mock_session_api.update.call_args[0][0]
         assert req.title == "Chat"
         assert req.model == "GLM-5"
-        assert req.cwd == "/tmp/work"
+        assert req.cwd == f"{allow_root}/work"
         assert req.user_id == "u-1"
         assert req.agent_id == "a-1"
         assert req.permission_mode == "ask"

--- a/src/engine/src/engine/community/api/tests/test_session_router.py
+++ b/src/engine/src/engine/community/api/tests/test_session_router.py
@@ -30,6 +30,7 @@ def _make_session(session_id: str = "sess-1", **kwargs):
     s.agent_id = kwargs.get("agent_id", None)
     s.model = kwargs.get("model", "gpt-4")
     s.runtime = kwargs.get("runtime", None)
+    s.cwd = kwargs.get("cwd", None)
     s.permission_mode = kwargs.get("permission_mode", None)
     s.created_at = _NOW
     s.updated_at = _NOW
@@ -199,6 +200,29 @@ class TestCreateSession:
         resp = client.post("/api/sessions", json={})
         assert resp.status_code == 200
         assert "runtime" not in resp.json()["data"]
+
+    def test_cwd_forwarded_to_create_request(self, client, mock_session_api):
+        resp = client.post("/api/sessions", json={
+            "title": "Report",
+            "cwd": "/home/admin/workspace",
+        })
+        assert resp.status_code == 200
+        req = mock_session_api.create.call_args[0][0]
+        assert req.cwd == "/home/admin/workspace"
+
+    def test_cwd_defaults_to_none(self, client, mock_session_api):
+        """Absent leaves the working directory to the engine: the claude_code
+        relay falls back to its own default, and an engine that models no
+        working directory ignores it."""
+        client.post("/api/sessions", json={})
+        req = mock_session_api.create.call_args[0][0]
+        assert req.cwd is None
+
+    def test_cwd_in_response(self, client, mock_session_api):
+        mock_session_api.create.return_value = _make_session(cwd="/home/admin/workspace")
+        resp = client.post("/api/sessions", json={"cwd": "/home/admin/workspace"})
+        assert resp.status_code == 200
+        assert resp.json()["data"]["cwd"] == "/home/admin/workspace"
 
 # ── GET /api/sessions/{session_id} ───────────────────────────────────────────
 


### PR DESCRIPTION
## Problem

The engine's session API takes a working directory on create. `SessionCreateRequest` carries `cwd`, and the `claude_code` adapter forwards it to `sessions.patch`, which binds a session's directory *before any turn runs* — the relay falls back to `DEFAULT_CWD` only when nothing arrives.

Nothing could reach it. Two boundaries dropped the field:

- the engine's own HTTP create body (`CreateSessionBody`) had no `cwd`, so `POST /api/sessions` could not express one even though the request model behind it could. `CreateSessionBody` sets no `model_config`, so pydantic's default `extra='ignore'` meant a `cwd` key was dropped **silently** — success response, no warning, session bound to the default directory anyway;
- the public `POST /openapi/v1/bots/{bot_id}/sessions` body published only `title` and `model`.

So a caller had no way to say where a session should run.

## Solution

Two commits.

### 1. `f9331c0` — carry `cwd` from OpenAPI to the engine

- **Public `SessionCreate`** publishes an optional `cwd`. The handler forwards it to `POST /api/sessions` and **omits the key entirely** when the caller left it unset — the relay body and the engine request model both read *absent* as "the engine picks", so sending nothing keeps that choice the engine's rather than making the backend pick a fallback.
- **Engine `CreateSessionBody`** accepts `cwd` and passes it into `SessionCreateRequest`, joining the chain that already ran from there down through the adapter, the plugin port and `sessions.patch`.

`PATCH` keeps its 422 for `cwd`. The 2026-07-30 ruling that withdrew the field was about a request that succeeds and does nothing depending on the bot's engine — which still describes rebinding an *established* session. On create the response reports the `cwd` that actually took effect (empty from an engine that models no working directory), so the answer distinguishes the two cases.

### 2. `d538a0d` — hold that `cwd` to the device's allowed workspace roots

Codex filed a **P1** on the forwarding line and it was correct. The public create route serves a bot's owner *and its member-level collaborators*; the value travelled verbatim to the relay, whose `validateDirPath` checks only *absolute / exists / is-a-directory* — `/etc` satisfies all three — and `claude_code` sessions are created with `permissionMode: bypassPermissions`. A collaborator could therefore have bound the agent to any directory on the device it can read. Every *other* caller-supplied `cwd` on this engine is already held to `AICODING_CWD_ALLOW_ROOTS` / `CONTAINER_WORKSPACE_BASE`; the session routes were the gap.

Both session routes that accept a `cwd` now canonicalise it and hold it to those roots, rejecting anything outside with a 400.

- **Engine-side, not backend-side:** the allowed roots are the *device's* configuration. A Backend copy would be exactly the engine-filesystem-path coupling `AGENTS.md` forbids. The gate also covers every other caller of `POST /api/sessions`, not just the new public route.
- **`/update` is gated too**, and this is not scope creep: the public create route reaches `/update` for a friend bot, whose requested fields are applied there rather than through the create body, so gating create alone would have left the same hole reachable from the same public entry point.
- The gate runs *before* each route's `try`, because both map `except Exception` to a 500 and would otherwise bury the 400.
- `_validate_cwd_prefix` (format + roots) rather than `validate_cwd`: existence is the relay's to enforce at bind time, and requiring it engine-side would reject a directory the engine process cannot stat but the relay can.

## Validation

- `pytest src` (engine) — **2442 passed, 5 skipped**.
- `pytest tests/community/adapters/http/openapi_v1 tests/community/architecture` (backend) — **1837 passed, 2 skipped**.
- CI green on `d538a0d`: all 8 checks, including Backend unit tests and Singlebox coverage.
- New cases cover: the forward, the omission when unset, and the engine's echo; and for the gate, rejection of `/etc`, of `..` traversal out of an allowed root, and of a relative path, that canonicalisation reaches the request, and the same gate on `/update`.

## Compatibility and risk

Additive and optional at both boundaries — a caller sending neither field behaves exactly as before, and the gateway's backward-compat gate (`check_compatible`) treats a new optional request property as compatible.

`src/gateway/configs/schemas/bots.openapi.json` is regenerated by release CI from `scripts/dump_openapi.py`, so it is deliberately left untouched here.

Two things a reviewer should weigh, both deliberate and documented in `docs/openapi-v1/engine-surface.md` rather than hidden:

1. **A refused `cwd` surfaces on the public route as `502`, not `400`.** The relay maps every engine 4xx that is not 404 or 501 to `EngineUpstreamError`. The request is safely refused, but the status under-describes it. Narrowing that mapping touches shared engine-runtime error handling for every route group, so it wants its own change.
2. **`openapi_v1/engine_runtime/sessions/router.py` now sits at exactly the 1000-line Rule 9 cap.** The gate passes, but the next line added to that file will fail it. Splitting the session-*file* routes out of that router is the obvious follow-up and is deliberately **not** bundled here.

`/update` gaining the roots check is a behaviour change for any existing caller that was passing a `cwd` outside the configured roots — such a call now gets a 400 instead of silently binding there. That is the intent of the fix.

Rollback is the revert of these two commits. No schema, storage, or config migration is involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RdChGiSuYbPztDr1EpteTh