### PR TITLE
fix(skill-center): clarify runtime recovery guidance

### DIFF
--- a/src/backend/src/agentclaw/community/core/skill_center/runtime_projection_contract.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/runtime_projection_contract.py
@@ -88,7 +88,13 @@ class RuntimeProjectionResult:
         return cls(status=RuntimeProjectionStatus.SKIPPED, reason=reason)
 
     @classmethod
-    def pending(cls, *, code: str, reason: str) -> "RuntimeProjectionResult":
+    def pending(
+        cls,
+        *,
+        code: str,
+        reason: str,
+        suggested_action: str | None = None,
+    ) -> "RuntimeProjectionResult":
         return cls(
             status=RuntimeProjectionStatus.PENDING,
             issues=(
@@ -98,6 +104,7 @@ class RuntimeProjectionResult:
                     reason=reason,
                     status=RuntimeProjectionStatus.PENDING,
                     retryable=True,
+                    suggested_action=suggested_action,
                 ),
             ),
         )

--- a/src/backend/src/agentclaw/community/core/skill_center/services/_mutation_flow.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/_mutation_flow.py
@@ -31,6 +31,10 @@ from agentclaw.community.log import get_logger
 
 logger = get_logger()
 
+_RUNTIME_SNAPSHOT_UNAVAILABLE_ACTION = (
+    "Bot 当前不可连接或仍在启动。能力集已保存；待 Bot 恢复后，请再次保存能力集完成同步。"
+)
+
 
 def skill_claim_scope(result: DesiredStateMutation) -> ProjectionScope:
     """A Skill mutation that adds the Skill, and with it its MCP dependencies.
@@ -230,6 +234,7 @@ class MutationProjectionFlow:
             return RuntimeProjectionResult.pending(
                 code="RUNTIME_SNAPSHOT_UNAVAILABLE",
                 reason="Bot 运行环境当前不可连接，能力状态已保存但尚未同步",
+                suggested_action=_RUNTIME_SNAPSHOT_UNAVAILABLE_ACTION,
             )
         try:
             snapshot_started_at = time.perf_counter()
@@ -241,6 +246,7 @@ class MutationProjectionFlow:
             return RuntimeProjectionResult.pending(
                 code="RUNTIME_SNAPSHOT_UNAVAILABLE",
                 reason="Bot 运行环境当前不可连接，能力状态已保存但尚未同步",
+                suggested_action=_RUNTIME_SNAPSHOT_UNAVAILABLE_ACTION,
             )
         self._log_timing(
             stage="snapshot_after",

--- a/src/backend/src/agentclaw/community/core/skill_center/services/runtime_projections/per_domain.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/runtime_projections/per_domain.py
@@ -400,6 +400,10 @@ class PerDomainRuntimeProjection(EngineRuntimeProjection):
                     reason="Skill 运行环境当前不可连接，能力状态已保存但尚未同步",
                     status=status,
                     retryable=status is RuntimeProjectionStatus.PENDING,
+                    suggested_action=(
+                        "Bot 当前未完成运行时同步。请稍后再次保存能力集；若持续失败，"
+                        "请联系管理员并提供错误详情。"
+                    ),
                 )
             )
         return RuntimeProjectionResult(
@@ -442,21 +446,23 @@ class PerDomainRuntimeProjection(EngineRuntimeProjection):
             "MANAGED_SOURCE_MISSING": (
                 "MANAGED_SOURCE_MISSING",
                 "Skill 的源文件已被删除或移动，平台已保留目标软链",
-                "请重新上传或恢复该 Skill；后续能力同步会再次尝试",
+                "该技能的内容暂时不可用。请重新同步或重新添加该技能后，再保存能力集。",
                 "DANGLING_SYMLINK",
                 "SYMLINK",
             ),
             "UNMANAGED_ACTIVE_ENTRY_RETAINED": (
                 "UNMANAGED_ACTIVE_ENTRY_RETAINED",
                 "Bot 生效目录中存在同名实体目录，平台没有覆盖或删除该目录",
-                "请备份并移走同名实体目录，然后重新执行能力变更",
+                "该技能已在 Bot 内被手动维护。为避免覆盖现有内容，平台没有替换它。"
+                "请联系 Bot 管理员确认处理后，再保存能力集。",
                 "DIRECTORY",
                 "SYMLINK",
             ),
             "EXTERNAL_ACTIVE_ENTRY_RETAINED": (
                 "EXTERNAL_ACTIVE_ENTRY_RETAINED",
                 "同名软链指向平台管理目录之外，平台没有修改该软链",
-                "请确认该软链用途；如需平台管理，请先移走该软链",
+                "该技能当前由其他配置管理，平台没有修改它。请联系 Bot 管理员确认"
+                "是否交由平台管理后，再保存能力集。",
                 "EXTERNAL_SYMLINK",
                 "SYMLINK",
             ),
@@ -466,7 +472,8 @@ class PerDomainRuntimeProjection(EngineRuntimeProjection):
             (
                 code or "SKILL_MAPPING_DEGRADED",
                 "Skill 运行时投影尚未完成",
-                "请在 Bot 运行环境恢复后再次执行能力变更",
+                "部分技能未完成运行时同步。请稍后再次保存能力集；若持续失败，"
+                "请联系管理员并提供错误详情。",
                 None,
                 None,
             ),

--- a/src/backend/tests/community/core/skill_center/services/runtime_projections/test_runtime_projection_messages.py
+++ b/src/backend/tests/community/core/skill_center/services/runtime_projections/test_runtime_projection_messages.py
@@ -1,0 +1,57 @@
+"""User-facing Runtime Projection recovery guidance."""
+
+from __future__ import annotations
+
+import pytest
+
+from agentclaw.community.core.skill_center.runtime_projection_contract import (
+    RuntimeProjectionResult,
+)
+from agentclaw.community.core.skill_center.services.runtime_projections.per_domain import (
+    PerDomainRuntimeProjection,
+)
+
+
+@pytest.mark.parametrize(
+    ("code", "expected_action"),
+    [
+        (
+            "MANAGED_SOURCE_MISSING",
+            "该技能的内容暂时不可用。请重新同步或重新添加该技能后，再保存能力集。",
+        ),
+        (
+            "UNMANAGED_ACTIVE_ENTRY_RETAINED",
+            "该技能已在 Bot 内被手动维护。为避免覆盖现有内容，平台没有替换它。"
+            "请联系 Bot 管理员确认处理后，再保存能力集。",
+        ),
+        (
+            "EXTERNAL_ACTIVE_ENTRY_RETAINED",
+            "该技能当前由其他配置管理，平台没有修改它。请联系 Bot 管理员确认"
+            "是否交由平台管理后，再保存能力集。",
+        ),
+        (
+            "UNKNOWN_MAPPING_FAILURE",
+            "部分技能未完成运行时同步。请稍后再次保存能力集；若持续失败，"
+            "请联系管理员并提供错误详情。",
+        ),
+    ],
+)
+def test_mapping_message_exposes_complete_user_action(
+    code: str,
+    expected_action: str,
+) -> None:
+    _, _, suggested_action, _, _ = PerDomainRuntimeProjection._mapping_message(code)
+
+    assert suggested_action == expected_action
+
+
+def test_pending_runtime_action_is_exposed_to_the_caller() -> None:
+    result = RuntimeProjectionResult.pending(
+        code="RUNTIME_SNAPSHOT_UNAVAILABLE",
+        reason="Bot 运行环境当前不可连接，能力状态已保存但尚未同步",
+        suggested_action="Bot 当前不可连接或仍在启动。能力集已保存；待 Bot 恢复后，请再次保存能力集完成同步。",
+    )
+
+    assert result.issues[0].suggested_action == (
+        "Bot 当前不可连接或仍在启动。能力集已保存；待 Bot 恢复后，请再次保存能力集完成同步。"
+    )


### PR DESCRIPTION
## Problem
Runtime Projection 的 `suggested_action` 暴露了软链、实体目录等实现细节。前端当前直接展示该字段，普通用户难以理解下一步应该做什么。

## Solution
为受管源缺失、容器内同名内容、外部配置、运行时不可连接和未知映射失败提供完整、面向用户的恢复建议。仅扩展 PENDING issue 的可选 `suggested_action`，不改变状态、错误码或 Runtime Projection 行为。

## Validation
- `uv run ruff check ...`
- `uv run pytest tests/community/core/skill_center/services/runtime_projections/test_runtime_projection_messages.py tests/community/core/skill_center/test_skill_set_management_service.py -q` → 115 passed
- `uv run pytest tests/community/architecture/test_module_boundaries.py -q` → 3 passed
- `uv run pytest -q` → 17001 passed, 59 skipped

## Compatibility and risk
返回结构保持不变；仅为原本没有建议文案的 PENDING issue 增加可选字段值，并优化既有文案。

## Related issues
- Runtime Projection 用户体验优化