### PR TITLE
feat(backend): enforce bot quotas by space

### DIFF
--- a/src/backend/docs/openapi-v1/README.md
+++ b/src/backend/docs/openapi-v1/README.md
@@ -1323,7 +1323,7 @@ the other six: this is what "done" looks like per category.
 | POST | `/openapi/v1/bots` | Create a bot; may need Passport authorization | `201 Envelope[Bot]` or `202 Envelope[BotAuthPending]` |
 | GET | `/openapi/v1/bots` | List caller's bots (`keyword`, `engine`, `status`, paged) | `Envelope[Page[Bot]]` |
 | GET | `/openapi/v1/bots/check-name` | Bot-name availability (`name`) | `Envelope[NameCheck]` |
-| GET | `/openapi/v1/bots/ceiling` | Bot-creation quota ceiling | `Envelope[Ceiling]` |
+| GET | `/openapi/v1/bots/ceiling` | Selected Space's Bot ceiling | `Envelope[Ceiling]` |
 | GET | `/openapi/v1/bots/{bot_id}` | Bot details | `Envelope[Bot]` |
 | PUT | `/openapi/v1/bots/{bot_id}` | Update bot (engine immutable) | `Envelope[Bot]` |
 | PUT | `/openapi/v1/bots/{bot_id}/space` | Change the Bot's owning Business Space | `Envelope[BotSpaceAssignment]` |
@@ -1342,6 +1342,26 @@ the other six: this is what "done" looks like per category.
 | PUT | `/openapi/v1/bots/{bot_id}/config-manifest` | Set/replace it; all-or-nothing, `422` lists every violation | `Envelope[ConfigManifest]` |
 | DELETE | `/openapi/v1/bots/{bot_id}/config-manifest` | Clear it | `Envelope[Deleted]` |
 | GET | `/openapi/v1/bots/{bot_id}/config-manifest/capabilities` | Which manifest constructs this bot accepts | `Envelope[ConfigManifestCapabilities]` |
+
+#### Space-scoped Bot quota
+
+Cloud Bot creation is charged to the selected Business Space. Personal Space
+reuses the owner's existing per-user `bots_ceiling` policy and includes both its
+numeric Space rows and legacy `space_id IS NULL` rows. Team Space counts every
+owner's non-deleted cloud Bot assigned to that exact Space, defaults to 20, and
+may be overridden independently through the operator-only
+`PUT /api/v1/access/spaces/{space_id}/bots-ceiling`; `DELETE` removes that
+override and restores 20. Desktop Bots do not consume either quota.
+
+The public create, authorization-completion, manifest-create, and move-in paths
+check capacity against the target Space. The final count and database write are
+serialized by a short Space-scoped distributed lock, so parallel requests
+cannot both consume the last slot. Existing over-limit Spaces remain readable
+and operable; only a new create or move-in is refused. A quota refusal is a 409
+whose `data` includes the Space identity plus its `ceiling` and current `used`
+count; unavailable quota coordination fails closed with 503. The
+legacy `/api` creation path is unchanged and retains its prior owner/device
+checks.
 
 #### Creating an Application Coding Bot
 

--- a/src/backend/docs/openapi-v1/README.zh-CN.md
+++ b/src/backend/docs/openapi-v1/README.zh-CN.md
@@ -783,7 +783,7 @@ Bot 核心路由已接到内部服务上。这里保留下来，是作为其余�
 | POST | `/openapi/v1/bots` | 创建 Agent；可能需要 Passport 授权 | `201 Envelope[Bot]` 或 `202 Envelope[BotAuthPending]` |
 | GET | `/openapi/v1/bots` | 列出调用者的 Agent（`keyword`、`engine`、`status`、分页） | `Envelope[Page[Bot]]` |
 | GET | `/openapi/v1/bots/check-name` | 重名检查（`name`） | `Envelope[NameCheck]` |
-| GET | `/openapi/v1/bots/ceiling` | 创建配额上限 | `Envelope[Ceiling]` |
+| GET | `/openapi/v1/bots/ceiling` | 当前空间的 Bot 上限 | `Envelope[Ceiling]` |
 | GET | `/openapi/v1/bots/{bot_id}` | 获取详情 | `Envelope[Bot]` |
 | PUT | `/openapi/v1/bots/{bot_id}` | 更新（`engine` 不可改） | `Envelope[Bot]` |
 | PUT | `/openapi/v1/bots/{bot_id}/space` | 变更 Bot 的归属业务空间 | `Envelope[BotSpaceAssignment]` |
@@ -795,6 +795,20 @@ Bot 核心路由已接到内部服务上。这里保留下来，是作为其余�
 | GET | `/openapi/v1/bots/{bot_id}/passport` | 获取 Agent Passport | `Envelope[Passport]` |
 | GET | `/openapi/v1/bots/{bot_id}/engine/config` | 读取引擎配置（自由格式 JSON） | `Envelope[dict]` |
 | PUT | `/openapi/v1/bots/{bot_id}/engine/config` | 写入引擎配置（自由格式 JSON） | `Envelope[dict]` |
+
+#### 按空间计算的 Bot 上限
+
+云端 Bot 创建会占用当前业务空间的额度。Personal Space 沿用 owner 现有的个人
+`bots_ceiling` 策略，计数同时包含数值型个人空间记录和历史 `space_id IS NULL` 记录；
+Team Space 按该空间下所有 owner 的未删除云端 Bot 统一计数，默认上限为 20。Operator 可通过
+`PUT /api/v1/access/spaces/{space_id}/bots-ceiling` 单独覆盖团队空间上限，通过 `DELETE`
+删除覆盖并恢复默认值 20。桌面 Bot 不占用这两类额度。
+
+公开创建、授权完成、manifest 创建及迁入空间链路均校验目标空间额度。最终计数与数据库写入由
+短时的空间级分布式锁串行化，避免并发请求同时占用最后一个名额。已经超限的空间仍可读取和进行
+既有操作，只拒绝继续创建或迁入。额度不足返回 409，`data` 会提供 `space_id`、
+`space_name`、`space_type`、`ceiling` 和 `used`；配额协调设施不可用时按失败关闭
+返回 503。旧 `/api` 创建链路不变，继续使用原有 owner/device 上限校验。
 
 #### 创建 Application Coding Bot
 

--- a/src/backend/src/agentclaw/community/adapters/http/access/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/access/router.py
@@ -6,9 +6,9 @@ Replaces:
 """
 from __future__ import annotations
 
-from typing import Annotated
+from typing import Annotated, Callable
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, Path, Query
 
 from agentclaw.community.adapters.http.access.schemas import (
     AllowDisallowData,
@@ -16,6 +16,7 @@ from agentclaw.community.adapters.http.access.schemas import (
     ApiResponse,
     QuotaData,
     SetBotsCeilingRequest,
+    SetSpaceBotsCeilingRequest,
     UpsertUserRequest,
     UserItem,
     UserListCheckData,
@@ -25,6 +26,7 @@ from agentclaw.community.adapters.http.access.schemas import (
 from agentclaw.community.adapters.http.auth.dependencies import get_current_user, require_operator
 from agentclaw.community.adapters.http.auth.models import AuthenticatedUser
 from agentclaw.community.api.policy_service import PolicyServiceProtocol
+from agentclaw.community.api.bot_quota_service import BotQuotaServiceProtocol
 from agentclaw.community.api.user_list_service import UserListServiceProtocol
 from agentclaw.community.api.user_service import UserServiceProtocol
 from agentclaw.community.core.access.errors import UserNotFoundError
@@ -282,3 +284,75 @@ async def set_bots_ceiling(
             error_code=500,
             data=None,
         )
+
+
+@access_router.put("/spaces/{space_id}/bots-ceiling", response_model=ApiResponse[dict])
+async def set_space_bots_ceiling(
+    space_id: Annotated[int, Path(gt=0)],
+    req: SetSpaceBotsCeilingRequest,
+    user: AuthenticatedUser = Depends(require_operator),  # noqa: B008
+    service: BotQuotaServiceProtocol = Injected(BotQuotaServiceProtocol),
+) -> ApiResponse[dict]:
+    """Set one Team Space override; only configured operators may call it."""
+    return _change_space_bots_ceiling(
+        action="set",
+        actor_id=user.staffId,
+        space_id=space_id,
+        mutate=lambda: service.set_team_ceiling(
+            space_id=space_id, ceiling=req.ceiling
+        ),
+    )
+
+
+@access_router.delete(
+    "/spaces/{space_id}/bots-ceiling", response_model=ApiResponse[dict]
+)
+async def reset_space_bots_ceiling(
+    space_id: Annotated[int, Path(gt=0)],
+    user: AuthenticatedUser = Depends(require_operator),  # noqa: B008
+    service: BotQuotaServiceProtocol = Injected(BotQuotaServiceProtocol),
+) -> ApiResponse[dict]:
+    """Remove one Team Space override and restore its deployment default."""
+    return _change_space_bots_ceiling(
+        action="reset",
+        actor_id=user.staffId,
+        space_id=space_id,
+        mutate=lambda: service.reset_team_ceiling(space_id=space_id),
+    )
+
+
+def _change_space_bots_ceiling(
+    *,
+    action: str,
+    actor_id: str,
+    space_id: int,
+    mutate: Callable[[], int],
+) -> ApiResponse[dict]:
+    try:
+        ceiling = mutate()
+    except Exception:
+        logger.exception(
+            "[access_router.space_bots_ceiling] action=%s space_id=%s failed",
+            action,
+            space_id,
+        )
+        return ApiResponse(
+            success=False,
+            message="更新团队空间 BOT 上限失败",
+            error_code=500,
+            data=None,
+        )
+    logger.info(
+        "[access_router.space_bots_ceiling] action=%s operator=%s "
+        "space_id=%s ceiling=%s",
+        action,
+        actor_id,
+        space_id,
+        ceiling,
+    )
+    return ApiResponse(
+        success=True,
+        message="OK",
+        error_code=200,
+        data={"spaceId": space_id, "ceiling": ceiling},
+    )

--- a/src/backend/src/agentclaw/community/adapters/http/access/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/access/schemas.py
@@ -33,6 +33,12 @@ class SetBotsCeilingRequest(BaseModel):
     ceiling: int = Field(..., gt=0, description="BOT count ceiling (must be > 0)")
 
 
+class SetSpaceBotsCeilingRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    ceiling: int = Field(..., gt=0, description="Team Space BOT count ceiling")
+
+
 class UserListCorrectionRequest(BaseModel):
     """One authenticated correction of a current-environment user-list entry."""
 

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/create_with_manifest.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/create_with_manifest.py
@@ -95,6 +95,7 @@ from agentclaw.community.plugin_api.passport import PassportPlugin
 # engine this surface refuses to create on must be refused here too, and a
 # second copy of the rule is a second thing to forget.
 from .router import (
+    BOT_QUOTA_CONFLICT_RESPONSES,
     _engine_properties_from_body,
     _require_publicly_creatable_engine,
     _require_service_capable_engine,
@@ -132,7 +133,7 @@ router = APIRouter(prefix="/openapi/v1/bots", tags=["bots"], route_class=PublicA
     # no grant to check before the bot exists, so without this an application
     # could create a bot as any user. See ``admission.py``.
     dependencies=[Depends(refuse_app_only_caller)],
-    responses=USER_SCOPED_403,
+    responses={**USER_SCOPED_403, **BOT_QUOTA_CONFLICT_RESPONSES},
     operation_id="create_bot_with_manifest",
 )
 @envelope_errors
@@ -210,6 +211,7 @@ async def create_bot_with_manifest(
         context=BotCreateContext(
             deployment_mode=BotCreateDeploymentMode.CLOUD,
             space_kind=current_space.kind,
+            space_quota=True,
         ),
         bot_service=bot_service,
         passport_plugin=passport_plugin,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py
@@ -59,6 +59,7 @@ from agentclaw.community.adapters.http.openapi_v1.responses import (
     page,
 )
 from agentclaw.community.api.bot_service import BotServiceProtocol
+from agentclaw.community.api.bot_quota_service import BotQuotaServiceProtocol
 from agentclaw.community.api.bot_space_service import BotSpaceServiceProtocol
 from agentclaw.community.api.skill_set_service_factory import (
     SkillSetServiceFactoryProtocol,
@@ -141,6 +142,7 @@ from .schemas import (
     BotAuthStatusPoll,
     BotCreate,
     BotInventoryItem,
+    BotQuotaExceededData,
     BotStatus,
     BotType,
     BotSpaceAssignment,
@@ -176,6 +178,13 @@ _GRANT_CHECKED_OWN_BOT = [Depends(require_granted_own_bot)]
 #: decision visible on the route that carries it, and holds even if the table
 #: entry were ever mislabelled. See ``refuse_app_only_caller``.
 _REFUSES_APP_ONLY = [Depends(refuse_app_only_caller)]
+
+BOT_QUOTA_CONFLICT_RESPONSES = {
+    409: {
+        "model": Envelope[BotQuotaExceededData],
+        "description": "The target Space has no capacity for another Bot.",
+    }
+}
 
 router = APIRouter(prefix="/openapi/v1/bots", tags=["bots"], route_class=PublicAPIRoute)
 
@@ -459,6 +468,7 @@ def _engine_properties_from_body(
     dependencies=_REFUSES_APP_ONLY,
     responses={
         **USER_SCOPED_403,
+        **BOT_QUOTA_CONFLICT_RESPONSES,
         202: {
             "model": Envelope[BotAuthPending],
             "description": "Needs user authorization",
@@ -539,6 +549,7 @@ async def create_bot(
         context=BotCreateContext(
             deployment_mode=BotCreateDeploymentMode.CLOUD,
             space_kind=current_space.kind,
+            space_quota=True,
         ),
         bot_service=bot_service,
         passport_plugin=passport_plugin,
@@ -719,15 +730,24 @@ async def get_bots_ceiling(
     request: Request,
     owner_id: UserIdDep,
     caller: ActingCallerDep,
-    bot_service: BotServiceProtocol = Injected(BotServiceProtocol),
+    x_space_id: Annotated[
+        str | None,
+        Header(
+            alias="X-Space-Id",
+            description="Business-space context; omit to use the personal space.",
+        ),
+    ] = None,
+    quota_service: BotQuotaServiceProtocol = Injected(BotQuotaServiceProtocol),
+    space_context: BusinessSpaceContextProtocol = Injected(
+        BusinessSpaceContextProtocol
+    ),
 ) -> Envelope[Ceiling]:
-    """Get the named user's bot-creation quota ceiling.
+    """Get the Bot ceiling for the selected business Space.
 
-    The number creation actually enforces: creating a bot while the user owns
-    this many live bots is refused (409). A ceiling of 0 or less means the
-    limit is disabled. For an application caller, reading it requires holding
-    at least one live delegation from the named user; without one the user is
-    answered as if they did not exist.
+    Personal Space keeps the named user's configured ceiling. Team Space uses
+    its own ceiling and counts Bots created by every member. For an application
+    caller, reading it still requires at least one live delegation from the
+    named user; without one the user is answered as if they did not exist.
     """
     # Names no bot, so there is no grant to check against one — but the answer
     # is still about a person's account, and a stranger application must not be
@@ -736,11 +756,6 @@ async def get_bots_ceiling(
     # relationship, the closest thing this operation has to a scope. An
     # application with no delegation learns nothing it did not already know.
     #
-    # Resolved through the same method creation enforces, not
-    # PolicyService.get_bots_ceiling directly: that one falls back to its own
-    # hardcoded default of 5, while creation falls back to the configured
-    # max_devices_per_entity. Reading it directly would advertise 5 to a caller
-    # whose deployment allows (or rejects at) a different number.
     granted = caller.granted_bot_ids()
     if granted is not None and not granted:
         # The named user goes to the log bounded and escaped, never into the
@@ -753,8 +768,13 @@ async def get_bots_ceiling(
             for_log(owner_id),
         )
         raise BotNotFoundError("no authorization from the named user")
-    ceiling = bot_service.get_bots_ceiling_for_owner(owner_id)
-    return envelope(Ceiling(ceiling=ceiling), request)
+    current_space = space_context.resolve_current(
+        owner_id=owner_id, header_space_id=x_space_id
+    )
+    snapshot = quota_service.inspect(
+        owner_id=owner_id, space_id=current_space.numeric_id
+    )
+    return envelope(Ceiling(ceiling=snapshot.ceiling), request)
 
 
 # ── Bot inventory card surface ─────────────────────────────────────────────
@@ -976,7 +996,7 @@ async def update_bot(
 @router.put(
     "/{bot_id}/space",
     response_model=Envelope[BotSpaceAssignment],
-    responses=USER_SCOPED_403,
+    responses={**USER_SCOPED_403, **BOT_QUOTA_CONFLICT_RESPONSES},
     dependencies=_GRANT_CHECKED_OWN_BOT,
 )
 @envelope_errors
@@ -1068,6 +1088,7 @@ async def restart_bot(
 #: model it actually returns.
 AUTH_STATUS_RESPONSES = {
     **USER_SCOPED_403,
+    **BOT_QUOTA_CONFLICT_RESPONSES,
     400: {
         "model": Envelope[BotAuthStatus],
         "description": "Authorization did not complete; `data.status` "
@@ -1153,11 +1174,12 @@ def _complete_auth_status(
             context=BotCreateContext(
                 deployment_mode=BotCreateDeploymentMode.CLOUD,
                 space_kind=current_space.kind,
+                space_quota=True,
             ),
             bot_service=bot_service,
             passport_plugin=passport_plugin,
             auth_rel_plugin=auth_rel_plugin,
-            )
+        )
     except AuthStatusUnavailableError:
         # The passport service answered with no status at all — typically the
         # apply is still propagating and the Passport is not ready yet. On this

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/schemas.py
@@ -502,7 +502,9 @@ class BotQuotaExceededData(BaseModel):
 
     space_id: str = Field(description="Identifier of the full target Space.")
     space_name: str = Field(description="Display name of the full target Space.")
-    space_type: Literal["PERSONAL", "TEAM"]
+    space_type: Literal["PERSONAL", "TEAM"] = Field(
+        description="Whether the quota belongs to a Personal or Team Space."
+    )
     ceiling: int = Field(gt=0, description="Configured Bot ceiling for the Space.")
     used: int = Field(ge=0, description="Current non-deleted cloud Bot count.")
 

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/schemas.py
@@ -487,16 +487,24 @@ class BotStatus(BaseModel):
 
 
 class Ceiling(BaseModel):
-    """Per-user bot creation quota."""
+    """Bot creation quota for the selected business Space."""
 
-    model_config = ConfigDict(json_schema_extra={"example": {"ceiling": 5}})
+    model_config = ConfigDict(json_schema_extra={"example": {"ceiling": 20}})
 
     ceiling: int = Field(
-        description="Maximum number of live bots the named user may own in "
-        "this deployment; creation is refused (409) at the limit. Desktop "
-        "bots do not count toward it. A value of 0 or less means the limit "
-        "is disabled."
+        description="Maximum number of non-deleted cloud Bots in this Space. "
+        "A value of 0 or less means the limit is disabled."
     )
+
+
+class BotQuotaExceededData(BaseModel):
+    """Actionable capacity facts returned when a Space cannot accept a Bot."""
+
+    space_id: str = Field(description="Identifier of the full target Space.")
+    space_name: str = Field(description="Display name of the full target Space.")
+    space_type: Literal["PERSONAL", "TEAM"]
+    ceiling: int = Field(gt=0, description="Configured Bot ceiling for the Space.")
+    used: int = Field(ge=0, description="Current non-deleted cloud Bot count.")
 
 
 class Passport(BaseModel):

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/responses.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/responses.py
@@ -105,6 +105,11 @@ from agentclaw.community.core.bot_management.services.bot_service import (
     BotServiceError,
     DeviceLimitError,
 )
+from agentclaw.community.core.bot_management.bot_quota import (
+    BotQuotaBusyError,
+    BotQuotaExceededError,
+    BotQuotaUnavailableError,
+)
 from agentclaw.community.core.bot_public.services.bot_public_service import (
     BotNotFoundError as BotPublicBotNotFoundError,
     BotPublicServiceError,
@@ -531,6 +536,9 @@ ENVELOPE_ERRORS: dict[type[Exception], tuple[int, str]] = {
     BotNameExistsError: (409, "Bot name already exists"),
     BotNameInvalidError: (400, "Invalid bot name"),
     BotLimitExceededError: (409, "Bot creation limit reached"),
+    BotQuotaExceededError: (409, "Bot quota exceeded for this Space"),
+    BotQuotaBusyError: (409, "Bot quota is being updated; retry"),
+    BotQuotaUnavailableError: (503, "Bot quota service unavailable"),
     DeviceLimitError: (409, "Device limit reached"),
     BotInvalidLifecycleStateError: (
         409,
@@ -1004,7 +1012,7 @@ def _error_data(exc: Exception) -> object | None:
 
     Almost every error on this surface answers with a fixed message and a null
     ``data`` — the message is contract, and anything caller- or
-    internal-specific stays out of it. Two failures are genuinely different:
+    internal-specific stays out of it. A few failures are genuinely different:
     they have a *structured* answer the caller needs in order to act, and it is
     derived entirely from what that caller sent or already knows.
 
@@ -1017,6 +1025,8 @@ def _error_data(exc: Exception) -> object | None:
     if isinstance(exc, ManifestValidationError):
         # The all-or-nothing refusal. The fixed message says a document was
         # rejected; this says which entries and why, in the caller's own terms.
+        return exc.as_payload()
+    if isinstance(exc, BotQuotaExceededError):
         return exc.as_payload()
     return None
 

--- a/src/backend/src/agentclaw/community/api/README.md
+++ b/src/backend/src/agentclaw/community/api/README.md
@@ -113,6 +113,7 @@ provides:
   - SkillMetadataParserProtocol
   - ServiceArtifactLineageReaderProtocol
   - ServiceEditLockServiceProtocol
+  - BotQuotaServiceProtocol
   - SpaceSkillOfflineServiceProtocol
 consumes:
   - "No service impls at import time — Protocols only declare shape, they don't depend on concrete services"
@@ -124,6 +125,7 @@ internal_dependencies:
   - agentclaw.community.core.bot_chat.schemas        # ConversationDetail, HealthCheckData — typed in bot_chat_service.py
   - agentclaw.community.core.bot_inventory.types   # Bot inventory/local workflow DTOs — typed in bot_inventory_service.py and local_bot_workflow_service.py
   - agentclaw.community.core.bot_management.bot_space  # Bot Space assignment result typed in bot_space_service.py
+  - agentclaw.community.core.bot_management.bot_quota_service_protocol  # Space-scoped Bot quota service contract
   - agentclaw.community.core.bot_startup_script.repository.models  # BotStartupScriptRecord — typed in bot_startup_script_service.py (real signatures, so the conformance gate can compare them)
   - agentclaw.community.core.bot_config_manifest.credentials.models  # SourceCredentialRecord — typed in source_credential_service.py (W3 #1471)
   - agentclaw.community.core.bot_config_manifest.credentials.service_protocol  # SourceCredentialServiceProtocol — defined in its owning core module, re-exported here (W3 #1471)

--- a/src/backend/src/agentclaw/community/api/bot_quota_service.py
+++ b/src/backend/src/agentclaw/community/api/bot_quota_service.py
@@ -1,0 +1,9 @@
+"""Public Service API for Space-scoped Bot quota operations."""
+
+from __future__ import annotations
+
+from agentclaw.community.core.bot_management.bot_quota_service_protocol import (
+    BotQuotaServiceProtocol,
+)
+
+__all__ = ["BotQuotaServiceProtocol"]

--- a/src/backend/src/agentclaw/community/core/access/policy_service_protocol.py
+++ b/src/backend/src/agentclaw/community/core/access/policy_service_protocol.py
@@ -14,8 +14,24 @@ class PolicyServiceProtocol(Protocol):
 
     def disallow(self, *, entity_id: str, entity_type: str) -> None: ...
 
-    def get_bots_ceiling(self, *, entity_id: str, default: int = 5) -> int: ...
+    def get_bots_ceiling(
+        self,
+        *,
+        entity_id: str,
+        default: int = 5,
+        entity_type: str = "staff",
+    ) -> int: ...
 
-    def set_bots_ceiling(self, *, entity_id: str, ceiling: int) -> None: ...
+    def set_bots_ceiling(
+        self,
+        *,
+        entity_id: str,
+        ceiling: int,
+        entity_type: str = "staff",
+    ) -> None: ...
+
+    def clear_bots_ceiling(
+        self, *, entity_id: str, entity_type: str = "staff"
+    ) -> bool: ...
 
     def get_quota(self) -> dict: ...

--- a/src/backend/src/agentclaw/community/core/access/services/policy_service.py
+++ b/src/backend/src/agentclaw/community/core/access/services/policy_service.py
@@ -86,8 +86,14 @@ class PolicyService(PolicyServiceProtocol):
         except (json.JSONDecodeError, AttributeError):
             return {}
 
-    def get_bots_ceiling(self, *, entity_id: str, default: int = 5) -> int:
-        """获取指定用户的 BOT 数量上限。
+    def get_bots_ceiling(
+        self,
+        *,
+        entity_id: str,
+        default: int = 5,
+        entity_type: str = "staff",
+    ) -> int:
+        """获取指定实体的 BOT 数量上限。
 
         读取 ``ac_access_control_policy.policy`` 中的 ``bots_ceiling`` 字段：
         - 无该用户记录 → 返回 default
@@ -97,7 +103,9 @@ class PolicyService(PolicyServiceProtocol):
         - ``bots_ceiling`` <= 0 → 返回 default
         - ``bots_ceiling`` > 0 → 返回该值
         """
-        record = self._repo.get_by_entity(entity_id=entity_id, entity_type="staff")
+        record = self._repo.get_by_entity(
+            entity_id=entity_id, entity_type=entity_type
+        )
         if not record or not record.policy:
             return default
 
@@ -110,8 +118,9 @@ class PolicyService(PolicyServiceProtocol):
             ceiling = int(raw_ceiling)
         except (ValueError, TypeError):
             logger.warning(
-                "[get_bots_ceiling] invalid bots_ceiling value for entity_id=%s: %r",
-                entity_id, raw_ceiling,
+                "[get_bots_ceiling] invalid bots_ceiling value for "
+                "entity_type=%s entity_id=%s: %r",
+                entity_type, entity_id, raw_ceiling,
             )
             return default
 
@@ -120,24 +129,59 @@ class PolicyService(PolicyServiceProtocol):
 
         return ceiling
 
-    def set_bots_ceiling(self, *, entity_id: str, ceiling: int) -> None:
-        """设置指定用户的 BOT 数量上限（merge 进现有 policy JSON）。
+    def set_bots_ceiling(
+        self,
+        *,
+        entity_id: str,
+        ceiling: int,
+        entity_type: str = "staff",
+    ) -> None:
+        """设置指定实体的 BOT 数量上限（merge 进现有 policy JSON）。
 
         保留现有 policy 中的其他 key（如 ``policy``），仅更新 ``bots_ceiling``。
         如果用户尚无 policy 记录，则创建一条。
         """
-        record = self._repo.get_by_entity(entity_id=entity_id, entity_type="staff")
+        record = self._repo.get_by_entity(
+            entity_id=entity_id, entity_type=entity_type
+        )
         existing = self._parse_policy_json(record.policy) if record else {}
 
         updated = {**existing, "bots_ceiling": str(ceiling)}
         self._repo.upsert_policy(
             entity_id=entity_id,
-            entity_type="staff",
+            entity_type=entity_type,
             policy=json.dumps(updated, ensure_ascii=False),
         )
         logger.info(
-            "[set_bots_ceiling] entity_id=%s, ceiling=%d", entity_id, ceiling,
+            "[set_bots_ceiling] entity_type=%s, entity_id=%s, ceiling=%d",
+            entity_type, entity_id, ceiling,
         )
+
+    def clear_bots_ceiling(
+        self, *, entity_id: str, entity_type: str = "staff"
+    ) -> bool:
+        """Remove only ``bots_ceiling`` while preserving other policy keys."""
+        record = self._repo.get_by_entity(
+            entity_id=entity_id, entity_type=entity_type
+        )
+        if record is None:
+            return False
+
+        existing = self._parse_policy_json(record.policy)
+        if "bots_ceiling" not in existing:
+            return False
+
+        del existing["bots_ceiling"]
+        self._repo.upsert_policy(
+            entity_id=entity_id,
+            entity_type=entity_type,
+            policy=json.dumps(existing, ensure_ascii=False),
+        )
+        logger.info(
+            "[clear_bots_ceiling] entity_type=%s, entity_id=%s",
+            entity_type, entity_id,
+        )
+        return True
 
     def _try_compete(self, *, entity_id: str) -> bool:
         """尝试竞争名额。"""

--- a/src/backend/src/agentclaw/community/core/bot_management/README.md
+++ b/src/backend/src/agentclaw/community/core/bot_management/README.md
@@ -19,6 +19,7 @@ provides:
   - "TeclawPublishTaskLifecycle"
   - "CreateBotForOthersService"
   - "DefaultBotPassportRepairService"
+  - "BotQuotaService and BotQuotaScope"
 consumes:
   - "DeviceAccessor"
   - "PassportPlugin"
@@ -33,6 +34,8 @@ consumes:
   - "HandlerRegistry"
   - "CommonConfigService"
   - "BotSpaceAccessProtocol (implemented by the Spaces context)"
+  - "SpaceAccessServiceProtocol"
+  - "CachePlugin quota lock"
 internal_dependencies:
   - agentclaw.community.core.repository.protocols.bot    # repository contracts consumed by this module
   - agentclaw.community.core.repository.protocols.devices    # repository contracts consumed by this module
@@ -57,6 +60,7 @@ internal_dependencies:
   - agentclaw.community.core.bot_management.bot_space    # narrow cross-context Space membership contract
   - agentclaw.community.core.spaces.errors    # typed Space membership failures propagated by Bot Space assignment
   - agentclaw.community.core.spaces.models    # SpaceRecord/SpaceType used by Bot Space assignment
+  - agentclaw.community.core.spaces.protocols    # Space lookup used by quota configuration
   - agentclaw.community.core.skill_center
   - agentclaw.community.core.task_queue
   - agentclaw.community.core.workspace
@@ -70,6 +74,7 @@ internal_dependencies:
   - agentclaw.community.plugin_api.passport
   - agentclaw.community.plugin_api.secret_resolver
   - agentclaw.community.plugin_api.auth_relationship
+  - agentclaw.community.plugin_api.cache
   - agentclaw.community.utils
   - agentclaw.community.utils.avernet_tenant
   - agentclaw.community.utils.env_utils

--- a/src/backend/src/agentclaw/community/core/bot_management/bot_quota.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/bot_quota.py
@@ -1,0 +1,73 @@
+"""Space-scoped Bot quota value objects and errors."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from agentclaw.community.core.spaces.models import SpaceType
+
+
+@dataclass(frozen=True, slots=True)
+class BotQuotaScope:
+    """The logical Space whose capacity one Bot creation consumes."""
+
+    owner_id: str
+    space_id: int | None
+    space_name: str
+    space_type: SpaceType
+
+    @property
+    def space_ref(self) -> str:
+        if self.space_id is None:
+            return f"personal:{self.owner_id}"
+        return str(self.space_id)
+
+    @property
+    def lock_scope(self) -> str:
+        if self.space_type is SpaceType.PERSONAL:
+            return f"personal:{self.owner_id}"
+        return f"team:{self.space_id}"
+
+
+@dataclass(frozen=True, slots=True)
+class BotQuotaSnapshot:
+    scope: BotQuotaScope
+    ceiling: int
+    used: int
+
+
+class BotQuotaError(Exception):
+    """Base error for Space-scoped Bot quota operations."""
+
+
+class BotQuotaConfigurationError(BotQuotaError):
+    """The requested quota scope or override is invalid."""
+
+
+class BotQuotaUnavailableError(BotQuotaError):
+    """Quota storage or serialization infrastructure is unavailable."""
+
+
+class BotQuotaBusyError(BotQuotaError):
+    """Another mutation currently owns the quota scope lock."""
+
+
+class BotQuotaExceededError(BotQuotaError):
+    """Adding the requested Bots would exceed the target Space ceiling."""
+
+    def __init__(self, snapshot: BotQuotaSnapshot) -> None:
+        self.snapshot = snapshot
+        super().__init__(
+            f"Space {snapshot.scope.space_ref} Bot quota exceeded: "
+            f"used={snapshot.used}, ceiling={snapshot.ceiling}"
+        )
+
+    def as_payload(self) -> dict[str, object]:
+        scope = self.snapshot.scope
+        return {
+            "space_id": scope.space_ref,
+            "space_name": scope.space_name,
+            "space_type": scope.space_type.value,
+            "ceiling": self.snapshot.ceiling,
+            "used": self.snapshot.used,
+        }

--- a/src/backend/src/agentclaw/community/core/bot_management/bot_quota_service_protocol.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/bot_quota_service_protocol.py
@@ -1,0 +1,31 @@
+"""Service contract for Space-scoped Bot quota enforcement."""
+
+from __future__ import annotations
+
+from contextlib import AbstractContextManager
+from typing import Protocol, runtime_checkable
+
+from agentclaw.community.core.bot_management.bot_quota import BotQuotaSnapshot
+
+
+@runtime_checkable
+class BotQuotaServiceProtocol(Protocol):
+    def inspect(self, *, owner_id: str, space_id: int | None) -> BotQuotaSnapshot: ...
+
+    def assert_can_add(
+        self,
+        *,
+        owner_id: str,
+        space_id: int | None,
+    ) -> BotQuotaSnapshot: ...
+
+    def guard_add(
+        self,
+        *,
+        owner_id: str,
+        space_id: int | None,
+    ) -> AbstractContextManager[BotQuotaSnapshot]: ...
+
+    def set_team_ceiling(self, *, space_id: int, ceiling: int) -> int: ...
+
+    def reset_team_ceiling(self, *, space_id: int) -> int: ...

--- a/src/backend/src/agentclaw/community/core/bot_management/create_context.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/create_context.py
@@ -1,0 +1,39 @@
+"""Caller-resolved context carried through Bot creation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+
+class BotCreateDeploymentMode(StrEnum):
+    """Deployment boundary relevant to Bot creation policy."""
+
+    CLOUD = "cloud"
+    LOCAL = "local"
+
+
+@dataclass(frozen=True)
+class BotCreateContext:
+    """Caller-resolved business context required by creation policy."""
+
+    deployment_mode: BotCreateDeploymentMode
+    space_kind: str
+    # Legacy callers keep BotService's established owner/device limit behavior.
+    space_quota: bool = False
+
+    def as_payload(self) -> dict[str, Any]:
+        return {
+            "deployment_mode": self.deployment_mode.value,
+            "space_kind": self.space_kind,
+            "space_quota": self.space_quota,
+        }
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, Any]) -> "BotCreateContext":
+        return cls(
+            deployment_mode=BotCreateDeploymentMode(payload["deployment_mode"]),
+            space_kind=payload["space_kind"],
+            space_quota=bool(payload.get("space_quota", False)),
+        )

--- a/src/backend/src/agentclaw/community/core/bot_management/create_flow.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/create_flow.py
@@ -23,6 +23,10 @@ from dataclasses import dataclass, field, replace
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 
+from agentclaw.community.core.bot_management.create_context import (
+    BotCreateContext,
+    BotCreateDeploymentMode as BotCreateDeploymentMode,
+)
 from agentclaw.community.core.bot_management.engines.provisioning import (
     BotCreateTemplateValidationMode,
     PreparedBotCreate,
@@ -66,21 +70,6 @@ if TYPE_CHECKING:
     from agentclaw.community.plugin_api.passport import PassportPlugin
 
 logger = get_logger()
-
-
-class BotCreateDeploymentMode(StrEnum):
-    """Deployment boundary relevant to Bot creation policy."""
-
-    CLOUD = "cloud"
-    LOCAL = "local"
-
-
-@dataclass(frozen=True)
-class BotCreateContext:
-    """Caller-resolved business context required by creation policy."""
-
-    deployment_mode: BotCreateDeploymentMode
-    space_kind: str
 
 
 def _reject_mixed_create_sources(spec: BotCreateSpec) -> None:
@@ -555,6 +544,8 @@ def create_bot_with_authorization(
         bot_id=bot_id,
         engine_type=spec.engine_type,
         bot_name=bot_name,
+        space_id=spec.space_id,
+        space_quota=context.space_quota,
     )
 
     passport_result = _apply_passport(
@@ -623,6 +614,7 @@ def create_bot_with_authorization(
         template_config=spec.template_config,
         cookie=cookie,
         space_id=spec.space_id,
+        space_quota=context.space_quota,
     )
 
     _record_owner_relationship(
@@ -708,6 +700,8 @@ def submit_bot_creation_with_manifest(
         bot_id=bot_id,
         engine_type=spec.engine_type,
         bot_name=bot_name,
+        space_id=spec.space_id,
+        space_quota=context.space_quota,
     )
 
     # Raises ManifestValidationError with every reason at once. Before Passport.
@@ -865,8 +859,7 @@ def creation_spec_to_payload(
         "template_validation_mode": spec.template_validation_mode.value,
         "space_id": spec.space_id,
         "engine_properties": spec.engine_properties,
-        "deployment_mode": context.deployment_mode.value,
-        "space_kind": context.space_kind,
+        **context.as_payload(),
     }
 
 
@@ -892,10 +885,7 @@ def creation_spec_from_payload(
             space_id=payload.get("space_id"),
             engine_properties=payload.get("engine_properties") or {},
         ),
-        BotCreateContext(
-            deployment_mode=BotCreateDeploymentMode(payload["deployment_mode"]),
-            space_kind=payload["space_kind"],
-        ),
+        BotCreateContext.from_payload(payload),
     )
 
 
@@ -990,6 +980,7 @@ def complete_bot_authorization(
         cookie=cookie,
         space_id=spec.space_id,
         provision=provision,
+        space_quota=context.space_quota,
     )
 
     _record_owner_relationship(

--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_quota_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_quota_service.py
@@ -1,0 +1,237 @@
+"""Space-scoped Bot quota policy and mutation serialization."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from hashlib import sha256
+from typing import Iterator, TYPE_CHECKING
+
+from injector import inject
+
+from agentclaw.community.core.access.policy_service_protocol import (
+    PolicyServiceProtocol,
+)
+from agentclaw.community.core.bot_management.bot_quota import (
+    BotQuotaBusyError,
+    BotQuotaConfigurationError,
+    BotQuotaError,
+    BotQuotaExceededError,
+    BotQuotaScope,
+    BotQuotaSnapshot,
+    BotQuotaUnavailableError,
+)
+from agentclaw.community.core.bot_management.bot_quota_service_protocol import (
+    BotQuotaServiceProtocol,
+)
+from agentclaw.community.core.repository.protocols.bot import BotRepository
+from agentclaw.community.core.spaces.models import SpaceType
+from agentclaw.community.core.spaces.protocols import SpaceAccessServiceProtocol
+from agentclaw.community.log import get_logger
+from agentclaw.community.plugin_api.cache import (
+    CacheLockInfrastructureError,
+    CachePlugin,
+)
+from agentclaw.community.utils.avernet_tenant import get_current_avernet_tenant
+from agentclaw.community.utils.env_utils import get_current_env
+
+if TYPE_CHECKING:
+    from agentclaw.community.di import config as cfg
+
+
+logger = get_logger()
+
+TEAM_DEFAULT_BOT_CEILING = 20
+_QUOTA_LOCK_TTL_SECONDS = 30
+
+
+class BotQuotaService(BotQuotaServiceProtocol):
+    @inject
+    def __init__(
+        self,
+        repository: BotRepository,
+        allocation_config: "cfg.DeviceAllocationConfig",
+        policy_service: PolicyServiceProtocol,
+        cache: CachePlugin,
+        space_access: SpaceAccessServiceProtocol,
+    ) -> None:
+        self._repository = repository
+        self._allocation_config = allocation_config
+        self._policy_service = policy_service
+        self._cache = cache
+        self._space_access = space_access
+
+    def inspect(self, *, owner_id: str, space_id: int | None) -> BotQuotaSnapshot:
+        try:
+            return self._inspect(self._scope(owner_id=owner_id, space_id=space_id))
+        except BotQuotaError:
+            raise
+        except Exception as exc:
+            raise BotQuotaUnavailableError("Bot quota state is unavailable") from exc
+
+    def _inspect(self, scope: BotQuotaScope) -> BotQuotaSnapshot:
+        ceiling = self._ceiling(scope)
+        if scope.space_type is SpaceType.PERSONAL:
+            used = self._repository.count_cloud_bots_in_personal_space(
+                owner_id=scope.owner_id,
+                personal_space_id=scope.space_id,
+            )
+        else:
+            if scope.space_id is None:
+                raise BotQuotaConfigurationError("Team Space requires a numeric id")
+            used = self._repository.count_cloud_bots_by_space(space_id=scope.space_id)
+        return BotQuotaSnapshot(scope=scope, ceiling=ceiling, used=int(used))
+
+    def assert_can_add(
+        self,
+        *,
+        owner_id: str,
+        space_id: int | None,
+    ) -> BotQuotaSnapshot:
+        return self._assert_available(
+            self.inspect(owner_id=owner_id, space_id=space_id)
+        )
+
+    @contextmanager
+    def guard_add(
+        self,
+        *,
+        owner_id: str,
+        space_id: int | None,
+    ) -> Iterator[BotQuotaSnapshot]:
+        try:
+            scope = self._scope(owner_id=owner_id, space_id=space_id)
+        except BotQuotaError:
+            raise
+        except Exception as exc:
+            raise BotQuotaUnavailableError("Bot quota state is unavailable") from exc
+        with self._locked(scope):
+            try:
+                snapshot = self._assert_available(self._inspect(scope))
+            except BotQuotaError:
+                raise
+            except Exception as exc:
+                raise BotQuotaUnavailableError(
+                    "Bot quota state is unavailable"
+                ) from exc
+            yield snapshot
+
+    def set_team_ceiling(self, *, space_id: int, ceiling: int) -> int:
+        if ceiling <= 0:
+            raise BotQuotaConfigurationError("ceiling must be positive")
+        scope = self._team_scope(space_id)
+        with self._locked(scope):
+            self._policy_service.set_bots_ceiling(
+                entity_type="space",
+                entity_id=str(space_id),
+                ceiling=ceiling,
+            )
+        return ceiling
+
+    def reset_team_ceiling(self, *, space_id: int) -> int:
+        scope = self._team_scope(space_id)
+        with self._locked(scope):
+            self._policy_service.clear_bots_ceiling(
+                entity_type="space", entity_id=str(space_id)
+            )
+            return self._policy_service.get_bots_ceiling(
+                entity_type="space",
+                entity_id=str(space_id),
+                default=TEAM_DEFAULT_BOT_CEILING,
+            )
+
+    def _ceiling(self, scope: BotQuotaScope) -> int:
+        if scope.space_type is SpaceType.TEAM:
+            if scope.space_id is None:
+                raise BotQuotaConfigurationError("Team Space requires a numeric id")
+            return self._policy_service.get_bots_ceiling(
+                entity_type="space",
+                entity_id=str(scope.space_id),
+                default=TEAM_DEFAULT_BOT_CEILING,
+            )
+
+        default = 0
+        try:
+            default = int(self._allocation_config.max_devices_per_entity)
+        except (TypeError, ValueError):
+            pass
+        return self._policy_service.get_bots_ceiling(
+            entity_type="staff",
+            entity_id=scope.owner_id,
+            default=default,
+        )
+
+    def _team_scope(self, space_id: int) -> BotQuotaScope:
+        scope = self._scope(owner_id="", space_id=space_id)
+        if scope.space_type is not SpaceType.TEAM:
+            raise BotQuotaConfigurationError(
+                "only Team Space ceilings can be configured here"
+            )
+        return scope
+
+    def _scope(self, *, owner_id: str, space_id: int | None) -> BotQuotaScope:
+        if space_id is None:
+            return BotQuotaScope(
+                owner_id=owner_id,
+                space_id=None,
+                space_name="Personal",
+                space_type=SpaceType.PERSONAL,
+            )
+        space = self._space_access.require_space(space_id=space_id)
+        if (
+            owner_id
+            and space.space_type is SpaceType.PERSONAL
+            and space.personal_owner_id != owner_id
+        ):
+            raise BotQuotaConfigurationError("Personal Space belongs to another user")
+        return BotQuotaScope(
+            owner_id=owner_id,
+            space_id=space.id,
+            space_name=space.name,
+            space_type=space.space_type,
+        )
+
+    @staticmethod
+    def _assert_available(snapshot: BotQuotaSnapshot) -> BotQuotaSnapshot:
+        if snapshot.ceiling > 0 and snapshot.used >= snapshot.ceiling:
+            raise BotQuotaExceededError(snapshot)
+        return snapshot
+
+    @contextmanager
+    def _locked(self, scope: BotQuotaScope) -> Iterator[None]:
+        lock_key = self._lock_key(scope)
+        try:
+            lock_value = self._cache.acquire_lock_strict(
+                lock_key, ttl=_QUOTA_LOCK_TTL_SECONDS
+            )
+        except CacheLockInfrastructureError as exc:
+            raise BotQuotaUnavailableError(
+                "Bot quota coordinator is unavailable"
+            ) from exc
+        if lock_value is None:
+            raise BotQuotaBusyError("Bot quota mutation is in progress")
+        try:
+            yield
+        finally:
+            try:
+                if not self._cache.release_lock(lock_key, lock_value):
+                    logger.warning(
+                        "[bot_quota] quota lock was no longer owned key=%s",
+                        lock_key,
+                    )
+            except Exception:
+                logger.exception(
+                    "[bot_quota] failed to release quota lock key=%s",
+                    lock_key,
+                )
+
+    @staticmethod
+    def _lock_key(scope: BotQuotaScope) -> str:
+        raw = "\0".join(
+            (
+                get_current_avernet_tenant(),
+                get_current_env(),
+                scope.lock_scope,
+            )
+        )
+        digest = sha256(raw.encode("utf-8")).hexdigest()
+        return f"bot-quota:{digest}"

--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -29,6 +29,10 @@ from agentclaw.community.core.bot_management.engines.registry import (
     normalize_engine_type,
     resolve_baas_engine_bucket,
 )
+from agentclaw.community.core.bot_management.bot_quota import (
+    BotQuotaError,
+    BotQuotaUnavailableError,
+)
 from agentclaw.community.core.bot_management.services.template_service import TemplateService
 from agentclaw.community.core.bot_management.services.aicoding.workspace_hosting_service import WorkspaceHostingService
 from agentclaw.community.core.desktop_bot.device_status_client import DeviceStatusClient
@@ -64,6 +68,9 @@ if TYPE_CHECKING:
     # ``SkillSetServiceFactory`` below.
     from agentclaw.community.di import config as cfg
     from agentclaw.community.core.access.policy_service_protocol import PolicyServiceProtocol
+    from agentclaw.community.core.bot_management.bot_quota_service_protocol import (
+        BotQuotaServiceProtocol,
+    )
 from agentclaw.community.core.bot_management.repository.models import BotRestartLockRecord
 from agentclaw.community.core.repository.protocols.bot import BotRestartLockRepositoryProtocol
 from agentclaw.community.core.repository.protocols.bot import BotRepository
@@ -349,6 +356,7 @@ class BotService(BotServiceProtocol):
         common_config_service: "CommonConfigService | None" = None,
         runtime_reconciler: "CoreBotRuntimeProjectorProtocol | None" = None,
         runtime_reconciler_provider: "Callable[[], CoreBotRuntimeProjectorProtocol] | None" = None,
+        bot_quota_service: "BotQuotaServiceProtocol | None" = None,
     ) -> None:
         self._repository = repository
         self._allocation_config = allocation_config
@@ -413,6 +421,7 @@ class BotService(BotServiceProtocol):
         self._common_config_service = common_config_service
         self._runtime_reconciler = runtime_reconciler
         self._runtime_reconciler_provider = runtime_reconciler_provider
+        self._bot_quota_service = bot_quota_service
 
     def _service_bot_image_policy_enabled(self) -> bool:
         """Whether draft create/restart should opt into image policy."""
@@ -1078,6 +1087,8 @@ class BotService(BotServiceProtocol):
         bot_id: Optional[str] = None,
         engine_type: Optional[str] = None,
         bot_name: Optional[str] = None,
+        space_id: int | None = None,
+        space_quota: bool = False,
     ) -> None:
         """Validate whether a bot creation request can start external auth.
 
@@ -1093,7 +1104,12 @@ class BotService(BotServiceProtocol):
         check stays where it is — this one narrows the window, it does not close
         it, since another create can take the name in between.
         """
-        self._check_bot_count_limit(user_id)
+        if space_quota:
+            self._require_bot_quota_service().assert_can_add(
+                owner_id=user_id, space_id=space_id
+            )
+        else:
+            self._check_bot_count_limit(user_id)
         if bot_name and bot_name.strip():
             if self._repository.get_by_bot_name(bot_name.strip()):
                 raise BotNameExistsError(f"Bot name '{bot_name}' already exists")
@@ -1104,6 +1120,12 @@ class BotService(BotServiceProtocol):
         """Reject Teclaw Cloud as the engine of the reserved Default Bot."""
         if bot_id == "default" and self.is_teclaw_bot(engine_type):
             raise DefaultBotTeclawNotAllowedError()
+
+    def _require_bot_quota_service(self) -> "BotQuotaServiceProtocol":
+        service = self._bot_quota_service
+        if service is None:
+            raise BotQuotaUnavailableError("Bot quota service is not configured")
+        return service
 
     def _check_device_limit(self, entity_id: str, entity_type: str, owner_id: str) -> None:
         """
@@ -1275,6 +1297,7 @@ class BotService(BotServiceProtocol):
         cookie: Optional[str] = None,
         space_id: Optional[int] = None,
         provision: bool = True,
+        space_quota: bool = False,
     ) -> Dict[str, Any]:
         """
         Create a new bot with async device allocation.
@@ -1336,6 +1359,8 @@ class BotService(BotServiceProtocol):
             user_id=user_id,
             bot_id=bot_id,
             engine_type=resolved_active_engine,
+            space_id=space_id,
+            space_quota=space_quota,
         )
 
         # Resolve entity info
@@ -1386,8 +1411,11 @@ class BotService(BotServiceProtocol):
             if self._repository.exists_by_bot_name(bot_name.strip()):
                 raise BotNameExistsError(f"Bot name '{bot_name}' already exists")
 
-        # Check device limit before creating bot (based on user's existing bots)
-        self._check_device_limit(resolved_entity_id, resolved_entity_type, user_id)
+        # The legacy route keeps its established owner/device limit. A Space-aware
+        # OpenAPI create has already checked the target Space's Bot rows and must
+        # not be blocked again by the owner's personal ceiling.
+        if not space_quota:
+            self._check_device_limit(resolved_entity_id, resolved_entity_type, user_id)
 
         logger.info(f"[bot_service.create_bot] Creating bot {bot_id} for user {user_id}, "
                    f"entity={resolved_entity_type}/{resolved_entity_id}, engines={resolved_engine_types}, "
@@ -1418,7 +1446,15 @@ class BotService(BotServiceProtocol):
                 "space_id": space_id,  # Business-space ownership: NULL -> personal fallback
             }
 
-            bot_record = self._repository.insert(bot_data)
+            if not space_quota:
+                bot_record = self._repository.insert(bot_data)
+            else:
+                # Serialize only the final count + row insert. Passport and
+                # device provisioning stay outside this short quota lease.
+                with self._require_bot_quota_service().guard_add(
+                    owner_id=user_id, space_id=space_id
+                ):
+                    bot_record = self._repository.insert(bot_data)
             logger.info(f"[bot_service.create_bot] Bot {bot_id} created with PENDING status")
 
             # Step 1.5: Create template record if template_config is provided
@@ -1526,7 +1562,7 @@ class BotService(BotServiceProtocol):
                 cookie=cookie,
             )
 
-        except BotServiceError:
+        except (BotServiceError, BotQuotaError):
             raise
         except Exception as e:
             logger.error(f"[bot_service.create_bot] Failed to create bot record: {e}")

--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_space_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_space_service.py
@@ -8,6 +8,9 @@ from agentclaw.community.core.bot_management.bot_space import (
     BotSpaceAccessProtocol,
     BotSpaceAssignmentResult,
 )
+from agentclaw.community.core.bot_management.bot_quota_service_protocol import (
+    BotQuotaServiceProtocol,
+)
 from agentclaw.community.core.bot_management.services.bot_service import (
     BotNotFoundError,
     BotOperationNotAllowedError,
@@ -15,7 +18,9 @@ from agentclaw.community.core.bot_management.services.bot_service import (
 from agentclaw.community.core.repository.protocols.bot import BotRepository
 from agentclaw.community.core.spaces.errors import SpaceAccessDeniedError
 from agentclaw.community.core.spaces.models import SpaceType
-from agentclaw.community.core.bot_management.bot_space_service_protocol import BotSpaceServiceProtocol
+from agentclaw.community.core.bot_management.bot_space_service_protocol import (
+    BotSpaceServiceProtocol,
+)
 
 
 class BotSpaceService(BotSpaceServiceProtocol):
@@ -30,9 +35,11 @@ class BotSpaceService(BotSpaceServiceProtocol):
         self,
         repository: BotRepository,
         space_access: BotSpaceAccessProtocol,
+        bot_quota: BotQuotaServiceProtocol,
     ) -> None:
         self._repository = repository
         self._space_access = space_access
+        self._bot_quota = bot_quota
 
     def change_space(
         self, *, bot_id: str, owner_id: str, space_id: int
@@ -70,11 +77,24 @@ class BotSpaceService(BotSpaceServiceProtocol):
         if not changed:
             return BotSpaceAssignmentResult(bot=bot, space=space, changed=False)
 
-        updated = self._repository.update_space_by_owner(
-            bot_id=bot_id,
-            owner_id=owner_id,
-            space_id=persisted_space_id,
+        normalizes_legacy_personal = (
+            bot.get("space_id") is None
+            and space.space_type is SpaceType.PERSONAL
+            and space.personal_owner_id == owner_id
         )
+        if bot.get("bot_type") == "desktop" or normalizes_legacy_personal:
+            updated = self._repository.update_space_by_owner(
+                bot_id=bot_id,
+                owner_id=owner_id,
+                space_id=persisted_space_id,
+            )
+        else:
+            with self._bot_quota.guard_add(owner_id=owner_id, space_id=space.id):
+                updated = self._repository.update_space_by_owner(
+                    bot_id=bot_id,
+                    owner_id=owner_id,
+                    space_id=persisted_space_id,
+                )
         if updated is None:
             # The Bot may have been deleted between the read and write. Mask it
             # exactly like the initial owner-scoped lookup.

--- a/src/backend/src/agentclaw/community/core/repository/implementations/bot/bot.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/bot/bot.py
@@ -53,6 +53,7 @@ from agentclaw.community.core.repository.implementations.bot.device_provider imp
 from agentclaw.community.core.repository.implementations.bot.reachability import (
     BotReachabilityQueries,
 )
+from agentclaw.community.core.repository.implementations.bot.quota import BotQuotaQueries
 from agentclaw.community.core.workspace.constants import SUPPORTED_ENGINE_TYPES
 from agentclaw.community.log import get_logger
 from agentclaw.community.plugin_api.database import DatabasePlugin
@@ -94,6 +95,7 @@ def _as_naive(dt: datetime) -> datetime:
 class BotRepository(
     BotDeviceProviderQueries,
     BotReachabilityQueries,
+    BotQuotaQueries,
     BotRepositoryProtocol,
 ):
     """Unified ORM ``BotRepository`` implementation."""

--- a/src/backend/src/agentclaw/community/core/repository/implementations/bot/quota.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/bot/quota.py
@@ -1,0 +1,55 @@
+"""Space-scoped quota counts for the unified Bot repository."""
+
+from __future__ import annotations
+
+from sqlalchemy import or_
+
+
+class BotQuotaQueries:
+    """Count live cloud Bots in Personal or Team Space scopes."""
+
+    def count_cloud_bots_in_personal_space(
+        self,
+        *,
+        owner_id: str,
+        personal_space_id: int | None,
+    ) -> int:
+        with self._db.orm_session() as db:
+            query = db.query(self.Model).filter(
+                self.Model.is_delete == 0,
+                self.Model.owner_id == owner_id,
+                or_(self.Model.bot_type.is_(None), self.Model.bot_type != "desktop"),
+                self._env(),
+            )
+            if personal_space_id is None:
+                query = query.filter(self.Model.space_id.is_(None))
+            else:
+                query = query.filter(
+                    or_(
+                        self.Model.space_id.is_(None),
+                        self.Model.space_id == personal_space_id,
+                    )
+                )
+            return query.count()
+
+    def count_cloud_bots_by_space(
+        self,
+        *,
+        space_id: int,
+    ) -> int:
+        with self._db.orm_session() as db:
+            return (
+                db.query(self.Model)
+                .filter(
+                    self.Model.is_delete == 0,
+                    self.Model.space_id == space_id,
+                    or_(
+                        self.Model.bot_type.is_(None), self.Model.bot_type != "desktop"
+                    ),
+                    self._env(),
+                )
+                .count()
+            )
+
+
+__all__ = ["BotQuotaQueries"]

--- a/src/backend/src/agentclaw/community/core/repository/protocols/bot/bot.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/bot/bot.py
@@ -305,6 +305,29 @@ class BotRepository(Protocol):
         ...
 
     @abstractmethod
+    def count_cloud_bots_in_personal_space(
+        self,
+        *,
+        owner_id: str,
+        personal_space_id: int | None,
+    ) -> int:
+        """Count an owner's live Bots in their logical Personal Space.
+
+        Legacy rows with ``space_id IS NULL`` belong to that same scope and are
+        included alongside the numeric Personal Space id when one exists.
+        """
+        ...
+
+    @abstractmethod
+    def count_cloud_bots_by_space(
+        self,
+        *,
+        space_id: int,
+    ) -> int:
+        """Count all live Bots assigned to one exact Space across owners."""
+        ...
+
+    @abstractmethod
     def exists_by_owner_and_bot_id(self, owner_id: str, bot_id: str) -> bool:
         """Check if a bot with specific bot_id exists for the owner."""
         ...

--- a/src/backend/src/agentclaw/community/di/container.py
+++ b/src/backend/src/agentclaw/community/di/container.py
@@ -32,6 +32,7 @@ from agentclaw.community.di.modules.bot_inventory_module import BotInventoryModu
 from agentclaw.community.di.modules.bot_management_module import BotManagementModule
 from agentclaw.community.di.modules.manifest_fetch_module import ManifestFetchModule
 from agentclaw.community.di.modules.bot_public_module import BotPublicModule
+from agentclaw.community.di.modules.bot_quota_module import BotQuotaModule
 from agentclaw.community.di.modules.task_module import TaskModule
 from agentclaw.community.di.modules.caller_identity_module import CallerIdentityModule
 from agentclaw.community.di.modules.channel_module import ChannelModule
@@ -117,6 +118,7 @@ def build_injector(
         SystemConfigModule(),
         CommonConfigModule(),
         BotManagementModule(),
+        BotQuotaModule(),
         ManifestFetchModule(),
         BotInventoryModule(),
         SkillsPoolModule(),

--- a/src/backend/src/agentclaw/community/di/modules/bot_management_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/bot_management_module.py
@@ -31,6 +31,7 @@ from injector import (
 )
 
 from agentclaw.community.api.bot_service import BotServiceProtocol
+from agentclaw.community.api.bot_quota_service import BotQuotaServiceProtocol
 from agentclaw.community.api.bot_space_service import BotSpaceServiceProtocol
 from agentclaw.community.api.create_bot_for_others_service import (
     CreateBotForOthersServiceProtocol,
@@ -511,6 +512,7 @@ class BotManagementModule(Module):
         task_queue_service: TaskQueueService,
         common_config_service: CommonConfigService,
         caller_identity_repo: CallerIdentityRepositoryProtocol,
+        bot_quota_service: BotQuotaServiceProtocol,
         injector: Injector,
     ) -> BotService:
         # Explicit provider: ``BotService.__init__`` types several
@@ -557,6 +559,7 @@ class BotManagementModule(Module):
             common_config_service=common_config_service,
             caller_identity_repo=caller_identity_repo,
             runtime_reconciler_provider=lambda: injector.get(CoreBotRuntimeProjectorProtocol),
+            bot_quota_service=bot_quota_service,
         )
 
     @singleton

--- a/src/backend/src/agentclaw/community/di/modules/bot_quota_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/bot_quota_module.py
@@ -1,0 +1,36 @@
+"""DI bindings for Space-scoped Bot quota enforcement."""
+
+from __future__ import annotations
+
+from injector import Module, inject, provider, singleton
+
+from agentclaw.community.api.bot_quota_service import BotQuotaServiceProtocol
+from agentclaw.community.api.policy_service import PolicyServiceProtocol
+from agentclaw.community.core.bot_management.services.bot_quota_service import (
+    BotQuotaService,
+)
+from agentclaw.community.core.repository.protocols.bot import BotRepository
+from agentclaw.community.core.spaces.protocols import SpaceAccessServiceProtocol
+from agentclaw.community.di import config as cfg
+from agentclaw.community.plugin_api.cache import CachePlugin
+
+
+class BotQuotaModule(Module):
+    @singleton
+    @provider
+    @inject
+    def bot_quota_service(
+        self,
+        repository: BotRepository,
+        allocation_config: cfg.DeviceAllocationConfig,
+        policy_service: PolicyServiceProtocol,
+        cache: CachePlugin,
+        space_access: SpaceAccessServiceProtocol,
+    ) -> BotQuotaServiceProtocol:
+        return BotQuotaService(
+            repository=repository,
+            allocation_config=allocation_config,
+            policy_service=policy_service,
+            cache=cache,
+            space_access=space_access,
+        )

--- a/src/backend/src/agentclaw/community/plugins/local/policy_service.py
+++ b/src/backend/src/agentclaw/community/plugins/local/policy_service.py
@@ -56,15 +56,39 @@ class LocalPolicyService:
             entity_id,
         )
 
-    def get_bots_ceiling(self, *, entity_id: str, default: int = 5) -> int:
+    def get_bots_ceiling(
+        self,
+        *,
+        entity_id: str,
+        default: int = 5,
+        entity_type: str = "staff",
+    ) -> int:
         """singlebox 不限 bot 数量上限。返回一个足够大的值。"""
         return 9999
 
-    def set_bots_ceiling(self, *, entity_id: str, ceiling: int) -> None:
+    def set_bots_ceiling(
+        self,
+        *,
+        entity_id: str,
+        ceiling: int,
+        entity_type: str = "staff",
+    ) -> None:
         logger.info(
-            "[LocalPolicyService] set_bots_ceiling(entity_id=%s, ceiling=%d) -> no-op",
-            entity_id, ceiling,
+            "[LocalPolicyService] set_bots_ceiling(entity_type=%s, "
+            "entity_id=%s, ceiling=%d) -> no-op",
+            entity_type,
+            entity_id,
+            ceiling,
         )
+
+    def clear_bots_ceiling(self, *, entity_id: str, entity_type: str = "staff") -> bool:
+        logger.info(
+            "[LocalPolicyService] clear_bots_ceiling(entity_type=%s, "
+            "entity_id=%s) -> no-op",
+            entity_type,
+            entity_id,
+        )
+        return False
 
     def get_quota(self) -> dict:
         """Return the API-facing unlimited quota shape used by the router."""

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_app_only_listings.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_app_only_listings.py
@@ -52,6 +52,7 @@ from agentclaw.community.api.cron_relay_service import (
 from agentclaw.community.api.local_bot_workflow_service import (
     LocalBotWorkflowServiceProtocol,
 )
+from agentclaw.community.api.bot_quota_service import BotQuotaServiceProtocol
 from agentclaw.community.api.bot_service import BotServiceProtocol
 from agentclaw.community.api.market_favorite_service import (
     MarketFavoriteServiceProtocol,
@@ -93,6 +94,11 @@ from agentclaw.community.core.bot_inventory.types import (
 from agentclaw.community.core.bot_management.services.bot_service import (
     BotNotFoundError,
 )
+from agentclaw.community.core.bot_management.bot_quota import (
+    BotQuotaScope,
+    BotQuotaSnapshot,
+)
+from agentclaw.community.core.spaces.models import SpaceType
 from agentclaw.community.core.gateway_principal import (
     AppPrincipal,
     GatewayApp,
@@ -217,6 +223,20 @@ class _Bots:
         return False
 
 
+class _Quota:
+    def inspect(self, *, owner_id: str, space_id: int | None) -> BotQuotaSnapshot:
+        return BotQuotaSnapshot(
+            scope=BotQuotaScope(
+                owner_id=owner_id,
+                space_id=space_id,
+                space_name="Personal",
+                space_type=SpaceType.PERSONAL,
+            ),
+            ceiling=5,
+            used=0,
+        )
+
+
 @pytest.fixture
 def bots():
     return _Bots()
@@ -234,6 +254,7 @@ def make_client(bots):
         class _M(Module):
             def configure(self, binder):
                 binder.bind(BotServiceProtocol, to=bots)
+                binder.bind(BotQuotaServiceProtocol, to=_Quota())
                 binder.bind(BotAppGrantServiceProtocol, to=_Grants(*grant_ids))
                 unexpected = _UnexpectedService()
                 binder.bind(CronRelayServiceProtocol, to=unexpected)
@@ -627,7 +648,7 @@ def test_an_owner_scoped_listing_does_not_widen_through_a_shared_bot_id(
 
 
 def test_the_ceiling_is_readable_with_a_delegation(make_client):
-    client = make_client(GRANTED)
+    client = make_client(GRANTED, space_context=NoopBusinessSpaceContext())
 
     assert _data(client.get("/openapi/v1/bots/ceiling"))["ceiling"] == 5
 

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_bots_endpoints.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_bots_endpoints.py
@@ -31,6 +31,7 @@ from agentclaw.community.adapters.http.openapi_v1.deprecated.auth_status import 
 )
 from agentclaw.community.adapters.http.openapi_v1.dependencies import require_principal
 from agentclaw.community.api.bot_service import BotServiceProtocol
+from agentclaw.community.api.bot_quota_service import BotQuotaServiceProtocol
 from agentclaw.community.api.bot_space_service import BotSpaceServiceProtocol
 from agentclaw.community.api.policy_service import PolicyServiceProtocol
 from agentclaw.community.api.skill_set_service_factory import (
@@ -41,10 +42,16 @@ from agentclaw.community.core.bot_management.services.bot_service import (
     BotNotFoundError,
     BotOperationNotAllowedError,
 )
+from agentclaw.community.core.bot_management.bot_quota import (
+    BotQuotaExceededError,
+    BotQuotaScope,
+    BotQuotaSnapshot,
+)
 from agentclaw.community.core.spaces.errors import (
     SpaceAccessDeniedError,
     SpaceNotFoundError,
 )
+from agentclaw.community.core.spaces.models import SpaceType
 from agentclaw.community.core.bot_inventory.adapters.noop_business_space import (
     NoopBusinessSpaceContext,
 )
@@ -54,7 +61,6 @@ from agentclaw.community.core.bot_inventory.errors import (
 from agentclaw.community.core.bot_inventory.protocols import (
     BusinessSpaceContextProtocol,
 )
-from agentclaw.community.core.bot_inventory.types import BusinessSpaceRef
 from agentclaw.community.api.engine_config_service import EngineConfigServiceProtocol
 from agentclaw.community.api.bot_startup_script_service import (
     BotStartupScriptServiceProtocol,
@@ -133,6 +139,22 @@ def bot_space():
 
 
 @pytest.fixture
+def quota():
+    service = MagicMock()
+    service.inspect.return_value = BotQuotaSnapshot(
+        scope=BotQuotaScope(
+            owner_id="u1",
+            space_id=None,
+            space_name="Personal",
+            space_type=SpaceType.PERSONAL,
+        ),
+        ceiling=7,
+        used=2,
+    )
+    return service
+
+
+@pytest.fixture
 def skill_set_factory():
     m = MagicMock()
     m.create.return_value.get_bot_mcp_codes.return_value = []
@@ -191,6 +213,7 @@ class _CountingNoopSpace(NoopBusinessSpaceContext):
 @pytest.fixture
 def client(
     svc,
+    quota,
     bot_space,
     policy,
     passport,
@@ -205,6 +228,7 @@ def client(
     class _M(Module):
         def configure(self, binder):
             binder.bind(BotServiceProtocol, to=svc)
+            binder.bind(BotQuotaServiceProtocol, to=quota)
             binder.bind(BotSpaceServiceProtocol, to=bot_space)
             binder.bind(PolicyServiceProtocol, to=policy)
             binder.bind(PassportPlugin, to=passport)
@@ -412,8 +436,9 @@ def test_check_name(client):
     assert data == {"name": "Foo", "exists": True}
 
 
-def test_ceiling(client):
-    assert _ok(client.get("/openapi/v1/bots/ceiling"))["ceiling"] == 7
+def test_ceiling(client, quota):
+    assert _ok(client.get("/openapi/v1/bots/ceiling")) == {"ceiling": 7}
+    quota.inspect.assert_called_once_with(owner_id="u1", space_id=None)
 
 
 def test_status(client):
@@ -604,24 +629,40 @@ def test_create_bot_201(client, svc, passport):
     assert body["data"]["bot_id"] == "b1"
     svc.create_bot.assert_called_once()
     assert svc.create_bot.call_args.kwargs["space_id"] is None
+    assert svc.create_bot.call_args.kwargs["space_quota"] is True
 
 
-def test_real_space_reference_exposes_numeric_id():
-    assert (
-        BusinessSpaceRef(space_id="42", name="Team", kind="team").numeric_id == 42
+def test_create_bot_returns_structured_quota_conflict_before_passport(
+    client, svc, passport
+):
+    scope = BotQuotaScope(
+        owner_id="u1",
+        space_id=None,
+        space_name="Personal",
+        space_type=SpaceType.PERSONAL,
+    )
+    svc.check_create_bot_preflight.side_effect = BotQuotaExceededError(
+        BotQuotaSnapshot(scope=scope, ceiling=5, used=5)
     )
 
+    response = client.post("/openapi/v1/bots", json=_CREATE_BODY)
 
-def test_synthetic_personal_reference_has_no_numeric_id():
-    assert (
-        BusinessSpaceRef(
-            space_id="personal:u1",
-            name="Personal",
-            kind="personal",
-        ).numeric_id
-        is None
-    )
-
+    assert response.status_code == 409
+    assert response.json() == {
+        "code": 409000,
+        "message": "Bot quota exceeded for this Space",
+        "data": {
+            "space_id": "personal:u1",
+            "space_name": "Personal",
+            "space_type": "PERSONAL",
+            "ceiling": 5,
+            "used": 5,
+        },
+        "request_id": "",
+    }
+    passport.apply_first_agent_passport.assert_not_called()
+    passport.apply_passport.assert_not_called()
+    svc.create_bot.assert_not_called()
 
 def test_create_bot_owner_relationship_failure_is_enveloped_502(
     client, passport, auth_rel
@@ -1726,16 +1767,20 @@ def test_update_omitting_a_field_still_leaves_it_unchanged(client, svc):
     assert kw["bot_desc"] is None  # untouched
 
 
-def test_ceiling_uses_the_limit_creation_enforces(client, svc):
-    """R10/F42: reporting must not resolve the quota differently from create.
-
-    ``PolicyService.get_bots_ceiling`` defaults to a hardcoded 5; creation falls
-    back to the configured ``max_devices_per_entity``. Reading the policy service
-    directly advertised 5 to a deployment that allows something else.
-    """
-    svc.get_bots_ceiling_for_owner.return_value = 12
+def test_ceiling_uses_the_limit_creation_enforces(client, quota):
+    """Reporting and creation resolve capacity through the same quota service."""
+    quota.inspect.return_value = BotQuotaSnapshot(
+        scope=BotQuotaScope(
+            owner_id="u1",
+            space_id=None,
+            space_name="Personal",
+            space_type=SpaceType.PERSONAL,
+        ),
+        ceiling=12,
+        used=3,
+    )
     assert _ok(client.get("/openapi/v1/bots/ceiling"))["ceiling"] == 12
-    svc.get_bots_ceiling_for_owner.assert_called_once_with("u1")
+    quota.inspect.assert_called_once_with(owner_id="u1", space_id=None)
 
 
 # ----- round-13 review regressions ------------------------------------------

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_openapi_error_schema.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_openapi_error_schema.py
@@ -24,6 +24,10 @@ _ERROR_REF = "#/components/schemas/ErrorEnvelope"
 # as failures, but the state itself is what the caller acts on, so it stays in
 # ``data`` and the route declares that shape. Every other error stays uniform.
 _DOCUMENTED_DATA_BEARING_ERRORS = {
+    ("/openapi/v1/bots", 409),
+    ("/openapi/v1/bots/with-manifest", 409),
+    ("/openapi/v1/bots/{bot_id}/auth-status", 409),
+    ("/openapi/v1/bots/{bot_id}/space", 409),
     ("/openapi/v1/bots/{bot_id}/auth-status", 400),
     ("/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/offline", 409),
 }

--- a/src/backend/tests/community/api/bot_management/test_router.py
+++ b/src/backend/tests/community/api/bot_management/test_router.py
@@ -1700,6 +1700,8 @@ class TestCreateBot:
             bot_id="default",
             engine_type="teclaw",
             bot_name="NewBot",
+            space_id=None,
+            space_quota=False,
         )
         passport.apply_first_agent_passport.assert_not_called()
         passport.apply_agent_passport.assert_not_called()

--- a/src/backend/tests/community/core/access/test_bots_ceiling.py
+++ b/src/backend/tests/community/core/access/test_bots_ceiling.py
@@ -1,14 +1,19 @@
 """Tests for PolicyService.get_bots_ceiling / set_bots_ceiling / allow-disallow merge."""
 import json
-import pytest
 from unittest.mock import MagicMock
 
 from agentclaw.community.core.access.services.policy_service import PolicyService
 from agentclaw.community.core.access.models import AccessControlPolicyRecord
 
 
-def _record(entity_id: str = "u1", policy: str | None = None) -> AccessControlPolicyRecord:
-    return AccessControlPolicyRecord(id=1, entity_id=entity_id, entity_type="staff", policy=policy)
+def _record(
+    entity_id: str = "u1",
+    policy: str | None = None,
+    entity_type: str = "staff",
+) -> AccessControlPolicyRecord:
+    return AccessControlPolicyRecord(
+        id=1, entity_id=entity_id, entity_type=entity_type, policy=policy
+    )
 
 
 def _make_service(get_result: AccessControlPolicyRecord | None = None) -> PolicyService:
@@ -77,6 +82,45 @@ class TestSetBotsCeiling:
         policy_json = json.loads(svc._repo.upsert_policy.call_args.kwargs["policy"])
         assert policy_json["policy"] == "on"
         assert policy_json["bots_ceiling"] == "12"
+
+    def test_team_space_uses_the_same_entity_typed_storage(self):
+        svc = _make_service(
+            get_result=_record(
+                entity_id="42",
+                entity_type="space",
+                policy=json.dumps({"policy": "on"}),
+            )
+        )
+
+        svc.set_bots_ceiling(entity_type="space", entity_id="42", ceiling=20)
+
+        svc._repo.get_by_entity.assert_called_once_with(
+            entity_type="space", entity_id="42"
+        )
+        assert svc._repo.upsert_policy.call_args.kwargs["entity_type"] == "space"
+
+
+class TestClearBotsCeiling:
+    def test_removes_only_ceiling_and_preserves_other_keys(self):
+        svc = _make_service(
+            get_result=_record(
+                entity_id="42",
+                entity_type="space",
+                policy=json.dumps({"policy": "on", "bots_ceiling": "25"}),
+            )
+        )
+
+        assert svc.clear_bots_ceiling(entity_type="space", entity_id="42") is True
+
+        written = json.loads(svc._repo.upsert_policy.call_args.kwargs["policy"])
+        assert written == {"policy": "on"}
+        assert svc._repo.upsert_policy.call_args.kwargs["entity_type"] == "space"
+
+    def test_missing_override_is_an_idempotent_noop(self):
+        svc = _make_service(get_result=_record(policy=json.dumps({"policy": "on"})))
+
+        assert svc.clear_bots_ceiling(entity_id="u1") is False
+        svc._repo.upsert_policy.assert_not_called()
 
 
 class TestAllowDisallowMerge:

--- a/src/backend/tests/community/core/bot_management/services/test_bot_quota_service.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_quota_service.py
@@ -1,0 +1,199 @@
+"""Space-scoped Bot quota policy, counting, and mutation serialization."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from agentclaw.community.core.bot_management.bot_quota import (
+    BotQuotaBusyError,
+    BotQuotaConfigurationError,
+    BotQuotaExceededError,
+    BotQuotaUnavailableError,
+)
+from agentclaw.community.core.bot_management.services.bot_quota_service import (
+    TEAM_DEFAULT_BOT_CEILING,
+    BotQuotaService,
+)
+from agentclaw.community.core.spaces.models import SpaceRecord, SpaceType
+from agentclaw.community.plugin_api.cache import CacheLockInfrastructureError
+from agentclaw.community.plugins.local.cache import MemoryCachePlugin
+
+pytestmark = pytest.mark.unit
+
+
+def _space(
+    *, space_id: int = 42, space_type: SpaceType = SpaceType.TEAM
+) -> SpaceRecord:
+    now = datetime(2026, 9, 3, tzinfo=UTC)
+    return SpaceRecord(
+        id=space_id,
+        space_code=f"spc-{space_id}",
+        space_type=space_type,
+        name="Team" if space_type is SpaceType.TEAM else "Personal",
+        personal_owner_id="u1" if space_type is SpaceType.PERSONAL else None,
+        env="dev",
+        created_by="u1",
+        updated_by="u1",
+        gmt_created=now,
+        gmt_modified=now,
+    )
+
+
+def _service(*, cache=None, max_personal: int = 5):
+    repository = MagicMock()
+    policy = MagicMock()
+    policy.get_bots_ceiling.side_effect = lambda *, default, **_kwargs: default
+    if cache is None:
+        cache = MagicMock()
+        cache.acquire_lock_strict.return_value = "lease-token"
+    access = MagicMock()
+    access.require_space.return_value = _space()
+    service = BotQuotaService(
+        repository=repository,
+        allocation_config=SimpleNamespace(max_devices_per_entity=max_personal),
+        policy_service=policy,
+        cache=cache,
+        space_access=access,
+    )
+    return service, repository, policy, cache, access
+
+
+def test_personal_space_reuses_the_owner_ceiling_and_counts_legacy_rows():
+    service, repository, policy, _cache, access = _service(max_personal=6)
+    access.require_space.return_value = _space(
+        space_id=7, space_type=SpaceType.PERSONAL
+    )
+    repository.count_cloud_bots_in_personal_space.return_value = 4
+
+    snapshot = service.inspect(owner_id="u1", space_id=7)
+
+    assert (snapshot.ceiling, snapshot.used) == (6, 4)
+    policy.get_bots_ceiling.assert_called_once_with(
+        entity_type="staff", entity_id="u1", default=6
+    )
+    repository.count_cloud_bots_in_personal_space.assert_called_once_with(
+        owner_id="u1",
+        personal_space_id=7,
+    )
+
+
+def test_team_space_defaults_to_twenty_and_counts_every_owner():
+    service, repository, policy, _cache, _access = _service()
+    repository.count_cloud_bots_by_space.return_value = 7
+
+    snapshot = service.inspect(owner_id="u1", space_id=42)
+
+    assert snapshot.ceiling == TEAM_DEFAULT_BOT_CEILING == 20
+    assert snapshot.used == 7
+    policy.get_bots_ceiling.assert_called_once_with(
+        entity_type="space", entity_id="42", default=20
+    )
+    repository.count_cloud_bots_by_space.assert_called_once_with(space_id=42)
+
+
+def test_team_space_uses_its_individual_override():
+    service, repository, policy, _cache, _access = _service()
+    repository.count_cloud_bots_by_space.return_value = 9
+    policy.get_bots_ceiling.return_value = 30
+    policy.get_bots_ceiling.side_effect = None
+
+    snapshot = service.inspect(owner_id="u1", space_id=42)
+
+    assert (snapshot.ceiling, snapshot.used) == (30, 9)
+
+
+def test_capacity_error_carries_only_actionable_space_facts():
+    service, repository, _policy, _cache, _access = _service()
+    repository.count_cloud_bots_by_space.return_value = 20
+
+    with pytest.raises(BotQuotaExceededError) as raised:
+        service.assert_can_add(owner_id="u1", space_id=42)
+
+    assert raised.value.as_payload() == {
+        "space_id": "42",
+        "space_name": "Team",
+        "space_type": "TEAM",
+        "ceiling": 20,
+        "used": 20,
+    }
+
+
+def test_guard_recounts_under_the_scope_lock_and_releases_it():
+    service, repository, _policy, cache, _access = _service()
+    repository.count_cloud_bots_by_space.return_value = 3
+
+    with service.guard_add(owner_id="u1", space_id=42) as snapshot:
+        assert snapshot.used == 3
+
+    cache.acquire_lock_strict.assert_called_once()
+    lock_key = cache.acquire_lock_strict.call_args.args[0]
+    assert lock_key.startswith("bot-quota:")
+    cache.release_lock.assert_called_once_with(lock_key, "lease-token")
+    repository.count_cloud_bots_by_space.assert_called_once_with(space_id=42)
+
+
+def test_a_second_mutation_on_the_same_scope_is_busy():
+    cache = MemoryCachePlugin()
+    service, repository, _policy, _cache, _access = _service(cache=cache)
+    repository.count_cloud_bots_by_space.return_value = 0
+
+    with service.guard_add(owner_id="u1", space_id=42):
+        with pytest.raises(BotQuotaBusyError):
+            with service.guard_add(owner_id="u1", space_id=42):
+                pass
+
+
+def test_cache_outage_fails_closed_instead_of_looking_like_contention():
+    service, _repository, _policy, cache, _access = _service()
+    cache.acquire_lock_strict.side_effect = CacheLockInfrastructureError("down")
+
+    with pytest.raises(BotQuotaUnavailableError):
+        with service.guard_add(owner_id="u1", space_id=None):
+            pass
+
+    cache.release_lock.assert_not_called()
+
+
+@pytest.mark.parametrize("failure_source", ["policy", "repository"])
+def test_quota_reads_fail_closed_when_state_is_unavailable(failure_source):
+    service, repository, policy, _cache, _access = _service()
+    if failure_source == "policy":
+        policy.get_bots_ceiling.side_effect = RuntimeError("policy unavailable")
+    else:
+        repository.count_cloud_bots_by_space.side_effect = RuntimeError(
+            "database unavailable"
+        )
+
+    with pytest.raises(BotQuotaUnavailableError):
+        service.inspect(owner_id="u1", space_id=42)
+
+
+def test_operator_override_only_accepts_a_real_team_space():
+    service, _repository, policy, _cache, access = _service()
+
+    assert service.set_team_ceiling(space_id=42, ceiling=25) == 25
+    access.require_space.assert_called_once_with(space_id=42)
+    policy.set_bots_ceiling.assert_called_once_with(
+        entity_type="space", entity_id="42", ceiling=25
+    )
+
+    access.require_space.return_value = _space(
+        space_id=7, space_type=SpaceType.PERSONAL
+    )
+    with pytest.raises(BotQuotaConfigurationError):
+        service.set_team_ceiling(space_id=7, ceiling=8)
+
+
+def test_reset_removes_only_the_override_and_returns_the_team_default():
+    service, _repository, policy, _cache, _access = _service()
+
+    ceiling = service.reset_team_ceiling(space_id=42)
+
+    assert ceiling == 20
+    policy.clear_bots_ceiling.assert_called_once_with(
+        entity_type="space", entity_id="42"
+    )

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_create_validation.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_create_validation.py
@@ -22,6 +22,15 @@ from agentclaw.community.core.bot_management.services.bot_service import (
     DeviceLimitError,
     validate_bot_name,
 )
+from agentclaw.community.core.bot_management.bot_quota import (
+    BotQuotaExceededError,
+    BotQuotaScope,
+    BotQuotaSnapshot,
+)
+from agentclaw.community.core.bot_management.bot_quota_service_protocol import (
+    BotQuotaServiceProtocol,
+)
+from agentclaw.community.core.spaces.models import SpaceType
 from agentclaw.community.core.devices.models import DeviceBindingStatus
 
 
@@ -50,7 +59,17 @@ def _make_service(max_bots: int = 5, current_bots: int = 0, policy_service=None)
     )
     svc._teclaw_provision_provider = lambda: teclaw_provision
     svc._policy_service = policy_service
+    svc._bot_quota_service = None
     return svc
+
+
+def _team_quota_scope() -> BotQuotaScope:
+    return BotQuotaScope(
+        owner_id="u1",
+        space_id=42,
+        space_name="Team",
+        space_type=SpaceType.TEAM,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -222,6 +241,45 @@ class TestCreateBotValidation:
         svc = _make_service(max_bots=3, current_bots=3)
         with pytest.raises(BotLimitExceededError):
             svc.check_create_bot_preflight("u1", "bot001", "openclaw")
+
+    def test_space_aware_preflight_uses_quota_instead_of_legacy_owner_count(self):
+        svc = _make_service(max_bots=1, current_bots=99)
+        quota = MagicMock(spec=BotQuotaServiceProtocol)
+        svc._bot_quota_service = quota
+
+        svc.check_create_bot_preflight(
+            "u1", "bot001", "openclaw", space_id=42, space_quota=True
+        )
+
+        quota.assert_can_add.assert_called_once_with(owner_id="u1", space_id=42)
+        svc._repository.count_by_owner.assert_not_called()
+
+    def test_final_quota_race_is_not_wrapped_as_a_device_error(self):
+        svc = _make_service(max_bots=1, current_bots=99)
+        quota = MagicMock(spec=BotQuotaServiceProtocol)
+        scope = _team_quota_scope()
+        error = BotQuotaExceededError(
+            BotQuotaSnapshot(scope=scope, ceiling=20, used=20)
+        )
+        quota.guard_add.side_effect = error
+        svc._bot_quota_service = quota
+        svc._repository.exists_by_bot_name.return_value = False
+
+        with pytest.raises(BotQuotaExceededError) as raised:
+            svc.create_bot(
+                user_id="u1",
+                nick_name="U1",
+                bot_name="Quota race",
+                bot_id="bot001",
+                space_id=42,
+                space_quota=True,
+            )
+
+        assert raised.value is error
+        svc._repository.insert.assert_not_called()
+        svc._repository.soft_delete_by_owner.assert_not_called()
+        svc._repository.count_by_owner.assert_not_called()
+        quota.guard_add.assert_called_once_with(owner_id="u1", space_id=42)
 
     def test_preflight_rejects_teclaw_for_default_bot(self):
         svc = _make_service()

--- a/src/backend/tests/community/core/bot_management/services/test_bot_space_service.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_space_service.py
@@ -11,6 +11,11 @@ from agentclaw.community.core.bot_management.services.bot_service import (
     BotNotFoundError,
     BotOperationNotAllowedError,
 )
+from agentclaw.community.core.bot_management.bot_quota import (
+    BotQuotaExceededError,
+    BotQuotaScope,
+    BotQuotaSnapshot,
+)
 from agentclaw.community.core.bot_management.services.bot_space_service import (
     BotSpaceService,
 )
@@ -55,13 +60,14 @@ def _service(*, bot: dict | None = None, space: SpaceRecord | None = None):
     access = MagicMock()
     if space is not None:
         access.require_space_member.return_value = (space, MagicMock())
-    return BotSpaceService(repository, access), repository, access
+    quota = MagicMock()
+    return BotSpaceService(repository, access, quota), repository, access, quota
 
 
 def test_moves_owned_cloud_bot_to_joined_team_space():
     bot = {"bot_id": "b1", "bot_type": "personal", "space_id": 7}
     target = _space(space_id=42)
-    service, repository, access = _service(bot=bot, space=target)
+    service, repository, access, quota = _service(bot=bot, space=target)
 
     result = service.change_space(bot_id="b1", owner_id="u1", space_id=42)
 
@@ -72,6 +78,7 @@ def test_moves_owned_cloud_bot_to_joined_team_space():
     repository.update_space_by_owner.assert_called_once_with(
         bot_id="b1", owner_id="u1", space_id=42
     )
+    quota.guard_add.assert_called_once()
 
 
 def test_moves_bot_back_to_owners_numeric_personal_space():
@@ -81,7 +88,7 @@ def test_moves_bot_back_to_owners_numeric_personal_space():
         space_type=SpaceType.PERSONAL,
         personal_owner_id="u1",
     )
-    service, repository, _access = _service(bot=bot, space=target)
+    service, repository, _access, quota = _service(bot=bot, space=target)
 
     result = service.change_space(bot_id="b1", owner_id="u1", space_id=8)
 
@@ -89,16 +96,37 @@ def test_moves_bot_back_to_owners_numeric_personal_space():
     repository.update_space_by_owner.assert_called_once_with(
         bot_id="b1", owner_id="u1", space_id=8
     )
+    quota.guard_add.assert_called_once()
+
+
+def test_normalizing_legacy_personal_space_does_not_consume_new_capacity():
+    bot = {"bot_id": "b1", "bot_type": "service", "space_id": None}
+    target = _space(
+        space_id=8,
+        space_type=SpaceType.PERSONAL,
+        personal_owner_id="u1",
+    )
+    service, repository, _access, quota = _service(bot=bot, space=target)
+    quota.guard_add.side_effect = AssertionError("quota must not be consulted")
+
+    result = service.change_space(bot_id="b1", owner_id="u1", space_id=8)
+
+    assert result.changed is True
+    repository.update_space_by_owner.assert_called_once_with(
+        bot_id="b1", owner_id="u1", space_id=8
+    )
+    quota.guard_add.assert_not_called()
 
 
 def test_missing_or_unowned_bot_is_masked_before_space_lookup():
-    service, repository, access = _service(bot=None, space=_space())
+    service, repository, access, quota = _service(bot=None, space=_space())
 
     with pytest.raises(BotNotFoundError):
         service.change_space(bot_id="b1", owner_id="u1", space_id=42)
 
     repository.update_space_by_owner.assert_not_called()
     access.require_space_member.assert_not_called()
+    quota.guard_add.assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -106,13 +134,14 @@ def test_missing_or_unowned_bot_is_masked_before_space_lookup():
 )
 def test_target_space_lookup_and_membership_failures_propagate(error):
     bot = {"bot_id": "b1", "bot_type": "personal", "space_id": None}
-    service, repository, access = _service(bot=bot)
+    service, repository, access, quota = _service(bot=bot)
     access.require_space_member.side_effect = error
 
     with pytest.raises(type(error)):
         service.change_space(bot_id="b1", owner_id="u1", space_id=42)
 
     repository.update_space_by_owner.assert_not_called()
+    quota.guard_add.assert_not_called()
 
 
 def test_another_users_personal_space_is_rejected_even_with_bad_membership_row():
@@ -122,39 +151,42 @@ def test_another_users_personal_space_is_rejected_even_with_bad_membership_row()
         space_type=SpaceType.PERSONAL,
         personal_owner_id="u2",
     )
-    service, repository, _access = _service(bot=bot, space=target)
+    service, repository, _access, quota = _service(bot=bot, space=target)
 
     with pytest.raises(SpaceAccessDeniedError):
         service.change_space(bot_id="b1", owner_id="u1", space_id=8)
 
     repository.update_space_by_owner.assert_not_called()
+    quota.guard_add.assert_not_called()
 
 
 def test_desktop_bot_cannot_move_to_team_space():
     bot = {"bot_id": "b1", "bot_type": "desktop", "space_id": None}
-    service, repository, _access = _service(bot=bot, space=_space())
+    service, repository, _access, quota = _service(bot=bot, space=_space())
 
     with pytest.raises(BotOperationNotAllowedError):
         service.change_space(bot_id="b1", owner_id="u1", space_id=42)
 
     repository.update_space_by_owner.assert_not_called()
+    quota.guard_add.assert_not_called()
 
 
 def test_same_space_is_idempotent_and_skips_the_write():
     bot = {"bot_id": "b1", "bot_type": "personal", "space_id": 42}
     target = _space(space_id=42)
-    service, repository, _access = _service(bot=bot, space=target)
+    service, repository, _access, quota = _service(bot=bot, space=target)
 
     result = service.change_space(bot_id="b1", owner_id="u1", space_id=42)
 
     assert result.changed is False
     assert result.bot is bot
     repository.update_space_by_owner.assert_not_called()
+    quota.guard_add.assert_not_called()
 
 
 def test_bot_disappearing_during_write_is_masked_as_not_found():
     bot = {"bot_id": "b1", "bot_type": "personal", "space_id": 7}
-    service, repository, _access = _service(bot=bot, space=_space())
+    service, repository, _access, _quota = _service(bot=bot, space=_space())
     repository.update_space_by_owner.return_value = None
 
     with pytest.raises(BotNotFoundError):
@@ -163,8 +195,29 @@ def test_bot_disappearing_during_write_is_masked_as_not_found():
 
 def test_persistence_failure_propagates_instead_of_returning_success():
     bot = {"bot_id": "b1", "bot_type": "personal", "space_id": 7}
-    service, repository, _access = _service(bot=bot, space=_space())
+    service, repository, _access, _quota = _service(bot=bot, space=_space())
     repository.update_space_by_owner.side_effect = RuntimeError("database unavailable")
 
     with pytest.raises(RuntimeError, match="database unavailable"):
         service.change_space(bot_id="b1", owner_id="u1", space_id=42)
+
+
+def test_full_target_space_blocks_the_move_before_the_write():
+    bot = {"bot_id": "b1", "bot_type": "personal", "space_id": 7}
+    target = _space(space_id=42)
+    service, repository, _access, quota = _service(bot=bot, space=target)
+    scope = BotQuotaScope(
+        owner_id="u1",
+        space_id=target.id,
+        space_name=target.name,
+        space_type=target.space_type,
+    )
+    quota.guard_add.side_effect = BotQuotaExceededError(
+        BotQuotaSnapshot(scope=scope, ceiling=20, used=20)
+    )
+
+    with pytest.raises(BotQuotaExceededError):
+        service.change_space(bot_id="b1", owner_id="u1", space_id=42)
+
+    repository.update_space_by_owner.assert_not_called()
+    quota.guard_add.assert_called_once_with(owner_id="u1", space_id=42)

--- a/src/backend/tests/community/core/bot_management/test_create_flow_with_manifest.py
+++ b/src/backend/tests/community/core/bot_management/test_create_flow_with_manifest.py
@@ -19,6 +19,8 @@ from agentclaw.community.core.bot_management.create_flow import (
     BotCreateContext,
     BotCreateDeploymentMode,
     BotCreateSpec,
+    creation_spec_from_payload,
+    creation_spec_to_payload,
     submit_bot_creation_with_manifest,
 )
 
@@ -211,3 +213,17 @@ def test_a_successful_submission_starts_the_job_and_discards_nothing():
     # creation has to be supplied again by the poll.
     assert started["bot_id"] == seam.persisted[0]["bot_id"]
     assert started["spec"]["engine_type"]
+
+
+def test_the_background_job_preserves_space_quota_enforcement():
+    context = BotCreateContext(
+        deployment_mode=BotCreateDeploymentMode.CLOUD,
+        space_kind="team",
+        space_quota=True,
+    )
+
+    payload = creation_spec_to_payload(_SPEC, context)
+    restored_spec, restored_context = creation_spec_from_payload(payload)
+
+    assert restored_spec == _SPEC
+    assert restored_context == context

--- a/src/backend/tests/community/e2e/test_bot_creation_flow.py
+++ b/src/backend/tests/community/e2e/test_bot_creation_flow.py
@@ -389,6 +389,8 @@ class TestRouterLogic:
             bot_id=test_bot_id,
             engine_type="openclaw",
             bot_name="My First Bot",
+            space_id=None,
+            space_quota=False,
         )
         mock_bot_service.create_bot.assert_called_once()
 
@@ -445,6 +447,8 @@ class TestRouterLogic:
             bot_id="default",
             engine_type="openclaw",
             bot_name="My First Bot",
+            space_id=None,
+            space_quota=False,
         )
         mock_bot_service.create_bot.assert_not_called()
 

--- a/src/backend/tests/community/endpoints/test_access_router.py
+++ b/src/backend/tests/community/endpoints/test_access_router.py
@@ -311,10 +311,11 @@ def set_bots_ceiling_forbidden_non_operator():
 
 @endpoint_test(
     method="PUT",
-    path="/api/v1/access/spaces/1/bots-ceiling",
+    path="/api/v1/access/spaces/{space_id}/bots-ceiling",
     scenario="operator_sets_team_space_ceiling",
     seed=_seed_operator_and_team,
     input=CaseInput(
+        path_params={"space_id": 1},
         json_body={"ceiling": 25},
         headers={"x-user-id": "u_operator"},
     ),
@@ -327,10 +328,11 @@ def set_team_space_ceiling_ok():
 
 @endpoint_test(
     method="PUT",
-    path="/api/v1/access/spaces/1/bots-ceiling",
+    path="/api/v1/access/spaces/{space_id}/bots-ceiling",
     scenario="non_operator_cannot_set_team_space_ceiling",
     seed=_seed_non_operator_and_team,
     input=CaseInput(
+        path_params={"space_id": 1},
         json_body={"ceiling": 25},
         headers={"x-user-id": "u_operator"},
     ),
@@ -346,10 +348,12 @@ def set_team_space_ceiling_forbidden_non_operator():
 
 @endpoint_test(
     method="DELETE",
-    path="/api/v1/access/spaces/1/bots-ceiling",
+    path="/api/v1/access/spaces/{space_id}/bots-ceiling",
     scenario="operator_resets_team_space_ceiling",
     seed=_seed_team_with_override,
-    input=CaseInput(headers={"x-user-id": "u_operator"}),
+    input=CaseInput(
+        path_params={"space_id": 1}, headers={"x-user-id": "u_operator"}
+    ),
     expect=ExpectSuccess(status=200, json_contains={"success": True}),
     extra_assertions=(_assert_space_ceiling_reset,),
 )
@@ -359,10 +363,12 @@ def reset_team_space_ceiling_ok():
 
 @endpoint_test(
     method="DELETE",
-    path="/api/v1/access/spaces/1/bots-ceiling",
+    path="/api/v1/access/spaces/{space_id}/bots-ceiling",
     scenario="non_operator_cannot_reset_team_space_ceiling",
     seed=_seed_non_operator_team_with_override,
-    input=CaseInput(headers={"x-user-id": "u_operator"}),
+    input=CaseInput(
+        path_params={"space_id": 1}, headers={"x-user-id": "u_operator"}
+    ),
     expect=ExpectError(
         status=403,
         json_contains={"detail": "权限不足：您没有操作员权限"},

--- a/src/backend/tests/community/endpoints/test_access_router.py
+++ b/src/backend/tests/community/endpoints/test_access_router.py
@@ -18,6 +18,7 @@ the real error handler renders the 403.
 from __future__ import annotations
 
 from tests.community.factories.access import make_staff_user
+from agentclaw.community.api.space_service import SpaceServiceProtocol
 from tests.community.framework import (
     CaseInput,
     ExpectError,
@@ -50,6 +51,36 @@ def _seed_non_operator(world):
 
     make_staff_user(world, user_id="u_operator")
     make_staff_user(world, user_id="u_target")
+    world.get(AuthPlugin).set_response("is_operator_allowed", False)
+
+
+def _seed_operator_and_team(world):
+    _seed_operator(world)
+    world.get(SpaceServiceProtocol).create_team(
+        name="Quota Team", creator_id="u_operator", create_sc_team=False
+    )
+
+
+def _seed_non_operator_and_team(world):
+    _seed_operator_and_team(world)
+    from agentclaw.community.plugin_api.auth import AuthPlugin
+
+    world.get(AuthPlugin).set_response("is_operator_allowed", False)
+
+
+def _seed_team_with_override(world):
+    _seed_operator_and_team(world)
+    from agentclaw.community.core.access.services.policy_service import PolicyService
+
+    world.get(PolicyService).set_bots_ceiling(
+        entity_type="space", entity_id="1", ceiling=33
+    )
+
+
+def _seed_non_operator_team_with_override(world):
+    _seed_team_with_override(world)
+    from agentclaw.community.plugin_api.auth import AuthPlugin
+
     world.get(AuthPlugin).set_response("is_operator_allowed", False)
 
 
@@ -126,6 +157,52 @@ def _assert_ceiling_not_written(response, world):
 
     svc = world.get(PolicyService)
     assert svc.get_bots_ceiling(entity_id="u_target", default=5) == 5
+
+
+def _assert_space_ceiling_persisted(response, world):
+    from agentclaw.community.core.access.services.policy_service import PolicyService
+
+    assert response.json()["data"] == {"spaceId": 1, "ceiling": 25}
+    assert (
+        world.get(PolicyService).get_bots_ceiling(
+            entity_type="space", entity_id="1", default=20
+        )
+        == 25
+    )
+
+
+def _assert_space_ceiling_not_written(response, world):
+    from agentclaw.community.core.access.services.policy_service import PolicyService
+
+    assert (
+        world.get(PolicyService).get_bots_ceiling(
+            entity_type="space", entity_id="1", default=20
+        )
+        == 20
+    )
+
+
+def _assert_space_ceiling_reset(response, world):
+    from agentclaw.community.core.access.services.policy_service import PolicyService
+
+    assert response.json()["data"] == {"spaceId": 1, "ceiling": 20}
+    assert (
+        world.get(PolicyService).get_bots_ceiling(
+            entity_type="space", entity_id="1", default=20
+        )
+        == 20
+    )
+
+
+def _assert_space_ceiling_override_preserved(response, world):
+    from agentclaw.community.core.access.services.policy_service import PolicyService
+
+    assert (
+        world.get(PolicyService).get_bots_ceiling(
+            entity_type="space", entity_id="1", default=20
+        )
+        == 33
+    )
 
 
 # ============================================================================
@@ -225,3 +302,72 @@ def set_bots_ceiling_ok():
 )
 def set_bots_ceiling_forbidden_non_operator():
     """A caller outside the operator allowlist is rejected before any write."""
+
+
+# ============================================================================
+# PUT / DELETE /api/v1/access/spaces/{space_id}/bots-ceiling
+# ============================================================================
+
+
+@endpoint_test(
+    method="PUT",
+    path="/api/v1/access/spaces/1/bots-ceiling",
+    scenario="operator_sets_team_space_ceiling",
+    seed=_seed_operator_and_team,
+    input=CaseInput(
+        json_body={"ceiling": 25},
+        headers={"x-user-id": "u_operator"},
+    ),
+    expect=ExpectSuccess(status=200, json_contains={"success": True}),
+    extra_assertions=(_assert_space_ceiling_persisted,),
+)
+def set_team_space_ceiling_ok():
+    """An operator can set a ceiling for one existing Team Space."""
+
+
+@endpoint_test(
+    method="PUT",
+    path="/api/v1/access/spaces/1/bots-ceiling",
+    scenario="non_operator_cannot_set_team_space_ceiling",
+    seed=_seed_non_operator_and_team,
+    input=CaseInput(
+        json_body={"ceiling": 25},
+        headers={"x-user-id": "u_operator"},
+    ),
+    expect=ExpectError(
+        status=403,
+        json_contains={"detail": "权限不足：您没有操作员权限"},
+    ),
+    extra_assertions=(_assert_space_ceiling_not_written,),
+)
+def set_team_space_ceiling_forbidden_non_operator():
+    """Team membership does not replace the existing operator authorization."""
+
+
+@endpoint_test(
+    method="DELETE",
+    path="/api/v1/access/spaces/1/bots-ceiling",
+    scenario="operator_resets_team_space_ceiling",
+    seed=_seed_team_with_override,
+    input=CaseInput(headers={"x-user-id": "u_operator"}),
+    expect=ExpectSuccess(status=200, json_contains={"success": True}),
+    extra_assertions=(_assert_space_ceiling_reset,),
+)
+def reset_team_space_ceiling_ok():
+    """Deleting an override restores the Team Space default of twenty."""
+
+
+@endpoint_test(
+    method="DELETE",
+    path="/api/v1/access/spaces/1/bots-ceiling",
+    scenario="non_operator_cannot_reset_team_space_ceiling",
+    seed=_seed_non_operator_team_with_override,
+    input=CaseInput(headers={"x-user-id": "u_operator"}),
+    expect=ExpectError(
+        status=403,
+        json_contains={"detail": "权限不足：您没有操作员权限"},
+    ),
+    extra_assertions=(_assert_space_ceiling_override_preserved,),
+)
+def reset_team_space_ceiling_forbidden_non_operator():
+    """A rejected reset leaves the existing Team Space override untouched."""

--- a/src/backend/tests/community/plugins/local/test_policy_service.py
+++ b/src/backend/tests/community/plugins/local/test_policy_service.py
@@ -1,7 +1,8 @@
 """Tests for LocalPolicyService — singlebox 全开放 PolicyService 实现。
 
-覆盖 6 个公开方法(check / allow / disallow / get_bots_ceiling /
-set_bots_ceiling / get_quota)的快乐路径 + structural Protocol conformance。
+覆盖 7 个公开方法(check / allow / disallow / get_bots_ceiling /
+set_bots_ceiling / clear_bots_ceiling / get_quota)的快乐路径 + structural
+Protocol conformance。
 """
 from agentclaw.community.api.policy_service import PolicyServiceProtocol
 from agentclaw.community.plugins.local.policy_service import LocalPolicyService
@@ -46,6 +47,11 @@ def test_get_bots_ceiling_returns_high_limit():
 def test_set_bots_ceiling_is_noop():
     svc = LocalPolicyService()
     assert svc.set_bots_ceiling(entity_id="user-1", ceiling=10) is None
+
+
+def test_clear_bots_ceiling_is_noop():
+    svc = LocalPolicyService()
+    assert svc.clear_bots_ceiling(entity_id="user-1") is False
 
 
 def test_get_quota_returns_high_limits():

--- a/src/backend/tests/community/repository/bot/test_bot_repository_unified.py
+++ b/src/backend/tests/community/repository/bot/test_bot_repository_unified.py
@@ -393,6 +393,49 @@ def test_count_by_owner_excludes_desktop(repo):
     assert repo.count_by_owner("emp1", exclude_bot_type="desktop") == 1
 
 
+def test_personal_space_count_includes_legacy_null_and_numeric_rows(repo, db):
+    repo.insert(_data(bot_id="legacy", owner_id="alice", space_id=None))
+    repo.insert(_data(bot_id="personal", owner_id="alice", space_id=11))
+    repo.insert(_data(bot_id="failed", owner_id="alice", space_id=11, status="FAILED"))
+    repo.insert(_data(bot_id="team", owner_id="alice", space_id=12))
+    repo.insert(_data(bot_id="other-owner", owner_id="bob", space_id=11))
+    repo.insert(
+        _data(bot_id="desktop", owner_id="alice", space_id=11, bot_type="desktop")
+    )
+    repo.insert(_data(bot_id="deleted", owner_id="alice", space_id=11, is_delete=1))
+    nullable = repo.insert(
+        _data(bot_id="legacy-null-type", owner_id="alice", space_id=11)
+    )
+    with db.orm_session() as session:
+        session.query(BotModel).filter(BotModel.id == nullable["id"]).update(
+            {BotModel.bot_type: None}
+        )
+
+    assert (
+        repo.count_cloud_bots_in_personal_space(
+            owner_id="alice", personal_space_id=11
+        )
+        == 4
+    )
+
+
+def test_team_space_count_spans_owners_and_ignores_status(repo, db):
+    repo.insert(_data(bot_id="alice", owner_id="alice", space_id=22))
+    repo.insert(_data(bot_id="bob", owner_id="bob", space_id=22, status="FAILED"))
+    nullable = repo.insert(_data(bot_id="legacy", owner_id="carol", space_id=22))
+    repo.insert(
+        _data(bot_id="desktop", owner_id="alice", space_id=22, bot_type="desktop")
+    )
+    repo.insert(_data(bot_id="deleted", owner_id="alice", space_id=22, is_delete=1))
+    repo.insert(_data(bot_id="other-space", owner_id="alice", space_id=23))
+    with db.orm_session() as session:
+        session.query(BotModel).filter(BotModel.id == nullable["id"]).update(
+            {BotModel.bot_type: None}
+        )
+
+    assert repo.count_cloud_bots_by_space(space_id=22) == 3
+
+
 def test_exists_by_owner_and_bot_type_only_matches_live_requested_type(repo):
     repo.insert(_data(bot_id="service", bot_type="service"))
     repo.insert(_data(bot_id="deleted-personal", bot_type="personal", is_delete=1))

--- a/src/gateway/configs/schemas/bots.openapi.json
+++ b/src/gateway/configs/schemas/bots.openapi.json
@@ -1714,13 +1714,13 @@
         "type": "object"
       },
       "Ceiling": {
-        "description": "Per-user bot creation quota.",
+        "description": "Bot creation quota for the selected business Space.",
         "example": {
-          "ceiling": 5
+          "ceiling": 20
         },
         "properties": {
           "ceiling": {
-            "description": "Maximum number of live bots the named user may own in this deployment; creation is refused (409) at the limit. Desktop bots do not count toward it. A value of 0 or less means the limit is disabled.",
+            "description": "Maximum number of non-deleted cloud Bots in this Space. A value of 0 or less means the limit is disabled.",
             "title": "Ceiling",
             "type": "integer"
           }
@@ -23588,6 +23588,92 @@
         ],
         "title": "SourceCredentialWrite",
         "description": "Register or rotate one named credential.\n\nOne body schema for every mechanism the endpoint will ever carry: the\ndiscriminating key is the authentication mechanism (type), and the\nstorage type is not the source type (git/oss/url is a *source* axis).\nRotation is the same request under the same name — no apply runs and\nthe next fetch uses the new value. Fails (422) when the type is a\nreserved future mechanism or the input is invalid."
+      },
+      "BotQuotaExceededData": {
+        "description": "Actionable capacity facts returned when a Space cannot accept a Bot.",
+        "properties": {
+          "ceiling": {
+            "description": "Configured Bot ceiling for the Space.",
+            "exclusiveMinimum": 0.0,
+            "title": "Ceiling",
+            "type": "integer"
+          },
+          "space_id": {
+            "description": "Identifier of the full target Space.",
+            "title": "Space Id",
+            "type": "string"
+          },
+          "space_name": {
+            "description": "Display name of the full target Space.",
+            "title": "Space Name",
+            "type": "string"
+          },
+          "space_type": {
+            "enum": [
+              "PERSONAL",
+              "TEAM"
+            ],
+            "title": "Space Type",
+            "type": "string"
+          },
+          "used": {
+            "description": "Current non-deleted cloud Bot count.",
+            "minimum": 0.0,
+            "title": "Used",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "space_id",
+          "space_name",
+          "space_type",
+          "ceiling",
+          "used"
+        ],
+        "title": "BotQuotaExceededData",
+        "type": "object"
+      },
+      "Envelope_BotQuotaExceededData_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
+        "properties": {
+          "code": {
+            "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
+            "title": "Code",
+            "type": "integer"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BotQuotaExceededData"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Response payload; present but null on errors or empty results."
+          },
+          "message": {
+            "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
+            "title": "Message",
+            "type": "string"
+          },
+          "request_id": {
+            "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
+            "title": "Request Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message",
+          "data",
+          "request_id"
+        ],
+        "title": "Envelope[BotQuotaExceededData]",
+        "type": "object"
       }
     }
   },
@@ -23969,17 +24055,12 @@
           "409": {
             "content": {
               "application/json": {
-                "example": {
-                  "code": 409000,
-                  "message": "Conflict",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
+                  "$ref": "#/components/schemas/Envelope_BotQuotaExceededData_"
                 }
               }
             },
-            "description": "Conflicts with current state"
+            "description": "The target Space has no capacity for another Bot."
           },
           "422": {
             "content": {
@@ -25763,7 +25844,7 @@
     },
     "/openapi/v1/bots/ceiling": {
       "get": {
-        "description": "Get the named user's bot-creation quota ceiling.\n\nThe number creation actually enforces: creating a bot while the user owns\nthis many live bots is refused (409). A ceiling of 0 or less means the\nlimit is disabled. For an application caller, reading it requires holding\nat least one live delegation from the named user; without one the user is\nanswered as if they did not exist.",
+        "description": "Get the Bot ceiling for the selected business Space.\n\nPersonal Space keeps the named user's configured ceiling. Team Space uses\nits own ceiling and counts Bots created by every member. For an application\ncaller, reading it still requires at least one live delegation from the\nnamed user; without one the user is answered as if they did not exist.",
         "operationId": "get_bots_ceiling_openapi_v1_bots_ceiling_get",
         "parameters": [
           {
@@ -25776,6 +25857,24 @@
               "minLength": 1,
               "title": "User Id",
               "type": "string"
+            }
+          },
+          {
+            "description": "Business-space context; omit to use the personal space.",
+            "in": "header",
+            "name": "X-Space-Id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Business-space context; omit to use the personal space.",
+              "title": "X-Space-Id"
             }
           }
         ],
@@ -52031,17 +52130,12 @@
           "409": {
             "content": {
               "application/json": {
-                "example": {
-                  "code": 409000,
-                  "message": "Conflict",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
+                  "$ref": "#/components/schemas/Envelope_BotQuotaExceededData_"
                 }
               }
             },
-            "description": "Conflicts with current state"
+            "description": "The target Space has no capacity for another Bot."
           },
           "422": {
             "content": {
@@ -52224,17 +52318,12 @@
           "409": {
             "content": {
               "application/json": {
-                "example": {
-                  "code": 409000,
-                  "message": "Conflict",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
+                  "$ref": "#/components/schemas/Envelope_BotQuotaExceededData_"
                 }
               }
             },
-            "description": "Conflicts with current state"
+            "description": "The target Space has no capacity for another Bot."
           },
           "422": {
             "content": {
@@ -82759,17 +82848,12 @@
           "409": {
             "content": {
               "application/json": {
-                "example": {
-                  "code": 409000,
-                  "message": "Conflict",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
+                  "$ref": "#/components/schemas/Envelope_BotQuotaExceededData_"
                 }
               }
             },
-            "description": "Conflicts with current state"
+            "description": "The target Space has no capacity for another Bot."
           },
           "422": {
             "content": {

--- a/src/gateway/configs/schemas/bots.openapi.json
+++ b/src/gateway/configs/schemas/bots.openapi.json
@@ -23609,6 +23609,7 @@
             "type": "string"
           },
           "space_type": {
+            "description": "Whether the quota belongs to a Personal or Team Space.",
             "enum": [
               "PERSONAL",
               "TEAM"


### PR DESCRIPTION
## Summary
- reuse the existing per-user Bot ceiling for Personal Spaces, including legacy `space_id IS NULL` rows
- enforce a default ceiling of 20 for Team Spaces, with operator-only per-Space PUT/DELETE overrides
- enforce target-Space capacity on OpenAPI create, authorization completion, manifest creation, and Bot move-in
- serialize the final quota recount and write with a Space-scoped distributed lock while preserving the legacy `/api` creation behavior
- publish structured 409 quota responses and refresh the gateway OpenAPI schema

## Verification
- `363 passed` for quota/OpenAPI/repository endpoint tests
- `568 passed` for backend architecture and DI tests
- `191 passed` for gateway contract/startup/schema tests
- generated quota-related OpenAPI objects match the checked-in schema
- pre-push SAST gate passed against latest `origin/dev`