### PR TITLE
fix(skill-center): align Space Skill timestamps with gmt fields

### DIFF
--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill_version.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill_version.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from datetime import datetime
-
 from injector import inject
 from sqlalchemy import and_, func
 
@@ -157,7 +155,6 @@ class SkillVersionRepository(
         name: str,
         metadata_json: str,
         description: str,
-        published_at: datetime,
     ) -> PublishedMaterializedSkillVersion:
         with self._db.orm_session() as session:
             locked = lock_skill_then_exact_version(
@@ -189,11 +186,12 @@ class SkillVersionRepository(
                 )
                 version.metadata_json = metadata_json
                 version.description = description
-                version.published_at = published_at
+                version.published_at = func.now()
                 version.status = "PUBLISHED"
                 skill.description = description
                 skill.status = "PUBLISHED"
                 session.flush()
+                session.refresh(version)
             else:
                 raise RuntimeError("Skill Version is not MATERIALIZING")
             skill_uuid = skill.skill_uuid

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/space_skill.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/space_skill.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
 from injector import inject
 from sqlalchemy import and_, func, or_
 from sqlalchemy.exc import IntegrityError
@@ -466,7 +465,7 @@ class SpaceSkillRepository(SpaceSkillRepositoryProtocol):
                 raise SpaceSkillGrantConflictError("owner cannot be removed as manager")
             if grant is not None and grant.status == "ACTIVE":
                 grant.status = "REVOKED"
-                grant.revoked_at = datetime.now(UTC).replace(tzinfo=None)
+                grant.revoked_at = func.now()
                 grant.revoked_by = actor_id
                 self._invalidate_lease(
                     session,
@@ -555,7 +554,7 @@ class SpaceSkillRepository(SpaceSkillRepositoryProtocol):
             current_owner.revoked_at = (
                 None
                 if retain_previous_owner_as_manager
-                else datetime.now(UTC).replace(tzinfo=None)
+                else func.now()
             )
             current_owner.revoked_by = (
                 None if retain_previous_owner_as_manager else actor_id
@@ -636,7 +635,7 @@ class SpaceSkillRepository(SpaceSkillRepositoryProtocol):
                     skill_id=skill_id,
                     holder_user_id=actor_id,
                     fencing_token=1,
-                    acquired_at=datetime.now(UTC).replace(tzinfo=None),
+                    acquired_at=func.now(),
                     env=env,
                 )
                 session.add(lease)
@@ -645,7 +644,7 @@ class SpaceSkillRepository(SpaceSkillRepositoryProtocol):
             else:
                 lease.holder_user_id = actor_id
                 lease.fencing_token += 1
-                lease.acquired_at = datetime.now(UTC).replace(tzinfo=None)
+                lease.acquired_at = func.now()
             session.flush()
             return self._lease_to_dict(lease)
 
@@ -698,7 +697,7 @@ class SpaceSkillRepository(SpaceSkillRepositoryProtocol):
                     skill_id=skill_id,
                     holder_user_id=actor_id,
                     fencing_token=1,
-                    acquired_at=datetime.now(UTC).replace(tzinfo=None),
+                    acquired_at=func.now(),
                     last_takeover_by=actor_id,
                     env=env,
                 )
@@ -709,7 +708,7 @@ class SpaceSkillRepository(SpaceSkillRepositoryProtocol):
                 # ignores it. Keep the fencing increment in SQL so concurrent local
                 # takeovers cannot both write the same value from a stale ORM object.
                 lease.fencing_token = SkillDraftEditLease.fencing_token + 1
-                lease.acquired_at = datetime.now(UTC).replace(tzinfo=None)
+                lease.acquired_at = func.now()
                 lease.last_takeover_by = actor_id
             session.flush()
             session.refresh(lease)

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/space_skill_offline.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/space_skill_offline.py
@@ -3,10 +3,8 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from datetime import datetime, timezone
-
 from injector import inject
-from sqlalchemy import or_
+from sqlalchemy import func, or_
 
 from agentclaw.community.core.models.skill import (
     BotSkillInstallation,
@@ -92,13 +90,14 @@ class SpaceSkillOfflineRepository(SpaceSkillOfflineRepositoryProtocol):
                 )
 
             guard(inspection)
-            offline_at = datetime.now(timezone.utc).replace(tzinfo=None)
-            skill.offline_at = offline_at
+            skill.offline_at = func.now()
             skill.offline_by = actor_id
             session.flush()
+            session.refresh(skill)
+            assert skill.offline_at is not None
             return OfflineCommit(
                 changed=True,
-                offline_at=offline_at,
+                offline_at=skill.offline_at,
             )
 
     def _inspection(

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/space_skill_publication.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/space_skill_publication.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import datetime
 
 from injector import inject
-from sqlalchemy import and_, or_
+from sqlalchemy import and_, func, or_
 from sqlalchemy.exc import IntegrityError
 
 from agentclaw.community.core.models.skill import (
@@ -449,7 +449,7 @@ class SpaceSkillPublicationRepository(SpaceSkillPublicationRepositoryProtocol):
             return self._work(session, attempt_id=attempt_id, env=env)
 
     def claim_sc_submission(
-        self, *, attempt_id: int, started_at: datetime, env: str
+        self, *, attempt_id: int, env: str
     ) -> PublicationSubmissionClaim:
         with self._db.transactional_orm_session() as session:
             attempt, _skill, _version = self._lock_attempt_aggregate(
@@ -460,28 +460,30 @@ class SpaceSkillPublicationRepository(SpaceSkillPublicationRepositoryProtocol):
             if attempt.status == "PREPARING" and attempt.sc_post_started_at is None:
                 if not work.package_url:
                     raise RuntimeError("Publication package is not prepared")
-                attempt.sc_post_started_at = started_at
+                attempt.sc_post_started_at = func.now()
                 attempt.status = "SC_SUBMITTING"
                 attempt.recovery_state = "AUTO_RETRYING"
                 attempt.recovery_kind = "SC_STATUS_CHECK"
                 may_submit = True
                 session.flush()
+                session.refresh(attempt)
                 work = self._work(session, attempt_id=attempt_id, env=env)
             return PublicationSubmissionClaim(work=work, may_submit=may_submit)
 
     def mark_waiting_sc(
-        self, *, attempt_id: int, accepted_at: datetime, env: str
+        self, *, attempt_id: int, env: str
     ) -> PublicationAttemptRecord:
         with self._db.transactional_orm_session() as session:
             attempt = self._attempt(session, attempt_id=attempt_id, env=env, lock=True)
             if attempt.status in ("SC_SUBMITTING", "RESULT_UNKNOWN"):
                 attempt.status = "WAITING_SC"
-                attempt.sc_accepted_at = attempt.sc_accepted_at or accepted_at
+                attempt.sc_accepted_at = attempt.sc_accepted_at or func.now()
                 attempt.recovery_state = "AUTO_RETRYING"
                 attempt.recovery_kind = "SC_STATUS_CHECK"
                 attempt.error_code = None
                 attempt.error_message = None
                 session.flush()
+                session.refresh(attempt)
             return self._record(attempt)
 
     def mark_result_unknown(
@@ -512,7 +514,6 @@ class SpaceSkillPublicationRepository(SpaceSkillPublicationRepositoryProtocol):
         attempt_id: int,
         error_code: str,
         error_message: str,
-        completed_at: datetime,
         env: str,
     ) -> PublicationAttemptRecord:
         with self._db.transactional_orm_session() as session:
@@ -535,8 +536,9 @@ class SpaceSkillPublicationRepository(SpaceSkillPublicationRepositoryProtocol):
             attempt.error_message = error_message
             attempt.recovery_state = "NOT_AVAILABLE"
             attempt.recovery_kind = None
-            attempt.completed_at = completed_at
+            attempt.completed_at = func.now()
             session.flush()
+            session.refresh(attempt)
             return self._record(attempt)
 
     def begin_materialization(
@@ -608,7 +610,6 @@ class SpaceSkillPublicationRepository(SpaceSkillPublicationRepositoryProtocol):
         *,
         attempt_id: int,
         skill_version_id: int,
-        completed_at: datetime,
         env: str,
     ) -> PublicationAttemptRecord:
         with self._db.transactional_orm_session() as session:
@@ -662,8 +663,9 @@ class SpaceSkillPublicationRepository(SpaceSkillPublicationRepositoryProtocol):
             attempt.recovery_kind = None
             attempt.error_code = None
             attempt.error_message = None
-            attempt.completed_at = completed_at
+            attempt.completed_at = func.now()
             session.flush()
+            session.refresh(attempt)
             return self._record(attempt)
 
     def mark_recovery_available(
@@ -757,6 +759,9 @@ class SpaceSkillPublicationRepository(SpaceSkillPublicationRepositoryProtocol):
         if row is None:
             raise PublicationAttemptNotFoundError("publication attempt not found")
         attempt, skill, binding, space = row
+        database_now = session.query(func.now()).scalar()
+        if not isinstance(database_now, datetime):
+            raise RuntimeError("database CURRENT_TIMESTAMP is not a datetime")
         if (
             attempt.status in ACTIVE_SKILL_PUBLICATION_ATTEMPT_STATUSES
             and not attempt.frozen_draft_locator
@@ -773,6 +778,7 @@ class SpaceSkillPublicationRepository(SpaceSkillPublicationRepositoryProtocol):
             skill_name=skill.name,
             draft_description=skill.draft_description or skill.description or "",
             package_url=skill.package_url,
+            database_now=database_now,
         )
 
     @staticmethod

--- a/src/backend/src/agentclaw/community/core/repository/protocols/skill_center.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/skill_center.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from collections.abc import Iterable
-from datetime import datetime
 from typing import Any, List, Optional, Protocol, TYPE_CHECKING, runtime_checkable
 
 if TYPE_CHECKING:
@@ -357,7 +356,6 @@ class SkillVersionMaterializationRepositoryProtocol(Protocol):
         name: str,
         metadata_json: str,
         description: str,
-        published_at: datetime,
     ) -> PublishedMaterializedSkillVersion: ...
 
 

--- a/src/backend/src/agentclaw/community/core/repository/protocols/space_skill_publication.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/space_skill_publication.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from datetime import datetime
 from typing import Protocol, TYPE_CHECKING, runtime_checkable
 
 if TYPE_CHECKING:
@@ -67,12 +66,12 @@ class SpaceSkillPublicationRepositoryProtocol(Protocol):
 
     @abstractmethod
     def claim_sc_submission(
-        self, *, attempt_id: int, started_at: datetime, env: str
+        self, *, attempt_id: int, env: str
     ) -> PublicationSubmissionClaim: ...
 
     @abstractmethod
     def mark_waiting_sc(
-        self, *, attempt_id: int, accepted_at: datetime, env: str
+        self, *, attempt_id: int, env: str
     ) -> PublicationAttemptRecord: ...
 
     @abstractmethod
@@ -93,7 +92,6 @@ class SpaceSkillPublicationRepositoryProtocol(Protocol):
         attempt_id: int,
         error_code: str,
         error_message: str,
-        completed_at: datetime,
         env: str,
     ) -> PublicationAttemptRecord: ...
 
@@ -114,7 +112,6 @@ class SpaceSkillPublicationRepositoryProtocol(Protocol):
         *,
         attempt_id: int,
         skill_version_id: int,
-        completed_at: datetime,
         env: str,
     ) -> PublicationAttemptRecord: ...
 

--- a/src/backend/src/agentclaw/community/core/skill_center/publication_contract.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/publication_contract.py
@@ -101,6 +101,7 @@ class PublicationWork:
     skill_name: str
     draft_description: str
     package_url: str | None
+    database_now: datetime
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_version_materializer.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_version_materializer.py
@@ -3,12 +3,10 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from datetime import UTC, datetime
 import hashlib
 import json
 import logging
 import time
-from typing import Callable
 from urllib.parse import urlsplit
 
 from agentclaw.community.core.skill_center.canonical_center_store import (
@@ -128,14 +126,12 @@ class SkillVersionMaterializer(SkillVersionMaterializerProtocol):
         http: HttpClient,
         validator: SkillPackageValidator,
         store: CanonicalCenterVersionStore,
-        clock: Callable[[], datetime] = lambda: datetime.now(UTC),
     ) -> None:
         self._versions = versions
         self._gateway = gateway
         self._http = http
         self._validator = validator
         self._store = store
-        self._clock = clock
 
     def materialize(
         self, request: SkillVersionMaterializationRequest
@@ -267,7 +263,6 @@ class SkillVersionMaterializer(SkillVersionMaterializerProtocol):
                 name=package.name,
                 metadata_json=metadata_json,
                 description=package.description,
-                published_at=self._clock(),
             )
             finish_stage()
             self._log_success(

--- a/src/backend/src/agentclaw/community/core/skill_center/services/space_skill_publication_task.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/space_skill_publication_task.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
 import hashlib
 import logging
 import re
@@ -150,7 +149,6 @@ class SpaceSkillPublicationTaskHandler:
         materializer: SkillVersionMaterializerProtocol,
         tenant_provider: Callable[[], str],
         env_provider: Callable[[], str],
-        clock: Callable[[], datetime] = lambda: datetime.now(UTC),
         auto_retry_seconds: int = SPACE_SKILL_PUBLICATION_AUTO_RETRY_SECONDS,
         poll_seconds: int = SPACE_SKILL_PUBLICATION_POLL_SECONDS,
     ) -> None:
@@ -161,7 +159,6 @@ class SpaceSkillPublicationTaskHandler:
         self._materializer = materializer
         self._tenant_provider = tenant_provider
         self._env_provider = env_provider
-        self._clock = clock
         self._auto_retry_seconds = auto_retry_seconds
         self._poll_seconds = poll_seconds
 
@@ -186,9 +183,7 @@ class SpaceSkillPublicationTaskHandler:
             prepared = self._prepare(work, env=env)
             if not isinstance(prepared, PublicationWork):
                 return prepared
-            claim = self._repository.claim_sc_submission(
-                attempt_id=attempt_id, started_at=self._clock(), env=env
-            )
+            claim = self._repository.claim_sc_submission(attempt_id=attempt_id, env=env)
             work = claim.work
             if claim.may_submit:
                 submitted = self._submit(work, env=env)
@@ -234,7 +229,6 @@ class SpaceSkillPublicationTaskHandler:
                     attempt_id=work.attempt.attempt_id,
                     error_code="SKILL_NAME_CHANGED",
                     error_message="Frozen Draft name differs from the Skill identity",
-                    completed_at=self._clock(),
                     env=env,
                 )
                 return Complete()
@@ -299,15 +293,12 @@ class SpaceSkillPublicationTaskHandler:
                     attempt_id=work.attempt.attempt_id,
                     error_code="SC_PUBLISH_REJECTED",
                     error_message="Skill Center rejected publication",
-                    completed_at=self._clock(),
                     env=env,
                 )
                 return Complete()
             return self._unknown_or_available(work, env=env)
         self._repository.mark_waiting_sc(
-            attempt_id=work.attempt.attempt_id,
-            accepted_at=self._clock(),
-            env=env,
+            attempt_id=work.attempt.attempt_id, env=env
         )
         return None
 
@@ -347,7 +338,6 @@ class SpaceSkillPublicationTaskHandler:
                 attempt_id=work.attempt.attempt_id,
                 error_code="SC_PUBLISH_REJECTED",
                 error_message="Skill Center rejected publication",
-                completed_at=self._clock(),
                 env=env,
             )
             return Complete()
@@ -357,9 +347,7 @@ class SpaceSkillPublicationTaskHandler:
         # eventual-consistency lag stays WAITING_SC rather than being presented
         # as an uncertain external publish outcome.
         self._repository.mark_waiting_sc(
-            attempt_id=work.attempt.attempt_id,
-            accepted_at=self._clock(),
-            env=env,
+            attempt_id=work.attempt.attempt_id, env=env
         )
         work = self._repository.get_work(attempt_id=work.attempt.attempt_id, env=env)
         try:
@@ -450,7 +438,6 @@ class SpaceSkillPublicationTaskHandler:
                 self._repository.complete_success(
                     attempt_id=work.attempt.attempt_id,
                     skill_version_id=published.skill_version_id,
-                    completed_at=self._clock(),
                     env=env,
                 )
                 self._delete_frozen_draft_best_effort(work, env=env)
@@ -583,11 +570,11 @@ class SpaceSkillPublicationTaskHandler:
             else work.attempt.gmt_created
         )
         start = start or work.attempt.gmt_modified or work.attempt.gmt_created
-        now = self._clock()
+        now = work.database_now
         if start.tzinfo is None and now.tzinfo is not None:
-            start = start.replace(tzinfo=UTC)
+            now = now.replace(tzinfo=None)
         elif start.tzinfo is not None and now.tzinfo is None:
-            now = now.replace(tzinfo=UTC)
+            start = start.replace(tzinfo=None)
         return (now - start).total_seconds() >= self._auto_retry_seconds
 
     @staticmethod

--- a/src/backend/src/agentclaw/community/core/skill_center/sql/2026_09_03_align_space_skill_timestamps_with_gmt.sql
+++ b/src/backend/src/agentclaw/community/core/skill_center/sql/2026_09_03_align_space_skill_timestamps_with_gmt.sql
@@ -1,0 +1,27 @@
+-- Align the seven explicit Space Skill timestamps with the existing gmt_* fields.
+--
+-- Preconditions:
+--   * Run against the TeamClaw database while the database/session time zone is
+--     Asia/Shanghai, matching the existing gmt_created/gmt_modified columns.
+--   * This is a forward-only schema repair. Existing DATETIME literals are not
+--     backfilled; only writes after the matching application deployment are in scope.
+--
+-- The application writes each of these fields with CURRENT_TIMESTAMP after this
+-- migration. Keeping them as TIMESTAMP makes storage and reads match gmt_*.
+
+ALTER TABLE ac_skill_version
+  MODIFY COLUMN published_at TIMESTAMP NULL DEFAULT NULL;
+
+ALTER TABLE ac_skill_publication_attempt
+  MODIFY COLUMN sc_post_started_at TIMESTAMP NULL DEFAULT NULL,
+  MODIFY COLUMN sc_accepted_at TIMESTAMP NULL DEFAULT NULL,
+  MODIFY COLUMN completed_at TIMESTAMP NULL DEFAULT NULL;
+
+ALTER TABLE ac_skill
+  MODIFY COLUMN offline_at TIMESTAMP NULL DEFAULT NULL COMMENT 'TeamClaw 本地可恢复下线时间';
+
+ALTER TABLE ac_skill_grant
+  MODIFY COLUMN revoked_at TIMESTAMP NULL DEFAULT NULL;
+
+ALTER TABLE ac_skill_draft_edit_lease
+  MODIFY COLUMN acquired_at TIMESTAMP NULL DEFAULT NULL;

--- a/src/backend/tests/community/acceptance/files/test_openapi_directory_download.py
+++ b/src/backend/tests/community/acceptance/files/test_openapi_directory_download.py
@@ -62,6 +62,31 @@ def _upload(client: httpx.Client, bot_id: str, path: str, filename: str, data: b
     assert response.status_code == 200, response.text
 
 
+def _mkdir_when_baas_visible(client: httpx.Client, bot_id: str, path: str) -> None:
+    """Create a directory after the newly active BaaS bot is queryable.
+
+    The Backend status poll may observe the activation callback a few
+    milliseconds before BaaS's bot-read path sees the same record. Retry only
+    that transient ``BOT_NOT_FOUND`` response; every other error remains a
+    test failure at its original boundary.
+    """
+    last_response: httpx.Response | None = None
+    for attempt in range(5):
+        response = client.post(
+            f"/api/resources/files/mkdir?bot_id={bot_id}",
+            data={"path": path},
+        )
+        if response.status_code == 200:
+            return
+        last_response = response
+        if "BOT_NOT_FOUND" not in response.text:
+            break
+        time.sleep(0.1 * (attempt + 1))
+
+    assert last_response is not None
+    assert last_response.status_code == 200, last_response.text
+
+
 @pytest.mark.acceptance
 def test_workspace_directory_download(live_backend):
     """Zip a workspace directory through the public API, get what the browser shows.
@@ -94,11 +119,7 @@ def test_workspace_directory_download(live_backend):
         # (each mkdir drops a .keep the download must filter) and an identity
         # file at the workspace root (hidden from a *root* download only).
         for directory in (parent, f"{parent}/nested"):
-            response = client.post(
-                f"/api/resources/files/mkdir?bot_id={bot_id}",
-                data={"path": directory},
-            )
-            assert response.status_code == 200, response.text
+            _mkdir_when_baas_visible(client, bot_id, directory)
         _upload(client, bot_id, parent, "notes.txt", notes_payload)
         _upload(client, bot_id, f"{parent}/nested", "deep.txt", deep_payload)
         _upload(client, bot_id, "", "AGENTS.md", b"# workspace identity\n")

--- a/src/backend/tests/community/core/skill_center/test_skill_version_materializer.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_version_materializer.py
@@ -139,7 +139,7 @@ class _Versions:
             name=kwargs["name"],
             description=kwargs["description"],
             metadata_json=kwargs["metadata_json"],
-            published_at=kwargs["published_at"],
+            published_at=datetime(2026, 8, 30, 12, 0),
         )
 
 
@@ -173,7 +173,6 @@ def _materializer(
         http=_Http(package),
         validator=SkillPackageValidator(SkillParser()),
         store=LocalCanonicalCenterVersionStore(),
-        clock=lambda: datetime(2026, 8, 30, 12, 0, tzinfo=UTC),
     )
 
 
@@ -554,7 +553,6 @@ def test_materializing_a_new_version_never_reactivates_a_terminally_offline_skil
         http=_Http(package),
         validator=SkillPackageValidator(SkillParser()),
         store=LocalCanonicalCenterVersionStore(),
-        clock=lambda: datetime(2026, 8, 30, 12, 0, tzinfo=UTC),
     ).materialize(
         SkillVersionMaterializationRequest(
             env="pre",

--- a/src/backend/tests/community/integration/skill_center/test_public_reference_materialization_identity.py
+++ b/src/backend/tests/community/integration/skill_center/test_public_reference_materialization_identity.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
-from datetime import UTC, datetime
 import hashlib
 import io
 import zipfile
@@ -143,7 +142,6 @@ def test_deterministic_public_identity_passes_real_canonical_ready_gate() -> Non
             http=_Http(package),
             validator=SkillPackageValidator(SkillParser()),
             store=store,
-            clock=lambda: datetime(2026, 8, 30, tzinfo=UTC),
         ).materialize(
             SkillVersionMaterializationRequest(
                 env="pre",
@@ -218,7 +216,6 @@ def test_public_wrapper_and_market_display_name_converge_to_manifest_name() -> N
             http=_Http(package),
             validator=SkillPackageValidator(SkillParser()),
             store=store,
-            clock=lambda: datetime(2026, 8, 30, tzinfo=UTC),
         ).materialize(
             SkillVersionMaterializationRequest(
                 env="pre",
@@ -244,7 +241,6 @@ def test_public_wrapper_and_market_display_name_converge_to_manifest_name() -> N
             http=_Http(package),
             validator=SkillPackageValidator(SkillParser()),
             store=store,
-            clock=lambda: datetime(2026, 8, 31, tzinfo=UTC),
         ).materialize(
             SkillVersionMaterializationRequest(
                 env="pre",

--- a/src/backend/tests/community/repository/skill_center/test_skill_version_repository.py
+++ b/src/backend/tests/community/repository/skill_center/test_skill_version_repository.py
@@ -33,9 +33,6 @@ from agentclaw.community.core.skill_center.services.bot_capability_state_reader 
 from agentclaw.community.core.skill_center.services.skill_version_resolver import (
     SkillVersionResolver,
 )
-from agentclaw.community.core.skill_center.materialization_contract import (
-    PublishedMaterializedSkillVersion,
-)
 from agentclaw.community.utils.avernet_tenant import avernet_tenant_scope
 
 
@@ -299,27 +296,14 @@ def test_materialization_publish_is_one_tenant_scoped_compare_and_set() -> None:
             name="skill-10",
             metadata_json='{"mcp_dependencies":[]}',
             description="new description",
-            published_at=datetime(2026, 8, 30, 12, 0, tzinfo=UTC),
         )
 
     assert target is not None
     assert target.status == "MATERIALIZING"
     assert target.skill_uuid == "00000000-0000-4000-8000-000000000010"
     assert target.skill_code == "public-weather"
-    assert published == PublishedMaterializedSkillVersion(
-        skill_version_id=101,
-        skill_id=10,
-        version_ordinal=1,
-        status="PUBLISHED",
-        skill_uuid="00000000-0000-4000-8000-000000000010",
-        sc_version_number="1.0.0",
-        sc_skill_id=1010,
-        sc_version_id=2101,
-        name="skill-10",
-        description="new description",
-        metadata_json='{"mcp_dependencies":[]}',
-        published_at=datetime(2026, 8, 30, 12, 0, tzinfo=UTC),
-    )
+    assert published.status == "PUBLISHED"
+    assert published.published_at is not None
     with db.orm_session() as session:
         version = session.get(SkillVersion, 101)
         skill = session.get(Skill, 10)
@@ -358,11 +342,10 @@ def test_public_first_publish_freezes_manifest_name_before_consumption() -> None
             env="pre",
             skill_id=10,
             skill_version_id=101,
-            name="dima",
-            metadata_json='{"mcp_dependencies":[]}',
-            description="Dima CLI",
-            published_at=datetime(2026, 8, 30, 12, 0, tzinfo=UTC),
-        )
+                name="dima",
+                metadata_json='{"mcp_dependencies":[]}',
+                description="Dima CLI",
+            )
 
     assert published.name == "dima"
     with db.orm_session() as session:
@@ -409,11 +392,10 @@ def test_public_name_convergence_fails_closed_after_installation_exists() -> Non
             env="pre",
             skill_id=10,
             skill_version_id=101,
-            name="dima",
-            metadata_json='{"mcp_dependencies":[]}',
-            description="Dima CLI",
-            published_at=datetime(2026, 8, 30, 12, 0, tzinfo=UTC),
-        )
+                name="dima",
+                metadata_json='{"mcp_dependencies":[]}',
+                description="Dima CLI",
+            )
 
     with db.orm_session() as session:
         skill = session.get(Skill, 10)
@@ -461,7 +443,6 @@ def test_materialization_publish_replay_requires_the_same_frozen_facts() -> None
             name="skill-10",
             metadata_json='{"mcp_dependencies":[]}',
             description="same",
-            published_at=datetime(2026, 8, 30, 13, 0, tzinfo=UTC),
         )
         with pytest.raises(RuntimeError, match="conflicts"):
             repo.publish_materialized(
@@ -471,7 +452,6 @@ def test_materialization_publish_replay_requires_the_same_frozen_facts() -> None
                 name="skill-10",
                 metadata_json='{"mcp_dependencies":[{"code":"other"}]}',
                 description="same",
-                published_at=datetime(2026, 8, 30, 13, 0, tzinfo=UTC),
             )
 
     assert replay.status == "PUBLISHED"
@@ -528,7 +508,6 @@ def test_space_publication_never_reactivates_terminally_offline_skill() -> None:
             name="weather",
             metadata_json='{"mcp_dependencies":[]}',
             description="online again",
-            published_at=datetime(2026, 8, 30, 12, 0, tzinfo=UTC),
         )
     with db.orm_session() as session:
         skill = session.get(Skill, 10)
@@ -544,7 +523,6 @@ def test_space_publication_never_reactivates_terminally_offline_skill() -> None:
             name="weather",
             metadata_json='{"mcp_dependencies":[]}',
             description="online again",
-            published_at=datetime(2026, 8, 30, 13, 0, tzinfo=UTC),
         )
     with db.orm_session() as session:
         skill = session.get(Skill, 10)
@@ -586,7 +564,6 @@ def test_sc_public_materialization_never_clears_offline_without_space_binding() 
             name="weather",
             metadata_json='{"mcp_dependencies":[]}',
             description="updated",
-            published_at=datetime(2026, 8, 30, 12, 0, tzinfo=UTC),
         )
 
     with db.orm_session() as session:
@@ -646,7 +623,6 @@ def test_space_binding_without_publication_attempt_never_clears_offline() -> Non
             name="weather",
             metadata_json='{"mcp_dependencies":[]}',
             description="updated",
-            published_at=datetime(2026, 8, 30, 12, 0, tzinfo=UTC),
         )
 
     with db.orm_session() as session:

--- a/src/backend/tests/community/repository/skill_center/test_space_skill_publication_repository.py
+++ b/src/backend/tests/community/repository/skill_center/test_space_skill_publication_repository.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
+from dataclasses import replace
 from datetime import UTC, datetime
 import io
 import logging
@@ -230,12 +231,10 @@ def _seed_waiting_publication(
     )
     repository.claim_sc_submission(
         attempt_id=attempt.attempt_id,
-        started_at=datetime(2026, 8, 30, 11, 0, tzinfo=UTC),
         env="test",
     )
     repository.mark_waiting_sc(
         attempt_id=attempt.attempt_id,
-        accepted_at=datetime(2026, 8, 30, 11, 1, tzinfo=UTC),
         env="test",
     )
     return space_id, skill_id, attempt.attempt_id
@@ -327,7 +326,6 @@ def test_mark_failed_rejects_version_that_appears_during_locking(
             attempt_id=attempt_id,
             error_code="SC_PUBLISH_REJECTED",
             error_message="rejected",
-            completed_at=datetime(2026, 8, 30, 12, 1, tzinfo=UTC),
             env="test",
         )
 
@@ -365,7 +363,6 @@ def test_complete_success_rechecks_attempt_after_canonical_locks(
         SpaceSkillPublicationRepository(db).complete_success(
             attempt_id=attempt_id,
             skill_version_id=version_id,
-            completed_at=datetime(2026, 8, 30, 12, 1, tzinfo=UTC),
             env="test",
         )
 
@@ -396,7 +393,6 @@ def test_complete_success_and_offline_overlap_converges(
             SpaceSkillPublicationRepository(db).complete_success(
                 attempt_id=attempt_id,
                 skill_version_id=version_id,
-                completed_at=datetime(2026, 8, 30, 12, 1, tzinfo=UTC),
                 env="test",
             )
         except BaseException as exc:  # pragma: no cover - asserted below
@@ -462,7 +458,6 @@ def test_mark_failed_and_begin_materialization_overlap_serializes_to_failed(
                 attempt_id=attempt_id,
                 error_code="SC_PUBLISH_REJECTED",
                 error_message="rejected",
-                completed_at=datetime(2026, 8, 30, 12, 1, tzinfo=UTC),
                 env="test",
             )
         except BaseException as exc:  # pragma: no cover - asserted below
@@ -1017,9 +1012,34 @@ def _handler(
         materializer=materializer,
         tenant_provider=get_current_avernet_tenant,
         env_provider=lambda: "test",
-        clock=lambda: datetime(2026, 8, 30, 12, 0, tzinfo=UTC),
         auto_retry_seconds=auto_retry_seconds,
     )
+
+
+def test_deadline_uses_database_session_clock() -> None:
+    db = _Database()
+    space_id, skill_id, attempt_id = _seed_waiting_publication(db)
+    repository = SpaceSkillPublicationRepository(db)
+    with db.orm_session() as session:
+        attempt = session.get(SkillPublicationAttempt, attempt_id)
+        assert attempt is not None
+        attempt.sc_post_started_at = datetime(2026, 8, 30, 10, 0)
+
+    handler = _handler(
+        db,
+        repository,
+        _Gateway(),
+        _Materializer(db),
+        auto_retry_seconds=15 * 60,
+    )
+
+    work = replace(
+        repository.get_work(attempt_id=attempt_id, env="test"),
+        database_now=datetime(2026, 8, 30, 10, 16),
+    )
+    assert work.space_id == space_id
+    assert work.attempt.skill_id == skill_id
+    assert handler._expired(work) is True
 
 
 def test_worker_submits_once_materializes_and_emits_published_seam() -> None:


### PR DESCRIPTION
## Summary
Align the seven explicit Space Skill timestamps with the existing `gmt_created` / `gmt_modified` storage and query semantics.

## Changes
- Write timestamps with database `CURRENT_TIMESTAMP` instead of Python UTC values.
- Restore target columns to `TIMESTAMP`; no historical backfill.
- Compare publication retry deadlines with the DB clock read in the same session as the attempt snapshot.

## Validation
- `16907 passed, 59 skipped` — community backend full suite
- Rebased onto GitHub `dev`; targeted suite: `94 passed`
- Ruff checks passed.

## DDL
Run `2026_09_03_align_space_skill_timestamps_with_gmt.sql` in an `Asia/Shanghai` database session before deployment.