### PR TITLE
fix: 展示 Skill 共同编辑申请人的花名和工号

### DIFF
--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill_editor_request.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill_editor_request.py
@@ -167,7 +167,10 @@ class SkillEditorRequestRepository(SkillEditorRequestRepositoryProtocol):
             owner_id = owner[0]
             title = WorkOrderMessageTitle.SKILL_COLLABORATOR_PENDING.value
             content = WorkOrderMessageContent.SKILL_COLLABORATOR_PENDING.value.format(
-                applicant_name=applicant_name,
+                applicant_display=_applicant_display(
+                    applicant_user_id=applicant_user_id,
+                    applicant_name=applicant_name,
+                ),
                 skill_name=skill.name,
             )
             order = WorkOrderModel(
@@ -464,6 +467,13 @@ class SkillEditorRequestRepository(SkillEditorRequestRepositoryProtocol):
                 synchronize_session=False,
             )
         session.flush()
+
+
+def _applicant_display(*, applicant_user_id: str, applicant_name: str) -> str:
+    normalized_name = applicant_name.strip()
+    if not normalized_name or normalized_name == applicant_user_id:
+        return f"「{applicant_user_id}」"
+    return f"「{normalized_name}」({applicant_user_id})"
 
 
 __all__ = ["SkillEditorRequestRepository"]

--- a/src/backend/src/agentclaw/community/core/skill_center/README.md
+++ b/src/backend/src/agentclaw/community/core/skill_center/README.md
@@ -184,6 +184,17 @@ internal_dependencies:
 
 ### Change impact
 
+`SpaceSkillEditorRequestService` is an additional consumer of the existing
+`StaffDeptPlugin` profile lookup: newly created Skill editor-request approval
+notifications persist the applicant as `「花名」(工号)` when the directory returns
+a nickname. The production composition supplies the corporate directory
+implementation; community and local implementations, a missing nickname, and
+`StaffProfileLookupError` all degrade to the previous work-number-only display
+without blocking the approval request. This is write-time presentation data
+only: public APIs, list reads, and already persisted notifications remain
+unchanged. Contract coverage verifies lookup and fallback, while repository
+coverage verifies the exact persisted notification text.
+
 `SkillPackageValidator` is the pure package boundary shared by Local upload and
 future Draft/materialization workflows. It owns safe relative paths, archive
 limits, wrapper normalization, the single `SKILL.md` rule, manifest validation,

--- a/src/backend/src/agentclaw/community/core/skill_center/services/space_skill_editor_request_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/space_skill_editor_request_service.py
@@ -4,17 +4,33 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
+from injector import inject
+
 from agentclaw.community.core.repository.protocols.work_orders import (
     WorkOrderRepositoryProtocol,
 )
 from agentclaw.community.core.work_orders.errors import WorkOrderInvalidReasonError
+from agentclaw.community.log import get_logger
+from agentclaw.community.plugin_api.staff_dept import (
+    StaffDeptPlugin,
+    StaffProfileLookupError,
+)
+from agentclaw.community.utils.work_no import normalize_work_no_for_lookup
+
+
+logger = get_logger()
+
+
 class SpaceSkillEditorRequestService:
+    @inject
     def __init__(
         self,
         repository: WorkOrderRepositoryProtocol,
+        staff_dept: StaffDeptPlugin,
         env_provider: Callable[[], str],
     ) -> None:
         self._repository = repository
+        self._staff_dept = staff_dept
         self._env_provider = env_provider
 
     def create_request(
@@ -28,14 +44,33 @@ class SpaceSkillEditorRequestService:
         normalized = reason.strip()
         if not normalized or len(normalized) > 512:
             raise WorkOrderInvalidReasonError("reason must contain 1-512 characters")
+        applicant_name = self._get_applicant_name(
+            applicant_user_id=applicant_user_id
+        )
         return self._repository.create_skill_editor_request(
             space_id=space_id,
             skill_id=skill_id,
             applicant_user_id=applicant_user_id,
-            applicant_name=applicant_user_id,
+            applicant_name=applicant_name,
             apply_reason=normalized,
             env=self._env_provider(),
         )
+
+    def _get_applicant_name(self, *, applicant_user_id: str) -> str:
+        try:
+            profile = self._staff_dept.get_profile_by_work_no(
+                work_no=normalize_work_no_for_lookup(applicant_user_id)
+            )
+        except StaffProfileLookupError:
+            logger.warning(
+                "failed to resolve Skill editor applicant nickname; falling back to user id",
+                extra={"user_id": applicant_user_id},
+                exc_info=True,
+            )
+            return applicant_user_id
+
+        nickname = (profile.nick_name or "").strip()
+        return nickname[:128] or applicant_user_id
 
 
 __all__ = ["SpaceSkillEditorRequestService"]

--- a/src/backend/src/agentclaw/community/core/work_orders/models.py
+++ b/src/backend/src/agentclaw/community/core/work_orders/models.py
@@ -186,7 +186,7 @@ class WorkOrderMessageContent(StrEnum):
         "你共同编辑 Bot「{bot_name}」的申请未通过。拒绝原因：{review_remark}"
     )
     SKILL_COLLABORATOR_PENDING = (
-        "用户「{applicant_name}」申请共同编辑 Skill「{skill_name}」，请及时处理。"
+        "用户{applicant_display}申请共同编辑 Skill「{skill_name}」，请及时处理。"
     )
     SKILL_COLLABORATOR_APPROVED = "你共同编辑 Skill「{skill_name}」的申请已通过。"
     SKILL_COLLABORATOR_REJECTED = (

--- a/src/backend/src/agentclaw/community/di/modules/spaces_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/spaces_module.py
@@ -109,6 +109,7 @@ from agentclaw.community.core.skill_center.skill_package import SkillPackageVali
 from agentclaw.community.core.skill_center.draft_content import DraftContentStore
 from agentclaw.community.plugin_api.space_skill_source import SpaceSkillSourcePlugin
 from agentclaw.community.plugin_api.object_storage import ObjectStoragePlugin
+from agentclaw.community.plugin_api.staff_dept import StaffDeptPlugin
 from agentclaw.community.core.task_queue.services.registry import HandlerRegistry
 from agentclaw.community.core.task_queue.services.task_queue_service import (
     TaskQueueService,
@@ -217,10 +218,12 @@ class SpacesModule(Module):
     @provider
     @inject
     def space_skill_editor_request_service(
-        self, repository: WorkOrderRepositoryProtocol
+        self,
+        repository: WorkOrderRepositoryProtocol,
+        staff_dept: StaffDeptPlugin,
     ) -> SpaceSkillEditorRequestServiceProtocol:
         """Assemble editor-request policy with environment at the boundary."""
-        return SpaceSkillEditorRequestService(repository, get_current_env)
+        return SpaceSkillEditorRequestService(repository, staff_dept, get_current_env)
 
     @singleton
     @provider

--- a/src/backend/tests/community/contracts/test_space_skill_editor_request_service.py
+++ b/src/backend/tests/community/contracts/test_space_skill_editor_request_service.py
@@ -9,18 +9,26 @@ from agentclaw.community.core.skill_center.services.space_skill_editor_request_s
     SpaceSkillEditorRequestService,
 )
 from agentclaw.community.core.work_orders.models import WorkOrderStatus
+from agentclaw.community.plugin_api.staff_dept import (
+    StaffProfileInfo,
+    StaffProfileLookupError,
+)
 
 
 def test_space_skill_editor_request_service_routes_through_work_order_repository(
 ) -> None:
     repository = MagicMock()
+    staff_dept = MagicMock()
+    staff_dept.get_profile_by_work_no.return_value = StaffProfileInfo(
+        work_no="200177", nick_name="张三"
+    )
     repository.create_skill_editor_request.return_value.status = WorkOrderStatus.PENDING
-    service = SpaceSkillEditorRequestService(repository, lambda: "test")
+    service = SpaceSkillEditorRequestService(repository, staff_dept, lambda: "test")
     assert isinstance(service, SpaceSkillEditorRequestServiceProtocol)
     result = service.create_request(
         space_id=7,
         skill_id=9,
-        applicant_user_id="member-1",
+        applicant_user_id="200177",
         reason="  maintain together  ",
     )
 
@@ -28,8 +36,36 @@ def test_space_skill_editor_request_service_routes_through_work_order_repository
     repository.create_skill_editor_request.assert_called_once_with(
         space_id=7,
         skill_id=9,
-        applicant_user_id="member-1",
-        applicant_name="member-1",
+        applicant_user_id="200177",
+        applicant_name="张三",
+        apply_reason="maintain together",
+        env="test",
+    )
+    staff_dept.get_profile_by_work_no.assert_called_once_with(work_no="200177")
+
+
+def test_space_skill_editor_request_service_falls_back_to_work_no_when_profile_lookup_fails(
+) -> None:
+    repository = MagicMock()
+    staff_dept = MagicMock()
+    staff_dept.get_profile_by_work_no.side_effect = StaffProfileLookupError(
+        "directory unavailable"
+    )
+    repository.create_skill_editor_request.return_value.status = WorkOrderStatus.PENDING
+    service = SpaceSkillEditorRequestService(repository, staff_dept, lambda: "test")
+
+    service.create_request(
+        space_id=7,
+        skill_id=9,
+        applicant_user_id="200177",
+        reason="maintain together",
+    )
+
+    repository.create_skill_editor_request.assert_called_once_with(
+        space_id=7,
+        skill_id=9,
+        applicant_user_id="200177",
+        applicant_name="200177",
         apply_reason="maintain together",
         env="test",
     )

--- a/src/backend/tests/community/core/repository/implementations/test_space_market_work_order_repositories.py
+++ b/src/backend/tests/community/core/repository/implementations/test_space_market_work_order_repositories.py
@@ -231,6 +231,43 @@ def test_skill_editor_review_atomically_controls_manager_grant(
     assert (manager is not None) is manager_expected
 
 
+def test_skill_editor_request_persists_display_name_and_work_no(db) -> None:
+    spaces = SpaceRepository(db)
+    team, skill_id = _space_skill(db, spaces)
+    spaces.add_member(
+        space_id=team.id,
+        user_id="200177",
+        role=SpaceRole.MEMBER,
+        creator_id="owner-1",
+        env="dev",
+    )
+    repository = _work_orders(db)
+
+    order = repository.create_skill_editor_request(
+        space_id=team.id,
+        skill_id=skill_id,
+        applicant_user_id="200177",
+        applicant_name="张三",
+        apply_reason="maintain together",
+        env="dev",
+    )
+
+    with db.orm_session() as session:
+        content = (
+            session.query(WorkOrderNotificationModel)
+            .filter(
+                WorkOrderNotificationModel.work_order_id == order.id,
+                WorkOrderNotificationModel.env == "dev",
+            )
+            .one()
+            .content
+        )
+
+    assert content == (
+        "用户「张三」(200177)申请共同编辑 Skill「review-skill」，请及时处理。"
+    )
+
+
 def test_skill_editor_request_rejects_personal_space(db) -> None:
     spaces = SpaceRepository(db)
     with spaces.create_personal_transaction(


### PR DESCRIPTION
## 修复内容

- 创建 Skill 共同编辑申请时通过 `StaffDeptPlugin` 查询申请人花名。
- 新通知写入 `用户「花名」(工号)…`；花名缺失或目录异常时降级为原工号文案。
- 不变更公开 API、列表读取逻辑或历史通知数据。

## 验证

- `uv run pytest tests/ -q`（退出码 0）
- 相关 contract、repository、DI 与架构门禁通过。

## 传播范围

- 新增 `SpaceSkillEditorRequestService` 对既有 `StaffDeptPlugin` 的消费者依赖；生产、community 与 local 绑定保持兼容。