### PR TITLE
fix(bcs): enable bcsfuse in prod and extend fusion timeout

### DIFF
--- a/src/bcs/configs/bcs-config-prod.toml
+++ b/src/bcs/configs/bcs-config-prod.toml
@@ -211,9 +211,9 @@ private_key = "${BCS_ALIPAY_PRIVATE_KEY}"
 alipay_public_key = "${BCS_ALIPAY_ALIPAY_PUBLIC_KEY}"
 
 [bcsfuse]
-enabled = false
+enabled = true
 url = "${FUSE_ENDPOINT}"
-fusion_timeout_ms = 120000
+fusion_timeout_ms = 300000
 sync_timeout_ms = 10000
 profile_id = "default"
 recommend_top_k = 10


### PR DESCRIPTION
## Problem
The production environment has `bcsfuse` disabled, so fusion features are unavailable there. Additionally, the existing 2-minute fusion timeout is too short for production workloads and can cause premature timeouts.

## Solution
Enabled `bcsfuse` in the production config and increased `fusion_timeout_ms` from 120000 to 300000 (5 minutes) to accommodate production fusion workloads.

## Validation
- Config-only change; no logic code modified
- Pre-push gate passed when pushing the branch