### PR TITLE
fix(eval-env): fix eval container session_id overwrite and missing extra_envs

### DIFF
--- a/src/baas/src/secbaas/community/core/service/bot_run/_baas_service.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_baas_service.py
@@ -243,6 +243,9 @@ class BaasBotService(BotService):
         # Resolve user id for the session
         user_id = resolve_user_id(metadata, binding_info, context, bot_id)
 
+        # 评测流量：提取 eval_id 供 consistency_key 构造使用
+        eval_id = metadata.get("eval_id") if metadata else None
+
         # Step 1: Resolve bot_uuid → WsConnectionInfo (also verifies bot is ACTIVE)
         env = get_current_env()
         logger.info(
@@ -260,7 +263,7 @@ class BaasBotService(BotService):
                 session_consistency_key = _adapter.session_consistency_key(
                     tc_bot_id=binding_info.bot_id,
                     user_id=user_id,
-                    run_id=run_id,
+                    run_id=eval_id or run_id,
                     session_id=session_id,
                 )
             else:
@@ -270,6 +273,7 @@ class BaasBotService(BotService):
                     user_id=user_id,
                     run_id=run_id,
                     session_id=session_id,
+                    eval_id=eval_id,
                 )
             consistency_key = (
                 _strip_agent_main_prefix(session_consistency_key)
@@ -1167,6 +1171,7 @@ class BaasBotService(BotService):
         user_id: str,
         run_id: str,
         session_id: str | None = None,
+        eval_id: str | None = None,
     ) -> str | None:
         """Create consistency key for session routing.
 
@@ -1176,15 +1181,22 @@ class BaasBotService(BotService):
         canonicalized by stripping a leading ``agent:main:`` so the DingTalk
         path (raw id) and the Open API path (prefixed id) hash to the same
         device. The persisted/returned session id contract is unchanged.
+
+        When ``eval_id`` is present (eval traffic) and ``session_id`` is None
+        (first round), the eval_id replaces run_id in the session field,
+        producing a structured key like ``agent:{id}:session:{evalId}:user:{uid}``
+        that is consistent with the production format.
         """
         if session_id is not None:
             return session_id
 
+        session_key = eval_id if eval_id else run_id
+
         if engine_type == "openclaw":
             # Fixed prefix 'agent:main:'
-            return f"agent:main:session:{run_id}:user:{user_id}"
+            return f"agent:main:session:{session_key}:user:{user_id}"
         elif engine_type == "claude_code":
-            return f"agent:{tc_bot_id}:session:{run_id}:user:{user_id}"
+            return f"agent:{tc_bot_id}:session:{session_key}:user:{user_id}"
         else:
             # TODO
             return None

--- a/src/baas/src/secbaas/community/plugins/eval_env/real/_real_session_log.py
+++ b/src/baas/src/secbaas/community/plugins/eval_env/real/_real_session_log.py
@@ -65,7 +65,6 @@ class RealEvalSessionLog(EvalSessionLog):
         """从 HTTP Header 提取评测标识并注入 metadata。"""
         if x_eval_id:
             metadata["eval_id"] = x_eval_id
-            metadata.setdefault("session_id", x_eval_id)
             if not x_eval_id.startswith("eval"):
                 logger.warning(
                     "[EvalSessionLog] x-eval-id format mismatch: %s, "

--- a/src/baas/tests/unit/core/service/bot_run/test_baas_service.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_baas_service.py
@@ -238,6 +238,62 @@ class TestSessionRoutingAffinityPrefix:
             == "agent:main:session:run-1:user:u-1"
         )
 
+    def test_eval_id_replaces_run_id_in_openclaw_key(self, service):
+        """eval_id 存在时用 evalId 替换 run_id 作为 session 字段值。"""
+        assert (
+            service._create_session_consistency_key(
+                engine_type="openclaw",
+                tc_bot_id=BOT_UUID,
+                user_id="u-1",
+                run_id="run-1",
+                session_id=None,
+                eval_id="eval-abc123",
+            )
+            == "agent:main:session:eval-abc123:user:u-1"
+        )
+
+    def test_eval_id_replaces_run_id_in_claude_code_key(self, service):
+        """eval_id 存在时 claude_code 引擎也用 evalId 替换 run_id。"""
+        assert (
+            service._create_session_consistency_key(
+                engine_type="claude_code",
+                tc_bot_id=BOT_UUID,
+                user_id="u-1",
+                run_id="run-1",
+                session_id=None,
+                eval_id="eval-abc123",
+            )
+            == f"agent:{BOT_UUID}:session:eval-abc123:user:u-1"
+        )
+
+    def test_eval_id_none_falls_back_to_run_id(self, service):
+        """eval_id=None 时回退到 run_id，与原有行为一致。"""
+        assert (
+            service._create_session_consistency_key(
+                engine_type="claude_code",
+                tc_bot_id=BOT_UUID,
+                user_id="u-1",
+                run_id="run-1",
+                session_id=None,
+                eval_id=None,
+            )
+            == f"agent:{BOT_UUID}:session:run-1:user:u-1"
+        )
+
+    def test_eval_id_ignored_when_session_id_provided(self, service):
+        """session_id 已传入时直接返回，eval_id 不生效。"""
+        assert (
+            service._create_session_consistency_key(
+                engine_type="openclaw",
+                tc_bot_id=BOT_UUID,
+                user_id="u-1",
+                run_id="run-1",
+                session_id="existing-session",
+                eval_id="eval-abc123",
+            )
+            == "existing-session"
+        )
+
     @pytest.mark.asyncio
     async def test_create_session_path_strips_prefix_before_resolve(
         self, service, wss_resolver

--- a/src/baas/tests/unit/plugins/eval_env/real/test_real_session_log.py
+++ b/src/baas/tests/unit/plugins/eval_env/real/test_real_session_log.py
@@ -48,7 +48,7 @@ class TestRealEvalSessionLog:
             x_default_tag=None,
         )
         assert result["eval_id"] == "eval-123"
-        assert result["session_id"] == "eval-123"
+        assert "session_id" not in result
 
     def test_extract_eval_headers_with_x_eval_id_format_warning(self):
         """x_eval_id 不以 'eval' 开头时应记录 warning 但依然注入。"""
@@ -60,7 +60,7 @@ class TestRealEvalSessionLog:
             x_default_tag=None,
         )
         assert result["eval_id"] == "bad-format-id"
-        assert result["session_id"] == "bad-format-id"
+        assert "session_id" not in result
 
     def test_extract_eval_headers_with_x_default_tag(self):
         log = RealEvalSessionLog()
@@ -82,7 +82,7 @@ class TestRealEvalSessionLog:
             x_default_tag="production",
         )
         assert result["eval_id"] == "eval-456"
-        assert result["session_id"] == "eval-456"
+        assert "session_id" not in result
         assert result["default_tag"] == "production"
         assert result["bot_options"]["lifecycle_stage"] == "production"
 

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/eval_publish_mixin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/eval_publish_mixin.py
@@ -11,6 +11,7 @@ from agentclaw.community.core.service_bot.services.bot_publish_service import (
     PublishNotFoundError,
 )
 from agentclaw.community.core.service_bot.services.deploy.service_publish_env import (
+    service_publish_extra_envs,
     service_publish_template_config,
 )
 from agentclaw.community.core.service_bot.services.publish_flow.errors import (
@@ -118,6 +119,7 @@ class EvalPublishMixin:
                 version=str(publish_record.version or 1),
                 delivery=delivery,
                 ext_info=ext_info,
+                extra_envs=service_publish_extra_envs(publish_record.ext, bot),
                 docker_image=image_pin.docker_image,
                 template_config=service_publish_template_config(bot),
             )


### PR DESCRIPTION
## Problem

Two defects in the eval-environment message delivery pipeline:

1. **E1 — eval_id bare value overwrites session_id**: `metadata.setdefault("session_id", x_eval_id)` in `_real_session_log.py` writes the eval_id bare value (e.g. `eval-dd7a...`) directly into session_id, breaking the structured format `agent:{botId}:session:{runId}:user:{userId}` and causing multi-round session continuation failures.

2. **B1a/B1b — eval_publish missing extra_envs**: `eval_publish_mixin.py` `_issue()` calls `release_async` without `extra_envs`, leaving eval containers missing:
   - `AGENTCLAW_SKILLS_LAYOUT` (all engines) — engines fall back to legacy layout
   - aicoding/claude_code engine-level env vars (`AIX_DEVFLOW_INFO`/`GIT_ADDRESSES`/`RELAY_DEFAULT_MODEL`/`RELAY_DEFAULT_RUNTIME`), conditionally affecting service bots where `consumes_template_config=True`

## Solution

**E1 fix** (2 files):
- Remove `metadata.setdefault("session_id", x_eval_id)` from `_real_session_log.py`
- Add `eval_id` parameter to `_create_session_consistency_key` in `_baas_service.py`: when eval_id exists, use it instead of run_id as the session field value, reusing the existing structured format generation logic. Adapters receive `eval_id or run_id` as run_id — no adapter signature changes needed.

**B1a/B1b fix** (1 file):
- Add `extra_envs=service_publish_extra_envs(publish_record.ext, bot)` to `release_kwargs` in `eval_publish_mixin.py`, aligning with the production `first_release` path.

## Validation

- Code review confirmed minimal change scope: E1 touches 2 files, B1a/B1b touches 1 file
- No automated tests produced (eval pipeline integration tests require a full BaaS + Backend environment)
- The corresponding OCB-side fix (D1 idempotent check) was committed separately on GitLab with unit tests

## Compatibility and risk

- **E1**: session_id format change — the first eval round now constructs a structured session_id server-side; subsequent rounds pass it through from the caller. Production path is unaffected (production does not enter the eval branch)
- **B1a/B1b**: non-breaking addition — eval containers go from having no env vars to having them; existing production Bot behavior is unaffected
- Rollback path: revert the two commits