### PR TITLE
test(backend): align coding creation contract expectations

### DIFF
--- a/src/backend/tests/community/core/bot_management/test_application_coding_create.py
+++ b/src/backend/tests/community/core/bot_management/test_application_coding_create.py
@@ -212,7 +212,7 @@ def test_prepare_application_coding_allows_any_business_space() -> None:
     for space_kind in ("personal", "team"):
         prepared = _strategy_prepare(
             engine_type="claude_code",
-            engine_properties={"template": {"devflow_workflow": "x"}},
+            engine_properties={"template_config": {"devflow_workflow": "x"}},
             space_kind=space_kind,
         )
         assert prepared.template_type == "applicationCoding"
@@ -741,8 +741,9 @@ def test_factory_snapshot_gates_match_application_coding() -> None:
         _strategy_prepare("openclaw", props)
     with pytest.raises(BotCombinationUnsupportedError):
         _strategy_prepare("claude_code", props, bot_type="service")
-    with pytest.raises(BotCombinationUnsupportedError):
-        _strategy_prepare("claude_code", props, space_kind="team")
+    prepared = _strategy_prepare("claude_code", props, space_kind="team")
+    assert prepared.template_type == "architect"
+    assert prepared.template_config == _FACTORY_SNAPSHOT
 
 
 def test_handcrafted_path_rejects_foreign_template_type() -> None:


### PR DESCRIPTION
## Summary

- update the business-space creation test to use the current `template_config` engine-properties contract
- align the factory-snapshot Team Space expectation with the policy that coding bots may be created in any business space
- leave production behavior unchanged

## Validation

- `59 passed` for `test_application_coding_create.py` and `test_combo_policy.py`
- Ruff passed for the changed file
- `git diff --check` passed
- pre-push SAST gate passed