### PR TITLE
fix(backend): reproject runtime after BaaS restart

### DIFF
--- a/src/backend/specs/2026-08-26-mcp-sync-and-passport-regressions/spec.md
+++ b/src/backend/specs/2026-08-26-mcp-sync-and-passport-regressions/spec.md
@@ -576,16 +576,19 @@ duplicative with it, not load-bearing for it.
 > it must *not* run — *"The Device callback publishes one event; it must not
 > also sync MCP."*
 >
-> Ownership moved to the event path: `report_device_alive` publishes
-> `DeviceActivatedEvent`, `SkillSymlinkListener` handles it, and its
-> `project(scope=ProjectionScope.everything())` is the **only** production
-> path that writes per-MCP configuration to a newly active container. The
-> other full-detail push (`device_service.py:1529`) sits inside the dead
-> method.
+> Ownership moved to the runtime-ready event path. First activation publishes
+> `DeviceActivatedEvent`; a successful BaaS restart publishes the narrower
+> `RuntimeProjectionRequestedEvent` so unrelated activation consumers are not
+> replayed. `SkillSymlinkListener` handles both and calls
+> `project(scope=ProjectionScope.everything())`. This is the general,
+> layout-neutral full-projection path for a newly active or restarted
+> container. AICoding's confirmed-template-update flow retains its narrower
+> authorization/Skill compensation; the other historical full-detail push
+> (`device_service.py:1529`) sits inside the dead method.
 >
 > So the projector's whole-set push on that path is load-bearing, not
 > duplicative — which is why `claim_all_mcp` survives with exactly one
-> caller. Every other path is mutation-triggered and names its own delta.
+> listener. Every direct mutation path names its own delta.
 
 **Skill-carried MCP dependencies.** `RuntimeProjectionResolver` folds each
 skill's `mcp_dependencies` into `mcp_server_codes`, so those codes reach the

--- a/src/backend/src/agentclaw/community/adapters/http/skill_center/CLAUDE.md
+++ b/src/backend/src/agentclaw/community/adapters/http/skill_center/CLAUDE.md
@@ -171,11 +171,11 @@ backend 统一产出（OSS 散目录 + tar.gz + meta），但 **engine 怎么拿
 
 ---
 
-## 五、VM 重建后的软链自动恢复（DeviceActivatedEvent）
+## 五、运行时启动与重启后的软链自动恢复
 
 **文件**：`core/skill_center/services/skill_symlink_listener.py`
 
-agentbox（桌面版）VM 重建（`upper.img` 删除）或首次启动后，软链会随上层文件系统重置而丢失。`DeviceActivatedEvent` 提供了一条**事件驱动的全量恢复链路**，在 VM 进入 active 状态时主动下发当前 Bot 的全部已激活 skill 软链。
+运行时首次启动或重建后，软链可能尚未建立或已随上层文件系统重置。首次 `PENDING -> ACTIVE` 由 `DeviceActivatedEvent` 触发；BaaS 重启发布成功由 `RuntimeProjectionRequestedEvent` 触发。两者进入同一个监听器，按 Installation 等控制面期望态执行完整 Runtime Projection。
 
 ### 触发时机
 
@@ -184,17 +184,18 @@ agentbox（桌面版）VM 重建（`upper.img` 删除）或首次启动后，软
 | Bot 首次创建 | `desktop_bot_service` 启动流程 | VM 进入 active 状态时发布 `DeviceActivatedEvent` |
 | VM 重启 | `desktop_bot_service` 健康检查回调 | 同上 |
 | VM 重建（`upper.img` 删除） | `desktop_bot_service` 重建后激活 | 同上 |
+| BaaS Bot 重启发布成功 | `BaasRestartPublishPollHandler` | 发布 `RuntimeProjectionRequestedEvent`，不重放其他激活副作用 |
 
 ### 实现路径
 
-1. `SkillSymlinkListener.startup()` 将 `self.handle` 订阅到事件总线的 `DeviceActivatedEvent`（幂等订阅，避免重复绑定）。
+1. `SkillSymlinkListener.startup()` 将 `self.handle` 幂等订阅到 `DeviceActivatedEvent` 和 `RuntimeProjectionRequestedEvent`。
 2. `SkillSymlinkListener.handle(event)` 接收到事件后：
    - 通过 `bot_repo.get_by_binding_id(event.binding_id)` 找到对应 Bot。
-   - 通过 `skill_set_factory.create()` + `get_symlink_mappings()` 获取该 Bot **全部已激活 skill** 的 `source → target` 软链映射。
-   - 调用 `device_sync.sync_symlinks(symlinks)` 一次性推送到 VM。
-3. 异常被捕获并记日志，不阻塞设备激活流程。
+   - 调用 `BotRuntimeProjector.project(scope=ProjectionScope.everything())`，从 Installation 等 SSOT 重新解析 Skill、MCP、CLI、Passport 的完整期望态。
+   - Projector 根据 Engine 与当前 Layout 选择实际交付路径；监听器本身不按 Legacy/Pool 分支。
+3. `PENDING` / `DEGRADED` 与异常都维持 best-effort 语义，不回滚已成功的设备启动或重启。仅当 DI 未提供 Projector 时，才回退到历史 `get_symlink_mappings() → sync_symlinks()` 兼容路径。
 
-> **关键结论**：agentbox VM 重建后，只要进入 active 状态，软链会自动全量恢复，用户无需手动重新激活 skill。若 `SkillSymlinkListener` 因异常未执行，可让用户重新激活 skill / 重启 Bot 触发 `SkillSetService._sync_symlinks_to_device_if_needed` 主动重推。
+> **关键结论**：运行时首次激活或 BaaS 重启发布成功后，系统都会按当前控制面期望态尝试一次完整投影；该动作是 best-effort，不改变同步 SkillSet 接口或任务终态语义。
 
 ---
 
@@ -226,7 +227,7 @@ device 层正处于 agentbox/arca 双链路拆分迁移中（背景见 `docs/sup
 | `core/repository/implementations/skill_center/capability_desired_state.py` | `CapabilityDesiredStateRepository` — 期望态 UoW；`tables/` 子包是 Installation/排除表 SQL 的唯一属地 |
 | `core/skill_center/services/skill_set_service.py` | `get_symlink_mappings()`（激活写路径已收敛到 desired-state 控制面） |
 | `core/skill_center/services/skill_service.py` | `upload_skill()`、`activate_skill()` 单个软链操作 |
-| `core/skill_center/services/skill_symlink_listener.py` | `SkillSymlinkListener` — 订阅 `DeviceActivatedEvent`，VM 激活后自动全量下发软链 |
+| `core/skill_center/services/skill_symlink_listener.py` | `SkillSymlinkListener` — 订阅激活/重投影事件，运行时就绪后按当前期望态执行全量投影 |
 | `core/skill_center/services/git_sync.py` | `GitSyncService` — git 来源同步（startup / sync_bootstrap / periodic / OSS） |
 | `core/skill_center/services/skill_center_sync_service.py` | `SkillCenterSyncService` — center:// 来源同步 |
 | `core/skill_center/factories.py` | `SkillSetServiceFactory` / `SkillServiceFactory`，Factory 层解析路径 |

--- a/src/backend/src/agentclaw/community/core/devices/services/baas_publish_task_handlers.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/baas_publish_task_handlers.py
@@ -2,14 +2,18 @@ from __future__ import annotations
 
 import time
 from dataclasses import replace
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Optional, cast
 
 from agentclaw.community.core.bot_management.engines import resolve_provisioning
 from agentclaw.community.core.common_config.service import CommonConfigService
 from agentclaw.community.core.bot_management.utils import clear_baas_publish_failure_ext
 from agentclaw.community.core.devices.models import DeviceBindingStatus
+from agentclaw.community.core.devices.repository.record import DeviceBindingRecord
 from agentclaw.community.core.events.bus import get_event_bus
-from agentclaw.community.core.events.types import BaasPublishCompletedEvent
+from agentclaw.community.core.events.types import (
+    BaasPublishCompletedEvent,
+    RuntimeProjectionRequestedEvent,
+)
 from agentclaw.community.core.service_bot.services.arca_image_pin import (
     persist_default_image_policy,
 )
@@ -57,6 +61,21 @@ def _publish_baas_completed(
             owner_id=owner_id,
             publish_id=publish_id,
             publish_kind=publish_kind,
+        )
+    )
+
+
+def _request_baas_runtime_projection(binding: DeviceBindingRecord) -> None:
+    """Request a full desired-state projection after a BaaS restart."""
+
+    get_event_bus().publish(
+        RuntimeProjectionRequestedEvent(
+            device_id=binding.device_id,
+            binding_id=binding.id,
+            entity_id=binding.entity_id,
+            entity_type=binding.entity_type,
+            device_provider=binding.device_provider,
+            sandbox_id=binding.device_props.get("sandbox_id"),
         )
     )
 
@@ -452,6 +471,7 @@ class BaasRestartPublishPollHandler:
         )
         if preflight is not None:
             return preflight
+        binding = cast(DeviceBindingRecord, binding)
         bot = None
         if self._bot_repository is not None:
             bot = self._bot_repository.get_by_binding_id(binding_id)
@@ -488,6 +508,7 @@ class BaasRestartPublishPollHandler:
             publish_id=publish_id,
             bot_uuid=bot_uuid,
             bot=bot,
+            binding=binding,
             image_policy_on_success=image_policy_on_success,
         )
 
@@ -656,6 +677,7 @@ class BaasRestartPublishPollHandler:
         publish_id: int,
         bot_uuid: str | None,
         bot: Any,
+        binding: DeviceBindingRecord,
         image_policy_on_success: str | None = None,
     ) -> TaskOutcome:
         if status == DeviceBindingStatus.ACTIVE.value:
@@ -694,6 +716,7 @@ class BaasRestartPublishPollHandler:
                 bot_id=bot_id,
                 owner_id=owner_id,
                 publish_id=publish_id,
+                binding=binding,
                 image_policy_on_success=image_policy_on_success,
             )
         if status == DeviceBindingStatus.FAILED.value:
@@ -714,6 +737,7 @@ class BaasRestartPublishPollHandler:
         bot_id: str,
         owner_id: str,
         publish_id: int,
+        binding: DeviceBindingRecord,
         image_policy_on_success: str | None,
     ) -> TaskOutcome:
         if image_policy_on_success == _DEFAULT_IMAGE_POLICY_VALUE:
@@ -740,6 +764,7 @@ class BaasRestartPublishPollHandler:
         # Clear only after every success-side persistence step has completed.
         # A failure above keeps the durable request/baseline/policy for replay.
         self._clear_restart_recovery_intent(binding_id=binding_id)
+        _request_baas_runtime_projection(binding)
         _publish_baas_completed(
             binding_id=binding_id,
             bot_id=bot_id,

--- a/src/backend/src/agentclaw/community/core/events/README.md
+++ b/src/backend/src/agentclaw/community/core/events/README.md
@@ -23,3 +23,8 @@ contract. Ordinary subscribers remain best-effort and cannot block siblings.
 Handlers registered with `required=True` are reserved for durable hand-off
 boundaries: all siblings still run, then `publish()` raises
 `RequiredEventDeliveryError` so the producer's retry mechanism can redeliver.
+
+`DeviceActivatedEvent` announces the first `PENDING -> ACTIVE` transition.
+`RuntimeProjectionRequestedEvent` is a narrower wake-up used after a successful
+runtime restart; it asks projection consumers to re-read current desired state
+without replaying unrelated activation side effects.

--- a/src/backend/src/agentclaw/community/core/events/types.py
+++ b/src/backend/src/agentclaw/community/core/events/types.py
@@ -30,6 +30,24 @@ class DeviceActivatedEvent:
 
 
 @dataclass(frozen=True)
+class RuntimeProjectionRequestedEvent:
+    """Request a best-effort projection of current Bot desired state.
+
+    Unlike ``DeviceActivatedEvent``, this event does not announce a binding
+    lifecycle transition.  It is emitted after a runtime restart succeeds so
+    projection consumers can rebuild runtime state without replaying unrelated
+    activation side effects.
+    """
+
+    device_id: str
+    binding_id: int
+    entity_id: str
+    entity_type: str
+    device_provider: str
+    sandbox_id: str | None = None
+
+
+@dataclass(frozen=True)
 class DeviceAliveEvent:
     """A validated PENDING device reported alive before its ACTIVE commit.
 

--- a/src/backend/src/agentclaw/community/core/skill_center/runtime_projection_contract.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/runtime_projection_contract.py
@@ -362,12 +362,12 @@ class ProjectionScope:
     released_mcp: frozenset[str] = frozenset()
     #: Treat *every* projected MCP code as claimed, ignoring ``claimed_mcp``.
     #:
-    #: Exactly one caller sets this: the device-activated listener
-    #: (``SkillSymlinkListener``, via ``DeviceActivatedEvent``). It is the one
-    #: place where "just re-declare the allow-list" is not enough, because a
-    #: newly active container holds *no* MCP configuration to refresh — there
-    #: is no prior state to converge on, only an empty device. Every other
-    #: path is mutation-triggered and names its own delta.
+    #: Exactly one listener sets this: ``SkillSymlinkListener``, via either a
+    #: first ``DeviceActivatedEvent`` or a post-restart
+    #: ``RuntimeProjectionRequestedEvent``. It is the one place where "just
+    #: re-declare the allow-list" is not enough, because a newly active or
+    #: restarted container must converge from its current runtime contents.
+    #: Every mutation-triggered path names its own delta instead.
     #:
     #: It is load-bearing, not a convenience: ``report_device_alive``
     #: deliberately does not push MCP details itself (see

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_symlink_listener.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_symlink_listener.py
@@ -1,9 +1,8 @@
-"""Event listener: full skill-symlink sync when a device becomes active.
+"""Event listener: full runtime projection when a runtime becomes ready.
 
-Subscribed to DeviceActivatedEvent. Triggered once per container ready
-callback (new bot, restart, or post-batch-restart) — ensures that every
-time a container comes up, its symlinks are refreshed from the DB's
-current active skill sets (including default sets).
+Subscribed to ``DeviceActivatedEvent`` for first activation and to
+``RuntimeProjectionRequestedEvent`` for successful BaaS restarts. Both paths
+refresh runtime state from the DB's current desired state.
 
 The listener is constructed via the DI injector at app startup; its
 ``handle`` method is bound to the event bus so the bus can dispatch with
@@ -17,7 +16,10 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 from agentclaw.community.core.repository.protocols.bot import BotRepository
-from agentclaw.community.core.events.types import DeviceActivatedEvent
+from agentclaw.community.core.events.types import (
+    DeviceActivatedEvent,
+    RuntimeProjectionRequestedEvent,
+)
 from agentclaw.community.kernel.lifecycle import LifecycleBase
 from agentclaw.community.log import get_logger
 
@@ -30,6 +32,7 @@ if TYPE_CHECKING:
 logger = get_logger()
 
 _TRANSITION_AUTHORITY = "transition"
+_RuntimeReadyEvent = DeviceActivatedEvent | RuntimeProjectionRequestedEvent
 
 
 def _run_reconcile_blocking(coro: Any) -> Any:
@@ -82,7 +85,7 @@ class SkillSymlinkListener(LifecycleBase):
         self._runtime_non_skill_reconcile = runtime_non_skill_reconcile
 
     async def startup(self) -> None:
-        """Lifecycle hook — subscribe ``self.handle`` to DeviceActivatedEvent.
+        """Subscribe ``self.handle`` to activation and reprojection events.
 
         Replaces the explicit wiring in the pre-R11
         ``_register_event_listeners()`` helper. Idempotent — checks
@@ -92,21 +95,24 @@ class SkillSymlinkListener(LifecycleBase):
         from agentclaw.community.core.events.bus import get_event_bus
 
         bus = get_event_bus()
-        existing = bus._handlers.get(DeviceActivatedEvent, [])  # type: ignore[attr-defined]
-        if self.handle in existing:
+        for event_type in (DeviceActivatedEvent, RuntimeProjectionRequestedEvent):
+            existing = bus._handlers.get(event_type, [])  # type: ignore[attr-defined]
+            if self.handle in existing:
+                logger.info(
+                    "[skill_symlink_listener] already subscribed to %s",
+                    event_type.__name__,
+                )
+                continue
+            bus.subscribe(event_type, self.handle)
             logger.info(
-                "[skill_symlink_listener] already subscribed to DeviceActivatedEvent"
+                "[skill_symlink_listener] subscribed to %s", event_type.__name__
             )
-            return
-        bus.subscribe(DeviceActivatedEvent, self.handle)
-        logger.info(
-            "[skill_symlink_listener] subscribed to DeviceActivatedEvent"
-        )
 
-    def handle(self, event: DeviceActivatedEvent) -> None:
+    def handle(self, event: _RuntimeReadyEvent) -> None:
         logger.info(
-            "[skill_symlink_listener] received DeviceActivatedEvent: "
+            "[skill_symlink_listener] received %s: "
             "device_id=%s binding_id=%s provider=%s sandbox_id=%s",
+            type(event).__name__,
             event.device_id,
             event.binding_id,
             event.device_provider,
@@ -134,10 +140,11 @@ class SkillSymlinkListener(LifecycleBase):
                 return
 
             is_desktop = bot.get("bot_type") == "desktop"
-            self._enqueue_desktop_reconciliation(
-                event=event,
-                is_desktop=is_desktop,
-            )
+            if isinstance(event, DeviceActivatedEvent):
+                self._enqueue_desktop_reconciliation(
+                    event=event,
+                    is_desktop=is_desktop,
+                )
             initial_authority = self._resolve_desktop_layout_authority(bot)
             ctx = self._resolver.resolve_for_bot(bot_id, owner_id)
             if ctx.binding_id != event.binding_id:
@@ -166,20 +173,21 @@ class SkillSymlinkListener(LifecycleBase):
                 return
 
             if self._runtime_reconcile is not None:
-                # DeviceActivatedEvent is emitted after a restart/ready
-                # transition.  Rebuild the complete DB desired state through
-                # the same Reconciler as explicit mutations; do not rebuild
-                # a legacy Default-exclusion mapping in this listener.
+                # Both first activation and explicit post-restart projection
+                # rebuild the complete DB desired state through the same
+                # Reconciler as explicit mutations; do not rebuild a legacy
+                # Default-exclusion mapping in this listener.
                 try:
                     outcome = self._runtime_reconcile(str(bot_id), str(owner_id))
                     if asyncio.iscoroutine(outcome):
                         _run_reconcile_blocking(outcome)
                 finally:
-                    self._reenqueue_if_desktop_cutover_started(
-                        event=event,
-                        bot=bot if is_desktop else None,
-                        initial_authority=initial_authority,
-                    )
+                    if isinstance(event, DeviceActivatedEvent):
+                        self._reenqueue_if_desktop_cutover_started(
+                            event=event,
+                            bot=bot if is_desktop else None,
+                            initial_authority=initial_authority,
+                        )
                 return
 
             from agentclaw.community.core.workspace.constants import DEFAULT_ENGINE_TYPE
@@ -206,11 +214,12 @@ class SkillSymlinkListener(LifecycleBase):
             try:
                 result = device_sync.sync_symlinks(symlinks)
             finally:
-                self._reenqueue_if_desktop_cutover_started(
-                    event=event,
-                    bot=bot if is_desktop else None,
-                    initial_authority=initial_authority,
-                )
+                if isinstance(event, DeviceActivatedEvent):
+                    self._reenqueue_if_desktop_cutover_started(
+                        event=event,
+                        bot=bot if is_desktop else None,
+                        initial_authority=initial_authority,
+                    )
             logger.info(
                 "[skill_symlink_listener] sync result: success=%s message=%s",
                 result.get("success"),

--- a/src/backend/tests/community/api/test_event_listener_registration.py
+++ b/src/backend/tests/community/api/test_event_listener_registration.py
@@ -7,7 +7,10 @@ import asyncio
 import pytest
 
 from agentclaw.community.core.events.bus import get_event_bus, reset_event_bus
-from agentclaw.community.core.events.types import DeviceActivatedEvent
+from agentclaw.community.core.events.types import (
+    DeviceActivatedEvent,
+    RuntimeProjectionRequestedEvent,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -34,6 +37,10 @@ def test_skill_symlink_listener_is_registered_by_startup_hook():
     bus = get_event_bus()
     handlers = bus._handlers.get(DeviceActivatedEvent, [])  # type: ignore[attr-defined]
     assert listener.handle in handlers
+    reprojection_handlers = bus._handlers.get(  # type: ignore[attr-defined]
+        RuntimeProjectionRequestedEvent, []
+    )
+    assert listener.handle in reprojection_handlers
 
 
 def test_register_is_idempotent():
@@ -44,3 +51,7 @@ def test_register_is_idempotent():
     bus = get_event_bus()
     handlers = bus._handlers.get(DeviceActivatedEvent, [])  # type: ignore[attr-defined]
     assert handlers.count(listener.handle) == 1
+    reprojection_handlers = bus._handlers.get(  # type: ignore[attr-defined]
+        RuntimeProjectionRequestedEvent, []
+    )
+    assert reprojection_handlers.count(listener.handle) == 1

--- a/src/backend/tests/community/core/devices/services/test_baas_publish_task_handlers.py
+++ b/src/backend/tests/community/core/devices/services/test_baas_publish_task_handlers.py
@@ -22,7 +22,11 @@ from agentclaw.community.core.devices.services.baas_publish_task_handlers import
     build_restart_publish_poll_payload,
 )
 from agentclaw.community.core.events.bus import get_event_bus, reset_event_bus
-from agentclaw.community.core.events.types import BaasPublishCompletedEvent
+from agentclaw.community.core.events.types import (
+    BaasPublishCompletedEvent,
+    DeviceActivatedEvent,
+    RuntimeProjectionRequestedEvent,
+)
 from agentclaw.community.core.task_queue.services.registry import HandlerRegistry
 from agentclaw.community.core.task_queue.types import Complete, Fail, Reschedule, Retry
 
@@ -1468,6 +1472,7 @@ def test_restart_poll_retries_on_transient_status_and_direct_unexpected_status()
         publish_id=1001,
         bot_uuid="uuid-001",
         bot={},
+        binding=repo.get_by_id.return_value,
     ) == Retry("unexpected publish status: ODD")
 
 
@@ -1640,10 +1645,23 @@ def test_create_init_replay_after_active_reemits_reconciliation_wakeup():
         reset_event_bus()
 
 
-def test_restart_success_publishes_baas_reconciliation_wakeup():
+def test_restart_success_requests_runtime_projection_and_baas_reconciliation():
     reset_event_bus()
     received: list[BaasPublishCompletedEvent] = []
+    projected: list[RuntimeProjectionRequestedEvent] = []
+    activated: list[DeviceActivatedEvent] = []
+    delivery_order: list[str] = []
     get_event_bus().subscribe(BaasPublishCompletedEvent, received.append)
+    get_event_bus().subscribe(RuntimeProjectionRequestedEvent, projected.append)
+    get_event_bus().subscribe(DeviceActivatedEvent, activated.append)
+    get_event_bus().subscribe(
+        BaasPublishCompletedEvent,
+        lambda _event: delivery_order.append("baas_completed"),
+    )
+    get_event_bus().subscribe(
+        RuntimeProjectionRequestedEvent,
+        lambda _event: delivery_order.append("runtime_projection"),
+    )
     try:
         repo = MagicMock()
         repo.get_by_id.return_value = _make_binding(
@@ -1694,6 +1712,18 @@ def test_restart_success_publishes_baas_reconciliation_wakeup():
                 publish_kind="restart",
             )
         ]
+        assert projected == [
+            RuntimeProjectionRequestedEvent(
+                device_id="device-001",
+                binding_id=42,
+                entity_id="owner-001",
+                entity_type="staff",
+                device_provider="baas",
+                sandbox_id=None,
+            )
+        ]
+        assert activated == []
+        assert delivery_order == ["runtime_projection", "baas_completed"]
     finally:
         reset_event_bus()
 

--- a/src/backend/tests/community/core/events/test_types.py
+++ b/src/backend/tests/community/core/events/test_types.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-from agentclaw.community.core.events.types import DeviceActivatedEvent
+from agentclaw.community.core.events.types import (
+    DeviceActivatedEvent,
+    RuntimeProjectionRequestedEvent,
+)
 
 
 class TestDeviceActivatedEvent:
@@ -31,3 +34,18 @@ class TestDeviceActivatedEvent:
             device_provider="local",
         )
         assert event.sandbox_id is None
+
+
+def test_runtime_projection_requested_event_carries_binding_identity() -> None:
+    event = RuntimeProjectionRequestedEvent(
+        device_id="device-1",
+        binding_id=42,
+        entity_id="owner-1",
+        entity_type="staff",
+        device_provider="baas",
+        sandbox_id="sandbox-1",
+    )
+
+    assert event.binding_id == 42
+    assert event.device_provider == "baas"
+    assert event.sandbox_id == "sandbox-1"

--- a/src/backend/tests/community/core/skill_center/services/test_skill_symlink_listener.py
+++ b/src/backend/tests/community/core/skill_center/services/test_skill_symlink_listener.py
@@ -7,7 +7,10 @@ from unittest.mock import MagicMock, call
 
 import pytest
 
-from agentclaw.community.core.events.types import DeviceActivatedEvent
+from agentclaw.community.core.events.types import (
+    DeviceActivatedEvent,
+    RuntimeProjectionRequestedEvent,
+)
 from agentclaw.community.core.skill_center.services.skill_symlink_listener import (
     SkillSymlinkListener,
 )
@@ -104,6 +107,35 @@ def _layout_state(
 
 
 class TestHandleDeviceActivated:
+    def test_restart_projection_trigger_is_layout_agnostic(self):
+        bot_query = MagicMock()
+        bot_query.get_by_binding_id.return_value = {
+            "bot_id": "service-1",
+            "owner_id": "u001",
+            "bot_type": "service",
+        }
+        layout_repository = MagicMock()
+        runtime_reconcile = MagicMock()
+        listener, _, dispatcher, _ = _make_listener(
+            bot_query=bot_query,
+            layout_repository=layout_repository,
+            runtime_reconcile=runtime_reconcile,
+        )
+
+        listener.handle(
+            RuntimeProjectionRequestedEvent(
+                device_id="device-001",
+                binding_id=42,
+                entity_id="u001",
+                entity_type="staff",
+                device_provider="baas",
+            )
+        )
+
+        runtime_reconcile.assert_called_once_with("service-1", "u001")
+        layout_repository.get.assert_not_called()
+        dispatcher.dispatch.assert_not_called()
+
     @pytest.mark.asyncio
     async def test_runtime_reconcile_blocks_even_inside_a_running_loop(self):
         completed = []

--- a/src/backend/tests/community/di/test_skills_pool_wiring.py
+++ b/src/backend/tests/community/di/test_skills_pool_wiring.py
@@ -1,6 +1,7 @@
 """Skills Pool 控制面业务边界的 DI 装配测试。"""
 
 from dataclasses import replace
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -55,14 +56,19 @@ from agentclaw.community.core.skills_pool.types import (
 )
 from agentclaw.community.core.task_queue.services.registry import HandlerRegistry
 from agentclaw.community.core.repository.protocols.bot import BotRepository
+from agentclaw.community.core.events.types import RuntimeProjectionRequestedEvent
 from agentclaw.community.core.skill_center.factories import SkillServiceFactory
 from agentclaw.community.core.skill_center.services.skill_symlink_listener import (
     SkillSymlinkListener,
+)
+from agentclaw.community.core.skill_center.runtime_projection_contract import (
+    ProjectionScope,
 )
 from agentclaw.community.core.skills_pool.ports import SkillsPoolRuntimeProtocol
 from agentclaw.community.core.repository.protocols.skills_pool import SkillsPoolSkillRepositoryProtocol
 from agentclaw.community.core.skills_pool.runtime import OpenClawSkillsPoolRuntime
 from agentclaw.community.di import DeployProfile, build_injector
+from agentclaw.community.di.modules.skill_center_module import SkillCenterModule
 from agentclaw.community.core.repository.implementations.skills_pool.layout import SkillsPoolLayoutRepository
 from agentclaw.community.core.repository.implementations.skill_center.skill import SkillRepository
 
@@ -242,6 +248,46 @@ def test_skill_symlink_listener_uses_public_desktop_layout_state(
         migration_generation=None,
     )
     assert authority(bot) == "legacy"
+
+
+def test_skill_symlink_listener_projects_everything_for_runtime_ready_events() -> None:
+    runtime_reconciler = MagicMock()
+    bot_repo = MagicMock()
+    bot_repo.get_by_binding_id.return_value = {
+        "bot_id": "service-1",
+        "owner_id": "owner-1",
+        "bot_type": "service",
+    }
+    resolver = MagicMock()
+    resolver.resolve_for_bot.return_value.binding_id = 42
+    layout_repository = MagicMock()
+    module = SkillCenterModule()
+    listener = module.skill_symlink_listener(
+        bot_repo=bot_repo,
+        skill_set_factory=MagicMock(),
+        resolver=resolver,
+        device_sync_dispatcher=MagicMock(),
+        layout_repository=layout_repository,
+        skills_pool_wakeup=MagicMock(),
+        runtime_reconciler=runtime_reconciler,
+    )
+
+    listener.handle(
+        RuntimeProjectionRequestedEvent(
+            device_id="device-1",
+            binding_id=42,
+            entity_id="owner-1",
+            entity_type="staff",
+            device_provider="baas",
+        )
+    )
+
+    runtime_reconciler.project.assert_called_once_with(
+        bot_id="service-1",
+        owner_id="owner-1",
+        scope=ProjectionScope.everything(),
+    )
+    layout_repository.get.assert_not_called()
 
 
 @pytest.mark.parametrize("template_type", ("personalCoding", "applicationCoding"))


### PR DESCRIPTION
## Problem

BaaS Bot 首次激活会通过 `DeviceActivatedEvent` 执行完整 Runtime Projection，但 BaaS 重启发布成功后只触发 Skills Pool reconcile。若首次投影未收敛，或运行时内容在重启后需要恢复，Installation 等控制面期望态不会被统一重新下发。

直接复用 `DeviceActivatedEvent` 还会误触发 Cron 等与重启投影无关的生命周期消费者。

## Solution

- 新增窄语义的 `RuntimeProjectionRequestedEvent`，只表达“按当前控制面期望态执行一次 best-effort 完整投影”。
- BaaS restart publish 成功并完成持久化后发布该事件，再保留既有 `BaasPublishCompletedEvent`。
- `SkillSymlinkListener` 同时监听首次激活与重投影事件，并统一调用 `BotRuntimeProjector.project(scope=ProjectionScope.everything())`。
- 触发层不读取或限制 Legacy/Pool layout；实际交付继续由 Runtime Projector 按 Engine/Layout 合同决定。
- 保持 `PENDING` / `DEGRADED` best-effort、同步 SkillSet API、既有 task retry/rollback 语义不变。

## Validation

- 227 个相关 Backend tests passed：BaaS publish handlers、DeviceService、SkillSymlinkListener、events、listener registration、Skills Pool DI、restart authorization，以及架构/DI 窄门禁。
- Ruff changed-files check passed。
- `git diff --check` passed。
- Standards / Spec 双轴 review：无 blocker、P1、P2。
- Backend 全量套件本地启动后因 `dev` 基线前进而停止；停止前 847 passed / 1 skipped / 0 failed。rebase 后未重复跑完整套件，交由 PR CI 完成。

## Compatibility and risk

这是内部事件扩展，不变更 OpenAPI、数据库 schema 或同步接口返回。专用事件避免重放 `DeviceActivatedEvent` 的其他副作用。投影仍为 best-effort，失败不会回滚已经成功的 BaaS 重启。

## Spec

同步更新 MCP sync/runtime-ready 事件合同及 Skill Center 架构说明。
