### PR TITLE
unify work-order event presentation

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/work_orders/converter.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/work_orders/converter.py
@@ -10,6 +10,8 @@ from agentclaw.community.core.work_orders.models import (
     WorkOrderMessageTitle,
     WorkOrderStatus,
     WorkOrderTitleKey,
+    notification_summary_for,
+    notification_title_for,
 )
 
 JsonObject = dict[str, Any]
@@ -39,10 +41,14 @@ _TITLE_KEY_BY_STATUS = {
 def display_title(
     stored_title: str | None,
     *,
+    event_type: str | None = None,
     biz_type: str | None = None,
     status: WorkOrderStatus | None = None,
-) -> str | None:
-    """Translate known persisted title formats and preserve unknown titles."""
+) -> str:
+    """Resolve titles from the event contract with legacy compatibility."""
+
+    if event_type is not None:
+        return notification_title_for(event_type, stored_title)
 
     key = _TITLE_KEY_BY_STORED_VALUE.get(stored_title or "")
     if key is not None:
@@ -52,6 +58,11 @@ def display_title(
     if biz_type == WorkOrderBizType.SPACE_JOIN.value and status is not None:
         return _TITLE_BY_KEY[_TITLE_KEY_BY_STATUS[status]]
     return stored_title
+
+
+def display_summary(event_type: str | None) -> str:
+    """Return the stable list/detail summary for an event."""
+    return notification_summary_for(event_type)
 
 
 def json_object(raw: str | None) -> JsonObject | None:

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/work_orders/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/work_orders/router.py
@@ -46,6 +46,7 @@ from agentclaw.community.adapters.http.openapi_v1.work_orders.schemas import (
     WorkOrderLegacyReviewResponse,
 )
 from agentclaw.community.adapters.http.openapi_v1.work_orders.converter import (
+    display_summary,
     display_title,
     json_object,
 )
@@ -132,7 +133,8 @@ def _list_item(item: DomainListItem) -> WorkOrderListItem:
             reviewed_at=None,
             recipient_user_id=notification.recipient_user_id,
             event_type=notification.event_type,
-            title=display_title(notification.title),
+            title=display_title(notification.title, event_type=notification.event_type) or "新的系统通知",
+            summary=display_summary(notification.event_type),
             content=json_object(notification.content),
             status=None,
             is_read=notification.is_read,
@@ -158,11 +160,14 @@ def _list_item(item: DomainListItem) -> WorkOrderListItem:
         if category is not None
         else WorkOrderItemType.APPROVAL
     )
+    event_type = notification.event_type if notification is not None else None
     title = display_title(
         notification.title if notification is not None else None,
+        event_type=event_type,
         biz_type=work_order.biz_type,
         status=work_order.status,
-    )
+    ) or "新的系统通知"
+    summary = display_summary(event_type)
     content = json_object(notification.content) if notification is not None else None
     return WorkOrderListItem(
         item_id=(
@@ -185,8 +190,9 @@ def _list_item(item: DomainListItem) -> WorkOrderListItem:
         recipient_user_id=notification.recipient_user_id
         if notification is not None
         else None,
-        event_type=notification.event_type if notification is not None else None,
+        event_type=event_type,
         title=title,
+        summary=summary,
         content=content,
         status=work_order.status,
         is_read=notification.is_read if notification is not None else None,
@@ -358,12 +364,15 @@ async def get_work_order(
             event_type=detail.event_type,
             title=display_title(
                 detail.title,
+                event_type=detail.event_type,
                 biz_type=work_order.biz_type,
                 status=work_order.status,
-            ),
+            ) or "新的系统通知",
+            summary=display_summary(detail.event_type),
             content=json_object(detail.content),
             status=work_order.status,
             reviewer_user_id=work_order.reviewer_user_id,
+            reviewer_user_name=detail.reviewer_user_name,
             review_remark=work_order.review_remark,
             reviewed_at=work_order.reviewed_at,
             biz_data=json_object(work_order.biz_data),
@@ -513,9 +522,11 @@ async def get_notification(
             event_type=record.event_type,
             title=display_title(
                 record.title,
+                event_type=record.event_type,
                 biz_type=record.biz_type,
                 status=detail.work_order_status,
-            ),
+            ) or "新的系统通知",
+            summary=display_summary(record.event_type),
             content=json_object(record.content),
             is_read=record.is_read,
             work_order_status=detail.work_order_status,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/work_orders/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/work_orders/schemas.py
@@ -372,7 +372,8 @@ class WorkOrderListItem(_UtcResponseModel):
     event_type: str | None = Field(
         description="Originating event, or null when no notification is attached."
     )
-    title: str | None = Field(description="Notification title, when available.")
+    title: str = Field(description="Canonical notification title.")
+    summary: str = Field(default="你有一条新的通知，请查看详情。", description="Stable notification summary.")
     content: dict[str, Any] | None = Field(
         description="Notification JSON object, or null when unavailable."
     )
@@ -407,7 +408,8 @@ class WorkOrderDetailResponse(_UtcResponseModel):
     event_type: str | None = Field(
         default=None, description="Legacy originating event, when available."
     )
-    title: str = Field(description="Display title of the work order.")
+    title: str = Field(description="Canonical display title of the work order.")
+    summary: str = Field(default="你有一条新的通知，请查看详情。", description="Stable notification summary.")
     content: dict[str, Any] | None = Field(
         default=None, description="Notification JSON object, when available."
     )
@@ -417,6 +419,9 @@ class WorkOrderDetailResponse(_UtcResponseModel):
     status: WorkOrderStatus = Field(description="Current work-order status.")
     reviewer_user_id: str | None = Field(
         description="Identifier of the reviewer after processing, otherwise null."
+    )
+    reviewer_user_name: str | None = Field(
+        description="Display name of the reviewer after processing, otherwise null."
     )
     review_remark: str | None = Field(
         description="Review comment after processing, otherwise null."
@@ -440,7 +445,8 @@ class NotificationDetailResponse(BaseModel):
         description="Presentation category of the notification."
     )
     event_type: str = Field(description="Legacy event represented by the notification.")
-    title: str = Field(description="Display title of the notification.")
+    title: str = Field(description="Canonical display title of the notification.")
+    summary: str = Field(default="你有一条新的通知，请查看详情。", description="Stable notification summary.")
     content: dict[str, Any] | None = Field(
         description="Notification JSON object, when present."
     )

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill_editor_request.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill_editor_request.py
@@ -34,6 +34,7 @@ from agentclaw.community.core.work_orders.models import (
     WorkOrderNotificationDraft,
     WorkOrderReviewResult,
     WorkOrderStatus,
+    notification_title_for,
 )
 from agentclaw.community.core.work_orders.repository.models import (
     WorkOrderApproverModel,
@@ -205,7 +206,9 @@ class SkillEditorRequestRepository(SkillEditorRequestRepositoryProtocol):
                     event_type=WorkOrderEventType.SKILL_COLLABORATOR_APPLIED.value,
                     biz_type=WorkOrderBizType.SKILL_COLLABORATOR.value,
                     biz_id=str(skill_id),
-                    title=title,
+                    title=notification_title_for(
+                        WorkOrderEventType.SKILL_COLLABORATOR_APPLIED.value, title
+                    ),
                     content=content,
                     env=env,
                 )
@@ -381,7 +384,10 @@ class SkillEditorRequestRepository(SkillEditorRequestRepositoryProtocol):
                     event_type=WorkOrderEventType.SKILL_COLLABORATOR_REVIEWED.value,
                     biz_type=WorkOrderBizType.SKILL_COLLABORATOR.value,
                     biz_id=str(skill_id),
-                    title=notification.title,
+                    title=notification_title_for(
+                        WorkOrderEventType.SKILL_COLLABORATOR_REVIEWED.value,
+                        notification.title,
+                    ),
                     content=notification.content,
                     env=env,
                 )

--- a/src/backend/src/agentclaw/community/core/repository/implementations/work_orders/bot_editor.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/work_orders/bot_editor.py
@@ -33,6 +33,7 @@ from agentclaw.community.core.work_orders.models import (
     WorkOrderNotificationDraft,
     WorkOrderReviewResult,
     WorkOrderStatus,
+    notification_title_for,
 )
 from agentclaw.community.core.work_orders.repository.models import (
     WorkOrderApproverModel,
@@ -193,7 +194,9 @@ class _BotEditorWorkOrderRepository:
                     event_type=WorkOrderEventType.BOT_COLLABORATOR_APPLIED.value,
                     biz_type=WorkOrderBizType.BOT_COLLABORATOR.value,
                     biz_id=bot_id,
-                    title=title,
+                    title=notification_title_for(
+                        WorkOrderEventType.BOT_COLLABORATOR_APPLIED.value, title
+                    ),
                     content=content,
                     env=env,
                 )
@@ -331,7 +334,10 @@ class _BotEditorWorkOrderRepository:
                         notification.biz_type, "value", notification.biz_type
                     ),
                     biz_id=notification.biz_id,
-                    title=notification.title,
+                    title=notification_title_for(
+                        getattr(notification.event_type, "value", notification.event_type),
+                        notification.title,
+                    ),
                     content=notification.content,
                     env=env,
                 )

--- a/src/backend/src/agentclaw/community/core/repository/implementations/work_orders/creation.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/work_orders/creation.py
@@ -24,6 +24,7 @@ from agentclaw.community.core.work_orders.models import (
     WorkOrderEventType,
     WorkOrderMessageContent,
     WorkOrderTitleKey,
+    notification_title_for,
 )
 from agentclaw.community.core.work_orders.repository.models import (
     WorkOrderApproverModel,
@@ -112,7 +113,7 @@ class _WorkOrderCreationRepository:
                     event_type=event_type,
                     biz_type=biz_type,
                     biz_id=biz_id,
-                    title=title,
+                    title=notification_title_for(event_type, title),
                     content=content,
                     env=env,
                 )
@@ -275,7 +276,9 @@ class _WorkOrderCreationRepository:
                         event_type=WorkOrderEventType.SPACE_JOIN_APPLIED.value,
                         biz_type=WorkOrderBizType.SPACE_JOIN.value,
                         biz_id=str(space_id),
-                        title=title,
+                        title=notification_title_for(
+                            WorkOrderEventType.SPACE_JOIN_APPLIED.value, title
+                        ),
                         content=content,
                         env=env,
                     )

--- a/src/backend/src/agentclaw/community/core/repository/implementations/work_orders/creation.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/work_orders/creation.py
@@ -105,6 +105,11 @@ class _WorkOrderCreationRepository:
                     )
 
             notifications = []
+            persisted_title = (
+                title
+                if event_type == WorkOrderEventType.SPACE_JOIN_APPLIED.value
+                else notification_title_for(event_type, title)
+            )
             for user_id in recipients:
                 notification = self._Notification(
                     work_order_id=work_order_id,
@@ -113,7 +118,7 @@ class _WorkOrderCreationRepository:
                     event_type=event_type,
                     biz_type=biz_type,
                     biz_id=biz_id,
-                    title=notification_title_for(event_type, title),
+                    title=persisted_title,
                     content=content,
                     env=env,
                 )
@@ -276,9 +281,7 @@ class _WorkOrderCreationRepository:
                         event_type=WorkOrderEventType.SPACE_JOIN_APPLIED.value,
                         biz_type=WorkOrderBizType.SPACE_JOIN.value,
                         biz_id=str(space_id),
-                        title=notification_title_for(
-                            WorkOrderEventType.SPACE_JOIN_APPLIED.value, title
-                        ),
+                        title=title,
                         content=content,
                         env=env,
                     )

--- a/src/backend/src/agentclaw/community/core/repository/implementations/work_orders/creation.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/work_orders/creation.py
@@ -23,7 +23,6 @@ from agentclaw.community.core.work_orders.models import (
     WorkOrderStatus,
     WorkOrderEventType,
     WorkOrderMessageContent,
-    WorkOrderTitleKey,
     notification_title_for,
 )
 from agentclaw.community.core.work_orders.repository.models import (
@@ -105,11 +104,6 @@ class _WorkOrderCreationRepository:
                     )
 
             notifications = []
-            persisted_title = (
-                title
-                if event_type == WorkOrderEventType.SPACE_JOIN_APPLIED.value
-                else notification_title_for(event_type, title)
-            )
             for user_id in recipients:
                 notification = self._Notification(
                     work_order_id=work_order_id,
@@ -118,7 +112,7 @@ class _WorkOrderCreationRepository:
                     event_type=event_type,
                     biz_type=biz_type,
                     biz_id=biz_id,
-                    title=persisted_title,
+                    title=notification_title_for(event_type, title),
                     content=content,
                     env=env,
                 )
@@ -260,7 +254,7 @@ class _WorkOrderCreationRepository:
             )
             db.add(row)
             db.flush()
-            title = WorkOrderTitleKey.SPACE_JOIN_PENDING.value
+            title = "空间加入申请待审批"
             content = WorkOrderMessageContent.SPACE_JOIN_PENDING.value.format(
                 applicant_name=applicant_name, space_name=space.name
             )
@@ -281,7 +275,9 @@ class _WorkOrderCreationRepository:
                         event_type=WorkOrderEventType.SPACE_JOIN_APPLIED.value,
                         biz_type=WorkOrderBizType.SPACE_JOIN.value,
                         biz_id=str(space_id),
-                        title=title,
+                        title=notification_title_for(
+                            WorkOrderEventType.SPACE_JOIN_APPLIED.value, title
+                        ),
                         content=content,
                         env=env,
                     )

--- a/src/backend/src/agentclaw/community/core/repository/implementations/work_orders/work_order.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/work_orders/work_order.py
@@ -51,7 +51,9 @@ from agentclaw.community.core.work_orders.models import (
     WorkOrderDecision,
     WorkOrderApproverStatus,
     WorkOrderEventCreatedResult,
+    WorkOrderEventType,
     reviewed_event_type_for,
+    notification_title_for,
 )
 from agentclaw.community.core.work_orders.repository.models import (
     WorkOrderModel,
@@ -822,7 +824,10 @@ class WorkOrderRepository(WorkOrderRepositoryProtocol):
                         notification.biz_type, "value", notification.biz_type
                     ),
                     biz_id=notification.biz_id,
-                    title=WorkOrderTitleKey[f"SPACE_JOIN_{target_status.value}"].value,
+                    title=notification_title_for(
+                        WorkOrderEventType.SPACE_JOIN_REVIEWED.value,
+                        notification.title,
+                    ),
                     content=notification.content,
                     env=env,
                 )

--- a/src/backend/src/agentclaw/community/core/repository/implementations/work_orders/work_order.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/work_orders/work_order.py
@@ -53,7 +53,6 @@ from agentclaw.community.core.work_orders.models import (
     WorkOrderEventCreatedResult,
     WorkOrderEventType,
     reviewed_event_type_for,
-    notification_title_for,
 )
 from agentclaw.community.core.work_orders.repository.models import (
     WorkOrderModel,
@@ -643,14 +642,11 @@ class WorkOrderRepository(WorkOrderRepositoryProtocol):
                 .first()
                 is not None
             )
-            event_type = (
-                notification.event_type
-                if notification is not None
-                else work_order.biz_type
-            )
-            title = (
-                notification.title if notification is not None else work_order.biz_type
-            )
+            # A work order without a notification has no originating event.
+            # Keep these fields empty so the delivery adapter can derive a
+            # compatible title from the business type and current status.
+            event_type = notification.event_type if notification is not None else None
+            title = notification.title if notification is not None else None
             return WorkOrderDetail(
                 work_order=work_order.to_record(),
                 event_type=event_type,
@@ -824,9 +820,10 @@ class WorkOrderRepository(WorkOrderRepositoryProtocol):
                         notification.biz_type, "value", notification.biz_type
                     ),
                     biz_id=notification.biz_id,
-                    title=notification_title_for(
-                        WorkOrderEventType.SPACE_JOIN_REVIEWED.value,
-                        notification.title,
+                    title=(
+                        WorkOrderTitleKey.SPACE_JOIN_APPROVED.value
+                        if target_status is WorkOrderStatus.APPROVED
+                        else WorkOrderTitleKey.SPACE_JOIN_REJECTED.value
                     ),
                     content=notification.content,
                     env=env,

--- a/src/backend/src/agentclaw/community/core/repository/implementations/work_orders/work_order.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/work_orders/work_order.py
@@ -47,12 +47,12 @@ from agentclaw.community.core.work_orders.models import (
     WorkOrderQueryType,
     WorkOrderReviewResult,
     WorkOrderStatus,
-    WorkOrderTitleKey,
     WorkOrderDecision,
     WorkOrderApproverStatus,
     WorkOrderEventCreatedResult,
     WorkOrderEventType,
     reviewed_event_type_for,
+    notification_title_for,
 )
 from agentclaw.community.core.work_orders.repository.models import (
     WorkOrderModel,
@@ -347,10 +347,8 @@ class WorkOrderRepository(WorkOrderRepositoryProtocol):
                     event_type=reviewed_event_type,
                     biz_type=order.biz_type,
                     biz_id=order.biz_id,
-                    title=(
-                        WorkOrderTitleKey[f"SPACE_JOIN_{target.value}"].value
-                        if order.biz_type == WorkOrderBizType.SPACE_JOIN.value
-                        else f"{order.biz_type} {target.value}"
+                    title=notification_title_for(
+                        reviewed_event_type, f"{order.biz_type} {target.value}"
                     ),
                     content=review_remark,
                     env=env,
@@ -820,10 +818,9 @@ class WorkOrderRepository(WorkOrderRepositoryProtocol):
                         notification.biz_type, "value", notification.biz_type
                     ),
                     biz_id=notification.biz_id,
-                    title=(
-                        WorkOrderTitleKey.SPACE_JOIN_APPROVED.value
-                        if target_status is WorkOrderStatus.APPROVED
-                        else WorkOrderTitleKey.SPACE_JOIN_REJECTED.value
+                    title=notification_title_for(
+                        WorkOrderEventType.SPACE_JOIN_REVIEWED.value,
+                        notification.title,
                     ),
                     content=notification.content,
                     env=env,

--- a/src/backend/src/agentclaw/community/core/spaces/services/space_member_service.py
+++ b/src/backend/src/agentclaw/community/core/spaces/services/space_member_service.py
@@ -27,6 +27,7 @@ from agentclaw.community.core.work_orders.models import (
     WorkOrderEventType,
     WorkOrderMessageContent,
     WorkOrderMessageTitle,
+    notification_title_for,
 )
 from agentclaw.community.log import get_logger
 from agentclaw.community.plugin_api.staff_dept import (
@@ -143,7 +144,10 @@ class SpaceMemberService(SpaceMemberServiceProtocol):
             applicant_user_id=None,
             approver_user_ids=[],
             recipient_user_ids=[normalized],
-            title=WorkOrderMessageTitle.SPACE_MEMBER_REMOVED.value,
+            title=notification_title_for(
+                WorkOrderEventType.SPACE_MEMBER_REMOVED.value,
+                WorkOrderMessageTitle.SPACE_MEMBER_REMOVED.value,
+            ),
             content={
                 "legacy_value": WorkOrderMessageContent.SPACE_MEMBER_REMOVED.format(
                     space_name=space.name

--- a/src/backend/src/agentclaw/community/core/work_orders/models.py
+++ b/src/backend/src/agentclaw/community/core/work_orders/models.py
@@ -56,48 +56,132 @@ class WorkOrderItemType(StrEnum):
 
 
 class WorkOrderEventType(StrEnum):
-    SPACE_JOIN_APPLIED = "SPACE_JOIN_APPLIED"
-    SPACE_JOIN_REVIEWED = "SPACE_JOIN_REVIEWED"
-    SPACE_MEMBER_ADDED = "SPACE_MEMBER_ADDED"
-    BOT_COLLABORATOR_APPLIED = "BOT_COLLABORATOR_APPLIED"
-    BOT_COLLABORATOR_REVIEWED = "BOT_COLLABORATOR_REVIEWED"
-    BOT_MEMBER_ADDED = "BOT_MEMBER_ADDED"
-    SKILL_COLLABORATOR_APPLIED = "SKILL_COLLABORATOR_APPLIED"
-    SKILL_COLLABORATOR_REVIEWED = "SKILL_COLLABORATOR_REVIEWED"
-    SKILL_MEMBER_ADDED = "SKILL_MEMBER_ADDED"
-    HUMAN2BOT_FRIEND_APPLIED = "HUMAN2BOT_FRIEND_APPLIED"
-    HUMAN2BOT_FRIEND_REVIEWED = "HUMAN2BOT_FRIEND_REVIEWED"
-    BOT2BOT_FRIEND_APPLIED = "BOT2BOT_FRIEND_APPLIED"
-    BOT2BOT_FRIEND_REVIEWED = "BOT2BOT_FRIEND_REVIEWED"
-    HUMAN2BOT_PUBLIC_ORDER_CREATED = "HUMAN2BOT_PUBLIC_ORDER_CREATED"
-    HUMAN2BOT_PUBLIC_ORDER_COMPLETED = "HUMAN2BOT_PUBLIC_ORDER_COMPLETED"
-    BOT2BOT_PUBLIC_ORDER_CREATED = "BOT2BOT_PUBLIC_ORDER_CREATED"
-    BOT2BOT_PUBLIC_ORDER_COMPLETED = "BOT2BOT_PUBLIC_ORDER_COMPLETED"
-    SPACE_MEMBER_REMOVED = "SPACE_MEMBER_REMOVED"
-    TASK_DISCOVERED = "TASK_DISCOVERED"
+    """Known notification events and their complete display contract.
+
+    Keeping the category, title, and summary beside the event value prevents
+    the event catalogue and presentation mappings from drifting apart.
+    """
+
+    def __new__(
+        cls,
+        value: str,
+        category: NotificationCategory,
+        title: str,
+        summary: str,
+    ):
+        member = str.__new__(cls, value)
+        member._value_ = value
+        member.notification_category = category
+        member.title = title
+        member.summary = summary
+        return member
+
+    SPACE_JOIN_APPLIED = (
+        "SPACE_JOIN_APPLIED", NotificationCategory.APPROVAL,
+        "空间加入申请待审批", "有新的空间加入申请，请及时处理。",
+    )
+    SPACE_JOIN_REVIEWED = (
+        "SPACE_JOIN_REVIEWED", NotificationCategory.NOTICE,
+        "空间加入申请已处理", "空间加入申请已有处理结果，请查看详情。",
+    )
+    SPACE_MEMBER_ADDED = (
+        "SPACE_MEMBER_ADDED", NotificationCategory.NOTICE,
+        "你已被添加到空间", "你已加入一个新的空间，请查看详情。",
+    )
+    SPACE_MEMBER_REMOVED = (
+        "SPACE_MEMBER_REMOVED", NotificationCategory.NOTICE,
+        "你已被移出空间", "你已被移出一个空间，请查看详情。",
+    )
+    BOT_COLLABORATOR_APPLIED = (
+        "BOT_COLLABORATOR_APPLIED", NotificationCategory.APPROVAL,
+        "Bot 共同编辑申请待审批", "有新的 Bot 共同编辑申请，请及时处理。",
+    )
+    BOT_COLLABORATOR_REVIEWED = (
+        "BOT_COLLABORATOR_REVIEWED", NotificationCategory.NOTICE,
+        "Bot 共同编辑申请已处理", "Bot 共同编辑申请已有处理结果，请查看详情。",
+    )
+    BOT_MEMBER_ADDED = (
+        "BOT_MEMBER_ADDED", NotificationCategory.NOTICE,
+        "你已被添加为 Bot 协作者", "你已获得一个 Bot 的协作权限，请查看详情。",
+    )
+    SKILL_COLLABORATOR_APPLIED = (
+        "SKILL_COLLABORATOR_APPLIED", NotificationCategory.APPROVAL,
+        "Skill 共同编辑申请待审批", "有新的 Skill 共同编辑申请，请及时处理。",
+    )
+    SKILL_COLLABORATOR_REVIEWED = (
+        "SKILL_COLLABORATOR_REVIEWED", NotificationCategory.NOTICE,
+        "Skill 共同编辑申请已处理", "Skill 共同编辑申请已有处理结果，请查看详情。",
+    )
+    SKILL_MEMBER_ADDED = (
+        "SKILL_MEMBER_ADDED", NotificationCategory.NOTICE,
+        "你已被添加为 Skill 协作者", "你已获得一个 Skill 的协作权限，请查看详情。",
+    )
+    HUMAN2BOT_FRIEND_APPLIED = (
+        "HUMAN2BOT_FRIEND_APPLIED", NotificationCategory.APPROVAL,
+        "人机好友申请待审批", "有新的人机好友申请，请及时处理。",
+    )
+    HUMAN2BOT_FRIEND_REVIEWED = (
+        "HUMAN2BOT_FRIEND_REVIEWED", NotificationCategory.NOTICE,
+        "人机好友申请已处理", "人机好友申请已有处理结果，请查看详情。",
+    )
+    BOT2BOT_FRIEND_APPLIED = (
+        "BOT2BOT_FRIEND_APPLIED", NotificationCategory.APPROVAL,
+        "Bot 好友申请待审批", "有新的 Bot 好友申请，请及时处理。",
+    )
+    BOT2BOT_FRIEND_REVIEWED = (
+        "BOT2BOT_FRIEND_REVIEWED", NotificationCategory.NOTICE,
+        "Bot 好友申请已处理", "Bot 好友申请已有处理结果，请查看详情。",
+    )
+    HUMAN2BOT_PUBLIC_ORDER_CREATED = (
+        "HUMAN2BOT_PUBLIC_ORDER_CREATED", NotificationCategory.NOTICE,
+        "人机公开订单已创建", "你有一条新的人机公开订单，请查看详情。",
+    )
+    HUMAN2BOT_PUBLIC_ORDER_COMPLETED = (
+        "HUMAN2BOT_PUBLIC_ORDER_COMPLETED", NotificationCategory.NOTICE,
+        "人机公开订单已完成", "一条人机公开订单已完成，请查看详情。",
+    )
+    BOT2BOT_PUBLIC_ORDER_CREATED = (
+        "BOT2BOT_PUBLIC_ORDER_CREATED", NotificationCategory.NOTICE,
+        "Bot 公开订单已创建", "你有一条新的 Bot 公开订单，请查看详情。",
+    )
+    BOT2BOT_PUBLIC_ORDER_COMPLETED = (
+        "BOT2BOT_PUBLIC_ORDER_COMPLETED", NotificationCategory.NOTICE,
+        "Bot 公开订单已完成", "一条 Bot 公开订单已完成，请查看详情。",
+    )
+    TASK_DISCOVERED = (
+        "TASK_DISCOVERED", NotificationCategory.NOTICE,
+        "发现新任务", "发现一条新任务，请查看详情。",
+    )
 
 
 EVENT_CATEGORIES: dict[WorkOrderEventType, NotificationCategory] = {
-    WorkOrderEventType.SPACE_JOIN_APPLIED: NotificationCategory.APPROVAL,
-    WorkOrderEventType.SPACE_JOIN_REVIEWED: NotificationCategory.NOTICE,
-    WorkOrderEventType.SPACE_MEMBER_ADDED: NotificationCategory.NOTICE,
-    WorkOrderEventType.BOT_COLLABORATOR_APPLIED: NotificationCategory.APPROVAL,
-    WorkOrderEventType.BOT_COLLABORATOR_REVIEWED: NotificationCategory.NOTICE,
-    WorkOrderEventType.BOT_MEMBER_ADDED: NotificationCategory.NOTICE,
-    WorkOrderEventType.SKILL_COLLABORATOR_APPLIED: NotificationCategory.APPROVAL,
-    WorkOrderEventType.SKILL_COLLABORATOR_REVIEWED: NotificationCategory.NOTICE,
-    WorkOrderEventType.SKILL_MEMBER_ADDED: NotificationCategory.NOTICE,
-    WorkOrderEventType.HUMAN2BOT_FRIEND_APPLIED: NotificationCategory.APPROVAL,
-    WorkOrderEventType.HUMAN2BOT_FRIEND_REVIEWED: NotificationCategory.NOTICE,
-    WorkOrderEventType.BOT2BOT_FRIEND_APPLIED: NotificationCategory.APPROVAL,
-    WorkOrderEventType.BOT2BOT_FRIEND_REVIEWED: NotificationCategory.NOTICE,
-    WorkOrderEventType.HUMAN2BOT_PUBLIC_ORDER_CREATED: NotificationCategory.NOTICE,
-    WorkOrderEventType.HUMAN2BOT_PUBLIC_ORDER_COMPLETED: NotificationCategory.NOTICE,
-    WorkOrderEventType.BOT2BOT_PUBLIC_ORDER_CREATED: NotificationCategory.NOTICE,
-    WorkOrderEventType.BOT2BOT_PUBLIC_ORDER_COMPLETED: NotificationCategory.NOTICE,
-    WorkOrderEventType.SPACE_MEMBER_REMOVED: NotificationCategory.NOTICE,
-    WorkOrderEventType.TASK_DISCOVERED: NotificationCategory.NOTICE,
+    event_type: event_type.notification_category for event_type in WorkOrderEventType
 }
+
+
+def event_type_definition(event_type: str | None) -> WorkOrderEventType | None:
+    """Return the canonical definition, or ``None`` for external/legacy values."""
+    try:
+        return WorkOrderEventType(event_type) if event_type else None
+    except ValueError:
+        return None
+
+
+def notification_title_for(
+    event_type: str | None, fallback_title: str | None = None
+) -> str:
+    """Return the canonical title while retaining a useful legacy fallback."""
+    definition = event_type_definition(event_type)
+    if definition is not None:
+        return definition.title
+    return fallback_title or "新的系统通知"
+
+
+def notification_summary_for(event_type: str | None) -> str:
+    """Return a non-empty summary for every known and unknown event."""
+    definition = event_type_definition(event_type)
+    return definition.summary if definition is not None else "你有一条新的通知，请查看详情。"
+
 
 # Approval events are extracted from the single classification table so new
 # event values only need one category entry above.
@@ -277,6 +361,7 @@ class WorkOrderDetail(BaseModel):
     space_id: int
     space_name: str
     applicant_name: str
+    reviewer_user_name: str | None = None
     can_approve: bool
 
 

--- a/src/backend/src/agentclaw/community/core/work_orders/models.py
+++ b/src/backend/src/agentclaw/community/core/work_orders/models.py
@@ -355,8 +355,8 @@ class WorkOrderListItem(BaseModel):
 
 class WorkOrderDetail(BaseModel):
     work_order: WorkOrderRecord
-    event_type: str
-    title: str
+    event_type: str | None
+    title: str | None
     content: str | None = None
     space_id: int
     space_name: str

--- a/src/backend/src/agentclaw/community/core/work_orders/services/work_order_service.py
+++ b/src/backend/src/agentclaw/community/core/work_orders/services/work_order_service.py
@@ -448,6 +448,24 @@ class WorkOrderService(WorkOrderServiceProtocol):
         nickname = (profile.nick_name or "").strip()
         return nickname[:128] or applicant_user_id
 
+    def _get_reviewer_name(self, *, reviewer_user_id: str | None) -> str | None:
+        if not reviewer_user_id:
+            return None
+        try:
+            profile = self._staff_dept.get_profile_by_work_no(
+                work_no=normalize_work_no_for_lookup(reviewer_user_id)
+            )
+        except StaffProfileLookupError:
+            logger.warning(
+                "failed to resolve reviewer nickname",
+                extra={"user_id": reviewer_user_id},
+                exc_info=True,
+            )
+            return None
+
+        nickname = (profile.nick_name or "").strip()
+        return nickname[:128] or None
+
     def list_items(
         self,
         *,
@@ -478,7 +496,13 @@ class WorkOrderService(WorkOrderServiceProtocol):
         )
         if detail is None:
             raise WorkOrderNotFoundError("work order not found")
-        return detail
+        return detail.model_copy(
+            update={
+                "reviewer_user_name": self._get_reviewer_name(
+                    reviewer_user_id=detail.work_order.reviewer_user_id
+                )
+            }
+        )
 
     def approve(self, *, work_order_id: int, actor_id: str, review_remark: str | None):
         normalized_remark = (review_remark or "").strip() or None

--- a/src/backend/tests/community/adapters/http/openapi_v1/work_orders/test_work_order_contract.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/work_orders/test_work_order_contract.py
@@ -411,13 +411,15 @@ def test_list_work_orders_maps_plain_and_notification_items(client, work_order_s
     assert items[0]["item_type"] == "APPROVAL"
     assert items[0]["notification_id"] is None
     assert items[0]["title"] == "空间加入申请待审批"
+    assert items[0]["summary"] == "你有一条新的通知，请查看详情。"
     assert items[0]["content"] is None
     assert items[0]["gmt_created"] == "2026-08-18T01:02:03"
     assert items[0]["gmt_modified"] == "2026-08-18T02:03:04"
     assert items[1]["item_id"] == "NOTIFICATION_21"
     assert items[1]["item_type"] == "NOTICE"
     assert items[1]["notification_id"] == 21
-    assert items[1]["title"] == "空间加入申请已通过"
+    assert items[1]["title"] == "空间加入申请已处理"
+    assert items[1]["summary"] == "空间加入申请已有处理结果，请查看详情。"
     assert items[1]["content"] == {"message": "approved"}
     assert items[1]["gmt_created"] == "2026-08-18T01:02:03"
     assert items[1]["gmt_modified"] == "2026-08-18T03:04:05"
@@ -464,23 +466,20 @@ def test_list_work_orders_derives_space_title_without_notification(
 
 
 @pytest.mark.parametrize(
-    ("stored_title", "expected"),
+    ("event_type", "stored_title", "expected"),
     [
-        ("空间加入申请待审批", "空间加入申请待审批"),
-        ("空间加入申请已通过", "空间加入申请已通过"),
-        ("空间加入申请未通过", "空间加入申请未通过"),
-        ("SPACE_JOIN APPROVED", "空间加入申请已通过"),
-        ("SPACE_JOIN REJECTED", "空间加入申请未通过"),
-        ("SPACE_JOIN_PENDING", "空间加入申请待审批"),
-        ("SPACE_JOIN_APPROVED", "空间加入申请已通过"),
-        ("SPACE_JOIN_REJECTED", "空间加入申请未通过"),
-        ("custom title", "custom title"),
+        (WorkOrderEventType.SPACE_JOIN_REVIEWED, None, "空间加入申请已处理"),
+        (WorkOrderEventType.SKILL_COLLABORATOR_APPLIED, None, "Skill 共同编辑申请待审批"),
+        (WorkOrderEventType.BOT2BOT_FRIEND_REVIEWED, "BOT_FRIEND APPROVED", "Bot 好友申请已处理"),
+        ("EXTERNAL_EVENT", "custom title", "custom title"),
     ],
 )
-def test_list_work_orders_translates_compatible_titles(
-    client, work_order_service, stored_title, expected
+def test_list_work_orders_uses_event_type_display_contract(
+    client, work_order_service, event_type, stored_title, expected
 ):
-    notification = _notification().model_copy(update={"title": stored_title})
+    notification = _notification().model_copy(
+        update={"event_type": event_type, "title": stored_title}
+    )
     work_order_service.list_items.return_value = (
         1,
         [
@@ -495,7 +494,9 @@ def test_list_work_orders_translates_compatible_titles(
     response = client.get("/openapi/v1/bots/work-orders")
 
     assert response.status_code == 200
-    assert response.json()["data"]["items"][0]["title"] == expected
+    item = response.json()["data"]["items"][0]
+    assert item["title"] == expected
+    assert item["summary"]
 
 
 def test_get_work_order_maps_nested_content(client, work_order_service):
@@ -667,7 +668,8 @@ def test_notification_detail_and_mark_read(client, notification_service):
         "work_order_id": 11,
         "notification_category": "APPROVAL",
         "event_type": "SPACE_JOIN_REVIEWED",
-        "title": "空间加入申请已通过",
+        "title": "空间加入申请已处理",
+        "summary": "空间加入申请已有处理结果，请查看详情。",
         "content": {"message": "approved"},
         "is_read": False,
         "work_order_status": "PENDING",
@@ -701,7 +703,8 @@ def test_notification_detail_wraps_historical_plain_text(client, notification_se
     response = client.get("/openapi/v1/bots/work-order-notifications/21")
 
     assert response.status_code == 200
-    assert response.json()["data"]["title"] == "空间加入申请已通过"
+    assert response.json()["data"]["title"] == "空间加入申请已处理"
+    assert response.json()["data"]["summary"] == "空间加入申请已有处理结果，请查看详情。"
     assert response.json()["data"]["content"] == {"legacy_value": "approved"}
 
 

--- a/src/backend/tests/community/adapters/http/openapi_v1/work_orders/test_work_order_contract.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/work_orders/test_work_order_contract.py
@@ -526,6 +526,29 @@ def test_get_work_order_maps_nested_content(client, work_order_service):
     )
 
 
+def test_get_work_order_without_notification_uses_business_status_title(
+    client, work_order_service
+):
+    work_order_service.get_detail.return_value = WorkOrderDetail(
+        work_order=_work_order(WorkOrderStatus.PENDING),
+        event_type=None,
+        title=None,
+        content=None,
+        space_id=7,
+        space_name="Team",
+        applicant_name="Applicant",
+        can_approve=True,
+    )
+
+    response = client.get("/openapi/v1/bots/work-orders/11")
+
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert data["event_type"] is None
+    assert data["title"] == "空间加入申请待审批"
+    assert data["summary"] == "你有一条新的通知，请查看详情。"
+
+
 def test_get_bot_editor_work_order_maps_business_content(client, work_order_service):
     record = _work_order(
         biz_data=json.dumps(

--- a/src/backend/tests/community/core/repository/implementations/test_space_market_work_order_repositories.py
+++ b/src/backend/tests/community/core/repository/implementations/test_space_market_work_order_repositories.py
@@ -50,7 +50,6 @@ from agentclaw.community.core.work_orders.models import (
     WorkOrderNotificationDraft,
     WorkOrderQueryType,
     WorkOrderStatus,
-    WorkOrderTitleKey,
 )
 from agentclaw.community.core.work_orders.repository.models import (
     WorkOrderApproverModel,
@@ -1046,7 +1045,7 @@ def test_work_order_repository_approve_and_notification_lifecycle(db) -> None:
     )
 
     notification = pending[0].notification
-    assert notification.title == "SPACE_JOIN_PENDING"
+    assert notification.title == "空间加入申请待审批"
     assert repository.count_unread(recipient_user_id="owner-1", env="dev") == 1
     owner_badge = repository.get_notification_badge_summary(
         recipient_user_id="owner-1", env="dev"
@@ -1168,7 +1167,7 @@ def test_work_order_repository_approve_and_notification_lifecycle(db) -> None:
     )
     assert applicant_total == 1
     applicant_notification = applicant_items[0].notification
-    assert applicant_notification.title == "SPACE_JOIN_APPROVED"
+    assert applicant_notification.title == "空间加入申请已处理"
     assert applicant_notification.content == approved_notification.content
     assert (
         repository.list_items(
@@ -1294,7 +1293,7 @@ def test_work_order_repository_rejects_and_requires_reviewer(db) -> None:
     )
     assert (
         applicant_items[0].notification.title
-        == "SPACE_JOIN_REJECTED"
+        == "空间加入申请已处理"
     )
     assert applicant_items[0].notification.content == "custom rejected content"
 
@@ -1332,33 +1331,6 @@ def test_badge_counts_distinct_pending_work_orders(db) -> None:
     assert summary.unread_count == 2
     assert summary.pending_approval_count == 1
     assert summary.badge_count == 1
-
-
-def test_space_join_event_persists_stable_title_key(db) -> None:
-    repository = WorkOrderRepository(db, _skill_editor_requests(db))
-
-    created = repository.create_work_order_event(
-        event_category=NotificationCategory.APPROVAL,
-        biz_type=WorkOrderBizType.SPACE_JOIN.value,
-        biz_id="space-join-1",
-        event_type=WorkOrderEventType.SPACE_JOIN_APPLIED.value,
-        applicant_user_id="applicant-space",
-        approver_user_ids=["reviewer-space"],
-        recipient_user_ids=[],
-        title=WorkOrderTitleKey.SPACE_JOIN_PENDING.value,
-        content="pending",
-        apply_reason=None,
-        biz_data=None,
-        env="dev",
-    )
-
-    with db.orm_session() as session:
-        assert (
-            session.query(WorkOrderNotificationModel.title)
-            .filter(WorkOrderNotificationModel.id == created.notification_ids[0])
-            .scalar()
-            == WorkOrderTitleKey.SPACE_JOIN_PENDING.value
-        )
 
 
 def test_friend_approval_context_and_reviewed_event_use_original_applied_event(

--- a/src/backend/tests/community/core/repository/implementations/test_space_market_work_order_repositories.py
+++ b/src/backend/tests/community/core/repository/implementations/test_space_market_work_order_repositories.py
@@ -50,7 +50,6 @@ from agentclaw.community.core.work_orders.models import (
     WorkOrderNotificationDraft,
     WorkOrderQueryType,
     WorkOrderStatus,
-    WorkOrderTitleKey,
 )
 from agentclaw.community.core.work_orders.repository.models import (
     WorkOrderApproverModel,
@@ -1044,7 +1043,7 @@ def test_work_order_repository_approve_and_notification_lifecycle(db) -> None:
     )
 
     notification = pending[0].notification
-    assert notification.title == WorkOrderTitleKey.SPACE_JOIN_PENDING.value
+    assert notification.title == "空间加入申请待审批"
     assert repository.count_unread(recipient_user_id="owner-1", env="dev") == 1
     owner_badge = repository.get_notification_badge_summary(
         recipient_user_id="owner-1", env="dev"
@@ -1166,7 +1165,7 @@ def test_work_order_repository_approve_and_notification_lifecycle(db) -> None:
     )
     assert applicant_total == 1
     applicant_notification = applicant_items[0].notification
-    assert applicant_notification.title == WorkOrderTitleKey.SPACE_JOIN_APPROVED.value
+    assert applicant_notification.title == "空间加入申请已处理"
     assert applicant_notification.content == approved_notification.content
     assert (
         repository.list_items(
@@ -1292,7 +1291,7 @@ def test_work_order_repository_rejects_and_requires_reviewer(db) -> None:
     )
     assert (
         applicant_items[0].notification.title
-        == WorkOrderTitleKey.SPACE_JOIN_REJECTED.value
+        == "空间加入申请已处理"
     )
     assert applicant_items[0].notification.content == "custom rejected content"
 

--- a/src/backend/tests/community/core/repository/implementations/test_space_market_work_order_repositories.py
+++ b/src/backend/tests/community/core/repository/implementations/test_space_market_work_order_repositories.py
@@ -50,6 +50,7 @@ from agentclaw.community.core.work_orders.models import (
     WorkOrderNotificationDraft,
     WorkOrderQueryType,
     WorkOrderStatus,
+    WorkOrderTitleKey,
 )
 from agentclaw.community.core.work_orders.repository.models import (
     WorkOrderApproverModel,
@@ -1033,6 +1034,8 @@ def test_work_order_repository_approve_and_notification_lifecycle(db) -> None:
     owner_detail = repository.get_detail(
         work_order_id=record.id, actor_id="owner-1", env="dev"
     )
+    assert owner_detail.event_type is not None
+    assert owner_detail.title is not None
     assert owner_detail.can_approve is True
     assert (
         repository.get_detail(work_order_id=record.id, actor_id="intruder", env="dev")
@@ -1043,7 +1046,7 @@ def test_work_order_repository_approve_and_notification_lifecycle(db) -> None:
     )
 
     notification = pending[0].notification
-    assert notification.title == "空间加入申请待审批"
+    assert notification.title == "SPACE_JOIN_PENDING"
     assert repository.count_unread(recipient_user_id="owner-1", env="dev") == 1
     owner_badge = repository.get_notification_badge_summary(
         recipient_user_id="owner-1", env="dev"
@@ -1165,7 +1168,7 @@ def test_work_order_repository_approve_and_notification_lifecycle(db) -> None:
     )
     assert applicant_total == 1
     applicant_notification = applicant_items[0].notification
-    assert applicant_notification.title == "空间加入申请已处理"
+    assert applicant_notification.title == "SPACE_JOIN_APPROVED"
     assert applicant_notification.content == approved_notification.content
     assert (
         repository.list_items(
@@ -1291,7 +1294,7 @@ def test_work_order_repository_rejects_and_requires_reviewer(db) -> None:
     )
     assert (
         applicant_items[0].notification.title
-        == "空间加入申请已处理"
+        == "SPACE_JOIN_REJECTED"
     )
     assert applicant_items[0].notification.content == "custom rejected content"
 
@@ -1329,6 +1332,33 @@ def test_badge_counts_distinct_pending_work_orders(db) -> None:
     assert summary.unread_count == 2
     assert summary.pending_approval_count == 1
     assert summary.badge_count == 1
+
+
+def test_space_join_event_persists_stable_title_key(db) -> None:
+    repository = WorkOrderRepository(db, _skill_editor_requests(db))
+
+    created = repository.create_work_order_event(
+        event_category=NotificationCategory.APPROVAL,
+        biz_type=WorkOrderBizType.SPACE_JOIN.value,
+        biz_id="space-join-1",
+        event_type=WorkOrderEventType.SPACE_JOIN_APPLIED.value,
+        applicant_user_id="applicant-space",
+        approver_user_ids=["reviewer-space"],
+        recipient_user_ids=[],
+        title=WorkOrderTitleKey.SPACE_JOIN_PENDING.value,
+        content="pending",
+        apply_reason=None,
+        biz_data=None,
+        env="dev",
+    )
+
+    with db.orm_session() as session:
+        assert (
+            session.query(WorkOrderNotificationModel.title)
+            .filter(WorkOrderNotificationModel.id == created.notification_ids[0])
+            .scalar()
+            == WorkOrderTitleKey.SPACE_JOIN_PENDING.value
+        )
 
 
 def test_friend_approval_context_and_reviewed_event_use_original_applied_event(

--- a/src/backend/tests/community/core/work_orders/test_event_type_presentation.py
+++ b/src/backend/tests/community/core/work_orders/test_event_type_presentation.py
@@ -1,0 +1,35 @@
+from agentclaw.community.core.work_orders.models import (
+    EVENT_CATEGORIES,
+    NotificationCategory,
+    WorkOrderEventType,
+    notification_summary_for,
+    notification_title_for,
+)
+
+
+def test_every_known_event_has_complete_display_contract():
+    assert set(EVENT_CATEGORIES) == set(WorkOrderEventType)
+    for event_type in WorkOrderEventType:
+        assert event_type.notification_category in (
+            NotificationCategory.APPROVAL,
+            NotificationCategory.NOTICE,
+        )
+        assert event_type.title
+        assert event_type.summary
+        assert notification_title_for(event_type.value) == event_type.title
+        assert notification_summary_for(event_type.value) == event_type.summary
+
+
+def test_unknown_event_keeps_supplied_title_and_uses_generic_summary():
+    assert notification_title_for("EXTERNAL_EVENT", "外部标题") == "外部标题"
+    assert notification_title_for("EXTERNAL_EVENT") == "新的系统通知"
+    assert notification_summary_for("EXTERNAL_EVENT") == "你有一条新的通知，请查看详情。"
+
+
+def test_known_event_overrides_historical_title():
+    assert (
+        notification_title_for(
+            WorkOrderEventType.SKILL_COLLABORATOR_APPLIED.value, "旧标题"
+        )
+        == "Skill 共同编辑申请待审批"
+    )

--- a/src/backend/tests/community/core/work_orders/test_work_order_service.py
+++ b/src/backend/tests/community/core/work_orders/test_work_order_service.py
@@ -733,6 +733,43 @@ def test_list_items_forwards_filters_and_normalizes_pagination() -> None:
     )
 
 
+def test_get_detail_resolves_reviewer_name_from_staff_directory() -> None:
+    staff_dept = MagicMock(spec=StaffDeptPlugin)
+    staff_dept.get_profile_by_work_no.return_value = StaffProfileInfo(
+        work_no="001234", nick_name=" Reviewer "
+    )
+    service, repository, *_ = _service(staff_dept=staff_dept)
+    repository.get_detail.return_value = _detail().model_copy(
+        update={
+            "work_order": _work_order().model_copy(
+                update={"reviewer_user_id": "1234"}
+            )
+        }
+    )
+
+    detail = service.get_detail(work_order_id=11, actor_id="owner-1")
+
+    assert detail.reviewer_user_name == "Reviewer"
+    staff_dept.get_profile_by_work_no.assert_called_once_with(work_no="001234")
+
+
+def test_get_detail_keeps_success_when_reviewer_lookup_fails() -> None:
+    staff_dept = MagicMock(spec=StaffDeptPlugin)
+    staff_dept.get_profile_by_work_no.side_effect = StaffProfileLookupError("down")
+    service, repository, *_ = _service(staff_dept=staff_dept)
+    repository.get_detail.return_value = _detail().model_copy(
+        update={
+            "work_order": _work_order().model_copy(
+                update={"reviewer_user_id": "1234"}
+            )
+        }
+    )
+
+    detail = service.get_detail(work_order_id=11, actor_id="owner-1")
+
+    assert detail.reviewer_user_name is None
+
+
 def test_get_detail_returns_record_and_missing_raises() -> None:
     service, repository, _, _, _ = _service()
     repository.get_detail.side_effect = [_detail(), None]

--- a/src/gateway/configs/schemas/bots.openapi.json
+++ b/src/gateway/configs/schemas/bots.openapi.json
@@ -15145,6 +15145,12 @@
             "title": "Notification Id",
             "type": "integer"
           },
+          "summary": {
+            "default": "你有一条新的通知，请查看详情。",
+            "description": "Stable notification summary.",
+            "title": "Summary",
+            "type": "string"
+          },
           "title": {
             "description": "Display title of the notification.",
             "title": "Title",
@@ -22533,9 +22539,27 @@
             "description": "Identifier of the reviewer after processing, otherwise null.",
             "title": "Reviewer User Id"
           },
+          "reviewer_user_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Display name of the reviewer after processing, otherwise null.",
+            "title": "Reviewer User Name"
+          },
           "status": {
             "$ref": "#/components/schemas/WorkOrderStatus",
             "description": "Current work-order status."
+          },
+          "summary": {
+            "default": "你有一条新的通知，请查看详情。",
+            "description": "Stable notification summary.",
+            "title": "Summary",
+            "type": "string"
           },
           "title": {
             "description": "Display title of the work order.",
@@ -22561,6 +22585,7 @@
           "title",
           "status",
           "reviewer_user_id",
+          "reviewer_user_name",
           "review_remark",
           "reviewed_at",
           "can_approve"
@@ -22937,6 +22962,12 @@
               }
             ],
             "description": "Related work-order status, when one exists."
+          },
+          "summary": {
+            "default": "你有一条新的通知，请查看详情。",
+            "description": "Stable notification summary.",
+            "title": "Summary",
+            "type": "string"
           },
           "title": {
             "anyOf": [


### PR DESCRIPTION
- 新增统一的事件类型枚举及对应标题、摘要、通知分类。
- 统一工单列表、详情和通知详情的返回展示。
- 兼容历史数据中的空标题、英文标题和旧审批标题。