### PR TITLE
fix(bots/all): expand engine=aicoding query to the claude_code form

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_inventory/services/bot_inventory_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_inventory/services/bot_inventory_service.py
@@ -33,6 +33,11 @@ from agentclaw.community.core.bot_inventory.types import (
     ServiceLifecycleCard,
 )
 from agentclaw.community.core.bot_collaborator.models import PermissionLevel
+from agentclaw.community.core.workspace.runtime_identity import (
+    AICODING_ENGINE_FORM,
+    normalize_runtime_engine,
+    uses_aicoding_runtime,
+)
 from agentclaw.community.log import get_logger
 from agentclaw.community.core.bot_inventory.bot_inventory_service_protocol import BotInventoryServiceProtocol
 
@@ -253,6 +258,54 @@ class BotInventoryService(BotInventoryServiceProtocol):
         engine: str | None,
         bot_ids: list[str] | None = None,
     ) -> list[Mapping[str, Any]]:
+        engines = _cloud_fetch_engines(engine)
+        rows: list[Mapping[str, Any]] = []
+        for eng in engines:
+            rows.extend(
+                self._fetch_cloud_pages(
+                    engine=eng,
+                    owner_id=owner_id,
+                    space=space,
+                    keyword=keyword,
+                    bot_ids=bot_ids,
+                )
+            )
+        # aicoding is claude_code's internal runtime form (PR #1719 engine/form
+        # vocabulary split): engine=aicoding fetches aicoding + claude_code
+        # batches, then collapses them to the aicoding runtime read model here.
+        if len(engines) > 1:
+            rows = _select_aicoding_runtime_rows(rows)
+        visible: list[Mapping[str, Any]] = []
+        for row in rows:
+            if row.get("bot_type") not in (None, "", "personal", "service"):
+                continue
+            try:
+                self._business_space.assert_bot_visible_in_current_space(
+                    bot=row,
+                    owner_id=str(row.get("owner_id") or owner_id),
+                    current_space=space,
+                )
+            except BotInventoryPermissionError:
+                continue
+            visible.append(row)
+        return visible
+
+    def _fetch_cloud_pages(
+        self,
+        *,
+        engine: str | None,
+        owner_id: str,
+        space: BusinessSpaceRef,
+        keyword: str | None,
+        bot_ids: list[str] | None,
+    ) -> list[Mapping[str, Any]]:
+        """Page through one engine's matching bots until exhausted.
+
+        ``attach_templates=False`` is load-bearing: inventory cards never read
+        ``template_config`` at fetch time (the page-slice template attach in
+        ``_attach_page_templates`` is the single, bounded entry point), so each
+        pulled page skips the batched template read.
+        """
         rows: list[Mapping[str, Any]] = []
         fetch_size = 200
         page = 1
@@ -265,9 +318,6 @@ class BotInventoryService(BotInventoryServiceProtocol):
                 engine=engine,
                 status=None,
                 bot_ids=bot_ids,
-                # Inventory cards carry no template_config (verified: neither
-                # BotInventoryItem nor the router mapping reads it), so skip
-                # the batched template read on every pulled page.
                 attach_templates=False,
                 page=page,
                 page_size=fetch_size,
@@ -284,20 +334,7 @@ class BotInventoryService(BotInventoryServiceProtocol):
             if len(page_items) < fetch_size:
                 break
             page += 1
-        visible: list[Mapping[str, Any]] = []
-        for row in rows:
-            if row.get("bot_type") not in (None, "", "personal", "service"):
-                continue
-            try:
-                self._business_space.assert_bot_visible_in_current_space(
-                    bot=row,
-                    owner_id=str(row.get("owner_id") or owner_id),
-                    current_space=space,
-                )
-            except BotInventoryPermissionError:
-                continue
-            visible.append(row)
-        return visible
+        return rows
 
     def _list_local_rows(
         self,
@@ -533,3 +570,47 @@ def _passport_id(ext: Mapping[str, Any]) -> str | None:
 def _raise_if_desktop_service_error(exc: Exception) -> None:
     if exc.__class__.__name__ in {"DesktopBotServiceError", "DesktopBotOrphanError"}:
         raise BotInventoryUpstreamError("desktop service failed") from exc
+
+
+def _cloud_fetch_engines(engine: str | None) -> list[str | None]:
+    """Resolve a list engine filter into the fetch batches the SQL layer needs.
+
+    ``aicoding`` is ``claude_code``'s internal runtime form (PR #1719 engine/form
+    vocabulary split): querying ``engine=aicoding`` must match both legacy rows
+    with a literal ``active_engine='aicoding'`` and post-split rows whose
+    ``active_engine='claude_code'`` carries the form on its template. Other
+    engine values pass through as a single batch unchanged.
+    """
+    if normalize_runtime_engine(engine) == AICODING_ENGINE_FORM:
+        return [AICODING_ENGINE_FORM, "claude_code"]
+    return [engine]
+
+
+def _select_aicoding_runtime_rows(
+    rows: list[Mapping[str, Any]],
+) -> list[Mapping[str, Any]]:
+    """Collapse the expanded aicoding batches into the aicoding runtime read model.
+
+    ``template_config`` is None: inventory rows are fetched with
+    ``attach_templates=False`` and carry no form marker, but an aicoding form
+    always travels with a coding ``template_type`` (applicationCoding /
+    personalCoding), so ``uses_aicoding_runtime``'s template_type arm is
+    authoritative; legacy ``active_engine='aicoding'`` rows short-circuit on
+    the engine arm. The two batches are disjoint by ``active_engine``; the
+    bot_id dedup is a defensive guard against upstream duplication only.
+    """
+    seen: set[str] = set()
+    out: list[Mapping[str, Any]] = []
+    for row in rows:
+        bot_id = str(row.get("bot_id") or "")
+        if bot_id in seen:
+            continue
+        if not uses_aicoding_runtime(
+            active_engine=row.get("active_engine"),
+            template_type=row.get("template_type"),
+            template_config=None,
+        ):
+            continue
+        seen.add(bot_id)
+        out.append(row)
+    return out

--- a/src/backend/tests/community/core/bot_inventory/services/test_bot_inventory_service.py
+++ b/src/backend/tests/community/core/bot_inventory/services/test_bot_inventory_service.py
@@ -18,6 +18,8 @@ from agentclaw.community.core.bot_inventory.protocols import (
 )
 from agentclaw.community.core.bot_inventory.services.bot_inventory_service import (
     BotInventoryService,
+    _cloud_fetch_engines,
+    _select_aicoding_runtime_rows,
 )
 from agentclaw.community.core.bot_inventory.services.lifecycle_view import (
     BotLifecycleView,
@@ -790,3 +792,301 @@ def test_page_slice_missing_template_row_leaves_config_none() -> None:
 
     assert items[0].template_type == "applicationCoding"
     assert items[0].template_config is None
+
+
+# ── aicoding engine expansion (PR #1719 engine/form vocabulary split) ──────
+# ``engine=aicoding`` is claude_code's internal runtime form: the inventory
+# expands it to two fetch batches (legacy ``active_engine='aicoding'`` and
+# post-split ``active_engine='claude_code'``) then collapses them with
+# ``uses_aicoding_runtime``. These cases mock the bot port by engine value.
+
+
+def _by_engine_page(rows_by_engine: dict):
+    """side_effect: dispatch on kwargs['engine'], returning prebuilt rows."""
+
+    def _list(**kwargs):
+        rows = rows_by_engine.get(kwargs["engine"], [])
+        return {"total": len(rows), "items": list(rows)}
+
+    return _list
+
+
+def _cloud_row(
+    bot_id: str,
+    active_engine: str,
+    template_type: str | None = None,
+    bot_type: str = "personal",
+) -> dict:
+    return {
+        "id": abs(sum(ord(c) for c in bot_id)) % 100_000,
+        "bot_id": bot_id,
+        "bot_name": bot_id,
+        "bot_desc": "",
+        "active_engine": active_engine,
+        "template_type": template_type,
+        "bot_type": bot_type,
+        "status": "ACTIVE",
+        "owner_id": "u1",
+    }
+
+
+def _list_cloud(inventory, bot, rows_by_engine, *, page=1, page_size=10, engine="aicoding"):
+    bot.list_bots_by_conditions.side_effect = _by_engine_page(rows_by_engine)
+    return inventory.list_items(
+        owner_id="u1",
+        space=NoopBusinessSpaceContext().resolve_current(
+            owner_id="u1", header_space_id=None
+        ),
+        keyword=None,
+        engine=engine,
+        deploy_mode=DeployMode.CLOUD,
+        page=page,
+        page_size=page_size,
+    )
+
+
+@pytest.mark.unit
+def test_aicoding_engine_expands_to_two_batches(service) -> None:
+    inventory, bot, _ = service
+
+    items, total = _list_cloud(
+        inventory,
+        bot,
+        {
+            "aicoding": [_cloud_row("a1", "aicoding")],
+            "claude_code": [_cloud_row("c1", "claude_code", "applicationCoding")],
+        },
+    )
+
+    engines_called = [c.kwargs["engine"] for c in bot.list_bots_by_conditions.call_args_list]
+    assert engines_called == ["aicoding", "claude_code"]
+    assert {item.bot_id for item in items} == {"a1", "c1"}
+    assert total == 2
+
+
+@pytest.mark.unit
+def test_aicoding_expansion_includes_legacy_and_new_form_rows(service) -> None:
+    inventory, bot, _ = service
+
+    items, total = _list_cloud(
+        inventory,
+        bot,
+        {
+            "aicoding": [_cloud_row("legacy1", "aicoding", None)],
+            "claude_code": [
+                _cloud_row("new_app", "claude_code", "applicationCoding"),
+                _cloud_row("new_personal", "claude_code", "personalCoding"),
+            ],
+        },
+    )
+
+    assert {item.bot_id for item in items} == {"legacy1", "new_app", "new_personal"}
+    assert total == 3
+
+
+@pytest.mark.unit
+def test_aicoding_expansion_excludes_plain_claude_code(service) -> None:
+    inventory, bot, _ = service
+
+    items, total = _list_cloud(
+        inventory,
+        bot,
+        {
+            "aicoding": [_cloud_row("legacy1", "aicoding")],
+            "claude_code": [
+                _cloud_row("plain_normalcc", "claude_code", "normalCC"),
+                _cloud_row("plain_none", "claude_code", None),
+                _cloud_row("form_app", "claude_code", "applicationCoding"),
+            ],
+        },
+    )
+
+    assert {item.bot_id for item in items} == {"legacy1", "form_app"}
+    assert total == 2
+
+
+@pytest.mark.unit
+def test_aicoding_expansion_dedups_duplicate_bot_id(service) -> None:
+    inventory, bot, _ = service
+
+    items, total = _list_cloud(
+        inventory,
+        bot,
+        {
+            "aicoding": [_cloud_row("dup", "aicoding")],
+            "claude_code": [_cloud_row("dup", "claude_code", "applicationCoding")],
+        },
+    )
+
+    assert [item.bot_id for item in items] == ["dup"]
+    assert total == 1
+
+
+@pytest.mark.unit
+def test_aicoding_expansion_paginates_after_filter(service) -> None:
+    inventory, bot, _ = service
+
+    items, total = _list_cloud(
+        inventory,
+        bot,
+        {
+            "aicoding": [_cloud_row(f"a{i}", "aicoding") for i in range(3)],
+            "claude_code": [
+                _cloud_row("p1", "claude_code", "normalCC"),
+                _cloud_row("p2", "claude_code", None),
+            ],
+        },
+        page=1,
+        page_size=2,
+    )
+
+    # total is taken from the collapsed set (3 aicoding), not the raw 5 rows.
+    assert total == 3
+    assert len(items) == 2
+
+
+@pytest.mark.unit
+def test_aicoding_expansion_stops_when_upstream_total_is_unreliable(service) -> None:
+    """A short page with no reliable ``total`` still terminates the fan-out via
+    the ``len(page_items) < fetch_size`` break (the loop's second exit arm), not
+    only the total-reaching-exhaustion arm."""
+    inventory, bot, _ = service
+
+    def _list(**kwargs):
+        if kwargs["engine"] == "aicoding":
+            return {"items": [_cloud_row("a1", "aicoding")]}  # no ``total`` key
+        if kwargs["engine"] == "claude_code":
+            return {"items": [_cloud_row("c1", "claude_code", "applicationCoding")]}
+        return {"items": []}
+
+    bot.list_bots_by_conditions.side_effect = _list
+
+    items, total = inventory.list_items(
+        owner_id="u1",
+        space=NoopBusinessSpaceContext().resolve_current(
+            owner_id="u1", header_space_id=None
+        ),
+        keyword=None,
+        engine="aicoding",
+        deploy_mode=DeployMode.CLOUD,
+        page=1,
+        page_size=10,
+    )
+
+    assert {item.bot_id for item in items} == {"a1", "c1"}
+    assert total == 2
+
+
+@pytest.mark.unit
+def test_aicoding_expansion_forwards_owner_scoping_and_attach_opt_out(service) -> None:
+    inventory, bot, _ = service
+
+    _list_cloud(
+        inventory,
+        bot,
+        {
+            "aicoding": [_cloud_row("a1", "aicoding")],
+            "claude_code": [_cloud_row("c1", "claude_code", "applicationCoding")],
+        },
+    )
+
+    # Both batches inherit the owner scope and the template-attach opt-out.
+    for call in bot.list_bots_by_conditions.call_args_list:
+        assert call.kwargs["owner_id"] == "u1"
+        assert call.kwargs["attach_templates"] is False
+
+
+@pytest.mark.unit
+def test_aicoding_expansion_skips_non_cloud_bot_types(service) -> None:
+    """A fetched row carrying a non-cloud bot_type (e.g. a desktop row leaking
+    through) is dropped by the visibility filter, not surfaced as an item."""
+    inventory, bot, _ = service
+
+    items, total = _list_cloud(
+        inventory,
+        bot,
+        {
+            "aicoding": [
+                _cloud_row("a1", "aicoding"),
+                _cloud_row("sneaky", "aicoding", bot_type="desktop"),
+            ],
+            "claude_code": [_cloud_row("c1", "claude_code", "applicationCoding")],
+        },
+    )
+
+    assert {item.bot_id for item in items} == {"a1", "c1"}
+    assert total == 2
+
+
+@pytest.mark.unit
+def test_claude_code_engine_does_not_expand(service) -> None:
+    """Regression guard: engine=claude_code stays a single batch with no filter."""
+    inventory, bot, _ = service
+
+    items, total = _list_cloud(
+        inventory,
+        bot,
+        {
+            "claude_code": [
+                _cloud_row("form_app", "claude_code", "applicationCoding"),
+                _cloud_row("plain", "claude_code", "normalCC"),
+            ],
+        },
+        engine="claude_code",
+    )
+
+    assert [c.kwargs["engine"] for c in bot.list_bots_by_conditions.call_args_list] == [
+        "claude_code"
+    ]
+    # No collapse filter: the plain claude_code row is kept.
+    assert {item.bot_id for item in items} == {"form_app", "plain"}
+    assert total == 2
+
+
+@pytest.mark.unit
+def test_non_aicoding_engine_single_batch_unchanged(service) -> None:
+    """Regression guard: a normal engine stays a single batch with no filter."""
+    inventory, bot, _ = service
+
+    items, total = _list_cloud(
+        inventory,
+        bot,
+        {"teclaw": [_cloud_row("t1", "teclaw")]},
+        engine="teclaw",
+    )
+
+    assert [c.kwargs["engine"] for c in bot.list_bots_by_conditions.call_args_list] == [
+        "teclaw"
+    ]
+    assert {item.bot_id for item in items} == {"t1"}
+    assert total == 1
+
+
+@pytest.mark.unit
+def test_cloud_fetch_engines_branches() -> None:
+    # aicoding expands only when the normalized value matches the form literal.
+    assert _cloud_fetch_engines("aicoding") == ["aicoding", "claude_code"]
+    assert _cloud_fetch_engines("AICODING") == ["aicoding", "claude_code"]
+    assert _cloud_fetch_engines("aicoding ") == ["aicoding", "claude_code"]
+    # Non-matching engines pass through verbatim as a single batch.
+    assert _cloud_fetch_engines("claude_code") == ["claude_code"]
+    assert _cloud_fetch_engines("teclaw") == ["teclaw"]
+    assert _cloud_fetch_engines(None) == [None]
+
+
+@pytest.mark.unit
+def test_select_aicoding_runtime_rows_branches() -> None:
+    rows = [
+        _cloud_row("a", "aicoding"),
+        _cloud_row("b", "claude_code", "applicationCoding"),
+        _cloud_row("c", "claude_code", "personalCoding"),
+        _cloud_row("d", "claude_code", "normalCC"),
+        _cloud_row("e", "claude_code", None),
+        _cloud_row("f", "teclaw"),
+        # duplicate bot_id 'a' from the other batch — defensive dedup keeps one
+        _cloud_row("a", "claude_code", "applicationCoding"),
+    ]
+
+    out = _select_aicoding_runtime_rows(rows)
+
+    assert [r["bot_id"] for r in out] == ["a", "b", "c"]


### PR DESCRIPTION
## Problem
PR #1719 (engine/form vocabulary split) made `aicoding` an internal runtime form of `claude_code`, not a product engine: new AICoding bots store `active_engine='claude_code'` with the `engine_form='aicoding'` marker on their template snapshot, while only pre-#1719 bots keep a literal `active_engine='aicoding'`. `GET /openapi/v1/bots/all?engine=aicoding` filters by exact-match on `active_engine` (`repository/implementations/bot/bot.py`), so it silently returns only legacy bots and drops every post-#1719 AICoding bot — the exact set the frontend queries for. The inventory card also carries no `template_config` (`_build_item` leaves it null), so the frontend cannot recover the form client-side.

## Solution
Expand `engine=aicoding` at the `BotInventoryService` application layer only (`core/bot_inventory/services/bot_inventory_service.py`):
- `_list_cloud_rows` resolves `_cloud_fetch_engines(engine)`, which turns `aicoding` into two fetch batches — legacy `active_engine='aicoding'` plus `active_engine='claude_code'` — then collapses them with the existing `uses_aicoding_runtime` predicate (`core/workspace/runtime_identity.py`). The predicate keys off the row's `template_type` (applicationCoding/personalCoding), so **no extra template read** is needed; legacy `aicoding` rows short-circuit on the engine arm.
- Extracted `_fetch_cloud_pages` (mechanical loop split, zero behavior change) and two module-level pure helpers `_cloud_fetch_engines` / `_select_aicoding_runtime_rows` for direct unit testing.

Pagination already happens in the service layer (`_list_cloud_rows` fetches all matching rows, `list_items` slices), so the two-batch fan-out + collapse happens **before** the slice — no pagination drift. No frontend / repository SQL / Protocol / router changes.

## Validation
- Affected surface (bot_inventory module + architecture nails): 342 passed.
- Service unit tests: 27 passed (15 existing + 12 new — two-batch expansion, legacy+form inclusion, plain-claude_code exclusion, dedup, post-filter pagination, owner/attach forwarding, non-cloud bot_type drop, short-page-without-total exit, claude_code/teclaw regression guards, two pure-helper branch tests).
- ruff clean on both files.
- changed-line coverage 98.0% (CI gate ≥80%); the only 2 uncovered lines are pre-existing visible-filter `BotInventoryPermissionError` handler paths unrelated to this change.

## Compatibility and risk
- `engine=claude_code` keeps its prior exact-match semantics (returns all claude_code rows incl. aicoding form) — unchanged by design.
- Legacy `active_engine='aicoding'` rows still matched via the first batch — no stored-engine rewrite on the read path.
- `engine=aicoding` makes 2 DB round-trips on that query path only; consistent with the inventory's existing fetch-all-then-page model.

## Follow-ups (out of scope)
- `/bots` (non-all, `adapters/http/openapi_v1/bots/router.py:565`) has the same gap but pages in SQL — the same expansion would lose pagination; tracked separately.
- Local/desktop path: no aicoding form exists, intentionally untouched.
- Precision backstop (read `engine_form` from template for the contradictory `normalCC + engine_form=aicoding` data) is documented in code but not needed for any real form.