### PR TITLE
  feat(agent): reset openclaw workspace HEARTBEAT.md from image template on startup

### DIFF
--- a/docker/agent/HEARTBEAT.md
+++ b/docker/agent/HEARTBEAT.md
@@ -1,0 +1,5 @@
+# HEARTBEAT.md
+
+# Keep this file empty (or with only comments) to skip heartbeat API calls.
+
+# Add tasks below when you want the agent to check something periodically.

--- a/docker/agent/avernet.dockerfile
+++ b/docker/agent/avernet.dockerfile
@@ -243,6 +243,15 @@ COPY docker/agent/openclaw.json /opt/openclaw.json.template
 # with a different provider scenario mounts its own file at the final path.
 COPY docker/agent/claude-settings.json /opt/claude-settings.json.template
 
+# HEARTBEAT.md template — staged in /opt like the templates above, but with
+# opposite runtime semantics. openclaw appends its own tasks to
+# workspace/HEARTBEAT.md while running, and /home/admin is NAS-mounted, so
+# the runtime copy persists across pod restarts. start_openclaw.sh copies
+# this template over it on EVERY startup (template-wins, unlike the
+# mount-wins claude-settings.json above), so each run starts from the
+# pristine empty heartbeat shipped in the image.
+COPY docker/agent/HEARTBEAT.md /opt/config/HEARTBEAT.md
+
 # Shared utility functions (logging, helpers).
 COPY docker/agent/util.sh /usr/local/bin/util.sh
 

--- a/docker/agent/start_openclaw.sh
+++ b/docker/agent/start_openclaw.sh
@@ -14,6 +14,9 @@
 #   1. Write .adaptorEnv (openclaw). Also clear a stale .relayEnv left by
 #      a previous claude_code pod, so a later manual
 #      `supervisorctl start claude_relay` cannot pick up old credentials.
+#      Then reset workspace/HEARTBEAT.md from the image template — openclaw
+#      appends tasks to that file at runtime and the /home/admin mount makes
+#      the runtime copy persist, so every startup must overwrite it.
 #   2. Wait for the supervisord socket
 #   3. Start the engine program via supervisorctl
 #   4. Wait for the engine /health endpoint
@@ -57,6 +60,23 @@ success "Engine env file written to $ADAPTOR_ENV_FILE"
 # would let a manual `supervisorctl start claude_relay` boot with old
 # credentials.
 rm -f /home/admin/.relayEnv
+
+# Reset the OpenClaw workspace heartbeat file from the image template.
+# openclaw reads and appends tasks to workspace/HEARTBEAT.md at runtime, and
+# /home/admin is NAS-mounted, so the runtime copy survives pod restarts. This
+# script runs after the mount (via docker exec start_service.sh) and before
+# openclaw's first on-demand start, so copying here overwrites whatever the
+# previous run generated. Unconditional copy — template-wins, the opposite
+# of start_claude_code.sh's mount-wins claude-settings.json staging.
+HEARTBEAT_TEMPLATE="/opt/config/HEARTBEAT.md"
+HEARTBEAT_TARGET="/home/admin/.openclaw/workspace/HEARTBEAT.md"
+if [ -f "$HEARTBEAT_TEMPLATE" ]; then
+    mkdir -p "$(dirname "$HEARTBEAT_TARGET")"
+    cp -f "$HEARTBEAT_TEMPLATE" "$HEARTBEAT_TARGET"
+    success "Workspace HEARTBEAT.md reset from template"
+else
+    warn "Heartbeat template missing at $HEARTBEAT_TEMPLATE - keeping existing file"
+fi
 
 # --- Step 2: Wait for supervisord socket ---
 


### PR DESCRIPTION
    
    openclaw appends tasks to ~/.openclaw/workspace/HEARTBEAT.md at runtime,
    and /home/admin is NAS-mounted, so agent-generated heartbeat content
    persists across pod restarts and stale tasks leak into fresh runs.
    
    Ship the pristine empty template in the image at /opt/config/HEARTBEAT.md
    (NAS mount shadows anything baked under /home/admin) and have
    start_openclaw.sh unconditionally copy it over the runtime file in
    Step 1, before openclaw's first on-demand start. Missing template only
    warns, keeping direct-recovery invocation of the script safe.
    
    Template-wins here — the opposite of claude-settings.json's mount-wins
    staging — since the goal is discarding persistent runtime state.