### PR TITLE
fix(engine): resolve relative OpenClaw session keys

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/sessions/converter_creation.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/sessions/converter_creation.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import re
 from typing import Any
 
 from agentclaw.community.adapters.http.openapi_v1.engine_runtime.enums import RuntimeStage
@@ -21,10 +22,26 @@ _LIMIT = 20
 # deployment, so keep the same three-attempt bound but allow up to two seconds
 # for convergence.
 _DELAYS = (0.0, 0.5, 1.5)
+_MANAGED_SESSION_KEY = re.compile(
+    r"^(?:agent:([^:]+):)?(session:[^:]+:user:[^:]+)$",
+    re.IGNORECASE,
+)
 
 
 def _matches(candidate_id: str, created_id: str) -> bool:
-    return candidate_id == created_id or candidate_id.endswith(f":{created_id}")
+    if candidate_id == created_id:
+        return True
+
+    candidate_match = _MANAGED_SESSION_KEY.fullmatch(candidate_id)
+    created_match = _MANAGED_SESSION_KEY.fullmatch(created_id)
+    if candidate_match is None or created_match is None:
+        return False
+
+    candidate_agent, candidate_relative = candidate_match.groups()
+    created_agent, created_relative = created_match.groups()
+    if (candidate_agent is None) == (created_agent is None):
+        return False
+    return candidate_relative.lower() == created_relative.lower()
 
 
 async def reconcile_created_session(

--- a/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_sessions.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_sessions.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import pytest
 
-from agentclaw.community.adapters.http.openapi_v1.engine_runtime.sessions import router
 from agentclaw.community.adapters.http.openapi_v1.engine_runtime.sessions import (
     converter_creation,
+    router,
 )
 from agentclaw.community.core.engine_runtime.errors import (
     EngineCapabilityUnsupportedError,
@@ -171,6 +171,48 @@ def test_create_session_fills_user_id_from_the_principal(client, relay):
     assert data["gmt_modified"] == ENGINE_SESSION["gmt_modified"]
     assert relay.calls[1]["method"] == "GET"
     assert relay.calls[1]["path"] == "/api/sessions"
+
+
+def test_create_session_reconciles_openclaw_lowercased_cloud_user_id(client, relay):
+    relative_id = "session:ABC-123:user:CloudUser"
+    canonical_id = "agent:main:session:abc-123:user:clouduser"
+    relay.results = [
+        EngineResult(data={**ENGINE_SESSION, "id": relative_id}),
+        EngineResult(data=[{**ENGINE_SESSION, "id": canonical_id}]),
+    ]
+
+    resp = client.post(_base(), json={"title": "Cloud"})
+
+    assert resp.status_code == 201, resp.json()
+    assert resp.json()["data"]["session_id"] == canonical_id
+
+
+@pytest.mark.parametrize(
+    ("candidate_id", "created_id", "expected"),
+    [
+        ("Opaque-ID", "Opaque-ID", True),
+        ("opaque-id", "Opaque-ID", False),
+        (
+            "agent:main:session:abc-123:user:clouduser",
+            "session:ABC-123:user:CloudUser",
+            True,
+        ),
+        (
+            "agent:other:session:abc-123:user:clouduser",
+            "agent:main:session:ABC-123:user:CloudUser",
+            False,
+        ),
+        (
+            "session:abc-123:user:clouduser",
+            "session:ABC-123:user:CloudUser",
+            False,
+        ),
+    ],
+)
+def test_create_session_reconciliation_matches_only_managed_openclaw_keys(
+    candidate_id, created_id, expected
+):
+    assert converter_creation._matches(candidate_id, created_id) is expected
 
 
 def test_create_session_other_engine_does_not_add_reconciliation_call(client, relay):

--- a/src/engine/src/engine/community/api/session/router.py
+++ b/src/engine/src/engine/community/api/session/router.py
@@ -26,7 +26,10 @@ from engine.community.core.session.models import (
     SessionUpdateRequest,
 )
 from engine.community.core.session_favorite import get_session_favorite_repository
-from engine.community.shared.utils import decode_session_key
+from engine.community.shared.utils import (
+    decode_session_key,
+    managed_session_keys_equal,
+)
 
 log = logging.getLogger("web-sessions")
 
@@ -186,7 +189,7 @@ async def get_session(session_id: str, engine: Optional[str] = None) -> ApiRespo
             (
                 s
                 for s in sessions
-                if s.id == session_id
+                if managed_session_keys_equal(s.id, session_id)
             ),
             None,
         )

--- a/src/engine/src/engine/community/api/tests/test_session_router.py
+++ b/src/engine/src/engine/community/api/tests/test_session_router.py
@@ -226,6 +226,20 @@ class TestGetSession:
         request = mock_session_api.list.call_args.args[0]
         assert request.session_key == "sess-101"
 
+    def test_found_accepts_openclaw_canonical_form_of_relative_create_id(
+        self, client, mock_session_api
+    ):
+        relative = "session:ABC-123:user:CloudUser"
+        canonical = "agent:main:session:abc-123:user:clouduser"
+        mock_session_api.list.return_value = [_make_session(canonical)]
+
+        resp = client.get(f"/api/sessions/{relative}")
+
+        assert resp.status_code == 200
+        assert resp.json()["data"]["id"] == canonical
+        request = mock_session_api.list.call_args.args[0]
+        assert request.session_key == relative
+
     def test_not_found_returns_404(self, client, mock_session_api):
         mock_session_api.list.return_value = []
         resp = client.get("/api/sessions/missing")

--- a/src/engine/src/engine/community/plugins/openclaw/_session.py
+++ b/src/engine/src/engine/community/plugins/openclaw/_session.py
@@ -10,6 +10,10 @@ import re
 from typing import Any
 
 from engine.community.openclaw.client.gateway_client import OpenClawGatewayClient
+from engine.community.shared.utils import (
+    managed_session_keys_equal,
+    normalize_managed_session_lookup_key,
+)
 
 log = logging.getLogger("openclaw-port")
 
@@ -153,12 +157,17 @@ class _SessionPortMixin:
         requested_session_key = (
             session_key if session_key and session_key.strip() else None
         )
+        lookup_session_key = (
+            normalize_managed_session_lookup_key(requested_session_key)
+            if requested_session_key is not None
+            else None
+        )
 
         # Push the lookup into the gateway before its default result cap is
         # applied. Keep the exact local filter because gateway search is fuzzy.
         list_params = (
-            {"search": requested_session_key}
-            if requested_session_key is not None
+            {"search": lookup_session_key}
+            if lookup_session_key is not None
             else {}
         )
 
@@ -197,7 +206,12 @@ class _SessionPortMixin:
 
         if requested_session_key is not None:
             # Filter before pagination so a copied key can be found beyond the current page.
-            raw_sessions = [s for s in raw_sessions if s.get("key") == requested_session_key]
+            raw_sessions = [
+                s
+                for s in raw_sessions
+                if isinstance(s.get("key"), str)
+                and managed_session_keys_equal(s["key"], requested_session_key)
+            ]
 
         # Step 5: Paginate BEFORE history fetch (legacy ordering).
         page = raw_sessions[offset: offset + limit]

--- a/src/engine/src/engine/community/plugins/openclaw/tests/test_session_port.py
+++ b/src/engine/src/engine/community/plugins/openclaw/tests/test_session_port.py
@@ -317,6 +317,29 @@ class TestSessionsList:
         sessions_list_calls = [call for call in client.calls if call[0] == "sessions.list"]
         assert sessions_list_calls == [("sessions.list", {"search": "target"}, None)]
 
+    async def test_session_key_filter_accepts_cloud_create_relative_key(self):
+        canonical = "agent:main:session:abc-123:user:clouduser"
+        impl, client = _make_impl({
+            "sessions.list": self._sessions_payload([
+                {"key": canonical, "label": "Cloud session", "model": None},
+            ]),
+            "chat.history": self._history_payload([]),
+            "providers.available": self._providers_payload(),
+        })
+
+        result = await impl.sessions_list(
+            token="tok",
+            session_key="session:ABC-123:user:CloudUser",
+        )
+
+        assert [session["key"] for session in result] == [canonical]
+        sessions_list_calls = [call for call in client.calls if call[0] == "sessions.list"]
+        assert sessions_list_calls == [(
+            "sessions.list",
+            {"search": "session:abc-123:user:clouduser"},
+            None,
+        )]
+
     async def test_session_key_filter_returns_empty_list_for_no_match(self):
         impl, client = _make_impl({
             "sessions.list": self._sessions_payload([

--- a/src/engine/src/engine/community/shared/tests/test_utils.py
+++ b/src/engine/src/engine/community/shared/tests/test_utils.py
@@ -3,7 +3,42 @@
 """
 import pytest
 
-from engine.community.shared.utils import decode_session_key, encode_session_key
+from engine.community.shared.utils import (
+    decode_session_key,
+    encode_session_key,
+    managed_session_keys_equal,
+    normalize_managed_session_lookup_key,
+)
+
+
+def test_managed_session_lookup_key_matches_openclaw_normalization():
+    assert normalize_managed_session_lookup_key(
+        "session:ABC-123:user:CloudUser"
+    ) == "session:abc-123:user:clouduser"
+    assert normalize_managed_session_lookup_key(
+        "agent:Main:session:ABC-123:user:CloudUser"
+    ) == "agent:Main:session:ABC-123:user:CloudUser"
+    assert normalize_managed_session_lookup_key("discord:dm:OpaqueUser") == (
+        "discord:dm:OpaqueUser"
+    )
+
+
+def test_managed_session_keys_match_relative_and_agent_scoped_forms():
+    relative = "session:ABC-123:user:CloudUser"
+    canonical = "agent:main:session:abc-123:user:clouduser"
+
+    assert managed_session_keys_equal(canonical, relative)
+    assert managed_session_keys_equal(relative, canonical)
+    assert not managed_session_keys_equal(
+        relative,
+        "session:abc-123:user:clouduser",
+    )
+    assert not managed_session_keys_equal(
+        canonical,
+        "agent:other:session:abc-123:user:clouduser",
+    )
+    assert not managed_session_keys_equal("Opaque-ID", "opaque-id")
+    assert not managed_session_keys_equal("prefix:target", "target")
 
 
 class TestEncodeSessionKey:

--- a/src/engine/src/engine/community/shared/utils.py
+++ b/src/engine/src/engine/community/shared/utils.py
@@ -2,6 +2,37 @@
 通用工具函数
 """
 import base64
+import re
+
+_MANAGED_SESSION_KEY = re.compile(
+    r"^(?:agent:([^:]+):)?(session:[^:]+:user:[^:]+)$",
+    re.IGNORECASE,
+)
+
+
+def normalize_managed_session_lookup_key(session_key: str) -> str:
+    """Normalize only the relative session key returned by OCB create."""
+    match = _MANAGED_SESSION_KEY.fullmatch(session_key)
+    if match is not None and match.group(1) is None:
+        return session_key.lower()
+    return session_key
+
+
+def managed_session_keys_equal(candidate: str, requested: str) -> bool:
+    """Match relative OCB keys with their agent-scoped OpenClaw form."""
+    if candidate == requested:
+        return True
+
+    candidate_match = _MANAGED_SESSION_KEY.fullmatch(candidate)
+    requested_match = _MANAGED_SESSION_KEY.fullmatch(requested)
+    if candidate_match is None or requested_match is None:
+        return False
+
+    candidate_agent, candidate_relative = candidate_match.groups()
+    requested_agent, requested_relative = requested_match.groups()
+    if (candidate_agent is None) == (requested_agent is None):
+        return False
+    return candidate_relative.lower() == requested_relative.lower()
 
 
 def encode_session_key(session_key: str) -> str:


### PR DESCRIPTION
## Summary
- normalize OCB-managed session lookup keys the same way OpenClaw does
- allow a relative create ID to resolve its agent-scoped canonical session without matching across agents
- make OpenAPI create reconciliation tolerate OpenClaw lowercasing cloud user IDs

Fixes the create-then-GET 404 reported in Dima work item 2026090300118783835.

## Tests
- Engine targeted tests: 114 passed
- Backend OpenAPI session tests: 90 passed
- changed-file Ruff F/I checks passed
- pre-push required SAST gates passed