### PR TITLE
feat(auth): make post-login redirect path configurable

### DIFF
--- a/src/bcs/configs/bcs-config-example.toml
+++ b/src/bcs/configs/bcs-config-example.toml
@@ -261,6 +261,10 @@ jwt_secret = "replace-with-oauth-jwt-secret"
 idle_timeout_minutes = 30
 base_url = "https://bcs.example.com"
 cookie_secure = true
+# Path the browser is redirected to after a successful OAuth login.
+# Must be a relative path starting with a single "/". Defaults to "/".
+# A query string is allowed, e.g. "/?login=success".
+success_redirect_path = "/"
 
 [auth.oauth.providers.github]
 kind = "github"

--- a/src/bcs/configs/bcs-config-prod.toml
+++ b/src/bcs/configs/bcs-config-prod.toml
@@ -201,6 +201,8 @@ base_url = "https://avernet.alipay.com"
 jwt_secret = "${BCS_ALIPAY_JWT_SECRET}"
 cookie_secure = true
 idle_timeout_minutes = 30
+# Preserve the prior hard-coded post-login redirect (frontend reads ?login=success).
+success_redirect_path = "/workspace"
 
 [auth.oauth.providers.alipay]
 kind = "alipay"

--- a/src/bcs/crates/adapters/http/bcs-http/src/oauth/mod.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/oauth/mod.rs
@@ -220,7 +220,7 @@ impl AuthService for OAuthRouteState {
 
         info!(provider = %request.provider, user_id = %claims.sub, "OAuth login successful");
         Ok(AuthRedirect {
-            location: "/?login=success".to_string(),
+            location: self.config.success_redirect_location().to_string(),
             set_cookie: session_cookie(&jwt, self.config.cookie_secure),
         })
     }
@@ -483,7 +483,7 @@ pub async fn callback_handler(
     (
         StatusCode::FOUND,
         [
-            ("location", "/?login=success".to_string()),
+            ("location", state.config.success_redirect_location().to_string()),
             ("set-cookie", cookie),
         ],
     )
@@ -788,6 +788,7 @@ mod tests {
                 base_url: "https://bcs.example.com".to_string(),
                 cookie_secure: false,
                 env: "test".to_string(),
+                success_redirect_path: "/".to_string(),
             },
             None,
         );
@@ -816,7 +817,7 @@ mod tests {
             .await
             .expect("complete login");
 
-        assert_eq!(result.location, "/?login=success");
+        assert_eq!(result.location, "/");
         assert!(result.set_cookie.starts_with("bcs_session="));
         assert!(result.set_cookie.contains("HttpOnly"));
         assert!(result.set_cookie.contains("SameSite=Lax"));
@@ -840,6 +841,7 @@ mod tests {
                 base_url: "https://bcs.example.com".to_string(),
                 cookie_secure: false,
                 env: "test".to_string(),
+                success_redirect_path: "/".to_string(),
             },
             None,
         );
@@ -871,6 +873,7 @@ mod tests {
                 base_url: "https://bcs.example.com".to_string(),
                 cookie_secure: false,
                 env: "test".to_string(),
+                success_redirect_path: "/".to_string(),
             },
             None,
         );

--- a/src/bcs/crates/bootstrap/bcs/src/auth_wiring.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/auth_wiring.rs
@@ -91,6 +91,7 @@ pub fn resolve_auth_config(cfg: &AuthChainConfig, env: &str) -> AuthConfig {
                 base_url: o.base_url.clone(),
                 cookie_secure,
                 env: env.to_string(),
+                success_redirect_path: o.success_redirect_path.clone(),
             })
         }),
     }

--- a/src/bcs/crates/plugin-api/bcs-auth-api/src/config.rs
+++ b/src/bcs/crates/plugin-api/bcs-auth-api/src/config.rs
@@ -17,11 +17,27 @@ pub struct OAuthConfig {
     /// (`(auth_source, external_user_id, env)`). Must be consistent between
     /// identity creation and session verification. Default: "default".
     pub env: String,
+    /// Path to redirect to after a successful login. Empty falls back to `/`
+    /// via [`OAuthConfig::success_redirect_location`].
+    pub success_redirect_path: String,
 }
 
 impl OAuthConfig {
     pub fn idle_timeout_secs(&self) -> u64 {
         self.idle_timeout_minutes * 60
+    }
+
+    /// The `Location` to redirect the browser to after a successful login.
+    /// Empty/whitespace falls back to `/`, so a default-constructed
+    /// [`OAuthConfig`] (e.g. in tests) behaves the same as the configured
+    /// default rather than emitting an empty `Location`.
+    pub fn success_redirect_location(&self) -> &str {
+        let path = self.success_redirect_path.trim();
+        if path.is_empty() {
+            "/"
+        } else {
+            path
+        }
     }
 
     /// Default `cookie_secure` derived from the `base_url` scheme: HTTPS
@@ -52,4 +68,29 @@ pub struct LocalAuthConfig {
     pub mock_user_id: Option<String>,
     pub mock_user_name: Option<String>,
     pub allow_mock_headers: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::OAuthConfig;
+
+    #[test]
+    fn success_redirect_location_defaults_to_root_when_empty() {
+        // A default-constructed config (e.g. tests) emits `/`, never an empty
+        // `Location` (which a browser treats as "stay on the current URL").
+        let config = OAuthConfig {
+            success_redirect_path: String::new(),
+            ..OAuthConfig::default()
+        };
+        assert_eq!(config.success_redirect_location(), "/");
+    }
+
+    #[test]
+    fn success_redirect_location_uses_configured_path() {
+        let config = OAuthConfig {
+            success_redirect_path: "/dashboard?login=success".to_string(),
+            ..OAuthConfig::default()
+        };
+        assert_eq!(config.success_redirect_location(), "/dashboard?login=success");
+    }
 }

--- a/src/bcs/crates/service-api/bcs-config-api/src/lib.rs
+++ b/src/bcs/crates/service-api/bcs-config-api/src/lib.rs
@@ -1036,6 +1036,13 @@ pub struct OAuthSettings {
     /// derived from `base_url` (https → secure). Set `false` for local HTTP dev.
     #[serde(default)]
     pub cookie_secure: Option<bool>,
+    /// Path to redirect to after a successful login (the `Location` emitted by
+    /// `/auth/callback/{provider}` and the OpenAPI v1 login flow). Defaults to
+    /// `/`. Must be a relative path starting with a single `/`; an absolute URL
+    /// or protocol-relative `//host` is rejected at load time (open-redirect
+    /// guard). A query string is allowed, e.g. `/?login=success`.
+    #[serde(default = "default_oauth_success_redirect_path")]
+    pub success_redirect_path: String,
     /// OAuth provider instances keyed by instance name, deserialized from
     /// `[auth.oauth.providers.<name>]`. The key is the instance name used as the
     /// `HashMap` key, the `/auth/url` entry, and the `{provider}` in
@@ -1100,6 +1107,17 @@ impl OAuthSettings {
     /// the set of valid kinds lives in the bootstrap factory — so it is
     /// validated there; this keeps the contract crate free of impl knowledge.
     pub fn validate(&self) -> Result<(), String> {
+        // success_redirect_path must be a same-origin relative path: a leading
+        // single `/` only. An absolute URL (http://host) or a protocol-relative
+        // `//host` would let a misconfigured value redirect users off-site
+        // right after they authenticate, so reject it at load time.
+        let redirect = self.success_redirect_path.trim();
+        if !redirect.starts_with('/') || redirect.starts_with("//") {
+            return Err(format!(
+                "auth.oauth.success_redirect_path must be a relative path starting with a single '/' (got {:?})",
+                self.success_redirect_path
+            ));
+        }
         for (name, p) in &self.providers {
             if name.is_empty() {
                 return Err("auth.oauth.providers has an empty instance name".to_string());
@@ -1121,6 +1139,10 @@ impl OAuthSettings {
 
 fn default_oauth_idle_timeout_minutes() -> u64 {
     30
+}
+
+fn default_oauth_success_redirect_path() -> String {
+    "/".to_string()
 }
 
 // ---------------------------------------------------------------------------

--- a/src/bcs/crates/services/bcs-edge-permission-store/src/lib.rs
+++ b/src/bcs/crates/services/bcs-edge-permission-store/src/lib.rs
@@ -1034,7 +1034,7 @@ impl BotActorConfigRepoPort for DbBotActorConfigStore {
 fn row_to_permission_request(row: &DbRow) -> ServiceResult<PermissionRequest> {
     // decided_at is a DB-managed timestamp (TEXT/`timestamp NULL`); parse the
     // stored instant back to epoch ms. `None` ⇒ not yet decided.
-    let decided_at = optional_string(row, "decided_at")?
+    let decided_at = optional_timestamp_text(row, "decided_at")?
         .and_then(|s| parse_timestamp_epoch_ms(&s));
     Ok(PermissionRequest {
         request_id: required_string(row, "request_id")?,
@@ -1194,6 +1194,17 @@ fn required_string(row: &DbRow, column: &'static str) -> ServiceResult<String> {
 
 fn optional_string(row: &DbRow, column: &'static str) -> ServiceResult<Option<String>> {
     row.get_string(column).map_err(|err| service_db_error(column, err))
+}
+
+fn optional_timestamp_text(row: &DbRow, column: &'static str) -> ServiceResult<Option<String>> {
+    match row.get(column) {
+        None | Some(DbValue::Null) => Ok(None),
+        Some(DbValue::String(value)) => Ok(Some(value.clone())),
+        Some(DbValue::Bytes(value)) => String::from_utf8(value.clone())
+            .map(Some)
+            .map_err(|err| service_db_error(column, DbError::Conversion(format!("column '{}' is not valid UTF-8: {}", column, err)))),
+        Some(other) => Err(service_db_error(column, DbError::Conversion(format!("column '{}' is not a timestamp string: {:?}", column, other)))),
+    }
 }
 
 fn required_u64(row: &DbRow, column: &'static str) -> ServiceResult<u64> {
@@ -1387,6 +1398,32 @@ mod tests {
         // Empty / unparseable / pre-epoch → None (NULL upstream becomes None).
         assert_eq!(parse_timestamp_epoch_ms(""), None);
         assert_eq!(parse_timestamp_epoch_ms("not-a-date"), None);
+    }
+
+    #[test]
+    fn permission_request_decided_at_accepts_bytes_timestamp() {
+        let mut columns = std::collections::BTreeMap::new();
+        columns.insert("request_id".to_string(), DbValue::from("req-1"));
+        columns.insert("edge_id".to_string(), DbValue::Null);
+        columns.insert("env".to_string(), DbValue::from("dev"));
+        columns.insert("from_id".to_string(), DbValue::from("human_1"));
+        columns.insert("to_id".to_string(), DbValue::from("x:bot"));
+        columns.insert("request_kind".to_string(), DbValue::from("connect"));
+        columns.insert("requested_ref_id".to_string(), DbValue::Null);
+        columns.insert("requested_rules".to_string(), DbValue::Null);
+        columns.insert("message".to_string(), DbValue::Null);
+        columns.insert("status".to_string(), DbValue::from("approved"));
+        columns.insert("decision_reason".to_string(), DbValue::Null);
+        columns.insert("created_by".to_string(), DbValue::from("human_1"));
+        columns.insert("decided_by".to_string(), DbValue::from("auto"));
+        columns.insert(
+            "decided_at".to_string(),
+            DbValue::from(b"2026-09-02 13:41:55".to_vec()),
+        );
+        let row = DbRow::new(columns);
+
+        let request = row_to_permission_request(&row).expect("permission request row");
+        assert_eq!(request.decided_at, Some(1_788_356_515_000));
     }
 
     async fn sqlite_store() -> DbEdgeGrantStore {


### PR DESCRIPTION
Add `[auth.oauth] success_redirect_path` (default "/"), used as the `Location` for `/auth/callback/{provider}` and the OpenAPI v1 login flow, replacing the hard-coded "/?login=success". A configured query string is allowed (e.g. "/?login=success"). Reject absolute URLs and protocol-relative "//host" at config-load time as an open-redirect guard; `OAuthConfig::success_redirect_location()` falls back to "/" so a default-constructed config never emits an empty Location.

<!--
Title format: <type>(<scope>): <concise outcome>
  e.g. feat(backend): add whitelist observed state
Types: feat | fix | refactor | docs | test | ci | build | chore
The title becomes the commit message on squash merge, so make it self-contained.
See "Pull Request Conventions" in AGENTS.md.
Delete the optional sections that do not apply.
-->

## Problem

<!-- The defect, gap, or requirement, and why it matters. -->

## Solution

<!-- The approach taken, and rejected alternatives when the choice is not obvious. -->

## Validation

<!-- Tests, gates, and manual checks you ran, with results. State what you could not run and why. -->

## Compatibility and risk (optional)

<!-- Contract, schema, config, or migration impact, and the rollback path. -->

## Spec (optional)

<!-- The contract or design document this change implements. -->

## Related issues (optional)

<!-- Issues this closes or relates to. -->
