### PR TITLE
feat(skills): filter Bot-local uploads in Skill listing

### DIFF
--- a/src/backend/specs/2026-08-20-skill-capability-upgrade/frontend-api.md
+++ b/src/backend/specs/2026-08-20-skill-capability-upgrade/frontend-api.md
@@ -510,6 +510,13 @@ file_paths=["SKILL.md","references/example.md"]
 上传成功可能是“新建”或“同名替换”。新建项默认 inactive；替换必须保留原 active、Membership
 和 skill_id。上传后刷新 Bot Skill detail/list，再按最终控制来源处理：
 
+```http
+GET /openapi/v1/bots/{bot_id}/skills?source=LOCAL&page=1&page_size=20&user_id={actor_id}&owner_id={bot_owner_id}
+```
+
+`source=LOCAL` 只返回该 Bot 上传的 `local://` Skill（包含 active 与 inactive）。省略 `source`
+仍保持“Bot 全部可达 Skill”的现有列表语义，不能在前端用名称或 active 状态猜 Local 来源。
+
 | 上传后状态 | 后续动作 |
 | --- | --- |
 | inactive 且无 Membership | 调用下面的 Membership PUT |

--- a/src/backend/specs/2026-08-20-skill-capability-upgrade/spec.md
+++ b/src/backend/specs/2026-08-20-skill-capability-upgrade/spec.md
@@ -363,7 +363,7 @@ skills-local / skills-repo / skill-center / MCP/CLI projection
 
 | Method | Path | Request | 语义 |
 | --- | --- | --- | --- |
-| GET | `/openapi/v1/bots/{bot_id}/skills` | optional `type=LOCAL\|REPO\|SPACE\|ALL` | 产品显式传 `ALL`；过滤、去重后再分页 |
+| GET | `/openapi/v1/bots/{bot_id}/skills` | optional `source=LOCAL` | 省略时列出 Bot 全部可达 Skill；`LOCAL` 只列出该 Bot 上传的 Local Skill |
 | GET | `/openapi/v1/bots/{bot_id}/skills/{skill_id}` | path | 服务端解析类型和 Bot 关系 |
 | GET | `/openapi/v1/bots/{bot_id}/skills/{skill_id}/content` | path | 返回可消费 `SKILL.md` |
 | GET | `/openapi/v1/bots/{bot_id}/skills/{skill_id}/parameters` | path | Bot 级参数 |
@@ -378,7 +378,7 @@ Bot-owned Local Asset
 ∪ 当前 Installation
 ```
 
-旧 `active` 字段表示当前是否存在 Installation。只增加 optional `type`、`managed_by`、`skill_set_id`，不增加 `direct_active/effective_active/sources`。
+旧 `active` 字段表示当前是否存在 Installation。只增加 optional `source=LOCAL`，不增加 `direct_active/effective_active/sources`。
 
 Direct activate/deactivate：
 

--- a/src/backend/specs/2026-08-23-openapi-v1-bot-skill-listing/spec.md
+++ b/src/backend/specs/2026-08-23-openapi-v1-bot-skill-listing/spec.md
@@ -103,9 +103,10 @@ removed.
 
 ## Out of Scope
 
-- A `type` query parameter or a `type` field on the `Skill` schema
-  (`2026-08-20-skill-capability-upgrade` *Phase 1*). This change makes the
-  listing complete; naming each row's source is its own change.
+- A source field on the `Skill` response. The additive `source=LOCAL` query
+  filter is supported for the legacy-compatible “Bot uploads” page; it filters
+  exact Bot-owned `local://` rows without changing the default complete-list
+  semantics. Naming every returned row's source remains out of scope.
 - `GET /skills/{skill_id}` and the three asset operations under it. They stay
   Local-only; only the collection changes.
 - Runtime reconciliation. The repair writes desired state; it never touches

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/skills/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/skills/router.py
@@ -8,7 +8,7 @@ non-public surfaces.
 from __future__ import annotations
 
 import json
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal
 
 from agentclaw.community.adapters.http.openapi_v1.admission import ActingCaller
 from agentclaw.community.adapters.http.openapi_v1.contracts import (
@@ -304,15 +304,23 @@ async def list_skills(
         description="Filter: case-insensitive substring match against the "
         "skill's name and description.",
     ),
+    source: Literal["LOCAL"] | None = Query(
+        default=None,
+        description=(
+            "Optional asset-source filter. LOCAL returns only Skills uploaded "
+            "to this Bot; omit for every Skill currently reachable by the Bot."
+        ),
+    ),
     query_service: SkillQueryServiceProtocol = Injected(
         SkillQueryServiceProtocol
     ),
 ) -> Envelope[Page[Skill]]:
     """List every skill the bot has, from stored desired state (paginated).
 
-    Covers both ways a bot reaches a skill: skills uploaded to this bot, and
-    skills a capability set of the bot's brings to it. Answers even while the
-    bot is offline — active is the desired state, not the live runtime.
+    Without the source filter, covers every way a Bot reaches a Skill: uploads to
+    this Bot, SkillSet membership, and direct installation. source=LOCAL
+    narrows the page to Bot-owned Local uploads. Answers even while the Bot is
+    offline — active is desired state, not observed runtime.
     """
     total, records = query_service.list_bot_skills(
         bot_id=bot_id,
@@ -322,6 +330,7 @@ async def list_skills(
         page_size=page.page_size,
         active=active,
         keyword=keyword,
+        source=source,
     )
     return page_envelope(total, [_to_skill(record) for record in records], request)
 

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill.py
@@ -422,6 +422,7 @@ class SkillRepository(
         page_size: int,
         active: bool | None,
         keyword: str | None,
+        source: str | None = None,
     ) -> tuple[int, list[dict]]:
         """Page every Skill one Bot reaches, by desired active state.
 
@@ -459,18 +460,24 @@ class SkillRepository(
                 self.Skill.bolt_id == bot_id,
                 self.Skill.user_id == _normalize_user_id(user_id),
             )
-            # Three ways, not two. A shared Skill the Bot activated directly
-            # belongs to no SkillSet and carries another owner's ``bolt_id``,
-            # so neither of the first two predicates finds it — yet
-            # ``list_bot_installed_assets`` puts it in the runtime projection, so
-            # leaving it out would hide a Skill the Bot is running.
-            reachable = [owned, installed]
-            if member_ids:
-                reachable.append(self.Skill.id.in_(member_ids))
             query = db.query(self.Skill, installed.label("active")).filter(
-                self.Skill.env == get_current_env(),
-                or_(*reachable),
+                self.Skill.env == get_current_env()
             )
+            if source == "LOCAL":
+                # A Local upload is an exact owner+Bot row. Do not let a
+                # shared Direct/SkillSet asset enter this legacy-compatible
+                # collection merely because it is currently installed.
+                query = query.filter(owned, self.Skill.git_path.like("local://%"))
+            else:
+                # Three ways, not two. A shared Skill the Bot activated directly
+                # belongs to no SkillSet and carries another owner's ``bolt_id``,
+                # so neither of the first two predicates finds it — yet
+                # ``list_bot_installed_assets`` puts it in the runtime projection,
+                # so leaving it out would hide a Skill the Bot is running.
+                reachable = [owned, installed]
+                if member_ids:
+                    reachable.append(self.Skill.id.in_(member_ids))
+                query = query.filter(or_(*reachable))
             if keyword and keyword.strip():
                 term = f"%{keyword.strip().lower()}%"
                 query = query.filter(

--- a/src/backend/src/agentclaw/community/core/repository/protocols/skill_center.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/skill_center.py
@@ -427,11 +427,13 @@ class SkillRepository(Protocol):
         page_size: int,
         active: bool | None,
         keyword: str | None,
+        source: str | None = None,
     ) -> tuple[int, list[dict]]:
         """Page desired-state metadata for every Skill one Bot reaches.
 
         ``skill_set_member_ids`` are the Skills a SkillSet bridges to the Bot,
         resolved by the SkillSet control plane; Bot-owned rows are found here.
+        ``source=LOCAL`` narrows to Bot-owned ``local://`` rows only.
         """
         ...
 

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_query_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_query_service.py
@@ -154,6 +154,7 @@ class SkillQueryService(SkillQueryServiceProtocol):
         page_size: int,
         active: bool | None,
         keyword: str | None,
+        source: str | None = None,
     ) -> tuple[int, list[dict[str, Any]]]:
         """Page every Skill the Bot has — owned rows and SkillSet-bridged ones.
 
@@ -175,6 +176,7 @@ class SkillQueryService(SkillQueryServiceProtocol):
             page_size=page_size,
             active=active,
             keyword=keyword,
+            source=source,
         )
 
     # ── Detail ──────────────────────────────────────────────────────

--- a/src/backend/src/agentclaw/community/core/skill_center/skill_query_service_protocol.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/skill_query_service_protocol.py
@@ -27,6 +27,7 @@ class SkillQueryServiceProtocol(Protocol):
         page_size: int,
         active: bool | None,
         keyword: str | None,
+        source: str | None = None,
     ) -> tuple[int, list[dict[str, Any]]]: ...
 
     @abstractmethod

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_app_only_bot_not_on_the_wire.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_app_only_bot_not_on_the_wire.py
@@ -164,7 +164,16 @@ class _Skills:
         }
 
     def list_bot_skills(
-        self, *, bot_id, owner_id, actor_id, page, page_size, active=None, keyword=None
+        self,
+        *,
+        bot_id,
+        owner_id,
+        actor_id,
+        page,
+        page_size,
+        active=None,
+        keyword=None,
+        source=None,
     ):
         self.listed.append((bot_id, owner_id))
         return 0, []

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_skills_contract.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_skills_contract.py
@@ -62,6 +62,11 @@ def test_collection_and_upload_are_bot_addressed_contracts() -> None:
     assert list_parameters["owner_id"]["required"] is False
     assert list_parameters["active"]["required"] is False
     assert list_parameters["keyword"]["required"] is False
+    assert list_parameters["source"]["required"] is False
+    assert {item.get("const") for item in list_parameters["source"]["schema"]["anyOf"]} == {
+        "LOCAL",
+        None,
+    }
 
     upload = paths["/openapi/v1/bots/{bot_id}/skills"]["post"]
     upload_parameters = {

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_skills_endpoints.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_skills_endpoints.py
@@ -492,7 +492,23 @@ def test_list_uses_verified_actor_and_exposes_only_public_metadata():
         "page_size": 7,
         "active": False,
         "keyword": "cast",
+        "source": None,
     }
+
+
+def test_list_forwards_local_source_filter_and_rejects_other_sources():
+    query = _Query()
+    client = _client(query)
+
+    response = client.get("/openapi/v1/bots/bot-1/skills?owner_id=owner&source=LOCAL")
+
+    assert response.status_code == 200
+    assert query.list_args is not None
+    assert query.list_args["source"] == "LOCAL"
+
+    invalid = client.get("/openapi/v1/bots/bot-1/skills?owner_id=owner&source=REPO")
+
+    assert invalid.status_code == 422
 
 
 def test_detail_derives_scope_from_skill_id_and_masks_invisible_rows():

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_skills_shared_bot_grant.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_skills_shared_bot_grant.py
@@ -122,7 +122,16 @@ class _Skills:
         }
 
     def list_bot_skills(
-        self, *, bot_id, owner_id, actor_id, page, page_size, active=None, keyword=None
+        self,
+        *,
+        bot_id,
+        owner_id,
+        actor_id,
+        page,
+        page_size,
+        active=None,
+        keyword=None,
+        source=None,
     ):
         assert (bot_id, owner_id) == (BOT, OWNER), (bot_id, owner_id)
         return 0, []
@@ -217,8 +226,8 @@ PAIRS = [
     (
         "list",
         "GET",
-        f"/openapi/v1/bots/{BOT}/skills?user_id={CALLER}&owner_id={OWNER}",
-        f"/openapi/v1/bots/skills?user_id={CALLER}&bot_id={BOT}&owner_entity_id={OWNER}",
+        f"/openapi/v1/bots/{BOT}/skills?user_id={CALLER}&owner_id={OWNER}&source=LOCAL",
+        f"/openapi/v1/bots/skills?user_id={CALLER}&bot_id={BOT}&owner_entity_id={OWNER}&source=LOCAL",
     ),
     (
         "get",

--- a/src/backend/tests/community/core/skill_center/test_skill_query_service.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_query_service.py
@@ -129,7 +129,7 @@ def _listing_service(
     return service, skills, sets, bots
 
 
-def _list(service, *, actor_id: str = "owner"):
+def _list(service, *, actor_id: str = "owner", source: str | None = None):
     return service.list_bot_skills(
         bot_id="bot",
         owner_id="owner",
@@ -138,6 +138,7 @@ def _list(service, *, actor_id: str = "owner"):
         page_size=20,
         active=None,
         keyword=None,
+        source=source,
     )
 
 
@@ -160,6 +161,16 @@ def test_the_repair_runs_before_the_page_is_cut():
     assert skills.calls[0]["skill_set_member_ids"] == frozenset({1, 2})
     assert skills.calls[0]["bot_id"] == "bot"
     assert skills.calls[0]["user_id"] == "owner"
+    assert skills.calls[0]["source"] is None
+
+
+def test_local_source_filter_is_forwarded_after_the_standard_flush():
+    service, skills, sets, _bots = _listing_service(bridge=_EMPTY)
+
+    _list(service, source="LOCAL")
+
+    assert len(sets.calls) == 1
+    assert skills.calls[0]["source"] == "LOCAL"
 
 
 def test_the_skillset_scope_uses_the_bots_engine_and_layout_precedence():

--- a/src/backend/tests/community/repository/skill_center/test_local_skill_query_tenant_isolation.py
+++ b/src/backend/tests/community/repository/skill_center/test_local_skill_query_tenant_isolation.py
@@ -48,6 +48,7 @@ def _page(repo, *, members=(), **overrides):
             "page_size": 20,
             "active": None,
             "keyword": None,
+            "source": None,
             **overrides,
         }
     )
@@ -114,8 +115,13 @@ def test_bot_owned_rows_are_listed_whatever_their_source_prefix(tmp_path):
             )
         total, rows = _page(repo)
 
-    assert total == 3
-    assert {row["name"] for row in rows} == {"forecast", "market", "space"}
+        assert total == 3
+        assert {row["name"] for row in rows} == {"forecast", "market", "space"}
+
+        local_total, local_rows = _page(repo, source="LOCAL")
+
+        assert local_total == 1
+        assert [row["name"] for row in local_rows] == ["forecast"]
 
 
 def test_a_bridged_row_is_listed_even_though_the_bot_does_not_own_it(tmp_path):
@@ -148,9 +154,14 @@ def test_a_bridged_row_is_listed_even_though_the_bot_does_not_own_it(tmp_path):
             }
         )
         total, rows = _page(repo, members=(int(shared["id"]),))
+        local_total, local_rows = _page(
+            repo, members=(int(shared["id"]),), source="LOCAL"
+        )
 
     assert total == 2
     assert {row["id"] for row in rows} == {mine["id"], shared["id"]}
+    assert local_total == 1
+    assert [row["id"] for row in local_rows] == [mine["id"]]
 
 
 def test_a_skill_both_owned_and_bridged_is_listed_once(tmp_path):

--- a/src/gateway/configs/schemas/bots.openapi.json
+++ b/src/gateway/configs/schemas/bots.openapi.json
@@ -37068,7 +37068,7 @@
     "/openapi/v1/bots/skills": {
       "get": {
         "deprecated": true,
-        "description": "List every skill the bot has, from stored desired state (paginated).\n\nCovers both ways a bot reaches a skill: skills uploaded to this bot, and\nskills a capability set of the bot's brings to it. Answers even while the\nbot is offline — active is the desired state, not the live runtime.\n\nDeprecated: use GET /openapi/v1/bots/{bot_id}/skills instead.",
+        "description": "List every skill the bot has, from stored desired state (paginated).\n\nWithout the source filter, covers every way a Bot reaches a Skill: uploads to\nthis Bot, SkillSet membership, and direct installation. source=LOCAL\nnarrows the page to Bot-owned Local uploads. Answers even while the Bot is\noffline — active is desired state, not observed runtime.\n\nDeprecated: use GET /openapi/v1/bots/{bot_id}/skills instead.",
         "operationId": "list_skills_openapi_v1_bots_skills_get",
         "parameters": [
           {
@@ -37134,6 +37134,25 @@
               ],
               "description": "Filter: case-insensitive substring match against the skill's name and description.",
               "title": "Keyword"
+            }
+          },
+          {
+            "description": "Optional asset-source filter. LOCAL returns only Skills uploaded to this Bot; omit for every Skill currently reachable by the Bot.",
+            "in": "query",
+            "name": "source",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "const": "LOCAL",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Optional asset-source filter. LOCAL returns only Skills uploaded to this Bot; omit for every Skill currently reachable by the Bot.",
+              "title": "Source"
             }
           },
           {
@@ -80400,7 +80419,7 @@
     },
     "/openapi/v1/bots/{bot_id}/skills": {
       "get": {
-        "description": "List every skill the bot has, from stored desired state (paginated).\n\nCovers both ways a bot reaches a skill: skills uploaded to this bot, and\nskills a capability set of the bot's brings to it. Answers even while the\nbot is offline — active is the desired state, not the live runtime.",
+        "description": "List every skill the bot has, from stored desired state (paginated).\n\nWithout the source filter, covers every way a Bot reaches a Skill: uploads to\nthis Bot, SkillSet membership, and direct installation. source=LOCAL\nnarrows the page to Bot-owned Local uploads. Answers even while the Bot is\noffline — active is desired state, not observed runtime.",
         "operationId": "list_skills_openapi_v1_bots__bot_id__skills_get",
         "parameters": [
           {
@@ -80448,6 +80467,25 @@
               ],
               "description": "Filter: case-insensitive substring match against the skill's name and description.",
               "title": "Keyword"
+            }
+          },
+          {
+            "description": "Optional asset-source filter. LOCAL returns only Skills uploaded to this Bot; omit for every Skill currently reachable by the Bot.",
+            "in": "query",
+            "name": "source",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "const": "LOCAL",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Optional asset-source filter. LOCAL returns only Skills uploaded to this Bot; omit for every Skill currently reachable by the Bot.",
+              "title": "Source"
             }
           },
           {


### PR DESCRIPTION
## Summary
- add additive `source=LOCAL` filtering to `GET /openapi/v1/bots/{bot_id}/skills`
- preserve the default complete Bot-capability listing
- limit LOCAL results to exact Bot-owned `local://` rows, excluding SkillSet and Direct shared assets
- update OpenAPI artifact and frontend/spec contracts

## Verification
- `DEPLOY_PROFILE=test uv run pytest -q`
- focused endpoint, service, repository, schema and conformance suites
- `DEPLOY_PROFILE=test uv run ruff check` on changed implementation/test files
- `git diff --check`