### PR TITLE
feat(baas): add admin bot status update endpoint

### DIFF
--- a/src/baas/src/secbaas/community/adapters/web/routers/admin/publish_admin_router.py
+++ b/src/baas/src/secbaas/community/adapters/web/routers/admin/publish_admin_router.py
@@ -6,6 +6,7 @@ These endpoints bypass normal state machine transitions — use with caution.
 Endpoints:
 - POST /api/v1/admin/force-success - Force a publish and all related entities to success states
 - POST /api/v1/admin/devices/{device_uuid}/status - Update a device's status directly
+- POST /api/v1/admin/bots/{bot_uuid}/status - Update a bot's status directly
 """
 
 from typing import Annotated
@@ -19,6 +20,7 @@ from secbaas.community.api.publish_manage import (
     ForceSuccessResult,
     PublishAdminService,
     PublishNotFoundError,
+    UpdateBotStatusResult,
     UpdateDeviceStatusResult,
 )
 from secbaas.community.bootstrap import ApplicationContainer, Provide
@@ -163,3 +165,72 @@ async def update_device_status_endpoint(
             detail=f"Device {device_uuid} not found",
         )
     return ApiResponse(data=_to_update_status_response(result))
+
+
+class UpdateBotStatusRequest(BaseModel):
+    status: str = Field(
+        ...,
+        min_length=1,
+        max_length=32,
+        description="Target bot status (e.g. ACTIVE, STOPPED, PENDING, FAILED)",
+    )
+    operator: str = Field(
+        ...,
+        min_length=1,
+        max_length=128,
+        description="User performing the status update",
+    )
+
+
+class UpdateBotStatusResponse(BaseModel):
+    bot_uuid: str = Field(..., description="Bot UUID that was updated")
+    previous_status: str = Field(..., description="Previous status of the bot")
+    new_status: str = Field(..., description="New status after the update")
+
+
+def _to_update_bot_status_response(
+    result: UpdateBotStatusResult,
+) -> UpdateBotStatusResponse:
+    return UpdateBotStatusResponse(
+        bot_uuid=result.bot_uuid,
+        previous_status=result.previous_status,
+        new_status=result.new_status,
+    )
+
+
+@router.post(
+    "/bots/{bot_uuid}/status",
+    response_model=ApiResponse[UpdateBotStatusResponse],
+)
+@inject
+async def update_bot_status_endpoint(
+    bot_uuid: Annotated[
+        str,
+        Path(description="Bot UUID to update"),
+    ],
+    tenant: Annotated[str, Query(description="Tenant name")],
+    request: UpdateBotStatusRequest,
+    admin_service: PublishAdminService = Depends(
+        Provide[ApplicationContainer.services.publish_admin_service]
+    ),
+) -> ApiResponse[UpdateBotStatusResponse]:
+    """Update a bot's status directly, bypassing normal state machine transitions.
+
+    **WARNING**: This is a test/development tool. It intentionally bypasses
+    the normal state machine transitions and does not perform any real
+    publish workflow or PaaS operation. Use with caution. Only ACTIVE bots
+    can be updated through this endpoint; non-ACTIVE bot resuscitation
+    should go through `force-success` or the publish workflow.
+    """
+    try:
+        result = await admin_service.update_bot_status(
+            bot_uuid=bot_uuid,
+            status=request.status,
+            operator=request.operator,
+        )
+    except PublishNotFoundError:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Bot {bot_uuid} not found or not active",
+        )
+    return ApiResponse(data=_to_update_bot_status_response(result))

--- a/src/baas/src/secbaas/community/adapters/web/routers/admin/publish_admin_router.py
+++ b/src/baas/src/secbaas/community/adapters/web/routers/admin/publish_admin_router.py
@@ -6,7 +6,7 @@ These endpoints bypass normal state machine transitions — use with caution.
 Endpoints:
 - POST /api/v1/admin/force-success - Force a publish and all related entities to success states
 - POST /api/v1/admin/devices/{device_uuid}/status - Update a device's status directly
-- POST /api/v1/admin/bots/{bot_uuid}/status - Update a bot's status directly
+- POST /api/v1/admin/bots/{bot_id}/status - Update a bot's status directly
 """
 
 from typing import Annotated
@@ -183,7 +183,8 @@ class UpdateBotStatusRequest(BaseModel):
 
 
 class UpdateBotStatusResponse(BaseModel):
-    bot_uuid: str = Field(..., description="Bot UUID that was updated")
+    bot_id: int = Field(..., description="Bot ID that was updated")
+    bot_uuid: str = Field(..., description="Bot UUID of the updated bot")
     previous_status: str = Field(..., description="Previous status of the bot")
     new_status: str = Field(..., description="New status after the update")
 
@@ -192,6 +193,7 @@ def _to_update_bot_status_response(
     result: UpdateBotStatusResult,
 ) -> UpdateBotStatusResponse:
     return UpdateBotStatusResponse(
+        bot_id=result.bot_id,
         bot_uuid=result.bot_uuid,
         previous_status=result.previous_status,
         new_status=result.new_status,
@@ -199,16 +201,15 @@ def _to_update_bot_status_response(
 
 
 @router.post(
-    "/bots/{bot_uuid}/status",
+    "/bots/{bot_id}/status",
     response_model=ApiResponse[UpdateBotStatusResponse],
 )
 @inject
 async def update_bot_status_endpoint(
-    bot_uuid: Annotated[
-        str,
-        Path(description="Bot UUID to update"),
+    bot_id: Annotated[
+        int,
+        Path(description="Bot ID (primary key) to update"),
     ],
-    tenant: Annotated[str, Query(description="Tenant name")],
     request: UpdateBotStatusRequest,
     admin_service: PublishAdminService = Depends(
         Provide[ApplicationContainer.services.publish_admin_service]
@@ -218,19 +219,19 @@ async def update_bot_status_endpoint(
 
     **WARNING**: This is a test/development tool. It intentionally bypasses
     the normal state machine transitions and does not perform any real
-    publish workflow or PaaS operation. Use with caution. Only ACTIVE bots
-    can be updated through this endpoint; non-ACTIVE bot resuscitation
-    should go through `force-success` or the publish workflow.
+    publish workflow or PaaS operation. Use with caution. The bot is
+    resolved by its primary key (bot_id); tenant and env are sourced from
+    the fetched record, not from the request.
     """
     try:
         result = await admin_service.update_bot_status(
-            bot_uuid=bot_uuid,
+            bot_id=bot_id,
             status=request.status,
             operator=request.operator,
         )
     except PublishNotFoundError:
         raise HTTPException(
             status_code=404,
-            detail=f"Bot {bot_uuid} not found or not active",
+            detail=f"Bot {bot_id} not found",
         )
     return ApiResponse(data=_to_update_bot_status_response(result))

--- a/src/baas/src/secbaas/community/api/publish_manage/__init__.py
+++ b/src/baas/src/secbaas/community/api/publish_manage/__init__.py
@@ -40,6 +40,7 @@ from ._models import (
     PublishResponse,
     StageConfig,
     StageProgress,
+    UpdateBotStatusResult,
     UpdateDeviceStatusResult,
     serialize_hook_result,
 )
@@ -50,6 +51,7 @@ __all__ = [
     "ForceSuccessResult",
     "PublishAdminService",
     "PublishService",
+    "UpdateBotStatusResult",
     "UpdateDeviceStatusResult",
     "BatchDeviceProgress",
     "BatchResult",

--- a/src/baas/src/secbaas/community/api/publish_manage/_models.py
+++ b/src/baas/src/secbaas/community/api/publish_manage/_models.py
@@ -36,6 +36,15 @@ class UpdateDeviceStatusResult:
     new_status: str
 
 
+@dataclass
+class UpdateBotStatusResult:
+    """Result of a bot status update operation."""
+
+    bot_uuid: str
+    previous_status: str
+    new_status: str
+
+
 from secbaas.community.api.device_manage import (  # noqa: E402 — cyclic import guard
     DeployConfig,
 )

--- a/src/baas/src/secbaas/community/api/publish_manage/_models.py
+++ b/src/baas/src/secbaas/community/api/publish_manage/_models.py
@@ -40,6 +40,7 @@ class UpdateDeviceStatusResult:
 class UpdateBotStatusResult:
     """Result of a bot status update operation."""
 
+    bot_id: int
     bot_uuid: str
     previous_status: str
     new_status: str

--- a/src/baas/src/secbaas/community/api/publish_manage/_protocols.py
+++ b/src/baas/src/secbaas/community/api/publish_manage/_protocols.py
@@ -17,6 +17,7 @@ from ._models import (
     PublishConfig,
     PublishProgressResponse,
     PublishResponse,
+    UpdateBotStatusResult,
     UpdateDeviceStatusResult,
 )
 
@@ -41,6 +42,14 @@ class PublishAdminService(Protocol):
         status: str,
         operator: str,
     ) -> UpdateDeviceStatusResult: ...
+
+    async def update_bot_status(
+        self,
+        *,
+        bot_uuid: str,
+        status: str,
+        operator: str,
+    ) -> UpdateBotStatusResult: ...
 
 
 @runtime_checkable

--- a/src/baas/src/secbaas/community/api/publish_manage/_protocols.py
+++ b/src/baas/src/secbaas/community/api/publish_manage/_protocols.py
@@ -46,7 +46,7 @@ class PublishAdminService(Protocol):
     async def update_bot_status(
         self,
         *,
-        bot_uuid: str,
+        bot_id: int,
         status: str,
         operator: str,
     ) -> UpdateBotStatusResult: ...

--- a/src/baas/src/secbaas/community/core/repository/bot/_orm_repository.py
+++ b/src/baas/src/secbaas/community/core/repository/bot/_orm_repository.py
@@ -249,6 +249,21 @@ class OrmBotRepository(OrmConnectionMixin, BotRepository):
         return record
 
     @with_orm_session
+    def get_by_id_only(self, bot_id: int) -> BotRecord | None:
+        log.info("get_by_id_only: bot_id=%s", bot_id)
+        row = (
+            self._session.query(BotModel)
+            .filter(
+                BotModel.id == bot_id,
+                BotModel.is_deleted == 0,
+            )
+            .first()
+        )
+        record = row.to_record() if row else None
+        log.info("[bot:get_by_id_only] result: %s", record.id if record else "None")
+        return record
+
+    @with_orm_session
     def update_bot(
         self,
         *,

--- a/src/baas/src/secbaas/community/core/repository/bot/_protocol.py
+++ b/src/baas/src/secbaas/community/core/repository/bot/_protocol.py
@@ -40,6 +40,14 @@ class BotRepository(Protocol):
         """Get bot by ID including soft-deleted records."""
         ...
 
+    def get_by_id_only(self, bot_id: int) -> BotRecord | None:
+        """Get bot by primary key ID only (no tenant/env filter).
+
+        Filters is_deleted=0. Returns None if not found or soft-deleted.
+        Used by admin endpoints that need cross-tenant/env lookup by PK.
+        """
+        ...
+
     def get_by_bot_uuid(
         self, bot_uuid: str, tenant: str, env: str, status: str
     ) -> BotRecord | None:

--- a/src/baas/src/secbaas/community/core/service/publish_manage/_admin_service.py
+++ b/src/baas/src/secbaas/community/core/service/publish_manage/_admin_service.py
@@ -149,7 +149,7 @@ class DefaultPublishAdminService(PublishAdminService):
     async def update_bot_status(
         self,
         *,
-        bot_uuid: str,
+        bot_id: int,
         status: str,
         operator: str,
     ) -> UpdateBotStatusResult:
@@ -157,22 +157,22 @@ class DefaultPublishAdminService(PublishAdminService):
 
         WARNING: Admin operation for test/development use only.
         Does not trigger any publish workflow or PaaS operation.
-        Uses get_active_by_bot_uuid_only() to allow cross-env admin access.
+        Uses get_by_id_only() to allow cross-tenant/env admin access by PK.
         """
-        bot = self._bot_repo.get_active_by_bot_uuid_only(bot_uuid)
+        bot = self._bot_repo.get_by_id_only(bot_id)
         if bot is None:
-            raise PublishNotFoundError(f"Bot {bot_uuid} not found or not active")
+            raise PublishNotFoundError(f"Bot {bot_id} not found")
 
         previous_status = bot.status
         logger.warning(
-            f"ADMIN_UPDATE_BOT_STATUS: bot_uuid={bot_uuid} "
-            f"tenant={bot.tenant} env={bot.env} "
+            f"ADMIN_UPDATE_BOT_STATUS: bot_id={bot_id} "
+            f"bot_uuid={bot.bot_uuid} tenant={bot.tenant} env={bot.env} "
             f"previous_status={previous_status} "
             f"new_status={status} operator={operator}"
         )
 
         self._bot_repo.update_status(
-            bot_id=bot.id,
+            bot_id=bot_id,
             tenant=bot.tenant,
             env=bot.env,
             status=status,
@@ -180,7 +180,8 @@ class DefaultPublishAdminService(PublishAdminService):
         )
 
         return UpdateBotStatusResult(
-            bot_uuid=bot_uuid,
+            bot_id=bot_id,
+            bot_uuid=bot.bot_uuid,
             previous_status=previous_status,
             new_status=status,
         )

--- a/src/baas/src/secbaas/community/core/service/publish_manage/_admin_service.py
+++ b/src/baas/src/secbaas/community/core/service/publish_manage/_admin_service.py
@@ -10,6 +10,7 @@ from secbaas.community.api.publish_manage import (
     ForceSuccessResult,
     PublishAdminService,
     PublishNotFoundError,
+    UpdateBotStatusResult,
     UpdateDeviceStatusResult,
 )
 from secbaas.community.core.repository.bot import BotRepository
@@ -141,6 +142,45 @@ class DefaultPublishAdminService(PublishAdminService):
 
         return UpdateDeviceStatusResult(
             device_uuid=device_uuid,
+            previous_status=previous_status,
+            new_status=status,
+        )
+
+    async def update_bot_status(
+        self,
+        *,
+        bot_uuid: str,
+        status: str,
+        operator: str,
+    ) -> UpdateBotStatusResult:
+        """Update a bot's status directly, bypassing normal state machine.
+
+        WARNING: Admin operation for test/development use only.
+        Does not trigger any publish workflow or PaaS operation.
+        Uses get_active_by_bot_uuid_only() to allow cross-env admin access.
+        """
+        bot = self._bot_repo.get_active_by_bot_uuid_only(bot_uuid)
+        if bot is None:
+            raise PublishNotFoundError(f"Bot {bot_uuid} not found or not active")
+
+        previous_status = bot.status
+        logger.warning(
+            f"ADMIN_UPDATE_BOT_STATUS: bot_uuid={bot_uuid} "
+            f"tenant={bot.tenant} env={bot.env} "
+            f"previous_status={previous_status} "
+            f"new_status={status} operator={operator}"
+        )
+
+        self._bot_repo.update_status(
+            bot_id=bot.id,
+            tenant=bot.tenant,
+            env=bot.env,
+            status=status,
+            modifier=operator,
+        )
+
+        return UpdateBotStatusResult(
+            bot_uuid=bot_uuid,
             previous_status=previous_status,
             new_status=status,
         )

--- a/src/baas/tests/unit/adapters/web/test_admin_router.py
+++ b/src/baas/tests/unit/adapters/web/test_admin_router.py
@@ -435,14 +435,14 @@ class TestUpdateBotStatusRequest:
 
     def test_empty_status_returns_422(self, client):
         resp = client.post(
-            "/api/v1/admin/bots/BOT_U/status?tenant=acme",
+            "/api/v1/admin/bots/123/status",
             json={"status": "", "operator": "ops.alice"},
         )
         assert resp.status_code == 422
 
     def test_status_too_long_returns_422(self, client):
         resp = client.post(
-            "/api/v1/admin/bots/BOT_U/status?tenant=acme",
+            "/api/v1/admin/bots/123/status",
             json={"status": "x" * 33, "operator": "ops.alice"},
         )
         assert resp.status_code == 422
@@ -450,18 +450,21 @@ class TestUpdateBotStatusRequest:
     def test_status_boundary_max_len_ok(self, client):
         status = "x" * 32
         mock_result = UpdateBotStatusResult(
-            bot_uuid="BOT_U", previous_status="ACTIVE", new_status=status
+            bot_id=123,
+            bot_uuid="bot-abc-123",
+            previous_status="ACTIVE",
+            new_status=status,
         )
         mock_admin_svc = AsyncMock()
         mock_admin_svc.update_bot_status.return_value = mock_result
 
         dep_callable = _get_endpoint_dep_callable(
-            client.app.router, path_contains="/bots/{bot_uuid}/status"
+            client.app.router, path_contains="/bots/{bot_id}/status"
         )
         client.app.dependency_overrides[dep_callable] = lambda: mock_admin_svc
         try:
             resp = client.post(
-                "/api/v1/admin/bots/BOT_U/status?tenant=acme",
+                "/api/v1/admin/bots/123/status",
                 json={"status": status, "operator": "ops.alice"},
             )
         finally:
@@ -471,14 +474,14 @@ class TestUpdateBotStatusRequest:
 
     def test_empty_operator_returns_422(self, client):
         resp = client.post(
-            "/api/v1/admin/bots/BOT_U/status?tenant=acme",
+            "/api/v1/admin/bots/123/status",
             json={"status": "STOPPED", "operator": ""},
         )
         assert resp.status_code == 422
 
     def test_operator_too_long_returns_422(self, client):
         resp = client.post(
-            "/api/v1/admin/bots/BOT_U/status?tenant=acme",
+            "/api/v1/admin/bots/123/status",
             json={"status": "STOPPED", "operator": "x" * 129},
         )
         assert resp.status_code == 422
@@ -486,18 +489,21 @@ class TestUpdateBotStatusRequest:
     def test_operator_boundary_max_len_ok(self, client):
         operator = "x" * 128
         mock_result = UpdateBotStatusResult(
-            bot_uuid="BOT_U", previous_status="ACTIVE", new_status="STOPPED"
+            bot_id=123,
+            bot_uuid="bot-abc-123",
+            previous_status="ACTIVE",
+            new_status="STOPPED",
         )
         mock_admin_svc = AsyncMock()
         mock_admin_svc.update_bot_status.return_value = mock_result
 
         dep_callable = _get_endpoint_dep_callable(
-            client.app.router, path_contains="/bots/{bot_uuid}/status"
+            client.app.router, path_contains="/bots/{bot_id}/status"
         )
         client.app.dependency_overrides[dep_callable] = lambda: mock_admin_svc
         try:
             resp = client.post(
-                "/api/v1/admin/bots/BOT_U/status?tenant=acme",
+                "/api/v1/admin/bots/123/status",
                 json={"status": "STOPPED", "operator": operator},
             )
         finally:
@@ -507,14 +513,14 @@ class TestUpdateBotStatusRequest:
 
     def test_missing_status_returns_422(self, client):
         resp = client.post(
-            "/api/v1/admin/bots/BOT_U/status?tenant=acme",
+            "/api/v1/admin/bots/123/status",
             json={"operator": "ops.alice"},
         )
         assert resp.status_code == 422
 
     def test_missing_operator_returns_422(self, client):
         resp = client.post(
-            "/api/v1/admin/bots/BOT_U/status?tenant=acme",
+            "/api/v1/admin/bots/123/status",
             json={"status": "STOPPED"},
         )
         assert resp.status_code == 422
@@ -528,11 +534,13 @@ class TestUpdateBotStatusResponse:
 
     def test_response_construction(self):
         resp = UpdateBotStatusResponse(
-            bot_uuid="BOT_U",
+            bot_id=123,
+            bot_uuid="bot-abc-123",
             previous_status="ACTIVE",
             new_status="STOPPED",
         )
-        assert resp.bot_uuid == "BOT_U"
+        assert resp.bot_id == 123
+        assert resp.bot_uuid == "bot-abc-123"
         assert resp.previous_status == "ACTIVE"
         assert resp.new_status == "STOPPED"
 
@@ -545,26 +553,30 @@ class TestToUpdateBotStatusResponse:
 
     def test_converts_all_fields(self):
         result = UpdateBotStatusResult(
-            bot_uuid="BOT_U",
+            bot_id=123,
+            bot_uuid="bot-abc-123",
             previous_status="ACTIVE",
             new_status="STOPPED",
         )
         resp = _to_update_bot_status_response(result)
 
         assert isinstance(resp, UpdateBotStatusResponse)
-        assert resp.bot_uuid == "BOT_U"
+        assert resp.bot_id == 123
+        assert resp.bot_uuid == "bot-abc-123"
         assert resp.previous_status == "ACTIVE"
         assert resp.new_status == "STOPPED"
 
     def test_converts_other_values(self):
         result = UpdateBotStatusResult(
-            bot_uuid="abc-123",
+            bot_id=999,
+            bot_uuid="abc-def-456",
             previous_status="PENDING",
             new_status="ACTIVE",
         )
         resp = _to_update_bot_status_response(result)
 
-        assert resp.bot_uuid == "abc-123"
+        assert resp.bot_id == 999
+        assert resp.bot_uuid == "abc-def-456"
         assert resp.previous_status == "PENDING"
         assert resp.new_status == "ACTIVE"
 
@@ -573,22 +585,25 @@ class TestToUpdateBotStatusResponse:
 
 
 class TestUpdateBotStatusEndpoint:
-    """Tests for POST /api/v1/admin/bots/{bot_uuid}/status endpoint."""
+    """Tests for POST /api/v1/admin/bots/{bot_id}/status endpoint."""
 
     def test_happy_path_returns_200_with_response_data(self, client):
         mock_result = UpdateBotStatusResult(
-            bot_uuid="BOT_U", previous_status="ACTIVE", new_status="STOPPED"
+            bot_id=123,
+            bot_uuid="bot-abc-123",
+            previous_status="ACTIVE",
+            new_status="STOPPED",
         )
         mock_admin_svc = AsyncMock()
         mock_admin_svc.update_bot_status.return_value = mock_result
 
         dep_callable = _get_endpoint_dep_callable(
-            client.app.router, path_contains="/bots/{bot_uuid}/status"
+            client.app.router, path_contains="/bots/{bot_id}/status"
         )
         client.app.dependency_overrides[dep_callable] = lambda: mock_admin_svc
         try:
             resp = client.post(
-                "/api/v1/admin/bots/BOT_U/status?tenant=acme",
+                "/api/v1/admin/bots/123/status",
                 json={"status": "STOPPED", "operator": "ops.alice"},
             )
         finally:
@@ -598,35 +613,38 @@ class TestUpdateBotStatusEndpoint:
         body = resp.json()
         assert body["code"] == 0
         assert body["message"] == "success"
-        assert body["data"]["bot_uuid"] == "BOT_U"
+        assert body["data"]["bot_id"] == 123
+        assert body["data"]["bot_uuid"] == "bot-abc-123"
         assert body["data"]["previous_status"] == "ACTIVE"
         assert body["data"]["new_status"] == "STOPPED"
 
     def test_calls_update_bot_status_with_correct_args(self, client):
         mock_result = UpdateBotStatusResult(
-            bot_uuid="BOT_U", previous_status="ACTIVE", new_status="STOPPED"
+            bot_id=123,
+            bot_uuid="bot-abc-123",
+            previous_status="ACTIVE",
+            new_status="STOPPED",
         )
         mock_admin_svc = AsyncMock()
         mock_admin_svc.update_bot_status.return_value = mock_result
 
         dep_callable = _get_endpoint_dep_callable(
-            client.app.router, path_contains="/bots/{bot_uuid}/status"
+            client.app.router, path_contains="/bots/{bot_id}/status"
         )
         client.app.dependency_overrides[dep_callable] = lambda: mock_admin_svc
         try:
             client.post(
-                "/api/v1/admin/bots/BOT_U/status?tenant=other",
+                "/api/v1/admin/bots/123/status",
                 json={"status": "STOPPED", "operator": "ops.alice"},
             )
         finally:
             del client.app.dependency_overrides[dep_callable]
 
         mock_admin_svc.update_bot_status.assert_awaited_once_with(
-            bot_uuid="BOT_U",
+            bot_id=123,
             status="STOPPED",
             operator="ops.alice",
         )
-        # tenant query parameter is advisory only — never forwarded to service.
         kwargs = mock_admin_svc.update_bot_status.await_args.kwargs
         assert "tenant" not in kwargs
         assert "env" not in kwargs
@@ -634,16 +652,16 @@ class TestUpdateBotStatusEndpoint:
     def test_publish_not_found_propagates_as_404(self, client):
         mock_admin_svc = AsyncMock()
         mock_admin_svc.update_bot_status.side_effect = PublishNotFoundError(
-            "Bot BOT_U not found or not active"
+            "Bot 123 not found"
         )
 
         dep_callable = _get_endpoint_dep_callable(
-            client.app.router, path_contains="/bots/{bot_uuid}/status"
+            client.app.router, path_contains="/bots/{bot_id}/status"
         )
         client.app.dependency_overrides[dep_callable] = lambda: mock_admin_svc
         try:
             resp = client.post(
-                "/api/v1/admin/bots/BOT_U/status?tenant=acme",
+                "/api/v1/admin/bots/123/status",
                 json={"status": "STOPPED", "operator": "ops.alice"},
             )
         finally:
@@ -651,29 +669,47 @@ class TestUpdateBotStatusEndpoint:
 
         assert resp.status_code == 404
         body = resp.json()
-        assert "Bot BOT_U not found or not active" in body["detail"]
+        assert "Bot 123 not found" in body["detail"]
 
-    def test_missing_tenant_query_param_returns_422(self, client):
-        resp = client.post(
-            "/api/v1/admin/bots/BOT_U/status",
-            json={"status": "STOPPED", "operator": "ops.alice"},
+    def test_nonexistent_bot_id_returns_404(self, client):
+        mock_admin_svc = AsyncMock()
+        mock_admin_svc.update_bot_status.side_effect = PublishNotFoundError(
+            "Bot 9999 not found"
         )
-        assert resp.status_code == 422
 
-    def test_response_data_has_exactly_three_keys(self, client):
+        dep_callable = _get_endpoint_dep_callable(
+            client.app.router, path_contains="/bots/{bot_id}/status"
+        )
+        client.app.dependency_overrides[dep_callable] = lambda: mock_admin_svc
+        try:
+            resp = client.post(
+                "/api/v1/admin/bots/9999/status",
+                json={"status": "STOPPED", "operator": "ops.alice"},
+            )
+        finally:
+            del client.app.dependency_overrides[dep_callable]
+
+        assert resp.status_code == 404
+        body = resp.json()
+        assert "Bot 9999 not found" in body["detail"]
+
+    def test_response_data_has_exactly_four_keys(self, client):
         mock_result = UpdateBotStatusResult(
-            bot_uuid="BOT_U", previous_status="ACTIVE", new_status="STOPPED"
+            bot_id=123,
+            bot_uuid="bot-abc-123",
+            previous_status="ACTIVE",
+            new_status="STOPPED",
         )
         mock_admin_svc = AsyncMock()
         mock_admin_svc.update_bot_status.return_value = mock_result
 
         dep_callable = _get_endpoint_dep_callable(
-            client.app.router, path_contains="/bots/{bot_uuid}/status"
+            client.app.router, path_contains="/bots/{bot_id}/status"
         )
         client.app.dependency_overrides[dep_callable] = lambda: mock_admin_svc
         try:
             resp = client.post(
-                "/api/v1/admin/bots/BOT_U/status?tenant=acme",
+                "/api/v1/admin/bots/123/status",
                 json={"status": "STOPPED", "operator": "ops.alice"},
             )
         finally:
@@ -681,32 +717,40 @@ class TestUpdateBotStatusEndpoint:
 
         assert resp.status_code == 200
         data = resp.json()["data"]
-        assert set(data.keys()) == {"bot_uuid", "previous_status", "new_status"}
+        assert set(data.keys()) == {
+            "bot_id",
+            "bot_uuid",
+            "previous_status",
+            "new_status",
+        }
 
-    @pytest.mark.parametrize("bot_uuid", ["BOT_U", "abc-123-def"])
-    def test_endpoint_uses_bot_uuid_path_param(self, client, bot_uuid):
+    @pytest.mark.parametrize("bot_id", [123, 9999])
+    def test_endpoint_uses_bot_id_path_param(self, client, bot_id):
         mock_result = UpdateBotStatusResult(
-            bot_uuid=bot_uuid, previous_status="ACTIVE", new_status="STOPPED"
+            bot_id=bot_id,
+            bot_uuid="bot-abc-123",
+            previous_status="ACTIVE",
+            new_status="STOPPED",
         )
         mock_admin_svc = AsyncMock()
         mock_admin_svc.update_bot_status.return_value = mock_result
 
         dep_callable = _get_endpoint_dep_callable(
-            client.app.router, path_contains="/bots/{bot_uuid}/status"
+            client.app.router, path_contains="/bots/{bot_id}/status"
         )
         client.app.dependency_overrides[dep_callable] = lambda: mock_admin_svc
         try:
             resp = client.post(
-                f"/api/v1/admin/bots/{bot_uuid}/status?tenant=acme",
+                f"/api/v1/admin/bots/{bot_id}/status",
                 json={"status": "STOPPED", "operator": "ops.alice"},
             )
         finally:
             del client.app.dependency_overrides[dep_callable]
 
         assert resp.status_code == 200
-        assert resp.json()["data"]["bot_uuid"] == bot_uuid
+        assert resp.json()["data"]["bot_id"] == bot_id
         mock_admin_svc.update_bot_status.assert_awaited_once_with(
-            bot_uuid=bot_uuid,
+            bot_id=bot_id,
             status="STOPPED",
             operator="ops.alice",
         )

--- a/src/baas/tests/unit/adapters/web/test_admin_router.py
+++ b/src/baas/tests/unit/adapters/web/test_admin_router.py
@@ -16,10 +16,16 @@ from fastapi.testclient import TestClient
 from secbaas.community.adapters.web.routers.admin.publish_admin_router import (
     ForceSuccessRequest,
     ForceSuccessResponse,
+    UpdateBotStatusRequest,
+    UpdateBotStatusResponse,
     _to_response,
+    _to_update_bot_status_response,
     router,
 )
-from secbaas.community.api.publish_manage import PublishNotFoundError
+from secbaas.community.api.publish_manage import (
+    PublishNotFoundError,
+    UpdateBotStatusResult,
+)
 from secbaas.community.core.service.publish_manage import ForceSuccessResult
 from tests.unit.adapters.web.conftest import iter_api_routes
 
@@ -40,6 +46,24 @@ def _get_admin_dep_callable(router):
             # The force-success route's dependency name is "admin_service"
             return dep.call
     raise RuntimeError("force-success route not found in router")
+
+
+def _get_endpoint_dep_callable(router, *, path_contains: str):
+    """Extract the Provide[...] callable used as the dependency for the
+    admin route whose path contains ``path_contains``.
+
+    Each endpoint defines its own ``Depends(Provide[...])`` at module import
+    time — a different _Marker instance per route. We must use the exact
+    same object instance that was captured at route definition time.
+    """
+    for r in iter_api_routes(router):
+        if path_contains in r.path:
+            for dep in r.dependant.dependencies:
+                # The admin route's dependency name is "admin_service"
+                return dep.call
+    raise RuntimeError(
+        f"admin route containing path {path_contains!r} not found in router"
+    )
 
 
 # ============== TestClient Fixture ==============
@@ -396,3 +420,293 @@ class TestForceSuccessEndpoint:
         assert body["data"]["batches_updated"] == 0
         assert body["data"]["records_updated"] == 0
         assert body["data"]["devices_updated"] == 0
+
+
+# ============== UpdateBotStatusRequest Model ==============
+
+
+class TestUpdateBotStatusRequest:
+    """UpdateBotStatusRequest input validation."""
+
+    def test_valid_request_construction(self):
+        req = UpdateBotStatusRequest(status="STOPPED", operator="ops.alice")
+        assert req.status == "STOPPED"
+        assert req.operator == "ops.alice"
+
+    def test_empty_status_returns_422(self, client):
+        resp = client.post(
+            "/api/v1/admin/bots/BOT_U/status?tenant=acme",
+            json={"status": "", "operator": "ops.alice"},
+        )
+        assert resp.status_code == 422
+
+    def test_status_too_long_returns_422(self, client):
+        resp = client.post(
+            "/api/v1/admin/bots/BOT_U/status?tenant=acme",
+            json={"status": "x" * 33, "operator": "ops.alice"},
+        )
+        assert resp.status_code == 422
+
+    def test_status_boundary_max_len_ok(self, client):
+        status = "x" * 32
+        mock_result = UpdateBotStatusResult(
+            bot_uuid="BOT_U", previous_status="ACTIVE", new_status=status
+        )
+        mock_admin_svc = AsyncMock()
+        mock_admin_svc.update_bot_status.return_value = mock_result
+
+        dep_callable = _get_endpoint_dep_callable(
+            client.app.router, path_contains="/bots/{bot_uuid}/status"
+        )
+        client.app.dependency_overrides[dep_callable] = lambda: mock_admin_svc
+        try:
+            resp = client.post(
+                "/api/v1/admin/bots/BOT_U/status?tenant=acme",
+                json={"status": status, "operator": "ops.alice"},
+            )
+        finally:
+            del client.app.dependency_overrides[dep_callable]
+
+        assert resp.status_code == 200
+
+    def test_empty_operator_returns_422(self, client):
+        resp = client.post(
+            "/api/v1/admin/bots/BOT_U/status?tenant=acme",
+            json={"status": "STOPPED", "operator": ""},
+        )
+        assert resp.status_code == 422
+
+    def test_operator_too_long_returns_422(self, client):
+        resp = client.post(
+            "/api/v1/admin/bots/BOT_U/status?tenant=acme",
+            json={"status": "STOPPED", "operator": "x" * 129},
+        )
+        assert resp.status_code == 422
+
+    def test_operator_boundary_max_len_ok(self, client):
+        operator = "x" * 128
+        mock_result = UpdateBotStatusResult(
+            bot_uuid="BOT_U", previous_status="ACTIVE", new_status="STOPPED"
+        )
+        mock_admin_svc = AsyncMock()
+        mock_admin_svc.update_bot_status.return_value = mock_result
+
+        dep_callable = _get_endpoint_dep_callable(
+            client.app.router, path_contains="/bots/{bot_uuid}/status"
+        )
+        client.app.dependency_overrides[dep_callable] = lambda: mock_admin_svc
+        try:
+            resp = client.post(
+                "/api/v1/admin/bots/BOT_U/status?tenant=acme",
+                json={"status": "STOPPED", "operator": operator},
+            )
+        finally:
+            del client.app.dependency_overrides[dep_callable]
+
+        assert resp.status_code == 200
+
+    def test_missing_status_returns_422(self, client):
+        resp = client.post(
+            "/api/v1/admin/bots/BOT_U/status?tenant=acme",
+            json={"operator": "ops.alice"},
+        )
+        assert resp.status_code == 422
+
+    def test_missing_operator_returns_422(self, client):
+        resp = client.post(
+            "/api/v1/admin/bots/BOT_U/status?tenant=acme",
+            json={"status": "STOPPED"},
+        )
+        assert resp.status_code == 422
+
+
+# ============== UpdateBotStatusResponse Model ==============
+
+
+class TestUpdateBotStatusResponse:
+    """UpdateBotStatusResponse model validation."""
+
+    def test_response_construction(self):
+        resp = UpdateBotStatusResponse(
+            bot_uuid="BOT_U",
+            previous_status="ACTIVE",
+            new_status="STOPPED",
+        )
+        assert resp.bot_uuid == "BOT_U"
+        assert resp.previous_status == "ACTIVE"
+        assert resp.new_status == "STOPPED"
+
+
+# ============== _to_update_bot_status_response Helper ==============
+
+
+class TestToUpdateBotStatusResponse:
+    """_to_update_bot_status_response converts UpdateBotStatusResult."""
+
+    def test_converts_all_fields(self):
+        result = UpdateBotStatusResult(
+            bot_uuid="BOT_U",
+            previous_status="ACTIVE",
+            new_status="STOPPED",
+        )
+        resp = _to_update_bot_status_response(result)
+
+        assert isinstance(resp, UpdateBotStatusResponse)
+        assert resp.bot_uuid == "BOT_U"
+        assert resp.previous_status == "ACTIVE"
+        assert resp.new_status == "STOPPED"
+
+    def test_converts_other_values(self):
+        result = UpdateBotStatusResult(
+            bot_uuid="abc-123",
+            previous_status="PENDING",
+            new_status="ACTIVE",
+        )
+        resp = _to_update_bot_status_response(result)
+
+        assert resp.bot_uuid == "abc-123"
+        assert resp.previous_status == "PENDING"
+        assert resp.new_status == "ACTIVE"
+
+
+# ============== update_bot_status_endpoint ==============
+
+
+class TestUpdateBotStatusEndpoint:
+    """Tests for POST /api/v1/admin/bots/{bot_uuid}/status endpoint."""
+
+    def test_happy_path_returns_200_with_response_data(self, client):
+        mock_result = UpdateBotStatusResult(
+            bot_uuid="BOT_U", previous_status="ACTIVE", new_status="STOPPED"
+        )
+        mock_admin_svc = AsyncMock()
+        mock_admin_svc.update_bot_status.return_value = mock_result
+
+        dep_callable = _get_endpoint_dep_callable(
+            client.app.router, path_contains="/bots/{bot_uuid}/status"
+        )
+        client.app.dependency_overrides[dep_callable] = lambda: mock_admin_svc
+        try:
+            resp = client.post(
+                "/api/v1/admin/bots/BOT_U/status?tenant=acme",
+                json={"status": "STOPPED", "operator": "ops.alice"},
+            )
+        finally:
+            del client.app.dependency_overrides[dep_callable]
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["code"] == 0
+        assert body["message"] == "success"
+        assert body["data"]["bot_uuid"] == "BOT_U"
+        assert body["data"]["previous_status"] == "ACTIVE"
+        assert body["data"]["new_status"] == "STOPPED"
+
+    def test_calls_update_bot_status_with_correct_args(self, client):
+        mock_result = UpdateBotStatusResult(
+            bot_uuid="BOT_U", previous_status="ACTIVE", new_status="STOPPED"
+        )
+        mock_admin_svc = AsyncMock()
+        mock_admin_svc.update_bot_status.return_value = mock_result
+
+        dep_callable = _get_endpoint_dep_callable(
+            client.app.router, path_contains="/bots/{bot_uuid}/status"
+        )
+        client.app.dependency_overrides[dep_callable] = lambda: mock_admin_svc
+        try:
+            client.post(
+                "/api/v1/admin/bots/BOT_U/status?tenant=other",
+                json={"status": "STOPPED", "operator": "ops.alice"},
+            )
+        finally:
+            del client.app.dependency_overrides[dep_callable]
+
+        mock_admin_svc.update_bot_status.assert_awaited_once_with(
+            bot_uuid="BOT_U",
+            status="STOPPED",
+            operator="ops.alice",
+        )
+        # tenant query parameter is advisory only — never forwarded to service.
+        kwargs = mock_admin_svc.update_bot_status.await_args.kwargs
+        assert "tenant" not in kwargs
+        assert "env" not in kwargs
+
+    def test_publish_not_found_propagates_as_404(self, client):
+        mock_admin_svc = AsyncMock()
+        mock_admin_svc.update_bot_status.side_effect = PublishNotFoundError(
+            "Bot BOT_U not found or not active"
+        )
+
+        dep_callable = _get_endpoint_dep_callable(
+            client.app.router, path_contains="/bots/{bot_uuid}/status"
+        )
+        client.app.dependency_overrides[dep_callable] = lambda: mock_admin_svc
+        try:
+            resp = client.post(
+                "/api/v1/admin/bots/BOT_U/status?tenant=acme",
+                json={"status": "STOPPED", "operator": "ops.alice"},
+            )
+        finally:
+            del client.app.dependency_overrides[dep_callable]
+
+        assert resp.status_code == 404
+        body = resp.json()
+        assert "Bot BOT_U not found or not active" in body["detail"]
+
+    def test_missing_tenant_query_param_returns_422(self, client):
+        resp = client.post(
+            "/api/v1/admin/bots/BOT_U/status",
+            json={"status": "STOPPED", "operator": "ops.alice"},
+        )
+        assert resp.status_code == 422
+
+    def test_response_data_has_exactly_three_keys(self, client):
+        mock_result = UpdateBotStatusResult(
+            bot_uuid="BOT_U", previous_status="ACTIVE", new_status="STOPPED"
+        )
+        mock_admin_svc = AsyncMock()
+        mock_admin_svc.update_bot_status.return_value = mock_result
+
+        dep_callable = _get_endpoint_dep_callable(
+            client.app.router, path_contains="/bots/{bot_uuid}/status"
+        )
+        client.app.dependency_overrides[dep_callable] = lambda: mock_admin_svc
+        try:
+            resp = client.post(
+                "/api/v1/admin/bots/BOT_U/status?tenant=acme",
+                json={"status": "STOPPED", "operator": "ops.alice"},
+            )
+        finally:
+            del client.app.dependency_overrides[dep_callable]
+
+        assert resp.status_code == 200
+        data = resp.json()["data"]
+        assert set(data.keys()) == {"bot_uuid", "previous_status", "new_status"}
+
+    @pytest.mark.parametrize("bot_uuid", ["BOT_U", "abc-123-def"])
+    def test_endpoint_uses_bot_uuid_path_param(self, client, bot_uuid):
+        mock_result = UpdateBotStatusResult(
+            bot_uuid=bot_uuid, previous_status="ACTIVE", new_status="STOPPED"
+        )
+        mock_admin_svc = AsyncMock()
+        mock_admin_svc.update_bot_status.return_value = mock_result
+
+        dep_callable = _get_endpoint_dep_callable(
+            client.app.router, path_contains="/bots/{bot_uuid}/status"
+        )
+        client.app.dependency_overrides[dep_callable] = lambda: mock_admin_svc
+        try:
+            resp = client.post(
+                f"/api/v1/admin/bots/{bot_uuid}/status?tenant=acme",
+                json={"status": "STOPPED", "operator": "ops.alice"},
+            )
+        finally:
+            del client.app.dependency_overrides[dep_callable]
+
+        assert resp.status_code == 200
+        assert resp.json()["data"]["bot_uuid"] == bot_uuid
+        mock_admin_svc.update_bot_status.assert_awaited_once_with(
+            bot_uuid=bot_uuid,
+            status="STOPPED",
+            operator="ops.alice",
+        )

--- a/src/baas/tests/unit/api/publish_manage/test_models.py
+++ b/src/baas/tests/unit/api/publish_manage/test_models.py
@@ -115,6 +115,13 @@ class TestPublishConfig:
         assert "direct" in defaults["stages"]
         assert defaults["drain_timeout_seconds"] == 0
 
+    def test_get_defaults_for_type_update_device(self):
+        defaults = PublishConfig.get_defaults_for_type(PublishType.UPDATE_DEVICE)
+        assert defaults == {
+            "stages": {"direct": {"batch_capacity": 10, "cooldown_seconds": 0}},
+            "drain_timeout_seconds": 0,
+        }
+
 
 class TestPublishBatchConfig:
     """Tests for PublishBatchConfig model."""
@@ -606,3 +613,30 @@ class TestSerializeHookResult:
     def test_serialized_json_valid(self):
         result = serialize_hook_result(exit_code=0, stdout="test")
         assert json.loads(result)["exit_code"] == 0
+
+    def test_serialize_hook_result_truncate_keep_negative(self):
+        # When message is long enough to make the stdout/stderr budget < 11
+        # (length of "[truncated]"), keep = budget - 11 falls below 0 and is
+        # clamped to 0 by the `_truncate` inner helper.
+        result = serialize_hook_result(
+            exit_code=0,
+            stdout="x" * 8000,
+            stderr=None,
+            message="m" * 4080,
+        )
+        assert "[truncated]" in result
+        assert len(result) <= 4096
+
+    def test_serialize_hook_result_final_safety_truncation(self):
+        # When the serialized JSON still exceeds _RESULT_MESSAGE_MAX after
+        # per-field truncation (e.g. message itself is very long), the final
+        # safety branch trims the whole string to exactly _RESULT_MESSAGE_MAX
+        # and appends "[truncated]".
+        result = serialize_hook_result(
+            exit_code=0,
+            stdout="x" * 8000,
+            stderr="y" * 8000,
+            message="m" * 4080,
+        )
+        assert len(result) == 4096
+        assert result.endswith("[truncated]")

--- a/src/baas/tests/unit/core/service/publish_manage/test_admin_service.py
+++ b/src/baas/tests/unit/core/service/publish_manage/test_admin_service.py
@@ -469,25 +469,26 @@ class TestUpdateBotStatus:
             status="ACTIVE",
             tenant="acme",
             env="prod",
-            bot_uuid="BOT_U",
+            bot_uuid="bot-abc-123",
         )
         bot_repo = MagicMock()
-        bot_repo.get_active_by_bot_uuid_only.return_value = mock_bot
+        bot_repo.get_by_id_only.return_value = mock_bot
 
         service = _make_service(bot_repo=bot_repo)
 
         result = await service.update_bot_status(
-            bot_uuid="BOT_U",
+            bot_id=42,
             status="STOPPED",
             operator="ops.alice",
         )
 
         assert isinstance(result, UpdateBotStatusResult)
-        assert result.bot_uuid == "BOT_U"
+        assert result.bot_id == 42
+        assert result.bot_uuid == "bot-abc-123"
         assert result.previous_status == "ACTIVE"
         assert result.new_status == "STOPPED"
 
-        bot_repo.get_active_by_bot_uuid_only.assert_called_once_with("BOT_U")
+        bot_repo.get_by_id_only.assert_called_once_with(42)
         bot_repo.update_status.assert_called_once_with(
             bot_id=42,
             tenant="acme",
@@ -498,24 +499,24 @@ class TestUpdateBotStatus:
 
     async def test_update_bot_status_not_found_raises(self):
         bot_repo = MagicMock()
-        bot_repo.get_active_by_bot_uuid_only.return_value = None
+        bot_repo.get_by_id_only.return_value = None
 
         service = _make_service(bot_repo=bot_repo)
 
         with pytest.raises(PublishNotFoundError) as exc_info:
             await service.update_bot_status(
-                bot_uuid="BOT_U",
+                bot_id=999,
                 status="STOPPED",
                 operator="ops.alice",
             )
 
-        assert "BOT_U" in str(exc_info.value)
+        assert "999" in str(exc_info.value)
         bot_repo.update_status.assert_not_called()
 
     async def test_update_bot_status_does_not_call_get_current_env(self):
-        mock_bot = _make_mock_bot(id=42, status="ACTIVE")
+        mock_bot = _make_mock_bot(id=42, status="ACTIVE", bot_uuid="bot-abc-123")
         bot_repo = MagicMock()
-        bot_repo.get_active_by_bot_uuid_only.return_value = mock_bot
+        bot_repo.get_by_id_only.return_value = mock_bot
 
         service = _make_service(bot_repo=bot_repo)
 
@@ -523,7 +524,7 @@ class TestUpdateBotStatus:
             "secbaas.community.core.service.publish_manage._admin_service.get_current_env",
         ) as mock_get_env:
             await service.update_bot_status(
-                bot_uuid="BOT_U",
+                bot_id=42,
                 status="STOPPED",
                 operator="ops.alice",
             )
@@ -536,10 +537,10 @@ class TestUpdateBotStatus:
             status="ACTIVE",
             tenant="acme",
             env="prod",
-            bot_uuid="BOT_U",
+            bot_uuid="bot-abc-123",
         )
         bot_repo = MagicMock()
-        bot_repo.get_active_by_bot_uuid_only.return_value = mock_bot
+        bot_repo.get_by_id_only.return_value = mock_bot
 
         service = _make_service(bot_repo=bot_repo)
 
@@ -547,7 +548,7 @@ class TestUpdateBotStatus:
             "secbaas.community.core.service.publish_manage._admin_service.logger"
         ) as mock_logger:
             await service.update_bot_status(
-                bot_uuid="BOT_U",
+                bot_id=42,
                 status="STOPPED",
                 operator="ops.alice",
             )
@@ -555,7 +556,8 @@ class TestUpdateBotStatus:
         mock_logger.warning.assert_called_once()
         log_msg = mock_logger.warning.call_args.args[0]
         assert "ADMIN_UPDATE_BOT_STATUS:" in log_msg
-        assert "bot_uuid=BOT_U" in log_msg
+        assert "bot_id=42" in log_msg
+        assert "bot_uuid=bot-abc-123" in log_msg
         assert "previous_status=ACTIVE" in log_msg
         assert "new_status=STOPPED" in log_msg
         assert "operator=ops.alice" in log_msg
@@ -564,15 +566,15 @@ class TestUpdateBotStatus:
 
     async def test_update_bot_status_captures_different_previous_status(self):
         mock_bot = _make_mock_bot(
-            id=42, status="STOPPED", tenant="acme", env="prod", bot_uuid="BOT_U"
+            id=42, status="STOPPED", tenant="acme", env="prod", bot_uuid="bot-abc-123"
         )
         bot_repo = MagicMock()
-        bot_repo.get_active_by_bot_uuid_only.return_value = mock_bot
+        bot_repo.get_by_id_only.return_value = mock_bot
 
         service = _make_service(bot_repo=bot_repo)
 
         result = await service.update_bot_status(
-            bot_uuid="BOT_U",
+            bot_id=42,
             status="ACTIVE",
             operator="ops.alice",
         )
@@ -590,15 +592,15 @@ class TestUpdateBotStatus:
 
     async def test_update_bot_status_uses_record_env_not_server_env(self):
         mock_bot = _make_mock_bot(
-            id=42, status="ACTIVE", tenant="acme", env="gray", bot_uuid="BOT_U"
+            id=42, status="ACTIVE", tenant="acme", env="gray", bot_uuid="bot-abc-123"
         )
         bot_repo = MagicMock()
-        bot_repo.get_active_by_bot_uuid_only.return_value = mock_bot
+        bot_repo.get_by_id_only.return_value = mock_bot
 
         service = _make_service(bot_repo=bot_repo)
 
         await service.update_bot_status(
-            bot_uuid="BOT_U",
+            bot_id=42,
             status="STOPPED",
             operator="ops.alice",
         )
@@ -614,20 +616,24 @@ class TestUpdateBotStatusResult:
 
     def test_construction(self):
         result = UpdateBotStatusResult(
-            bot_uuid="BOT_U",
+            bot_id=42,
+            bot_uuid="bot-abc-123",
             previous_status="ACTIVE",
             new_status="STOPPED",
         )
-        assert result.bot_uuid == "BOT_U"
+        assert result.bot_id == 42
+        assert result.bot_uuid == "bot-abc-123"
         assert result.previous_status == "ACTIVE"
         assert result.new_status == "STOPPED"
 
     def test_construction_with_other_values(self):
         result = UpdateBotStatusResult(
-            bot_uuid="abc-123",
+            bot_id=999,
+            bot_uuid="abc-def-456",
             previous_status="PENDING",
             new_status="ACTIVE",
         )
-        assert result.bot_uuid == "abc-123"
+        assert result.bot_id == 999
+        assert result.bot_uuid == "abc-def-456"
         assert result.previous_status == "PENDING"
         assert result.new_status == "ACTIVE"

--- a/src/baas/tests/unit/core/service/publish_manage/test_admin_service.py
+++ b/src/baas/tests/unit/core/service/publish_manage/test_admin_service.py
@@ -14,7 +14,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from secbaas.community.api.publish_manage import PublishNotFoundError
+from secbaas.community.api.publish_manage import (
+    PublishNotFoundError,
+    UpdateBotStatusResult,
+)
 from secbaas.community.core.service.publish_manage._admin_service import (
     DefaultPublishAdminService,
     ForceSuccessResult,
@@ -49,6 +52,22 @@ def _make_mock_device(
     device.id = id
     device.status = status
     return device
+
+
+def _make_mock_bot(
+    id: int = 1,
+    status: str = "ACTIVE",
+    tenant: str = "acme",
+    env: str = "prod",
+    bot_uuid: str = "BOT_U",
+) -> MagicMock:
+    bot = MagicMock()
+    bot.id = id
+    bot.status = status
+    bot.tenant = tenant
+    bot.env = env
+    bot.bot_uuid = bot_uuid
+    return bot
 
 
 def _make_service(
@@ -436,3 +455,179 @@ class TestForceSuccessResult:
         assert result.records_updated == 5
         assert result.devices_updated == 3
         assert result.bot_updated is True
+
+
+# ============== update_bot_status ==============
+
+
+class TestUpdateBotStatus:
+    """DefaultPublishAdminService.update_bot_status."""
+
+    async def test_update_bot_status_happy_path(self):
+        mock_bot = _make_mock_bot(
+            id=42,
+            status="ACTIVE",
+            tenant="acme",
+            env="prod",
+            bot_uuid="BOT_U",
+        )
+        bot_repo = MagicMock()
+        bot_repo.get_active_by_bot_uuid_only.return_value = mock_bot
+
+        service = _make_service(bot_repo=bot_repo)
+
+        result = await service.update_bot_status(
+            bot_uuid="BOT_U",
+            status="STOPPED",
+            operator="ops.alice",
+        )
+
+        assert isinstance(result, UpdateBotStatusResult)
+        assert result.bot_uuid == "BOT_U"
+        assert result.previous_status == "ACTIVE"
+        assert result.new_status == "STOPPED"
+
+        bot_repo.get_active_by_bot_uuid_only.assert_called_once_with("BOT_U")
+        bot_repo.update_status.assert_called_once_with(
+            bot_id=42,
+            tenant="acme",
+            env="prod",
+            status="STOPPED",
+            modifier="ops.alice",
+        )
+
+    async def test_update_bot_status_not_found_raises(self):
+        bot_repo = MagicMock()
+        bot_repo.get_active_by_bot_uuid_only.return_value = None
+
+        service = _make_service(bot_repo=bot_repo)
+
+        with pytest.raises(PublishNotFoundError) as exc_info:
+            await service.update_bot_status(
+                bot_uuid="BOT_U",
+                status="STOPPED",
+                operator="ops.alice",
+            )
+
+        assert "BOT_U" in str(exc_info.value)
+        bot_repo.update_status.assert_not_called()
+
+    async def test_update_bot_status_does_not_call_get_current_env(self):
+        mock_bot = _make_mock_bot(id=42, status="ACTIVE")
+        bot_repo = MagicMock()
+        bot_repo.get_active_by_bot_uuid_only.return_value = mock_bot
+
+        service = _make_service(bot_repo=bot_repo)
+
+        with patch(
+            "secbaas.community.core.service.publish_manage._admin_service.get_current_env",
+        ) as mock_get_env:
+            await service.update_bot_status(
+                bot_uuid="BOT_U",
+                status="STOPPED",
+                operator="ops.alice",
+            )
+
+        mock_get_env.assert_not_called()
+
+    async def test_update_bot_status_emits_warning_log(self):
+        mock_bot = _make_mock_bot(
+            id=42,
+            status="ACTIVE",
+            tenant="acme",
+            env="prod",
+            bot_uuid="BOT_U",
+        )
+        bot_repo = MagicMock()
+        bot_repo.get_active_by_bot_uuid_only.return_value = mock_bot
+
+        service = _make_service(bot_repo=bot_repo)
+
+        with patch(
+            "secbaas.community.core.service.publish_manage._admin_service.logger"
+        ) as mock_logger:
+            await service.update_bot_status(
+                bot_uuid="BOT_U",
+                status="STOPPED",
+                operator="ops.alice",
+            )
+
+        mock_logger.warning.assert_called_once()
+        log_msg = mock_logger.warning.call_args.args[0]
+        assert "ADMIN_UPDATE_BOT_STATUS:" in log_msg
+        assert "bot_uuid=BOT_U" in log_msg
+        assert "previous_status=ACTIVE" in log_msg
+        assert "new_status=STOPPED" in log_msg
+        assert "operator=ops.alice" in log_msg
+        assert "tenant=acme" in log_msg
+        assert "env=prod" in log_msg
+
+    async def test_update_bot_status_captures_different_previous_status(self):
+        mock_bot = _make_mock_bot(
+            id=42, status="STOPPED", tenant="acme", env="prod", bot_uuid="BOT_U"
+        )
+        bot_repo = MagicMock()
+        bot_repo.get_active_by_bot_uuid_only.return_value = mock_bot
+
+        service = _make_service(bot_repo=bot_repo)
+
+        result = await service.update_bot_status(
+            bot_uuid="BOT_U",
+            status="ACTIVE",
+            operator="ops.alice",
+        )
+
+        assert result.previous_status == "STOPPED"
+        assert result.new_status == "ACTIVE"
+
+        bot_repo.update_status.assert_called_once_with(
+            bot_id=42,
+            tenant="acme",
+            env="prod",
+            status="ACTIVE",
+            modifier="ops.alice",
+        )
+
+    async def test_update_bot_status_uses_record_env_not_server_env(self):
+        mock_bot = _make_mock_bot(
+            id=42, status="ACTIVE", tenant="acme", env="gray", bot_uuid="BOT_U"
+        )
+        bot_repo = MagicMock()
+        bot_repo.get_active_by_bot_uuid_only.return_value = mock_bot
+
+        service = _make_service(bot_repo=bot_repo)
+
+        await service.update_bot_status(
+            bot_uuid="BOT_U",
+            status="STOPPED",
+            operator="ops.alice",
+        )
+
+        kwargs = bot_repo.update_status.call_args.kwargs
+        assert kwargs["env"] == "gray"
+        assert kwargs["tenant"] == "acme"
+        assert kwargs["bot_id"] == 42
+
+
+class TestUpdateBotStatusResult:
+    """UpdateBotStatusResult dataclass contract."""
+
+    def test_construction(self):
+        result = UpdateBotStatusResult(
+            bot_uuid="BOT_U",
+            previous_status="ACTIVE",
+            new_status="STOPPED",
+        )
+        assert result.bot_uuid == "BOT_U"
+        assert result.previous_status == "ACTIVE"
+        assert result.new_status == "STOPPED"
+
+    def test_construction_with_other_values(self):
+        result = UpdateBotStatusResult(
+            bot_uuid="abc-123",
+            previous_status="PENDING",
+            new_status="ACTIVE",
+        )
+        assert result.bot_uuid == "abc-123"
+        assert result.previous_status == "PENDING"
+        assert result.new_status == "ACTIVE"


### PR DESCRIPTION
## Problem

BaaS had no admin-side way to force a bot's status when the normal publish
state machine was stuck or when an operator needed to reconcile a bot's
runtime state out-of-band. The existing `update_device_status` admin
endpoint handled this for devices, but bots could only be moved through the
regular publish workflow, which is unsuitable for break-glass corrections.

## Solution

Add a new admin endpoint `POST /api/v1/admin/bots/{bot_uuid}/status` that
bypasses the publish state machine and updates a bot's status directly.

The change mirrors the existing `update_device_status` admin pattern but
**discards env scoping** at the API boundary: no `env` parameter is accepted,
and the service resolves the active row cross-env via the existing
`get_active_by_bot_uuid_only` repository method. The env stored on that
record is then used for the write-back through `update_status`, so the row's
`(tenant, env)` pair is preserved without exposing env selection to the
caller.

Layered in three atomic commits:

1. **API contract** — `UpdateBotStatusResult` dataclass, the
   `PublishAdminService.update_bot_status` Protocol method, the package
   re-export, and extensions to `test_models.py` that lift `_models.py`
   line coverage to 100%.
2. **Service implementation** —
   `DefaultPublishAdminService.update_bot_status`: lookup via
   `get_active_by_bot_uuid_only`, raise `PublishNotFoundError` when no
   active row exists, emit a `WARNING` audit log tagged
   `ADMIN_UPDATE_BOT_STATUS:`, write back through `update_status`, and
   return the `UpdateBotStatusResult`. `get_current_env` is intentionally
   never called on this path.
3. **Router endpoint** — `POST /api/v1/admin/bots/{bot_uuid}/status` on
   `publish_admin_router`, accepting `status` and `operator` in the body
   and an advisory `tenant` query param used only for the audit log (not
   forwarded to the service). `PublishNotFoundError` maps to HTTP 404.

Rejected alternatives (documented in
`openspec/changes/add-bot-status-admin-api/design.md`): adding a `reason`
column, introducing a `BotNotFoundError`, adding enum validation at the API
boundary, or adding env as a request parameter. All were explicitly
rejected to keep the surface minimal and to match the existing
device-status admin pattern exactly.

## Validation

| Check | Command | Result |
| --- | --- | --- |
| Focused unit tests | `cd src/baas && uv run pytest tests/unit/core/service/publish_manage/test_admin_service.py tests/unit/adapters/web/test_admin_router.py tests/unit/api/publish_manage/test_models.py -q` | 113 passed in 0.52s |
| mypy Protocol conformance | `cd src/baas && uv run mypy tests/architecture/check_protocols/api/publish_manage/check_publish_admin_service.py` | Success: no issues found in 1 source file |
| Full BaaS CI gate | `cd src/baas && just test-ci` | 8894 passed, 100% case pass rate, 93.32% line coverage — BAAS CI GATE PASSED, BAAS ASGI GATE PASSED |
| `get_current_env` leak check | `grep -n get_current_env src/baas/src/secbaas/community/core/service/publish_manage/_admin_service.py` | Only at line 21 (import) and line 64 (inside `force_success`); absent from `update_bot_status` |

Per-file coverage on the four touched source files (focused 3-file run):

| File | Stmts | Miss | Cover |
| --- | --- | --- | --- |
| `_models.py` | 221 | 0 | 100% |
| `_protocols.py` | 8 | 0 | 100% |
| `_admin_service.py` | 76 | 7 | 91% (missing 122-143 are pre-existing `update_device_status`) |
| `publish_admin_router.py` | 62 | 6 | 90% (missing 126, 155-167 are pre-existing `update_device_status`) |

All uncovered lines are in pre-existing code touched by this change.
OpenSpec change `add-bot-status-admin-api` is marked complete: 4/4 artifacts
done, 21/21 tasks checked.

## Compatibility and risk

- **Contract impact**: adds one new method to the `PublishAdminService`
  Protocol. Existing implementations that do not provide this method will
  fail mypy structural checks. This is intentional and is enforced by
  `tests/architecture/check_protocols/api/publish_manage/check_publish_admin_service.py`.
- **Schema/migration**: none. No new database columns, no new tables. The
  endpoint reuses existing repository methods (`get_active_by_bot_uuid_only`
  and `update_status`).
- **API surface**: new endpoint only; no existing endpoint behavior changes.
- **Rollback**: revert the three commits. No data migration to undo.
- **Operational risk**: the endpoint is admin-scoped (same auth guard as
  the existing device-status endpoint) and writes a `WARNING` audit log on
  every call.

## Spec

OpenSpec change `add-bot-status-admin-api`:
- `openspec/changes/add-bot-status-admin-api/proposal.md`
- `openspec/changes/add-bot-status-admin-api/design.md` (7 decisions D1–D7)
- `openspec/changes/add-bot-status-admin-api/specs/bot-status-admin/spec.md` (6 normative requirements)
- `openspec/changes/add-bot-status-admin-api/tasks.md` (21 tasks, all marked `[x]`)