### PR TITLE
fix(aicoding): unify engine-form matching across SQL filters and gates

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py
@@ -575,7 +575,14 @@ async def list_bots(
     ] = None,
     engine: Annotated[
         str | None,
-        Query(description="Filter: only bots on this engine, matched exactly."),
+        Query(
+            description=(
+                "Filter: only bots on this engine. Values other than 'aicoding' "
+                "match the stored engine exactly; 'aicoding' expands to both the "
+                "legacy literal spelling and post-split claude_code coding-form "
+                "bots (engine/form vocabulary split)."
+            ),
+        ),
     ] = None,
     status: Annotated[
         str | None,
@@ -791,7 +798,14 @@ async def list_inventory(
     ] = None,
     engine: Annotated[
         str | None,
-        Query(description="Filter inventory items by engine, matched exactly."),
+        Query(
+            description=(
+                "Filter inventory items by engine. Values other than 'aicoding' "
+                "match the stored engine exactly; 'aicoding' expands to both the "
+                "legacy literal spelling and post-split claude_code coding-form "
+                "bots (engine/form vocabulary split)."
+            ),
+        ),
     ] = None,
     deploy_mode: Annotated[
         DeployMode | None,

--- a/src/backend/src/agentclaw/community/core/bot_collaborator/services/aicoding/member_management_capability.py
+++ b/src/backend/src/agentclaw/community/core/bot_collaborator/services/aicoding/member_management_capability.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 
 from typing import Any, Dict, Mapping, Optional
 
+from agentclaw.community.core.workspace.runtime_identity import (
+    normalize_runtime_engine,
+)
 from agentclaw.community.log import get_logger
 
 logger = get_logger()
@@ -86,16 +89,24 @@ class AICodingMemberManagementCapability:
         """AICoding coding bots or opted-in templates use member management.
 
         应用 Coding Bot（``applicationCoding``）与个人 Coding Bot
-        （``personalCoding``）都运行在 ``claude_code`` 引擎上，并复用协作者表
-        做应用成员管理。其它 Bot 必须通过模板 ``member_management`` 显式开关
-        放行；模板开关是引擎无关的显式契约，一旦开启即代表该 Bot 支持成员
-        协作语义。
+        （``personalCoding``）复用协作者表做应用成员管理;引擎拼写按
+        engine/form 词汇分裂前后两半皆认（legacy ``aicoding`` 字面值与
+        ``claude_code``）。其它 Bot 必须通过模板 ``member_management`` 显式
+        开关放行；模板开关是引擎无关的显式契约，一旦开启即代表该 Bot 支持
+        成员协作语义。
         """
         if self._has_template_switch_enabled(bot, bot_id):
             return True
+        # 引擎拼写收敛:applicationCoding/personalCoding 的 coding bot 在
+        # engine/form 词汇分裂前后两半都存在(legacy ``active_engine='aicoding'``
+        # 与 ``claude_code``),按拼写任一命中即认定。枚举保持窄集——member
+        # 语义不随 runtime 谓词(uses_aicoding_runtime)放宽到 architect 等
+        # 其它 coding 模板形态。
+        engine = normalize_runtime_engine(bot.get("active_engine"))
         return (
-            bot.get("active_engine") == "claude_code"
-            and bot.get("template_type") in ("applicationCoding", "personalCoding")
+            engine in ("aicoding", "claude_code")
+            and bot.get("template_type")
+            in ("applicationCoding", "personalCoding")
         )
 
     def _has_template_switch_enabled(

--- a/src/backend/src/agentclaw/community/core/bot_collaborator/services/aicoding/utils/member_management.py
+++ b/src/backend/src/agentclaw/community/core/bot_collaborator/services/aicoding/utils/member_management.py
@@ -3,20 +3,26 @@ from __future__ import annotations
 
 from agentclaw.community.core.bot_collaborator.services.aicoding.member_management_capability import (
     AICodingMemberManagementCapability,
-    get_template_ext,
-    has_member_management_enabled,
 )
 from agentclaw.community.core.bot_collaborator.services.member_management_capability import (
     MemberManagementCapabilityService,
 )
+from agentclaw.community.core.workspace.runtime_identity import (
+    normalize_runtime_engine,
+)
 
 
 def is_coding_app_bot(bot: object) -> bool:
-    """Return whether the bot matches AICoding application-coding semantics."""
+    """Return whether the bot matches AICoding application-coding semantics.
+
+    引擎拼写按 engine/form 词汇分裂前后两半皆认（legacy ``aicoding`` 字面
+    值与 ``claude_code``）。
+    """
     if not isinstance(bot, dict):
         return False
+    engine = normalize_runtime_engine(bot.get("active_engine"))
     return (
-        bot.get("active_engine") == "claude_code"
+        engine in ("aicoding", "claude_code")
         and bot.get("template_type") == "applicationCoding"
     )
 

--- a/src/backend/src/agentclaw/community/core/repository/implementations/bot/bot.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/bot/bot.py
@@ -59,6 +59,45 @@ from agentclaw.community.core.repository.protocols.bot import (
 
 logger = get_logger()
 
+#: ``aicoding`` is ``claude_code``'s internal runtime form (engine/form
+#: vocabulary split), not an independently filterable engine value: a
+#: ``engine=aicoding`` filter must match both the legacy literal
+#: ``active_engine='aicoding'`` rows and the post-split ``claude_code`` rows
+#: carrying a coding template. The SQL criterion below mirrors
+#: ``workspace.runtime_identity.uses_aicoding_runtime`` arm-by-arm (legacy
+#: short-circuit / form marker / non-empty non-``normalCC`` template): the
+#: form-marker arm cannot be expressed on these columns (the marker lives in
+#: the ``ac_templates.ext`` snapshot), but every form-marked row also matches
+#: the template arm — creation writes the marker only for template-backed
+#: bots. Parity with the predicate is pinned by
+#: ``test_repository_engine_form_filter_parity``.
+_CODING_FORM_ENGINE = "aicoding"
+_REAL_CODING_ENGINE = "claude_code"
+_NEUTRAL_TEMPLATE_TYPE = "normalcc"
+
+
+def engine_form_filter_criterion(model: Any, engine: str) -> Any:
+    """One SQLAlchemy criterion for an engine filter value, form-aware.
+
+    ``aicoding`` expands to the union of both spellings; every other value
+    keeps its historical exact-match semantics (``engine=claude_code`` stays
+    the full claude_code population, aicoding form included — unchanged by
+    design, matching the /bots/all expansion).
+    """
+    normalized = (engine or "").strip().lower().replace("-", "_")
+    if normalized != _CODING_FORM_ENGINE:
+        return model.active_engine == engine
+    coding_template = and_(
+        model.template_type.isnot(None),
+        model.template_type != "",
+        func.lower(model.template_type) != _NEUTRAL_TEMPLATE_TYPE,
+    )
+    return or_(
+        model.active_engine == _CODING_FORM_ENGINE,
+        and_(model.active_engine == _REAL_CODING_ENGINE, coding_template),
+    )
+
+
 # Prod's exact ``update_by_owner`` allowlist. Any field not here
 # (e.g. engine_types, creator_id, entity_id) is silently ignored —
 # faithful prod parity.
@@ -385,7 +424,8 @@ class BotRepository(
             if space_id is not None:
                 query = query.filter(self.Model.space_id == space_id)
             if engine:
-                query = query.filter(self.Model.active_engine == engine)
+                # aicoding form-aware: exact-match for every other value.
+                query = query.filter(engine_form_filter_criterion(self.Model, engine))
             if status:
                 query = query.filter(self.Model.status == status)
             total = query.count()
@@ -873,9 +913,11 @@ class BotRepository(
             if bot_type:
                 query = query.filter(self.Model.bot_type == bot_type)
 
-            # active_engine 过滤
+            # active_engine 过滤 (aicoding form-aware: exact-match otherwise)
             if active_engine:
-                query = query.filter(self.Model.active_engine == active_engine)
+                query = query.filter(
+                    engine_form_filter_criterion(self.Model, active_engine)
+                )
 
             # bot_id 过滤
             if bot_id:

--- a/src/backend/src/agentclaw/community/core/repository/implementations/bot/bot.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/bot/bot.py
@@ -45,6 +45,9 @@ from injector import inject
 from sqlalchemy import and_, func, or_
 
 from agentclaw.community.core.bot_management.errors import BotLookupAmbiguousError
+from agentclaw.community.core.repository.implementations.bot.engine_filter import (
+    engine_criterion,
+)
 from agentclaw.community.core.repository.implementations.bot.reachability import (
     BotReachabilityQueries,
 )
@@ -58,44 +61,6 @@ from agentclaw.community.core.repository.protocols.bot import (
 )
 
 logger = get_logger()
-
-#: ``aicoding`` is ``claude_code``'s internal runtime form (engine/form
-#: vocabulary split), not an independently filterable engine value: a
-#: ``engine=aicoding`` filter must match both the legacy literal
-#: ``active_engine='aicoding'`` rows and the post-split ``claude_code`` rows
-#: carrying a coding template. The SQL criterion below mirrors
-#: ``workspace.runtime_identity.uses_aicoding_runtime`` arm-by-arm (legacy
-#: short-circuit / form marker / non-empty non-``normalCC`` template): the
-#: form-marker arm cannot be expressed on these columns (the marker lives in
-#: the ``ac_templates.ext`` snapshot), but every form-marked row also matches
-#: the template arm — creation writes the marker only for template-backed
-#: bots. Parity with the predicate is pinned by
-#: ``test_repository_engine_form_filter_parity``.
-_CODING_FORM_ENGINE = "aicoding"
-_REAL_CODING_ENGINE = "claude_code"
-_NEUTRAL_TEMPLATE_TYPE = "normalcc"
-
-
-def engine_form_filter_criterion(model: Any, engine: str) -> Any:
-    """One SQLAlchemy criterion for an engine filter value, form-aware.
-
-    ``aicoding`` expands to the union of both spellings; every other value
-    keeps its historical exact-match semantics (``engine=claude_code`` stays
-    the full claude_code population, aicoding form included — unchanged by
-    design, matching the /bots/all expansion).
-    """
-    normalized = (engine or "").strip().lower().replace("-", "_")
-    if normalized != _CODING_FORM_ENGINE:
-        return model.active_engine == engine
-    coding_template = and_(
-        model.template_type.isnot(None),
-        model.template_type != "",
-        func.lower(model.template_type) != _NEUTRAL_TEMPLATE_TYPE,
-    )
-    return or_(
-        model.active_engine == _CODING_FORM_ENGINE,
-        and_(model.active_engine == _REAL_CODING_ENGINE, coding_template),
-    )
 
 
 # Prod's exact ``update_by_owner`` allowlist. Any field not here
@@ -424,8 +389,7 @@ class BotRepository(
             if space_id is not None:
                 query = query.filter(self.Model.space_id == space_id)
             if engine:
-                # aicoding form-aware: exact-match for every other value.
-                query = query.filter(engine_form_filter_criterion(self.Model, engine))
+                query = query.filter(engine_criterion(self.Model, engine))
             if status:
                 query = query.filter(self.Model.status == status)
             total = query.count()
@@ -913,11 +877,9 @@ class BotRepository(
             if bot_type:
                 query = query.filter(self.Model.bot_type == bot_type)
 
-            # active_engine 过滤 (aicoding form-aware: exact-match otherwise)
+            # active_engine 过滤
             if active_engine:
-                query = query.filter(
-                    engine_form_filter_criterion(self.Model, active_engine)
-                )
+                query = query.filter(engine_criterion(self.Model, active_engine))
 
             # bot_id 过滤
             if bot_id:

--- a/src/backend/src/agentclaw/community/core/repository/implementations/bot/engine_filter.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/bot/engine_filter.py
@@ -1,0 +1,47 @@
+"""Engine-filter SQL criteria for the bot repository.
+
+``aicoding`` is ``claude_code``'s internal runtime form (engine/form
+vocabulary split), not an independently filterable engine value: a
+``engine=aicoding`` filter must match both the legacy literal
+``active_engine='aicoding'`` rows and the post-split ``claude_code`` rows
+carrying a coding template. The SQL criterion mirrors
+``workspace.runtime_identity.uses_aicoding_runtime`` arm-by-arm (legacy
+short-circuit / form marker / non-empty non-``normalCC`` template): the
+form-marker arm cannot be expressed on these columns (the marker lives in
+the ``ac_templates.ext`` snapshot), but every form-marked row also matches
+the template arm — creation writes the marker only for template-backed
+bots. Parity with the predicate is pinned by
+``test_bot_engine_form_filter``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy import and_, func, or_
+
+_CODING_FORM_ENGINE = "aicoding"
+_REAL_CODING_ENGINE = "claude_code"
+_NEUTRAL_TEMPLATE_TYPE = "normalcc"
+
+
+def engine_criterion(model: Any, engine: str) -> Any:
+    """One SQLAlchemy criterion for an engine filter value, form-aware.
+
+    ``aicoding`` expands to the union of both spellings; every other value
+    keeps its historical exact-match semantics (``engine=claude_code`` stays
+    the full claude_code population, aicoding form included — unchanged by
+    design, matching the /bots/all expansion).
+    """
+    normalized = (engine or "").strip().lower().replace("-", "_")
+    if normalized != _CODING_FORM_ENGINE:
+        return model.active_engine == engine
+    coding_template = and_(
+        model.template_type.isnot(None),
+        model.template_type != "",
+        func.lower(model.template_type) != _NEUTRAL_TEMPLATE_TYPE,
+    )
+    return or_(
+        model.active_engine == _CODING_FORM_ENGINE,
+        and_(model.active_engine == _REAL_CODING_ENGINE, coding_template),
+    )

--- a/src/backend/src/agentclaw/community/core/service_bot/services/bot_publish_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/bot_publish_service.py
@@ -1,7 +1,7 @@
 """Bot Publish Service - Bot发布服务业务逻辑层。"""
 import copy
 import threading
-from typing import Any, Callable, Dict, Optional, TYPE_CHECKING
+from typing import Any, Callable, Dict, Mapping, Optional, TYPE_CHECKING
 
 from agentclaw.community.core.service_bot.repository.models import BotPublishRecord, PublishStatus
 from agentclaw.community.core.repository.protocols.publishing import BotPublishRepositoryProtocol
@@ -35,6 +35,7 @@ from agentclaw.community.core.service_bot.services.arca_image_pin import (
 )
 from agentclaw.community.core.task_queue.services.task_queue_service import TaskQueueService
 from agentclaw.community.core.service_bot.types import PublishStage
+from agentclaw.community.core.workspace.runtime_identity import uses_aicoding_runtime
 from agentclaw.community.utils.avernet_tenant import bind_current_avernet_tenant
 from agentclaw.community.utils.env_utils import get_current_env
 from agentclaw.community.log import get_logger
@@ -1334,9 +1335,18 @@ class BotPublishService(PublishDraftRestoreMixin, PublishRollbackMixin):
                 f"Bot is already a service bot: bot_id={bot_id}"
             )
 
-        # 4. 检查是否为 aicoding 类型（不支持升级）
+        # 4. 检查是否为 aicoding 类型（不支持升级）。aicoding 是 claude_code 的
+        #    内部 runtime form（engine/form 词汇分裂），两半拼写都要拦：
+        #    legacy 字面 ``active_engine='aicoding'`` 与 ``claude_code`` +
+        #    coding 模板（uses_aicoding_runtime 三臂判定），否则 post-split 的
+        #    coding bot 会被放走升级、按 coding 容器做 service 化重启。
         active_engine = bot.get("active_engine", "")
-        if active_engine == "aicoding":
+        template_config = bot.get("template_config")
+        if uses_aicoding_runtime(
+            active_engine=active_engine,
+            template_type=bot.get("template_type"),
+            template_config=template_config if isinstance(template_config, Mapping) else None,
+        ):
             raise BotTypeNotSupportedError(
                 f"aicoding type bot cannot be upgraded to service: bot_id={bot_id}"
             )

--- a/src/backend/tests/community/core/bot_collaborator/test_member_management_utils.py
+++ b/src/backend/tests/community/core/bot_collaborator/test_member_management_utils.py
@@ -20,21 +20,29 @@ def _capability_service(template_service=None):
 def test_aicoding_capability_matches_coding_bots():
     capability = AICodingMemberManagementCapability()
 
-    # 应用 Coding Bot 与个人 Coding Bot（均在 claude_code 引擎上）放行
+    # 应用 Coding Bot 与个人 Coding Bot 放行;引擎拼写按 engine/form 词汇
+    # 分裂前后两半皆认(post-split ``claude_code`` 与 legacy ``aicoding`` 字面值)。
     assert capability.is_member_management_enabled(
         {"active_engine": "claude_code", "template_type": "applicationCoding"}, None
     ) is True
     assert capability.is_member_management_enabled(
         {"active_engine": "claude_code", "template_type": "personalCoding"}, None
     ) is True
-    # 非 coding 模板仍拒绝
+    assert capability.is_member_management_enabled(
+        {"active_engine": "aicoding", "template_type": "applicationCoding"}, None
+    ) is True
+    assert capability.is_member_management_enabled(
+        {"active_engine": "aicoding", "template_type": "personalCoding"}, None
+    ) is True
+    # 非 coding 模板仍拒绝;member 语义不随 runtime 谓词放宽到 architect 等
+    # 其它 coding 形态模板。
     assert capability.is_member_management_enabled(
         {"active_engine": "claude_code", "template_type": "chat"}, None
     ) is False
-    # personalCoding 仅 claude_code 引擎放行，其它引擎拒绝（实际不存在该组合，但保守不放行）
     assert capability.is_member_management_enabled(
-        {"active_engine": "aicoding", "template_type": "personalCoding"}, None
+        {"active_engine": "claude_code", "template_type": "architect"}, None
     ) is False
+    # personalCoding 的无关引擎(未参与词汇分裂的引擎)拒绝
     assert capability.is_member_management_enabled(
         {"active_engine": "openclaw", "template_type": "personalCoding"}, None
     ) is False
@@ -140,3 +148,25 @@ def test_capability_service_can_manage_collaborators_keeps_service_bot_behavior(
         "bot-123",
     ) is True
     assert service.can_manage_collaborators({"bot_type": "personal"}, "bot-123") is False
+
+
+def test_is_coding_app_bot_matches_both_engine_spells():
+    from agentclaw.community.core.bot_collaborator.services.aicoding.utils.member_management import (
+        is_coding_app_bot,
+    )
+
+    # 两半拼写皆认:post-split claude_code 与 legacy aicoding 字面值。
+    assert is_coding_app_bot(
+        {"active_engine": "claude_code", "template_type": "applicationCoding"}
+    ) is True
+    assert is_coding_app_bot(
+        {"active_engine": "aicoding", "template_type": "applicationCoding"}
+    ) is True
+    # personalCoding 不是应用 coding;无关引擎字典拼写拒绝。
+    assert is_coding_app_bot(
+        {"active_engine": "claude_code", "template_type": "personalCoding"}
+    ) is False
+    assert is_coding_app_bot(
+        {"active_engine": "openclaw", "template_type": "applicationCoding"}
+    ) is False
+    assert is_coding_app_bot("not-a-bot") is False

--- a/src/backend/tests/community/core/repository/implementations/test_bot_engine_form_filter.py
+++ b/src/backend/tests/community/core/repository/implementations/test_bot_engine_form_filter.py
@@ -1,0 +1,123 @@
+"""Parity between the SQL engine filter and ``uses_aicoding_runtime``.
+
+``engine_form_filter_criterion`` mirrors the runtime predicate arm-by-arm on
+the ``ac_bots`` column set (see its docstring in
+``repository/implementations/bot/bot.py``). This module pins that parity with
+in-memory SQLite: the rows the SQL criterion matches for ``engine=aicoding``
+are exactly the rows ``uses_aicoding_runtime`` accepts, across both vocabulary
+spells — and every other engine value keeps its exact-match semantics.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session
+
+from agentclaw.community.core.repository.implementations.bot.bot import (
+    engine_form_filter_criterion,
+)
+from agentclaw.community.core.workspace.runtime_identity import (
+    uses_aicoding_runtime,
+)
+from agentclaw.community.plugin_api.models import Base, BotModel
+
+pytestmark = pytest.mark.unit
+
+#: (suffix, active_engine, template_type) representative rows across the
+#: vocabulary split: legacy literal aicoding, post-split claude_code coding
+#: template forms, plain claude_code, and an unrelated engine.
+_ROWS = [
+    ("legacy_app", "aicoding", "applicationCoding"),
+    ("legacy_personal", "aicoding", "personalCoding"),
+    ("legacy_no_template", "aicoding", None),
+    ("new_app", "claude_code", "applicationCoding"),
+    ("new_personal", "claude_code", "personalCoding"),
+    ("new_architect", "claude_code", "architect"),
+    ("plain_cc", "claude_code", "normalCC"),
+    ("plain_cc_uppercase", "claude_code", "NORMALCC"),
+    ("plain_cc_no_template", "claude_code", None),
+    ("plain_cc_blank_template", "claude_code", ""),
+    ("openclaw_app", "openclaw", "applicationCoding"),
+    ("openclaw_no_template", "openclaw", None),
+    ("teclaw", "teclaw", None),
+]
+
+
+@pytest.fixture()
+def session() -> Session:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine, tables=[BotModel.__table__])
+    with Session(engine) as db:
+        for suffix, active_engine, template_type in _ROWS:
+            db.add(
+                BotModel(
+                    bot_id=f"bot_{suffix}",
+                    entity_id="u1",
+                    entity_type="staff",
+                    creator_id="u1",
+                    owner_id="u1",
+                    active_engine=active_engine,
+                    template_type=template_type,
+                )
+            )
+        db.commit()
+        yield db
+    engine.dispose()
+
+
+def _sql_matched(session: Session, engine_filter: str) -> set[str]:
+    rows = session.scalars(
+        select(BotModel).where(
+            engine_form_filter_criterion(BotModel, engine_filter)
+        )
+    ).all()
+    return {row.bot_id for row in rows}
+
+
+def _predicate_matches() -> set[str]:
+    return {
+        f"bot_{suffix}"
+        for suffix, active_engine, template_type in _ROWS
+        if uses_aicoding_runtime(
+            active_engine=active_engine,
+            template_type=template_type,
+        )
+    }
+
+
+def test_aicoding_filter_matches_the_runtime_predicate_exactly(session) -> None:
+    # Contract: SQL criterion == uses_aicoding_runtime over both vocabulary
+    # spells. If someone edits one side without the other, this fails. The
+    # form-marker arm cannot be expressed in SQL but is subsumed by the
+    # template arm (see the helper's docstring), so the sets stay equal.
+    assert _sql_matched(session, "aicoding") == _predicate_matches()
+    # Legacy literal rows survive and post-split forms are no longer dropped.
+    assert "bot_legacy_app" in _sql_matched(session, "aicoding")
+    assert "bot_new_app" in _sql_matched(session, "aicoding")
+    # Plain/neutral spellings stay excluded.
+    assert "bot_plain_cc" not in _sql_matched(session, "aicoding")
+    assert "bot_plain_cc_uppercase" not in _sql_matched(session, "aicoding")
+    assert "bot_plain_cc_no_template" not in _sql_matched(session, "aicoding")
+
+
+def test_non_aicoding_filters_keep_exact_match_semantics(session) -> None:
+    # Historical semantics are untouched for every other value:
+    # claude_code stays the full weight (aicoding form included), openclaw /
+    # teclaw stay literal. No expansion outside the aicoding value.
+    claude_code_rows = _sql_matched(session, "claude_code")
+    assert "bot_new_app" in claude_code_rows  # form included, unchanged
+    assert "bot_plain_cc" in claude_code_rows
+    assert "bot_legacy_app" not in claude_code_rows
+    assert not _sql_matched(session, "aicoding") & _sql_matched(session, "openclaw")
+    assert _sql_matched(session, "teclaw") == {"bot_teclaw"}
+
+
+def test_aicoding_spelling_normalization(session) -> None:
+    # The expansion keys off the same normalization as the registry: a
+    # differently-cased aicoding value still expands. (Hyphen variants are
+    # not part of the engine vocabulary — "ai-coding" normalizes to
+    # "ai_coding", a different value — and keep exact-match semantics.)
+    assert _sql_matched(session, "AICODING") == _sql_matched(session, "aicoding")
+    assert _sql_matched(session, " Aicoding ") == _sql_matched(session, "aicoding")
+    assert _sql_matched(session, "ai-coding") == set()

--- a/src/backend/tests/community/core/repository/implementations/test_bot_engine_form_filter.py
+++ b/src/backend/tests/community/core/repository/implementations/test_bot_engine_form_filter.py
@@ -1,11 +1,12 @@
 """Parity between the SQL engine filter and ``uses_aicoding_runtime``.
 
-``engine_form_filter_criterion`` mirrors the runtime predicate arm-by-arm on
-the ``ac_bots`` column set (see its docstring in
-``repository/implementations/bot/bot.py``). This module pins that parity with
-in-memory SQLite: the rows the SQL criterion matches for ``engine=aicoding``
-are exactly the rows ``uses_aicoding_runtime`` accepts, across both vocabulary
-spells — and every other engine value keeps its exact-match semantics.
+``engine_criterion`` (
+``repository/implementations/bot/engine_filter.py``) mirrors the runtime
+predicate arm-by-arm on the ``ac_bots`` column set. This module pins that
+parity with in-memory SQLite: the rows the SQL criterion matches for
+``engine=aicoding`` are exactly the rows ``uses_aicoding_runtime`` accepts,
+across both vocabulary spells — and every other engine value keeps its
+exact-match semantics.
 """
 
 from __future__ import annotations
@@ -14,8 +15,8 @@ import pytest
 from sqlalchemy import create_engine, select
 from sqlalchemy.orm import Session
 
-from agentclaw.community.core.repository.implementations.bot.bot import (
-    engine_form_filter_criterion,
+from agentclaw.community.core.repository.implementations.bot.engine_filter import (
+    engine_criterion,
 )
 from agentclaw.community.core.workspace.runtime_identity import (
     uses_aicoding_runtime,
@@ -69,7 +70,7 @@ def session() -> Session:
 def _sql_matched(session: Session, engine_filter: str) -> set[str]:
     rows = session.scalars(
         select(BotModel).where(
-            engine_form_filter_criterion(BotModel, engine_filter)
+            engine_criterion(BotModel, engine_filter)
         )
     ).all()
     return {row.bot_id for row in rows}

--- a/src/backend/tests/community/core/service_bot/services/test_bot_publish_service.py
+++ b/src/backend/tests/community/core/service_bot/services/test_bot_publish_service.py
@@ -1098,6 +1098,41 @@ class TestUpgradeBotToService:
             nick_name="Test User",
         )
 
+    @pytest.mark.parametrize(
+        "active_engine,template_type",
+        [
+            # legacy 字面拼写（历史行为，回归保护）
+            ("aicoding", "personalCoding"),
+            # post-split 形态:claude_code + coding 模板（修复前被放走）
+            ("claude_code", "applicationCoding"),
+            ("claude_code", "personalCoding"),
+        ],
+    )
+    def test_upgrade_rejects_both_aicoding_spells(self, active_engine, template_type):
+        """升级 gate 按两半拼写拦 aicoding 形态（engine/form 词汇分裂后）。"""
+        mock_bot_repo = Mock()
+        mock_bot_repo.get_by_id_and_owner.return_value = {
+            "id": 100,
+            "bot_id": "bot_001",
+            "bot_name": "Coding Bot",
+            "bot_type": "personal",
+            "active_engine": active_engine,
+            "template_type": template_type,
+            "owner_id": "user_001",
+        }
+        bcn_service = Mock()
+
+        service = _make_service(
+            bot_publish_repo=Mock(),
+            bot_repo=mock_bot_repo,
+            bcn_service=bcn_service,
+        )
+
+        with pytest.raises(BotTypeNotSupportedError):
+            service.upgrade_bot_to_service(bot_id="bot_001", owner_id="user_001")
+        # 拒升级时绝不能已触发 BCN 切换（修复前 claude_code 拼写一路走到这里）。
+        bcn_service.switch_bot.assert_not_called()
+
     def test_upgrade_bot_to_service_with_existing_publish(self):
         """已有发布记录时，只更新 bot_type，不创建新发布记录，返回已有发布记录，但会异步重启 Bot。"""
         # Arrange


### PR DESCRIPTION
## Problem

PR #1719 (engine/form vocabulary split) left four engine-identity checks matching a single spelling. After the split, "an aicoding bot" exists in two representations — legacy `active_engine='aicoding'` and `claude_code` + coding template — so each check silently drops or mis-routes half the population:

| Surface | Symptom |
|---|---|
| `GET /openapi/v1/bots?engine=aicoding` (`list_by_conditions` SQL) | Drops every post-split bot; `engine=claude_code` drops legacy rows |
| `POST /api/bots/search` (`search_bots` SQL) | Same, on the search surface |
| `upgrade_bot_to_service` | Only intercepts legacy `=='aicoding'`; post-split coding bots sail through the BCN switch and the coding-container service-ization restart |
| AICoding member-management capability | Requires the `claude_code` spelling; legacy `aicoding`+`personalCoding` bots are refused collaborator management |

Same gap class as the `/bots/all` inventory expansion already merged via #1869; this covers the SQL-paginated surfaces and the remaining literal gates.

## Solution

**SQL single-query expansion** (`engine_form_filter_criterion` in the bot repository): `engine=aicoding` expands to one OR criterion — `active_engine='aicoding'` OR (`claude_code` AND non-empty non-`normalCC` `template_type`). Unlike the service-layer two-batch fetch-and-collapse used by `/bots/all`, this keeps the count and pagination exact within a single query — the two-batch pattern would break SQL pagination. All other engine values keep exact-match semantics; query descriptions now state the expansion.

**Gate convergence**: `upgrade_bot_to_service` now intercepts via `uses_aicoding_runtime` (all three arms) **before** any external effect (BCN switch not called on rejection); member-management accepts both engine spells while keeping the template enum deliberately narrow (no broadening to architect — that stays an explicit template switch). Compat helper `is_coding_app_bot` follows, plus two dead re-export imports dropped (baseline pre-existing).

The SQL criterion mirrors `runtime_identity.uses_aicoding_runtime` arm-by-arm on the ac_bots columns; parity is pinned by `test_bot_engine_form_filter` across a representative row matrix of both spells — editing either side alone fails the test.

## Validation

- `test_bot_engine_form_filter`: 3 passed (SQL↔predicate parity, non-aicoding exact-match regressions, spelling normalization)
- repository + bot_collaborator + service_bot: 1266 passed
- openapi_v1 + contracts: 1883 passed, 2 skipped (query-description change does not break contract snapshots)
- ruff clean on all modified files

## Follow-ups (out of scope)

- `bot_service._allocate_device_async` / `create_bot_instances` skill-set symlinks: `engine_type = active_engine if =='claude_code' else None` sends legacy rows to the openclaw default bucket — touches the skill_set surface, tracked separately.
- `device_service` mcp sync passes bare `active_engine` without template_config (currently no visible delta; both buckets are identical today).
- Error-code split: same `BotTemplateInvalidError` maps 400 (internal) vs 422 (public) — the long-pending engine-properties review decision.
