### PR TITLE
fix(backend): carry template_type through the legacy applicationCoding fold

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_inventory/services/bot_inventory_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_inventory/services/bot_inventory_service.py
@@ -33,6 +33,11 @@ from agentclaw.community.core.bot_inventory.types import (
     ServiceLifecycleCard,
 )
 from agentclaw.community.core.bot_collaborator.models import PermissionLevel
+from agentclaw.community.core.workspace.runtime_identity import (
+    AICODING_ENGINE_FORM,
+    normalize_runtime_engine,
+    uses_aicoding_runtime,
+)
 from agentclaw.community.log import get_logger
 from agentclaw.community.core.bot_inventory.bot_inventory_service_protocol import BotInventoryServiceProtocol
 
@@ -253,6 +258,54 @@ class BotInventoryService(BotInventoryServiceProtocol):
         engine: str | None,
         bot_ids: list[str] | None = None,
     ) -> list[Mapping[str, Any]]:
+        engines = _cloud_fetch_engines(engine)
+        rows: list[Mapping[str, Any]] = []
+        for eng in engines:
+            rows.extend(
+                self._fetch_cloud_pages(
+                    engine=eng,
+                    owner_id=owner_id,
+                    space=space,
+                    keyword=keyword,
+                    bot_ids=bot_ids,
+                )
+            )
+        # aicoding is claude_code's internal runtime form (PR #1719 engine/form
+        # vocabulary split): engine=aicoding fetches aicoding + claude_code
+        # batches, then collapses them to the aicoding runtime read model here.
+        if len(engines) > 1:
+            rows = _select_aicoding_runtime_rows(rows)
+        visible: list[Mapping[str, Any]] = []
+        for row in rows:
+            if row.get("bot_type") not in (None, "", "personal", "service"):
+                continue
+            try:
+                self._business_space.assert_bot_visible_in_current_space(
+                    bot=row,
+                    owner_id=str(row.get("owner_id") or owner_id),
+                    current_space=space,
+                )
+            except BotInventoryPermissionError:
+                continue
+            visible.append(row)
+        return visible
+
+    def _fetch_cloud_pages(
+        self,
+        *,
+        engine: str | None,
+        owner_id: str,
+        space: BusinessSpaceRef,
+        keyword: str | None,
+        bot_ids: list[str] | None,
+    ) -> list[Mapping[str, Any]]:
+        """Page through one engine's matching bots until exhausted.
+
+        ``attach_templates=False`` is load-bearing: inventory cards never read
+        ``template_config`` at fetch time (the page-slice template attach in
+        ``_attach_page_templates`` is the single, bounded entry point), so each
+        pulled page skips the batched template read.
+        """
         rows: list[Mapping[str, Any]] = []
         fetch_size = 200
         page = 1
@@ -265,9 +318,6 @@ class BotInventoryService(BotInventoryServiceProtocol):
                 engine=engine,
                 status=None,
                 bot_ids=bot_ids,
-                # Inventory cards carry no template_config (verified: neither
-                # BotInventoryItem nor the router mapping reads it), so skip
-                # the batched template read on every pulled page.
                 attach_templates=False,
                 page=page,
                 page_size=fetch_size,
@@ -284,20 +334,7 @@ class BotInventoryService(BotInventoryServiceProtocol):
             if len(page_items) < fetch_size:
                 break
             page += 1
-        visible: list[Mapping[str, Any]] = []
-        for row in rows:
-            if row.get("bot_type") not in (None, "", "personal", "service"):
-                continue
-            try:
-                self._business_space.assert_bot_visible_in_current_space(
-                    bot=row,
-                    owner_id=str(row.get("owner_id") or owner_id),
-                    current_space=space,
-                )
-            except BotInventoryPermissionError:
-                continue
-            visible.append(row)
-        return visible
+        return rows
 
     def _list_local_rows(
         self,
@@ -533,3 +570,47 @@ def _passport_id(ext: Mapping[str, Any]) -> str | None:
 def _raise_if_desktop_service_error(exc: Exception) -> None:
     if exc.__class__.__name__ in {"DesktopBotServiceError", "DesktopBotOrphanError"}:
         raise BotInventoryUpstreamError("desktop service failed") from exc
+
+
+def _cloud_fetch_engines(engine: str | None) -> list[str | None]:
+    """Resolve a list engine filter into the fetch batches the SQL layer needs.
+
+    ``aicoding`` is ``claude_code``'s internal runtime form (PR #1719 engine/form
+    vocabulary split): querying ``engine=aicoding`` must match both legacy rows
+    with a literal ``active_engine='aicoding'`` and post-split rows whose
+    ``active_engine='claude_code'`` carries the form on its template. Other
+    engine values pass through as a single batch unchanged.
+    """
+    if normalize_runtime_engine(engine) == AICODING_ENGINE_FORM:
+        return [AICODING_ENGINE_FORM, "claude_code"]
+    return [engine]
+
+
+def _select_aicoding_runtime_rows(
+    rows: list[Mapping[str, Any]],
+) -> list[Mapping[str, Any]]:
+    """Collapse the expanded aicoding batches into the aicoding runtime read model.
+
+    ``template_config`` is None: inventory rows are fetched with
+    ``attach_templates=False`` and carry no form marker, but an aicoding form
+    always travels with a coding ``template_type`` (applicationCoding /
+    personalCoding), so ``uses_aicoding_runtime``'s template_type arm is
+    authoritative; legacy ``active_engine='aicoding'`` rows short-circuit on
+    the engine arm. The two batches are disjoint by ``active_engine``; the
+    bot_id dedup is a defensive guard against upstream duplication only.
+    """
+    seen: set[str] = set()
+    out: list[Mapping[str, Any]] = []
+    for row in rows:
+        bot_id = str(row.get("bot_id") or "")
+        if bot_id in seen:
+            continue
+        if not uses_aicoding_runtime(
+            active_engine=row.get("active_engine"),
+            template_type=row.get("template_type"),
+            template_config=None,
+        ):
+            continue
+        seen.add(bot_id)
+        out.append(row)
+    return out

--- a/src/backend/src/agentclaw/community/core/bot_management/create_flow.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/create_flow.py
@@ -30,11 +30,10 @@ from agentclaw.community.core.bot_management.engines.provisioning import (
 )
 from agentclaw.community.core.bot_management.engines.registry import (
     get_engine_provisioning_registry,
-    normalize_engine_type,
 )
-from agentclaw.community.core.bot_management.engines.aicoding.strategy import (
-    AICODING_ENGINE_TYPE,
-    CLAUDE_CODE_ENGINE_TYPE,
+from agentclaw.community.core.bot_management.legacy_create_compat import (
+    legacy_template_engine_properties,
+    normalize_legacy_engine_alias,
 )
 from agentclaw.community.core.bot_management.manifest_seam import (
     ManifestCreationSeam,
@@ -50,10 +49,6 @@ from agentclaw.community.core.bot_management.services.bot_service import (
 from agentclaw.community.core.mcp.services._defaults import get_default_cli_items
 from agentclaw.community.core.mcp.services.passport_scope import (
     filter_passport_mcp_codes,
-)
-from agentclaw.community.core.workspace.runtime_identity import (
-    AICODING_ENGINE_FORM,
-    ENGINE_FORM_KEY,
 )
 from agentclaw.community.log import get_logger
 from agentclaw.community.plugin_api.auth_relationship import AuthRelationshipError
@@ -96,49 +91,6 @@ def _reject_mixed_create_sources(spec: BotCreateSpec) -> None:
         raise BotTemplateInvalidError(
             "engine_properties cannot be combined with legacy template fields"
         )
-
-
-# Legacy internal-engine values folded at the shared create seam. ``aicoding``
-# is the internal implementation engine of ``claude_code``, not a product
-# engine: new bots store the real engine and carry the form marker
-# (``engine_form``) in their template snapshot instead (engine/form vocabulary
-# split — docs/superpowers/specs/2026-08-31-engine-vocabulary-template-form-design.md).
-_LEGACY_ENGINE_ALIASES = {AICODING_ENGINE_TYPE: CLAUDE_CODE_ENGINE_TYPE}
-
-
-def _normalize_legacy_engine_alias(spec: BotCreateSpec) -> BotCreateSpec:
-    """Fold legacy internal-engine values into the real engine (old-link compat).
-
-    Internal callers (``/api/bots``) may still send ``engine_type="aicoding"``.
-    The bot is created on the real engine (``claude_code``); a template-backed
-    create records the server-managed ``engine_form`` marker in the template
-    snapshot so runtime/bucket routing stays equivalent. A plain no-template
-    bot has no form — it is simply a plain ``claude_code`` bot. The public
-    surface never reaches this: it rejects internal engines with 400.
-
-    Idempotent: a spec already on the real engine passes through unchanged.
-    """
-    real_engine = _LEGACY_ENGINE_ALIASES.get(
-        normalize_engine_type(spec.engine_type, default="")
-    )
-    if real_engine is None:
-        return spec
-    template_config = spec.template_config
-    if spec.template_type and template_config is not None:
-        template_config = {**template_config, ENGINE_FORM_KEY: AICODING_ENGINE_FORM}
-    logger.info(
-        "[create_flow] folded legacy engine alias: requested_engine=%s "
-        "engine=%s template_type=%s form_marker_written=%s",
-        spec.engine_type,
-        real_engine,
-        spec.template_type,
-        spec.template_type and template_config is not None,
-    )
-    return replace(
-        spec,
-        engine_type=real_engine,
-        template_config=template_config,
-    )
 
 
 def _prepare_with_engine_strategy(
@@ -309,24 +261,17 @@ def _prepare_create(
     # aicoding strategy rejects application-coding creates on any engine other
     # than claude_code, so normalizing afterwards would keep rejecting the
     # old link's engine_type="aicoding" + applicationCoding combination.
-    spec = _normalize_legacy_engine_alias(spec)
+    spec = normalize_legacy_engine_alias(spec)
 
     if spec.engine_properties:
         prepared = _prepare_with_engine_strategy(spec, context)
     elif spec.template_type == "applicationCoding":
         # Keeping the "template_config" key preserves legacy intent when the
         # caller omits the config, so both input shapes share the Strategy gate.
-        # ``template_type`` rides along: a template-factory snapshot (full
-        # identity: template_key + template_uid) is rejected by the strategy
-        # unless ``engine_properties.template_type`` declares its type, and the
-        # internal surface only expresses that declaration through this fold.
         prepared = _prepare_with_engine_strategy(
             replace(
                 spec,
-                engine_properties={
-                    "template_type": spec.template_type,
-                    "template_config": spec.template_config,
-                },
+                engine_properties=legacy_template_engine_properties(spec),
             ),
             context,
         )

--- a/src/backend/src/agentclaw/community/core/bot_management/create_flow.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/create_flow.py
@@ -316,8 +316,18 @@ def _prepare_create(
     elif spec.template_type == "applicationCoding":
         # Keeping the "template_config" key preserves legacy intent when the
         # caller omits the config, so both input shapes share the Strategy gate.
+        # ``template_type`` rides along: a template-factory snapshot (full
+        # identity: template_key + template_uid) is rejected by the strategy
+        # unless ``engine_properties.template_type`` declares its type, and the
+        # internal surface only expresses that declaration through this fold.
         prepared = _prepare_with_engine_strategy(
-            replace(spec, engine_properties={"template_config": spec.template_config}),
+            replace(
+                spec,
+                engine_properties={
+                    "template_type": spec.template_type,
+                    "template_config": spec.template_config,
+                },
+            ),
             context,
         )
     else:

--- a/src/backend/src/agentclaw/community/core/bot_management/legacy_create_compat.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/legacy_create_compat.py
@@ -1,0 +1,91 @@
+"""Legacy internal-caller input folds for bot creation.
+
+The internal ``/api/bots`` surface still sends shapes the public surface has
+moved past: the ``aicoding`` engine alias, and top-level template fields
+instead of the ``engine_properties`` bag. Both folds live here — at the shared
+create seam — so ``create_flow`` works on the canonical form only.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import TYPE_CHECKING, Any
+
+from agentclaw.community.core.bot_management.engines.aicoding.strategy import (
+    AICODING_ENGINE_TYPE,
+    CLAUDE_CODE_ENGINE_TYPE,
+)
+from agentclaw.community.core.bot_management.engines.registry import (
+    normalize_engine_type,
+)
+from agentclaw.community.core.workspace.runtime_identity import (
+    AICODING_ENGINE_FORM,
+    ENGINE_FORM_KEY,
+)
+from agentclaw.community.log import get_logger
+
+if TYPE_CHECKING:
+    # TYPE_CHECKING-only: BotCreateSpec lives in create_flow, which imports
+    # this module — a runtime import would be circular.
+    from agentclaw.community.core.bot_management.create_flow import BotCreateSpec
+
+
+logger = get_logger()
+
+# Legacy internal-engine values folded at the shared create seam. ``aicoding``
+# is the internal implementation engine of ``claude_code``, not a product
+# engine: new bots store the real engine and carry the form marker
+# (``engine_form``) in their template snapshot instead (engine/form vocabulary
+# split — docs/superpowers/specs/2026-08-31-engine-vocabulary-template-form-design.md).
+_LEGACY_ENGINE_ALIASES = {AICODING_ENGINE_TYPE: CLAUDE_CODE_ENGINE_TYPE}
+
+
+def normalize_legacy_engine_alias(spec: BotCreateSpec) -> BotCreateSpec:
+    """Fold legacy internal-engine values into the real engine (old-link compat).
+
+    Internal callers (``/api/bots``) may still send ``engine_type="aicoding"``.
+    The bot is created on the real engine (``claude_code``); a template-backed
+    create records the server-managed ``engine_form`` marker in the template
+    snapshot so runtime/bucket routing stays equivalent. A plain no-template
+    bot has no form — it is simply a plain ``claude_code`` bot. The public
+    surface never reaches this: it rejects internal engines with 400.
+
+    Idempotent: a spec already on the real engine passes through unchanged.
+    """
+    real_engine = _LEGACY_ENGINE_ALIASES.get(
+        normalize_engine_type(spec.engine_type, default="")
+    )
+    if real_engine is None:
+        return spec
+    template_config = spec.template_config
+    if spec.template_type and template_config is not None:
+        template_config = {**template_config, ENGINE_FORM_KEY: AICODING_ENGINE_FORM}
+    logger.info(
+        "[create_flow] folded legacy engine alias: requested_engine=%s "
+        "engine=%s template_type=%s form_marker_written=%s",
+        spec.engine_type,
+        real_engine,
+        spec.template_type,
+        spec.template_type and template_config is not None,
+    )
+    return replace(
+        spec,
+        engine_type=real_engine,
+        template_config=template_config,
+    )
+
+
+def legacy_template_engine_properties(spec: BotCreateSpec) -> dict[str, Any]:
+    """Fold the legacy top-level template pair into the engine_properties bag.
+
+    Keeping the ``template_config`` key preserves legacy intent when the caller
+    omits the config. ``template_type`` rides along: a template-factory
+    snapshot (full identity: ``template_key`` + ``template_uid``) is rejected
+    by the strategy unless ``engine_properties.template_type`` declares its
+    type, and the internal surface only expresses that declaration through
+    this fold — the public surface's nested bag already carries it.
+    """
+    return {
+        "template_type": spec.template_type,
+        "template_config": spec.template_config,
+    }

--- a/src/backend/tests/community/core/bot_inventory/services/test_bot_inventory_service.py
+++ b/src/backend/tests/community/core/bot_inventory/services/test_bot_inventory_service.py
@@ -18,6 +18,8 @@ from agentclaw.community.core.bot_inventory.protocols import (
 )
 from agentclaw.community.core.bot_inventory.services.bot_inventory_service import (
     BotInventoryService,
+    _cloud_fetch_engines,
+    _select_aicoding_runtime_rows,
 )
 from agentclaw.community.core.bot_inventory.services.lifecycle_view import (
     BotLifecycleView,
@@ -790,3 +792,301 @@ def test_page_slice_missing_template_row_leaves_config_none() -> None:
 
     assert items[0].template_type == "applicationCoding"
     assert items[0].template_config is None
+
+
+# ── aicoding engine expansion (PR #1719 engine/form vocabulary split) ──────
+# ``engine=aicoding`` is claude_code's internal runtime form: the inventory
+# expands it to two fetch batches (legacy ``active_engine='aicoding'`` and
+# post-split ``active_engine='claude_code'``) then collapses them with
+# ``uses_aicoding_runtime``. These cases mock the bot port by engine value.
+
+
+def _by_engine_page(rows_by_engine: dict):
+    """side_effect: dispatch on kwargs['engine'], returning prebuilt rows."""
+
+    def _list(**kwargs):
+        rows = rows_by_engine.get(kwargs["engine"], [])
+        return {"total": len(rows), "items": list(rows)}
+
+    return _list
+
+
+def _cloud_row(
+    bot_id: str,
+    active_engine: str,
+    template_type: str | None = None,
+    bot_type: str = "personal",
+) -> dict:
+    return {
+        "id": abs(sum(ord(c) for c in bot_id)) % 100_000,
+        "bot_id": bot_id,
+        "bot_name": bot_id,
+        "bot_desc": "",
+        "active_engine": active_engine,
+        "template_type": template_type,
+        "bot_type": bot_type,
+        "status": "ACTIVE",
+        "owner_id": "u1",
+    }
+
+
+def _list_cloud(inventory, bot, rows_by_engine, *, page=1, page_size=10, engine="aicoding"):
+    bot.list_bots_by_conditions.side_effect = _by_engine_page(rows_by_engine)
+    return inventory.list_items(
+        owner_id="u1",
+        space=NoopBusinessSpaceContext().resolve_current(
+            owner_id="u1", header_space_id=None
+        ),
+        keyword=None,
+        engine=engine,
+        deploy_mode=DeployMode.CLOUD,
+        page=page,
+        page_size=page_size,
+    )
+
+
+@pytest.mark.unit
+def test_aicoding_engine_expands_to_two_batches(service) -> None:
+    inventory, bot, _ = service
+
+    items, total = _list_cloud(
+        inventory,
+        bot,
+        {
+            "aicoding": [_cloud_row("a1", "aicoding")],
+            "claude_code": [_cloud_row("c1", "claude_code", "applicationCoding")],
+        },
+    )
+
+    engines_called = [c.kwargs["engine"] for c in bot.list_bots_by_conditions.call_args_list]
+    assert engines_called == ["aicoding", "claude_code"]
+    assert {item.bot_id for item in items} == {"a1", "c1"}
+    assert total == 2
+
+
+@pytest.mark.unit
+def test_aicoding_expansion_includes_legacy_and_new_form_rows(service) -> None:
+    inventory, bot, _ = service
+
+    items, total = _list_cloud(
+        inventory,
+        bot,
+        {
+            "aicoding": [_cloud_row("legacy1", "aicoding", None)],
+            "claude_code": [
+                _cloud_row("new_app", "claude_code", "applicationCoding"),
+                _cloud_row("new_personal", "claude_code", "personalCoding"),
+            ],
+        },
+    )
+
+    assert {item.bot_id for item in items} == {"legacy1", "new_app", "new_personal"}
+    assert total == 3
+
+
+@pytest.mark.unit
+def test_aicoding_expansion_excludes_plain_claude_code(service) -> None:
+    inventory, bot, _ = service
+
+    items, total = _list_cloud(
+        inventory,
+        bot,
+        {
+            "aicoding": [_cloud_row("legacy1", "aicoding")],
+            "claude_code": [
+                _cloud_row("plain_normalcc", "claude_code", "normalCC"),
+                _cloud_row("plain_none", "claude_code", None),
+                _cloud_row("form_app", "claude_code", "applicationCoding"),
+            ],
+        },
+    )
+
+    assert {item.bot_id for item in items} == {"legacy1", "form_app"}
+    assert total == 2
+
+
+@pytest.mark.unit
+def test_aicoding_expansion_dedups_duplicate_bot_id(service) -> None:
+    inventory, bot, _ = service
+
+    items, total = _list_cloud(
+        inventory,
+        bot,
+        {
+            "aicoding": [_cloud_row("dup", "aicoding")],
+            "claude_code": [_cloud_row("dup", "claude_code", "applicationCoding")],
+        },
+    )
+
+    assert [item.bot_id for item in items] == ["dup"]
+    assert total == 1
+
+
+@pytest.mark.unit
+def test_aicoding_expansion_paginates_after_filter(service) -> None:
+    inventory, bot, _ = service
+
+    items, total = _list_cloud(
+        inventory,
+        bot,
+        {
+            "aicoding": [_cloud_row(f"a{i}", "aicoding") for i in range(3)],
+            "claude_code": [
+                _cloud_row("p1", "claude_code", "normalCC"),
+                _cloud_row("p2", "claude_code", None),
+            ],
+        },
+        page=1,
+        page_size=2,
+    )
+
+    # total is taken from the collapsed set (3 aicoding), not the raw 5 rows.
+    assert total == 3
+    assert len(items) == 2
+
+
+@pytest.mark.unit
+def test_aicoding_expansion_stops_when_upstream_total_is_unreliable(service) -> None:
+    """A short page with no reliable ``total`` still terminates the fan-out via
+    the ``len(page_items) < fetch_size`` break (the loop's second exit arm), not
+    only the total-reaching-exhaustion arm."""
+    inventory, bot, _ = service
+
+    def _list(**kwargs):
+        if kwargs["engine"] == "aicoding":
+            return {"items": [_cloud_row("a1", "aicoding")]}  # no ``total`` key
+        if kwargs["engine"] == "claude_code":
+            return {"items": [_cloud_row("c1", "claude_code", "applicationCoding")]}
+        return {"items": []}
+
+    bot.list_bots_by_conditions.side_effect = _list
+
+    items, total = inventory.list_items(
+        owner_id="u1",
+        space=NoopBusinessSpaceContext().resolve_current(
+            owner_id="u1", header_space_id=None
+        ),
+        keyword=None,
+        engine="aicoding",
+        deploy_mode=DeployMode.CLOUD,
+        page=1,
+        page_size=10,
+    )
+
+    assert {item.bot_id for item in items} == {"a1", "c1"}
+    assert total == 2
+
+
+@pytest.mark.unit
+def test_aicoding_expansion_forwards_owner_scoping_and_attach_opt_out(service) -> None:
+    inventory, bot, _ = service
+
+    _list_cloud(
+        inventory,
+        bot,
+        {
+            "aicoding": [_cloud_row("a1", "aicoding")],
+            "claude_code": [_cloud_row("c1", "claude_code", "applicationCoding")],
+        },
+    )
+
+    # Both batches inherit the owner scope and the template-attach opt-out.
+    for call in bot.list_bots_by_conditions.call_args_list:
+        assert call.kwargs["owner_id"] == "u1"
+        assert call.kwargs["attach_templates"] is False
+
+
+@pytest.mark.unit
+def test_aicoding_expansion_skips_non_cloud_bot_types(service) -> None:
+    """A fetched row carrying a non-cloud bot_type (e.g. a desktop row leaking
+    through) is dropped by the visibility filter, not surfaced as an item."""
+    inventory, bot, _ = service
+
+    items, total = _list_cloud(
+        inventory,
+        bot,
+        {
+            "aicoding": [
+                _cloud_row("a1", "aicoding"),
+                _cloud_row("sneaky", "aicoding", bot_type="desktop"),
+            ],
+            "claude_code": [_cloud_row("c1", "claude_code", "applicationCoding")],
+        },
+    )
+
+    assert {item.bot_id for item in items} == {"a1", "c1"}
+    assert total == 2
+
+
+@pytest.mark.unit
+def test_claude_code_engine_does_not_expand(service) -> None:
+    """Regression guard: engine=claude_code stays a single batch with no filter."""
+    inventory, bot, _ = service
+
+    items, total = _list_cloud(
+        inventory,
+        bot,
+        {
+            "claude_code": [
+                _cloud_row("form_app", "claude_code", "applicationCoding"),
+                _cloud_row("plain", "claude_code", "normalCC"),
+            ],
+        },
+        engine="claude_code",
+    )
+
+    assert [c.kwargs["engine"] for c in bot.list_bots_by_conditions.call_args_list] == [
+        "claude_code"
+    ]
+    # No collapse filter: the plain claude_code row is kept.
+    assert {item.bot_id for item in items} == {"form_app", "plain"}
+    assert total == 2
+
+
+@pytest.mark.unit
+def test_non_aicoding_engine_single_batch_unchanged(service) -> None:
+    """Regression guard: a normal engine stays a single batch with no filter."""
+    inventory, bot, _ = service
+
+    items, total = _list_cloud(
+        inventory,
+        bot,
+        {"teclaw": [_cloud_row("t1", "teclaw")]},
+        engine="teclaw",
+    )
+
+    assert [c.kwargs["engine"] for c in bot.list_bots_by_conditions.call_args_list] == [
+        "teclaw"
+    ]
+    assert {item.bot_id for item in items} == {"t1"}
+    assert total == 1
+
+
+@pytest.mark.unit
+def test_cloud_fetch_engines_branches() -> None:
+    # aicoding expands only when the normalized value matches the form literal.
+    assert _cloud_fetch_engines("aicoding") == ["aicoding", "claude_code"]
+    assert _cloud_fetch_engines("AICODING") == ["aicoding", "claude_code"]
+    assert _cloud_fetch_engines("aicoding ") == ["aicoding", "claude_code"]
+    # Non-matching engines pass through verbatim as a single batch.
+    assert _cloud_fetch_engines("claude_code") == ["claude_code"]
+    assert _cloud_fetch_engines("teclaw") == ["teclaw"]
+    assert _cloud_fetch_engines(None) == [None]
+
+
+@pytest.mark.unit
+def test_select_aicoding_runtime_rows_branches() -> None:
+    rows = [
+        _cloud_row("a", "aicoding"),
+        _cloud_row("b", "claude_code", "applicationCoding"),
+        _cloud_row("c", "claude_code", "personalCoding"),
+        _cloud_row("d", "claude_code", "normalCC"),
+        _cloud_row("e", "claude_code", None),
+        _cloud_row("f", "teclaw"),
+        # duplicate bot_id 'a' from the other batch — defensive dedup keeps one
+        _cloud_row("a", "claude_code", "applicationCoding"),
+    ]
+
+    out = _select_aicoding_runtime_rows(rows)
+
+    assert [r["bot_id"] for r in out] == ["a", "b", "c"]

--- a/src/backend/tests/community/core/bot_management/test_application_coding_create.py
+++ b/src/backend/tests/community/core/bot_management/test_application_coding_create.py
@@ -746,6 +746,22 @@ def test_factory_snapshot_gates_match_application_coding() -> None:
     assert prepared.template_config == _FACTORY_SNAPSHOT
 
 
+def test_legacy_fold_supplies_template_type_for_factory_snapshot() -> None:
+    # The internal /api/bots surface declares application-coding intent through
+    # top-level template_type/template_config; the fold into the
+    # engine_properties bag must carry template_type along, or the strategy's
+    # factory branch rejects a full-identity snapshot (template_key +
+    # template_uid) for lacking a declared type.
+    prepared = _prepare_spec(
+        _application_coding_spec(template_config=dict(_FACTORY_SNAPSHOT))
+    )
+    assert prepared.template_type == "applicationCoding"
+    assert prepared.template_config == _FACTORY_SNAPSHOT
+    # The bag is consumed by the strategy on success — re-feeding the prepared
+    # spec must not trip the mixed-source invariant.
+    assert prepared.engine_properties == {}
+
+
 def test_handcrafted_path_rejects_foreign_template_type() -> None:
     with pytest.raises(BotTemplateInvalidError):
         _strategy_prepare(


### PR DESCRIPTION
## Problem

Creating a bot via the internal `/api/bots` surface with a template-factory snapshot (full identity: `template_key` + `template_uid`, e.g. the 应用 Bot snapshot resolved from available-tc-list) failed with:

```json
{"success": false, "message": "engine_properties.template_type is required for template factory snapshots", "error_code": 400}
```

## Root cause

The internal surface declares application-coding intent through **top-level** `template_type`/`template_config` (`_bot_create_spec`). `create_flow._prepare_create` folds those into the `engine_properties` bag before the strategy gate, but the fold only carried `template_config` — `template_type` was dropped.

In `AicodingProvisioningStrategy.prepare_create`:
- `declarative_type = engine_properties.get("template_type")` → `None`
- `_is_factory_snapshot` → `True` (snapshot carries `template_key` + `template_uid`)
- the factory branch requires a declared type → 400

The public OpenAPI surface never hit this (its nested `engine_properties` body already carries `template_type`), and old internal callers with hand-written configs never hit it either (no factory identity → hand-crafted path, which tolerates a missing declaration). Only the new internal-route + factory-snapshot combination tripped.

## Solution

Fold `template_type` along with `template_config` in `create_flow.py` (`~/_prepare_create`'s `applicationCoding` branch; the `elif` guarantees the folded value). Behavior scan:
- factory snapshots: declared type present → passthrough succeeds, `template_type` lands as before
- hand-written configs: `declarative_type` becomes `"applicationCoding"`; the non-factory gate only rejects *foreign* declared values, so behavior is unchanged
- outside `_ENGINE_PROPERTIES_KEYS`: no; unknown-key gate passes

## Validation

- [x] RED: reverted fix → new test fails with the exact production error (`template_type is required for template factory snapshots`)
- [x] GREEN: `tests/community/core/bot_management/test_application_coding_create.py` 49 passed
- [x] Affected subsets: `core/bot_management` + `_flows/bot_management` → 1047 passed; `adapters/http/openapi_v1` (bot) → 668 passed, 2 skipped
- [x] Added regression: `test_legacy_fold_supplies_template_type_for_factory_snapshot`