### PR TITLE
feat(backend): allow coding bot creation in any business space

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_inventory/policies/combo_policy.py
+++ b/src/backend/src/agentclaw/community/core/bot_inventory/policies/combo_policy.py
@@ -63,6 +63,9 @@ def assert_application_coding_create(
     messages). This copy has no production caller today — keep the two in
     sync, or single-source them once bot_inventory may depend on
     bot_management.
+
+    No space-kind gate: coding bots may be created in any business space
+    (``space_kind`` stays a parameter to mirror the strategy signature).
     """
     if deployment_mode is not DeployMode.CLOUD:
         return ComboDecision(False, "application coding is cloud-only")
@@ -72,6 +75,4 @@ def assert_application_coding_create(
         )
     if bot_type != "personal":
         return ComboDecision(False, "application coding bot must be personal")
-    if space_kind != "personal":
-        return ComboDecision(False, "application coding is personal-space only")
     return ComboDecision(True)

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
@@ -199,10 +199,10 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
             raise BotCombinationUnsupportedError(
                 "application coding bot must be personal"
             )
-        if space_kind != "personal":
-            raise BotCombinationUnsupportedError(
-                "application coding is personal-space only"
-            )
+        # No space-kind gate: coding bots may be created in any business space
+        # the caller is a member of (personal or team). ``space_kind`` stays in
+        # the signature so the strategy-interface contract and the
+        # ``combo_policy`` mirror keep matching.
 
         template = engine_properties["template"]
         if template is None:

--- a/src/backend/tests/community/core/bot_inventory/policies/test_combo_policy.py
+++ b/src/backend/tests/community/core/bot_inventory/policies/test_combo_policy.py
@@ -83,11 +83,13 @@ def test_application_coding_engine_matrix() -> None:
 
 
 @pytest.mark.unit
-def test_application_coding_supported_combination() -> None:
+@pytest.mark.parametrize("space_kind", ["personal", "team"])
+def test_application_coding_supported_combination(space_kind: str) -> None:
+    # No space-kind gate: coding bots may be created in any business space.
     ok = assert_application_coding_create(
         engine="claude_code",
         bot_type="personal",
-        space_kind="personal",
+        space_kind=space_kind,
         deployment_mode=DeployMode.CLOUD,
     )
     assert ok.ok
@@ -108,17 +110,11 @@ def test_application_coding_rejects_aicoding_engine() -> None:
 
 
 @pytest.mark.unit
-def test_application_coding_rejects_service_team_and_local() -> None:
+def test_application_coding_rejects_service_and_local() -> None:
     assert not assert_application_coding_create(
         engine="claude_code",
         bot_type="service",
         space_kind="personal",
-        deployment_mode=DeployMode.CLOUD,
-    ).ok
-    assert not assert_application_coding_create(
-        engine="claude_code",
-        bot_type="personal",
-        space_kind="team",
         deployment_mode=DeployMode.CLOUD,
     ).ok
     assert not assert_application_coding_create(

--- a/src/backend/tests/community/core/bot_management/test_application_coding_create.py
+++ b/src/backend/tests/community/core/bot_management/test_application_coding_create.py
@@ -188,7 +188,6 @@ def test_prepare_plain_bot_has_no_hosting_requirement() -> None:
         ({"engine_properties": {"template": {}}}, BotTemplateInvalidError),
         ({"engine_type": "aicoding"}, BotCombinationUnsupportedError),
         ({"bot_type": "service"}, BotCombinationUnsupportedError),
-        ({"space_kind": "team"}, BotCombinationUnsupportedError),
         ({"deployment_mode": "local"}, BotCombinationUnsupportedError),
     ],
 )
@@ -205,6 +204,20 @@ def test_prepare_rejects_invalid_application_coding_combinations(
     params.update(overrides)
     with pytest.raises(error):
         _strategy_prepare(**params)
+
+
+def test_prepare_application_coding_allows_any_business_space() -> None:
+    # No space-kind gate: a coding bot may be created in any business space
+    # the caller is a member of, not just their personal one.
+    for space_kind in ("personal", "team"):
+        prepared = _strategy_prepare(
+            engine_type="claude_code",
+            engine_properties={"template": {"devflow_workflow": "x"}},
+            space_kind=space_kind,
+        )
+        assert prepared.template_type == "applicationCoding"
+        assert prepared.template_config == {"devflow_workflow": "x"}
+        assert prepared.requires_workspace_hosting is True
 
 
 def test_prepare_application_coding_without_config_preserves_legacy_default() -> None:


### PR DESCRIPTION
## Problem

`POST /openapi/v1/bots` with coding-template `engine_properties`（applicationCoding / personalCoding / 模板工厂快照）命中 409000 `Coding template combination not supported` 只要请求带了非个人空间的 `space_id`。预发日志实锤底层门是 `application coding is personal-space only`（trace 反查 `[Public 409] BotCombinationUnsupportedError`）：aicoding 组合门的 `space_kind != "personal"` 一刀切拒绝团队空间，coding bot 只能建在个人空间。

## Solution

- 删除 `AicodingProvisioningStrategy.prepare_create` 的 space-kind 门；其余组合门（cloud / claude_code / bot_type=personal）保持历史顺序与 409 错误族不变
- `bot_inventory/policies/combo_policy.py` 的 production-dead 镜像 `assert_application_coding_create` 同步删门（两处按注释要求保持 in sync）
- `space_kind` 参数在两处签名里保留：strategy 接口契约不动，镜像与策略签名继续对齐
- 测试：strategy 侧新增 team-space 正向用例（parametrize 去掉 team 拒绝项）；combo_policy 侧 supported 组合参数化铺开 personal/team

内部 `/api/bots` 路由本来就硬编码 `space_kind="personal"`，不受影响；openapi_v1 面（create + 202 后 auth-status 完成创建）与 config-manifest 创建流程统一放开。

## Validation

- [x] 受影响子集：`tests/community/core/bot_management/` + `tests/community/core/bot_inventory/` 全绿（1111 passed）
- [x] 全量：`bash scripts/ci_test.sh --base origin/dev` → **16907 passed, 59 skipped**，case pass rate 100%，line coverage 88.52%，changed-line 门通过（src 侧改动均为删行+注释，无新增可执行行）

> 注：预发环境跑 REL20260901（含 #1797 的 v3 契约），该分支为 dev；若需预发验证此放开，需要把本 PR cherry-pick 到 REL——与 #1797 同样的场外动作。