### PR TITLE
fix(bot_build): rescue aicoding extra-include files via container fallback on NFS root_squash

### DIFF
--- a/src/backend/src/agentclaw/community/core/service_bot/services/bot_build_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/bot_build_service.py
@@ -15,7 +15,10 @@ import asyncio
 import copy
 import hashlib
 import json
+import os
+import shlex
 import subprocess
+import tempfile
 import time
 import uuid
 from dataclasses import replace
@@ -973,6 +976,8 @@ class BotBuildService:
             build_plan: EngineBuildPlan | None,
             command_name: str,
             error_message: str,
+            device_id: str | None = None,
+            device_source_root: str | None = None,
             chown: str | None = None,
             timeout_seconds: float | None = None,
     ) -> None:
@@ -995,6 +1000,23 @@ class BotBuildService:
                     admin_is_file = source_file.is_file()
                 except PermissionError:
                     if not self._sudo_is_file(source_file, timeout_seconds):
+                        # NFS root_squash: host sudo (root -> nobody) still
+                        # cannot read the uid-1000-owned sandbox file. As a
+                        # last resort, read it from inside the source bot's
+                        # BaaS container (runs as the file owner uid 1000),
+                        # bypassing root_squash. Only when a device is
+                        # available (publish/migrate path); restore_draft
+                        # reads host artifacts and never reaches here.
+                        if device_id and device_source_root:
+                            if self._sync_extra_include_file_via_device(
+                                device_id=device_id,
+                                device_source_root=device_source_root,
+                                rel_path=normalized,
+                                target_file=target_dir / normalized,
+                                chown=chown,
+                                timeout_seconds=timeout_seconds,
+                            ):
+                                continue
                         logger.info(
                             "[BotBuildService._sync_extra_include_files] "
                             "Skip unreadable extra include file (admin cannot "
@@ -1045,6 +1067,102 @@ class BotBuildService:
                     exc,
                     exc_info=True,
                 )
+
+    def _sync_extra_include_file_via_device(
+            self,
+            *,
+            device_id: str,
+            device_source_root: str,
+            rel_path: str,
+            target_file: Path,
+            chown: str | None = None,
+            timeout_seconds: float | None = None,
+    ) -> bool:
+        """Read an extra-include file from the source bot's BaaS container
+        and write it into the migration target.
+
+        Fallback for ``_sync_extra_include_files`` when the host-side
+        ``sudo`` copy cannot read the file because NFS ``root_squash`` maps
+        root to ``nobody`` on sandbox-owned files (uid 1000 / mode 0600).
+        ``exec_shell_new`` runs ``cat`` *inside* the BaaS bot container as
+        the file owner (uid 1000), so it reads its own file and we capture
+        ``stdout`` -- the same pattern ``_generate_mcp_config`` uses to read
+        ``mcporter.json``. The captured content is staged through a local
+        temp file and copied by ``sudo rsync`` to the target, mirroring the
+        host copy path (incl. ``--chown``) so the artifact stays consistent.
+
+        Returns True on success, False on any failure so the caller degrades
+        to skipping the file (never blocks publish/restore).
+        """
+        device_path = f"{device_source_root.rstrip('/')}/{rel_path}"
+        cmd = f"cat {shlex.quote(device_path)}"
+        try:
+            result = self._device_service.exec_shell_new(
+                device_id=device_id,
+                shell_cmd=cmd,
+            )
+        except Exception as exc:  # noqa: BLE001 - best-effort fallback
+            logger.warning(
+                "[BotBuildService._sync_extra_include_file_via_device] "
+                "exec_shell_new failed for %s on device %s: %s",
+                device_path, device_id, exc, exc_info=True,
+            )
+            return False
+
+        if result.exit_code != 0:
+            logger.info(
+                "[BotBuildService._sync_extra_include_file_via_device] "
+                "container cat failed (exit=%s) for %s: stderr=%s",
+                result.exit_code, device_path, result.stderr,
+            )
+            return False
+
+        content = result.stdout if result.stdout is not None else ""
+        # Stage captured content to a local temp file, then ``sudo rsync`` it
+        # into the NFS target (root reads the local temp freely; writing to
+        # the target works the same as the primary migration rsync).
+        # Failure-safe: bind tmp_path first so a mkstemp failure is handled by
+        # the except below and the finally never references an unbound name.
+        # The whole block is best-effort: any error returns False -> the caller
+        # degrades to skipping this file (publish/restore never blocked).
+        tmp_path = None
+        try:
+            tmp_fd, tmp_path = tempfile.mkstemp(
+                suffix=f".{Path(rel_path).name}",
+                prefix="extra_include_",
+            )
+            with os.fdopen(tmp_fd, "w", encoding="utf-8") as fh:
+                fh.write(content)
+            target_file.parent.mkdir(parents=True, exist_ok=True)
+            rsync_cmd = ["sudo", "rsync", "-av"]
+            if chown:
+                rsync_cmd.append(f"--chown={chown}")
+            rsync_cmd.extend([tmp_path, str(target_file)])
+            self._run_local_command(
+                cmd=rsync_cmd,
+                command_name="rsync extra include (device)",
+                error_message="rsync extra include file (device) failed",
+                timeout_seconds=timeout_seconds,
+            )
+            logger.info(
+                "[BotBuildService._sync_extra_include_file_via_device] "
+                "synced %s via device container (file owner uid) to %s",
+                device_path, target_file,
+            )
+            return True
+        except Exception as exc:  # noqa: BLE001 - best-effort fallback
+            logger.warning(
+                "[BotBuildService._sync_extra_include_file_via_device] "
+                "failed to stage/copy %s to %s: %s",
+                device_path, target_file, exc, exc_info=True,
+            )
+            return False
+        finally:
+            if tmp_path is not None:
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
 
     def _migrate_bot_instance(
         self,
@@ -1138,12 +1256,27 @@ class BotBuildService:
                 error_message="rsync migration failed",
             )
 
+            # Device-side fallback for extra-include files that are unreadable
+            # on the NAS merge area due to NFS root_squash (uid-1000-owned
+            # sessions/cron-tasks.json). Only the publish/migrate path has the
+            # source bot's BaaS container online to cat the file as its owner.
+            # Defensive: provider.get_base_path() must never abort the
+            # migrate; on any failure degrade to "no device fallback" (old
+            # skip behavior) rather than fail the whole publish.
+            try:
+                device_source_root = (
+                    str(provider.get_base_path()) if provider else None
+                )
+            except Exception:
+                device_source_root = None
             self._sync_extra_include_files(
                 source_dir=source_dir,
                 target_dir=target_dir,
                 build_plan=build_plan,
                 command_name="rsync extra include",
                 error_message="rsync extra include file failed",
+                device_id=device_id,
+                device_source_root=device_source_root,
             )
 
             # 额外同步目录：例如 claude_code 需要把 source_dir 同级的 .claude

--- a/src/backend/tests/community/core/service_bot/services/test_bot_build_service_draft_restore.py
+++ b/src/backend/tests/community/core/service_bot/services/test_bot_build_service_draft_restore.py
@@ -1,4 +1,5 @@
 
+import shutil
 import subprocess
 from unittest.mock import MagicMock
 
@@ -7,6 +8,8 @@ import pytest
 from agentclaw.community.core.service_bot.services import bot_build_service as module
 from agentclaw.community.core.service_bot.services.bot_build_service import BotBuildService
 from agentclaw.community.core.workspace.engine_sandbox import EngineBuildPlan
+
+from agentclaw.community.kernel.device_dto import CommandResult
 
 
 def test_restore_draft_arca_rsyncs_versioned_artifact_into_draft_nas(monkeypatch, tmp_path):
@@ -429,3 +432,180 @@ def test_sync_extra_include_files_logs_and_continues_on_invalid_path(tmp_path, c
 
     svc._run_local_command.assert_not_called()
     assert "Failed to sync extra include file" in caplog.text
+
+# ---------------------------------------------------------------------------
+# Device-container fallback (_sync_extra_include_file_via_device) for
+# extra-include files unreadable on the NAS merge area due to NFS root_squash
+# (uid-1000-owned sessions/cron-tasks.json). The host sudo copy sees root
+# squashed to nobody; the file is instead `cat`-ed from the source bot's BaaS
+# container (uid 1000 owner), matching the _generate_mcp_config pattern.
+# ---------------------------------------------------------------------------
+
+
+def _extra_include_plan():
+    return EngineBuildPlan(
+        engine_type="aicoding",
+        source_root_name=".aicoding",
+        migration_subpath="aicoding",
+        workspace_subdir="workspace",
+        mcp_config_relpath="workspace/config/mcporter.json",
+        skill_source_relpath="workspace/skills",
+        skill_target_relpath="workspace/skills",
+        rsync_excludes=["sessions"],
+        extra_include_files=["sessions/cron-tasks.json"],
+    )
+
+
+def _fake_rsync_copy(**kwargs):
+    """Simulate `sudo rsync src dst` so tests can assert landed content."""
+    cmd = kwargs["cmd"]
+    shutil.copyfile(cmd[-2], cmd[-1])
+
+
+class _UnreadableSourceFile:
+    """Stand-in for a NAS sandbox file the service uid cannot stat: exists()
+    / is_file() raise PermissionError (NFS root_squash, uid-1000/0600).
+
+    ``source_dir / rel`` returns self so the whole unreadable path is one
+    object that triggers the PermissionError branch in _sync_extra_include_files.
+    """
+
+    def __truediv__(self, other):
+        return self
+
+    def exists(self):
+        raise PermissionError("simulated EACCES")
+
+    def is_file(self):
+        raise PermissionError("simulated EACCES")
+
+    def __str__(self):
+        return "/host/.merge_nas/bot/.aicoding/sessions/cron-tasks.json"
+
+
+def test_sync_extra_include_file_via_device_reads_from_container(tmp_path):
+    svc = object.__new__(BotBuildService)
+    svc._device_service = MagicMock()
+    svc._device_service.exec_shell_new.return_value = CommandResult(
+        stdout='{"tasks":[]}', exit_code=0, stderr="",
+    )
+    svc._run_local_command = MagicMock(side_effect=_fake_rsync_copy)
+
+    target_file = tmp_path / "target" / "sessions" / "cron-tasks.json"
+
+    ok = svc._sync_extra_include_file_via_device(
+        device_id="dev-1",
+        device_source_root="/home/admin/.aicoding",
+        rel_path="sessions/cron-tasks.json",
+        target_file=target_file,
+        chown="1000:1000",
+        timeout_seconds=42,
+    )
+
+    assert ok is True
+    esn = svc._device_service.exec_shell_new.call_args.kwargs
+    assert esn["device_id"] == "dev-1"
+    assert esn["shell_cmd"] == "cat /home/admin/.aicoding/sessions/cron-tasks.json"
+    rsync_cmd = svc._run_local_command.call_args.kwargs["cmd"]
+    assert rsync_cmd[:4] == ["sudo", "rsync", "-av", "--chown=1000:1000"]
+    assert rsync_cmd[-1] == str(target_file)
+    assert svc._run_local_command.call_args.kwargs["timeout_seconds"] == 42
+    assert target_file.read_text() == '{"tasks":[]}'
+
+
+def test_sync_extra_include_file_via_device_returns_false_when_cat_fails(tmp_path):
+    svc = object.__new__(BotBuildService)
+    svc._device_service = MagicMock()
+    svc._device_service.exec_shell_new.return_value = CommandResult(
+        stdout="", exit_code=1, stderr="No such file or directory",
+    )
+    svc._run_local_command = MagicMock()
+
+    ok = svc._sync_extra_include_file_via_device(
+        device_id="dev-1",
+        device_source_root="/home/admin/.aicoding",
+        rel_path="sessions/cron-tasks.json",
+        target_file=tmp_path / "target" / "sessions" / "cron-tasks.json",
+    )
+
+    assert ok is False
+    svc._device_service.exec_shell_new.assert_called_once()
+    svc._run_local_command.assert_not_called()
+
+
+def test_sync_extra_include_files_falls_back_to_device_on_root_squash(tmp_path):
+    """Host admin + root probe both fail (NFS root_squash): the file is rescued
+    from the source bot container (uid 1000 owner) instead of being skipped."""
+    plan = _extra_include_plan()
+    target_dir = tmp_path / "target"
+
+    svc = object.__new__(BotBuildService)
+    svc._device_service = MagicMock()
+    svc._device_service.exec_shell_new.return_value = CommandResult(
+        stdout='{"tasks":[1]}', exit_code=0, stderr="",
+    )
+    svc._run_local_command = MagicMock(side_effect=_fake_rsync_copy)
+    svc._sudo_is_file = MagicMock(return_value=False)  # root probe fails (squashed)
+
+    svc._sync_extra_include_files(
+        source_dir=_UnreadableSourceFile(),  # admin stat -> PermissionError
+        target_dir=target_dir,
+        build_plan=plan,
+        command_name="rsync extra include",
+        error_message="rsync extra include file failed",
+        device_id="dev-1",
+        device_source_root="/home/admin/.aicoding",
+    )
+
+    assert svc._device_service.exec_shell_new.call_count == 1
+    assert svc._device_service.exec_shell_new.call_args.kwargs["device_id"] == "dev-1"
+    assert (target_dir / "sessions" / "cron-tasks.json").read_text() == '{"tasks":[1]}'
+
+
+def test_sync_extra_include_files_skip_when_no_device_and_root_probe_fails(tmp_path, caplog):
+    """restore_draft path has no device: unreadable file is still skipped (old behavior)."""
+    plan = _extra_include_plan()
+    svc = object.__new__(BotBuildService)
+    svc._run_local_command = MagicMock()
+    svc._sudo_is_file = MagicMock(return_value=False)
+    caplog.set_level("INFO")
+
+    svc._sync_extra_include_files(
+        source_dir=_UnreadableSourceFile(),
+        target_dir=tmp_path / "target",
+        build_plan=plan,
+        command_name="rsync extra include",
+        error_message="rsync extra include file failed",
+    )
+
+    svc._run_local_command.assert_not_called()
+    # no device available -> graceful skip (remaining old behavior)
+    assert "Skip unreadable extra include file" in caplog.text
+
+
+
+def test_sync_extra_include_files_device_exec_failure_does_not_block(tmp_path, caplog):
+    """A failure inside the device fallback (device not ACTIVE, RPC error, ...)
+    must NOT abort the publish: the file is skipped gracefully and the method
+    returns normally (best-effort, never raises)."""
+    plan = _extra_include_plan()
+    caplog.set_level("INFO")
+    svc = object.__new__(BotBuildService)
+    svc._device_service = MagicMock()
+    svc._device_service.exec_shell_new.side_effect = RuntimeError("device offline")
+    svc._run_local_command = MagicMock()
+    svc._sudo_is_file = MagicMock(return_value=False)
+
+    # must not raise
+    svc._sync_extra_include_files(
+        source_dir=_UnreadableSourceFile(),
+        target_dir=tmp_path / "target",
+        build_plan=plan,
+        command_name="rsync extra include",
+        error_message="rsync extra include file failed",
+        device_id="dev-1",
+        device_source_root="/home/admin/.aicoding",
+    )
+
+    svc._run_local_command.assert_not_called()  # host copy never attempted
+    assert "Skip unreadable extra include file" in caplog.text


### PR DESCRIPTION
fix(bot_build): rescue aicoding extra-include files via container fallback on NFS root_squash

When publishing a service bot, aicoding's extra-include file
sessions/cron-tasks.json is excluded from the main rsync (sessions is
excluded) and re-included via _sync_extra_include_files. The host-side
sudo copy runs on the NAS merge area with NFS root_squash: root is mapped
to nobody and cannot stat/read the uid-1000 / mode-0600 sandbox file, so
the file was silently skipped (INFO "Skip unreadable extra include file")
and never landed in the prepub artifact -- cron tasks were missing in prepub.

Add a device-container fallback mirroring _generate_mcp_config: when the
host admin stat AND the root probe both fail (root_squash), cat the file
from inside the source bot's BaaS container (runs as the file owner uid
1000, bypassing root_squash), stage it through a local temp file, and
sudo rsync it into the target (incl. --chown for the restore path).
restore_draft keeps the old host-only behavior (no live container/device).

The new path is fully best-effort / failure-safe:
- _sync_extra_include_file_via_device never raises (returns True/False);
- provider.get_base_path() derivation is guarded (degrades to no-fallback);
- temp file is pre-bound and unlinked defensively.
Any error degrades to the previous "skip" behavior, never blocking publish.

Adds tests covering the device rescue path, cat failure, and exec failure
non-blocking.

Root cause trace (prepub log):
  Skip unreadable extra include file (admin cannot stat, root probe failed):
  /home/admin/.merge_nas/.../.aicoding/sessions/cron-tasks.json