### PR TITLE
fix(aliyun_ack): 修复沙箱环境变量配置丢失问题

### DIFF
--- a/src/baas/src/secbaas/community/plugins/sandbox/arca/aliyun_ack/_sandbox_plugin.py
+++ b/src/baas/src/secbaas/community/plugins/sandbox/arca/aliyun_ack/_sandbox_plugin.py
@@ -235,7 +235,7 @@ class AliyunAckSandboxPlugin(ArcaSandboxPlugin):
         Returns the deployment name.
         """
         images = self._default_images.get(template_id) or {}
-        config_envs = _parse_envs_string(images.pop("env", ""))
+        config_envs = _parse_envs_string(images.get("env", ""))
         merged_envs = {**config_envs, **(envs or {})}
         variables = _build_template_vars(
             uid,
@@ -249,6 +249,13 @@ class AliyunAckSandboxPlugin(ArcaSandboxPlugin):
             outbound_operation_rule=outbound_operation_rule,
         )
         rendered = _render_template(template_id, variables)
+        logger.info(
+            "[aliyun_ack] rendered template uid=%s namespace=%s template_id=%s\n%s",
+            uid,
+            namespace,
+            template_id,
+            rendered,
+        )
 
         docs = list(yaml.safe_load_all(rendered))
         client = self._client()
@@ -292,7 +299,6 @@ class AliyunAckSandboxPlugin(ArcaSandboxPlugin):
             ready_timeout_in_seconds * 3,
         )
         ready_timeout_in_seconds = ready_timeout_in_seconds * 3
-
 
         namespace = self._get_namespace()
         sandbox_id = f"{template_id}-{uuid.uuid4().hex[:12]}"

--- a/src/baas/tests/integration/core/service/paas/test_aliyun_ack_integration.py
+++ b/src/baas/tests/integration/core/service/paas/test_aliyun_ack_integration.py
@@ -78,6 +78,8 @@ def _select_aliyun_ack(bootstrap_init: ApplicationContainer) -> PaasServiceFacto
             "aliyun_ack_cluster": ack_cluster,
         }
     )
+    bootstrap_init.services.paas_sandbox_plugins.reset()
+    bootstrap_init.services.paas_service_factory.reset()
     return bootstrap_init.services.paas_service_factory()
 
 

--- a/src/baas/tests/unit/plugins/sandbox/arca/aliyun_ack/test_sandbox_plugin.py
+++ b/src/baas/tests/unit/plugins/sandbox/arca/aliyun_ack/test_sandbox_plugin.py
@@ -198,6 +198,102 @@ class TestCreateSyncSandbox:
                 )
         assert result == "avernet-agent-uid"
 
+    def test_create_with_config_envs(self) -> None:
+        """Config envs from default_images should be rendered into the Deployment."""
+        default_images = {
+            TEMPLATE_ID: {
+                "avernet-agent": "agent:latest",
+                "avernet-sidecar": "sidecar:latest",
+                "init": "init:latest",
+                "nas-server": "nas.example.com",
+                "env": "BCS_URL=ws://bcs.example.com/ws/bot;FOO=bar",
+            }
+        }
+        with _CoreHarness() as h:
+            _plugin(default_images=default_images).create_sync_sandbox(
+                template_id=TEMPLATE_ID, ready_timeout_in_seconds=1
+            )
+        deployment = next(
+            d for d in self._rendered_docs(h) if d.get("kind") == "Deployment"
+        )
+        envs = deployment["spec"]["template"]["spec"]["containers"][0]["env"]
+        env_map = {e["name"]: e["value"] for e in envs}
+        assert env_map["BCS_URL"] == "ws://bcs.example.com/ws/bot"
+        assert env_map["FOO"] == "bar"
+
+    def test_create_with_runtime_envs_override_config(self) -> None:
+        """Runtime envs should override config envs with the same key."""
+        default_images = {
+            TEMPLATE_ID: {
+                "avernet-agent": "agent:latest",
+                "avernet-sidecar": "sidecar:latest",
+                "init": "init:latest",
+                "nas-server": "nas.example.com",
+                "env": "BCS_URL=ws://config.example.com/ws/bot",
+            }
+        }
+        with _CoreHarness() as h:
+            _plugin(default_images=default_images).create_sync_sandbox(
+                template_id=TEMPLATE_ID,
+                envs={"BCS_URL": "ws://runtime.example.com/ws/bot"},
+                ready_timeout_in_seconds=1,
+            )
+        deployment = next(
+            d for d in self._rendered_docs(h) if d.get("kind") == "Deployment"
+        )
+        envs = deployment["spec"]["template"]["spec"]["containers"][0]["env"]
+        env_map = {e["name"]: e["value"] for e in envs}
+        assert env_map["BCS_URL"] == "ws://runtime.example.com/ws/bot"
+
+    def test_create_without_envs_no_env_section(self) -> None:
+        """When no envs are provided, the Deployment should have no env section."""
+        default_images = {
+            TEMPLATE_ID: {
+                "avernet-agent": "agent:latest",
+                "avernet-sidecar": "sidecar:latest",
+                "init": "init:latest",
+                "nas-server": "nas.example.com",
+                "env": "",
+            }
+        }
+        with _CoreHarness() as h:
+            _plugin(default_images=default_images).create_sync_sandbox(
+                template_id=TEMPLATE_ID, ready_timeout_in_seconds=1
+            )
+        deployment = next(
+            d for d in self._rendered_docs(h) if d.get("kind") == "Deployment"
+        )
+        container = deployment["spec"]["template"]["spec"]["containers"][0]
+        assert "env" not in container
+
+    def test_config_envs_not_mutated_across_calls(self) -> None:
+        """default_images config should not be mutated by repeated calls."""
+        default_images = {
+            TEMPLATE_ID: {
+                "avernet-agent": "agent:latest",
+                "avernet-sidecar": "sidecar:latest",
+                "init": "init:latest",
+                "nas-server": "nas.example.com",
+                "env": "BCS_URL=ws://bcs.example.com/ws/bot",
+            }
+        }
+        plugin = _plugin(default_images=default_images)
+        with _CoreHarness() as h:
+            plugin.create_sync_sandbox(
+                template_id=TEMPLATE_ID, ready_timeout_in_seconds=1
+            )
+            # Second call should still see the same config envs
+            plugin.create_sync_sandbox(
+                template_id=TEMPLATE_ID, ready_timeout_in_seconds=1
+            )
+        # Both calls should have rendered envs
+        for call in h.create_from_yaml.call_args_list:
+            docs = call.kwargs["yaml_objects"]
+            deployment = next(d for d in docs if d.get("kind") == "Deployment")
+            envs = deployment["spec"]["template"]["spec"]["containers"][0]["env"]
+            env_map = {e["name"]: e["value"] for e in envs}
+            assert env_map["BCS_URL"] == "ws://bcs.example.com/ws/bot"
+
 
 class TestConnect:
     def test_connect_success(self) -> None:


### PR DESCRIPTION
- 将 images.pop("env", "") 改为 images.get("env", "")，避免修改全局配置字典导致后续创建沙箱时环境变量丢失
- 新增模板渲染日志，便于排查环境变量注入问题
- 补充单元测试覆盖配置环境变量解析、运行时覆盖、无环境变量场景及配置不变性验证
- 修复集成测试中 dependency_injector 缓存未重置导致的选择器绑定问题

