### PR TITLE
fix: 展示 Skill 协作者花名及工号

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/spaces/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/spaces/router.py
@@ -510,6 +510,7 @@ async def list_space_skill_grants(
 @router.put(
     "/{space_id}/skills/{skill_id}/managers/{manager_user_id}",
     response_model=Envelope[SkillGrantItem],
+    response_model_exclude_none=True,
     dependencies=_REFUSES_APP_ONLY,
 )
 @envelope_errors
@@ -533,6 +534,7 @@ async def add_space_skill_manager(
 @router.delete(
     "/{space_id}/skills/{skill_id}/managers/{manager_user_id}",
     response_model=Envelope[SkillGrantItem],
+    response_model_exclude_none=True,
     dependencies=_REFUSES_APP_ONLY,
 )
 @envelope_errors

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/spaces/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/spaces/schemas.py
@@ -70,6 +70,7 @@ class SkillGrantItem(BaseModel):
     """One active OWNER or MANAGER Grant."""
 
     user_id: str = Field(description="User holding this active Skill Grant.")
+    display_name: str | None = Field(None, description="Current staff-directory display name.")
     role: SkillRole = Field(description="Role held by the user for this Skill.")
 
 

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill_editor_request.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill_editor_request.py
@@ -35,6 +35,7 @@ from agentclaw.community.core.work_orders.models import (
     WorkOrderReviewResult,
     WorkOrderStatus,
     notification_title_for,
+    skill_collaborator_applicant_display,
 )
 from agentclaw.community.core.work_orders.repository.models import (
     WorkOrderApproverModel,
@@ -168,7 +169,7 @@ class SkillEditorRequestRepository(SkillEditorRequestRepositoryProtocol):
             owner_id = owner[0]
             title = WorkOrderMessageTitle.SKILL_COLLABORATOR_PENDING.value
             content = WorkOrderMessageContent.SKILL_COLLABORATOR_PENDING.value.format(
-                applicant_display=_applicant_display(
+                applicant_display=skill_collaborator_applicant_display(
                     applicant_user_id=applicant_user_id,
                     applicant_name=applicant_name,
                 ),
@@ -473,13 +474,4 @@ class SkillEditorRequestRepository(SkillEditorRequestRepositoryProtocol):
                 synchronize_session=False,
             )
         session.flush()
-
-
-def _applicant_display(*, applicant_user_id: str, applicant_name: str) -> str:
-    normalized_name = applicant_name.strip()
-    if not normalized_name or normalized_name == applicant_user_id:
-        return f"「{applicant_user_id}」"
-    return f"「{normalized_name}」({applicant_user_id})"
-
-
 __all__ = ["SkillEditorRequestRepository"]

--- a/src/backend/src/agentclaw/community/core/repository/protocols/skill_center_types.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/skill_center_types.py
@@ -93,6 +93,7 @@ class SpaceSkillGrantItem(TypedDict):
 
     user_id: str
     role: Literal["OWNER", "MANAGER"]
+    display_name: NotRequired[str | None]
 
 
 class SpaceSkillGrantSetRecord(TypedDict):

--- a/src/backend/src/agentclaw/community/core/skill_center/services/space_skill_grant_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/space_skill_grant_service.py
@@ -20,6 +20,15 @@ from agentclaw.community.core.skill_center.errors import (
 )
 from agentclaw.community.core.spaces.models import SpaceRole, SpaceType
 from agentclaw.community.core.spaces.protocols import SpaceAccessServiceProtocol
+from agentclaw.community.log import get_logger
+from agentclaw.community.plugin_api.staff_dept import (
+    StaffDeptPlugin,
+    StaffProfileLookupError,
+)
+from agentclaw.community.utils.work_no import normalize_work_no_for_lookup
+
+
+logger = get_logger()
 
 
 def space_skill_actor_permissions(
@@ -56,10 +65,12 @@ class SpaceSkillGrantService:
         self,
         access: SpaceAccessServiceProtocol,
         repository: SpaceSkillRepository,
+        staff_dept: StaffDeptPlugin,
         env_provider: Callable[[], str],
     ) -> None:
         self._access = access
         self._repository = repository
+        self._staff_dept = staff_dept
         self._env_provider = env_provider
 
     def list_grants(
@@ -183,17 +194,18 @@ class SpaceSkillGrantService:
         if role != "OWNER":
             raise SpaceSkillGrantForbiddenError("skill owner required")
 
-    @classmethod
     def _present(
-        cls,
+        self,
         record: SpaceSkillGrantSetRecord,
         *,
         space_type,
         space_role,
     ) -> SpaceSkillGrantViewRecord:
         return {
-            "owner": record["owner"],
-            "managers": record["managers"],
+            "owner": self._with_display_name(record["owner"]),
+            "managers": [
+                self._with_display_name(manager) for manager in record["managers"]
+            ],
             "actor": {
                 "skill_role": record["actor_role"],
                 "permissions": space_skill_actor_permissions(
@@ -203,3 +215,20 @@ class SpaceSkillGrantService:
                 ),
             },
         }
+
+    def _with_display_name(self, grant: SpaceSkillGrantItem) -> SpaceSkillGrantItem:
+        user_id = grant["user_id"]
+        try:
+            profile = self._staff_dept.get_profile_by_work_no(
+                work_no=normalize_work_no_for_lookup(user_id)
+            )
+        except StaffProfileLookupError:
+            logger.warning(
+                "failed to resolve Skill Grant display name",
+                extra={"user_id": user_id},
+                exc_info=True,
+            )
+            display_name = None
+        else:
+            display_name = (profile.nick_name or "").strip()[:128] or None
+        return {**grant, "display_name": display_name}

--- a/src/backend/src/agentclaw/community/core/work_orders/models.py
+++ b/src/backend/src/agentclaw/community/core/work_orders/models.py
@@ -278,6 +278,17 @@ class WorkOrderMessageContent(StrEnum):
     )
 
 
+def skill_collaborator_applicant_display(
+    *, applicant_user_id: str, applicant_name: str
+) -> str:
+    """Format the stable identity shown in a Skill editor request."""
+
+    normalized_name = applicant_name.strip()
+    if not normalized_name or normalized_name == applicant_user_id:
+        return f"「{applicant_user_id}」"
+    return f"「{normalized_name}」({applicant_user_id})"
+
+
 class WorkOrderApproverRecord(BaseModel):
     id: int
     work_order_id: int

--- a/src/backend/src/agentclaw/community/core/work_orders/services/work_order_service.py
+++ b/src/backend/src/agentclaw/community/core/work_orders/services/work_order_service.py
@@ -64,6 +64,7 @@ from agentclaw.community.core.work_orders.models import (
     WorkOrderApproverStatus,
     WorkOrderDecision,
     WorkOrderEventCreatedResult,
+    skill_collaborator_applicant_display,
 )
 from agentclaw.community.core.work_orders.protocols import (
     SkillCollaboratorApprovalHandlerProtocol,
@@ -477,7 +478,7 @@ class WorkOrderService(WorkOrderServiceProtocol):
         page_no: int,
         page_size: int,
     ):
-        return self._repository.list_items(
+        total, items = self._repository.list_items(
             actor_id=actor_id,
             env=get_current_env(),
             query_type=query_type,
@@ -486,6 +487,38 @@ class WorkOrderService(WorkOrderServiceProtocol):
             biz_id=biz_id,
             offset=(page_no - 1) * page_size,
             limit=page_size,
+        )
+        return total, [self._present_skill_collaborator_item(item) for item in items]
+
+    def _present_skill_collaborator_item(self, item):
+        """Refresh pending Skill-request copy so historical rows gain a nickname."""
+
+        work_order = item.work_order
+        notification = item.notification
+        if (
+            work_order is None
+            or notification is None
+            or work_order.biz_type != WorkOrderBizType.SKILL_COLLABORATOR.value
+            or notification.event_type
+            != WorkOrderEventType.SKILL_COLLABORATOR_APPLIED.value
+        ):
+            return item
+        skill_name = str(_business_data(work_order.biz_data).get("skill_name") or "")
+        if not skill_name:
+            return item
+        applicant_user_id = work_order.applicant_user_id
+        applicant_name = self._get_applicant_name(applicant_user_id=applicant_user_id)
+        content = WorkOrderMessageContent.SKILL_COLLABORATOR_PENDING.value.format(
+            applicant_display=skill_collaborator_applicant_display(
+                applicant_user_id=applicant_user_id,
+                applicant_name=applicant_name,
+            ),
+            skill_name=skill_name,
+        )
+        return item.model_copy(
+            update={
+                "notification": notification.model_copy(update={"content": content})
+            }
         )
 
     def get_detail(self, *, work_order_id: int, actor_id: str):

--- a/src/backend/src/agentclaw/community/di/modules/spaces_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/spaces_module.py
@@ -84,6 +84,7 @@ from agentclaw.community.core.skill_center.canonical_center_store import (
     CanonicalCenterVersionStore,
 )
 from agentclaw.community.plugin_api.skill_center_gateway import SkillCenterGateway
+from agentclaw.community.plugin_api.staff_dept import StaffDeptPlugin
 from agentclaw.community.core.skill_center.services.space_skill_version_query_service import (
     SpaceSkillVersionQueryService,
 )
@@ -182,9 +183,10 @@ class SpacesModule(Module):
         self,
         access: CoreSpaceAccessServiceProtocol,
         repository: SpaceSkillRepository,
+        staff_dept: StaffDeptPlugin,
     ) -> SpaceSkillGrantServiceProtocol:
         """Assemble Grant policy with environment resolution at the DI boundary."""
-        return SpaceSkillGrantService(access, repository, get_current_env)
+        return SpaceSkillGrantService(access, repository, staff_dept, get_current_env)
 
     @singleton
     @provider

--- a/src/backend/tests/community/contracts/test_space_skill_grant_service.py
+++ b/src/backend/tests/community/contracts/test_space_skill_grant_service.py
@@ -15,6 +15,7 @@ from agentclaw.community.core.skill_center.services.space_skill_grant_service im
     SpaceSkillGrantService,
 )
 from agentclaw.community.core.spaces.models import SpaceRole, SpaceType
+from agentclaw.community.plugin_api.staff_dept import StaffDeptPlugin, StaffProfileInfo
 
 
 def _consumer():
@@ -24,7 +25,11 @@ def _consumer():
         SimpleNamespace(role=SpaceRole.MEMBER),
     )
     repository = MagicMock()
-    service = SpaceSkillGrantService(access, repository, lambda: "test")
+    staff_dept = MagicMock(spec=StaffDeptPlugin)
+    staff_dept.get_profile_by_work_no.return_value = StaffProfileInfo(
+        work_no="owner-1", nick_name="Owner"
+    )
+    service = SpaceSkillGrantService(access, repository, staff_dept, lambda: "test")
     assert isinstance(service, SpaceSkillGrantServiceProtocol)
     return service, repository
 
@@ -40,6 +45,7 @@ def test_consumer_reads_actor_permissions_through_the_repository_contract():
     result = service.list_grants(space_id=7, skill_id=9, actor_id="owner-1")
 
     assert result["actor"]["permissions"]["manage_grants"] is True
+    assert result["owner"]["display_name"] == "Owner"
     repository.list_grants.assert_called_once_with(
         space_id=7, skill_id=9, actor_id="owner-1", env="test"
     )

--- a/src/backend/tests/community/core/skill_center/services/test_space_skill_grant_service.py
+++ b/src/backend/tests/community/core/skill_center/services/test_space_skill_grant_service.py
@@ -13,9 +13,16 @@ from agentclaw.community.core.skill_center.services.space_skill_grant_service im
     SpaceSkillGrantService,
 )
 from agentclaw.community.core.spaces.models import SpaceRole, SpaceType
+from agentclaw.community.plugin_api.staff_dept import (
+    StaffDeptPlugin,
+    StaffProfileInfo,
+    StaffProfileLookupError,
+)
 
 
-def _service(*, actor_role=SpaceRole.MEMBER, space_type=SpaceType.TEAM):
+def _service(
+    *, actor_role=SpaceRole.MEMBER, space_type=SpaceType.TEAM, staff_dept=None
+):
     access = MagicMock()
     access.require_space_member.return_value = (
         SimpleNamespace(space_type=space_type, created_by="space-admin"),
@@ -27,8 +34,15 @@ def _service(*, actor_role=SpaceRole.MEMBER, space_type=SpaceType.TEAM):
         "managers": [],
         "actor_role": None,
     }
+    if staff_dept is None:
+        staff_dept = MagicMock(spec=StaffDeptPlugin)
+        staff_dept.get_profile_by_work_no.side_effect = (
+            lambda *, work_no: StaffProfileInfo(
+                work_no=work_no, nick_name=f"{work_no}-name"
+            )
+        )
     return (
-        SpaceSkillGrantService(access, repository, lambda: "test"),
+        SpaceSkillGrantService(access, repository, staff_dept, lambda: "test"),
         access,
         repository,
     )
@@ -56,6 +70,41 @@ def test_list_grants_returns_acl_qualifications_not_state_predictions():
     repository.list_grants.assert_called_once_with(
         space_id=7, skill_id=9, actor_id="space-admin", env="test"
     )
+    assert result["owner"]["display_name"] == "owner-1-name"
+
+
+def test_list_grants_resolves_owner_and_manager_display_names():
+    service, _, repository = _service()
+    repository.list_grants.return_value["managers"] = [
+        {"user_id": "manager-1", "role": "MANAGER"}
+    ]
+
+    result = service.list_grants(space_id=7, skill_id=9, actor_id="owner-1")
+
+    assert result["owner"]["display_name"] == "owner-1-name"
+    assert result["managers"] == [
+        {
+            "user_id": "manager-1",
+            "role": "MANAGER",
+            "display_name": "manager-1-name",
+        }
+    ]
+
+
+def test_list_grants_keeps_user_ids_when_profile_lookup_fails():
+    staff_dept = MagicMock(spec=StaffDeptPlugin)
+    staff_dept.get_profile_by_work_no.side_effect = StaffProfileLookupError(
+        "directory unavailable"
+    )
+    service, _, _ = _service(staff_dept=staff_dept)
+
+    result = service.list_grants(space_id=7, skill_id=9, actor_id="owner-1")
+
+    assert result["owner"] == {
+        "user_id": "owner-1",
+        "role": "OWNER",
+        "display_name": None,
+    }
 
 
 def test_owner_can_idempotently_add_manager():

--- a/src/backend/tests/community/core/work_orders/test_work_order_service.py
+++ b/src/backend/tests/community/core/work_orders/test_work_order_service.py
@@ -39,6 +39,7 @@ from agentclaw.community.core.work_orders.models import (
     WorkOrderEventStatus,
     WorkOrderEventCreatedResult,
     WorkOrderItemType,
+    WorkOrderListItem,
     WorkOrderNotificationDetail,
     WorkOrderNotificationDraft,
     WorkOrderNotificationBadgeSummary,
@@ -731,6 +732,58 @@ def test_list_items_forwards_filters_and_normalizes_pagination() -> None:
         offset=20,
         limit=10,
     )
+
+
+def test_list_items_refreshes_historical_skill_editor_request_copy() -> None:
+    staff_dept = MagicMock(spec=StaffDeptPlugin)
+    staff_dept.get_profile_by_work_no.return_value = StaffProfileInfo(
+        work_no="200177", nick_name="张三"
+    )
+    service, repository, _, _, _ = _service(staff_dept=staff_dept)
+    work_order = _work_order().model_copy(
+        update={
+            "biz_type": WorkOrderBizType.SKILL_COLLABORATOR,
+            "biz_id": "1123982",
+            "applicant_user_id": "200177",
+            "biz_data": json.dumps({"skill_name": "qa"}),
+        }
+    )
+    notification = _notification().model_copy(
+        update={
+            "event_type": WorkOrderEventType.SKILL_COLLABORATOR_APPLIED,
+            "biz_type": WorkOrderBizType.SKILL_COLLABORATOR,
+            "biz_id": "1123982",
+            "content": "用户「200177」申请共同编辑 Skill「qa」，请及时处理。",
+        }
+    )
+    repository.list_items.return_value = (
+        1,
+        [
+            WorkOrderListItem(
+                work_order=work_order,
+                notification=notification,
+                can_approve=True,
+            )
+        ],
+    )
+
+    _, items = service.list_items(
+        actor_id="owner-1",
+        query_type=WorkOrderQueryType.PENDING_FOR_ME,
+        item_type=WorkOrderItemType.APPROVAL,
+        page_no=1,
+        page_size=10,
+    )
+
+    assert items[0].notification is not None
+    assert (
+        items[0].notification.content
+        == "用户「张三」(200177)申请共同编辑 Skill「qa」，请及时处理。"
+    )
+    assert (
+        notification.content == "用户「200177」申请共同编辑 Skill「qa」，请及时处理。"
+    )
+    staff_dept.get_profile_by_work_no.assert_called_once_with(work_no="200177")
 
 
 def test_get_detail_resolves_reviewer_name_from_staff_directory() -> None:

--- a/src/gateway/configs/schemas/bots.openapi.json
+++ b/src/gateway/configs/schemas/bots.openapi.json
@@ -899,6 +899,190 @@
         "title": "BotCreateEngineProperties",
         "type": "object"
       },
+      "BotCreateWithManifest": {
+        "additionalProperties": false,
+        "description": "Create a bot, with its configuration, in one request.\n\nEvery field of the ordinary create body, plus the manifest. Inheriting rather\nthan restating them is deliberate: a field added to creation must not silently\nbe missing here, and two hand-maintained copies would drift.",
+        "example": {
+          "bot_desc": "Summarizes weekly industry news.",
+          "bot_name": "research-assistant",
+          "bot_type": "personal",
+          "cluster_name": "ACRA",
+          "config_manifest": "schema_version: 1\nscript:\n  body: \"echo provisioned\"\n",
+          "engine": "openclaw"
+        },
+        "properties": {
+          "bot_desc": {
+            "description": "Description of what the bot is for.",
+            "title": "Bot Desc",
+            "type": "string"
+          },
+          "bot_name": {
+            "description": "Display name. Must be non-blank, must not contain '@', and must be unused within the tenant (409 on a duplicate); leading and trailing whitespace is trimmed.",
+            "title": "Bot Name",
+            "type": "string"
+          },
+          "bot_type": {
+            "description": "Kind of bot to create: 'personal' — a bot for the named user's own use, with a single draft runtime; 'service' — a bot built to be published, gaining verify/online runtimes through its publish lifecycle.",
+            "enum": [
+              "personal",
+              "service"
+            ],
+            "title": "Bot Type",
+            "type": "string"
+          },
+          "cluster_name": {
+            "description": "Deployment cluster, in strict 1:1 correspondence with the engine: 'ANDC' for engine 'teclaw', 'ACRA' for every other engine. On create the engine/cluster pair is validated against this rule (400 on mismatch).",
+            "enum": [
+              "ACRA",
+              "ANDC"
+            ],
+            "title": "Cluster Name",
+            "type": "string"
+          },
+          "config_manifest": {
+            "description": "The manifest document (YAML), exactly as `PUT /bots/{bot_id}/config-manifest` accepts it — with one difference: a category no materializer can apply yet is **refused here** rather than stored inert, because accepting it would mean authorizing, creating the bot, and only then failing to configure it.\n\nSubmit it once. The poll never accepts it again, so the manifest that was validated is always the manifest that gets applied.\n\nIteration 1 rule: a manifest's `script` must not depend on anything else the same manifest declares. On a first boot the script is baked into the start command and runs before any other category has been delivered.",
+            "title": "Config Manifest",
+            "type": "string"
+          },
+          "engine": {
+            "description": "Engine that powers the bot, fixed at creation. The valid set is deployment-configured — read it from the engine group's available-engines endpoint; an unlisted engine is refused (400). Internal implementation engines (e.g. 'aicoding', the internal runtime behind 'claude_code') are not accepted; runtime forms travel on the template, not the engine.",
+            "title": "Engine",
+            "type": "string"
+          },
+          "engine_properties": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BotCreateEngineProperties"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional engine-specific properties. Omit for a plain bot; provide template_config (hand-written application-coding or a template-factory snapshot) for a template-backed bot."
+          },
+          "space_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Business space to associate with the bot, when applicable.",
+            "title": "Space Id"
+          }
+        },
+        "required": [
+          "bot_name",
+          "bot_desc",
+          "engine",
+          "cluster_name",
+          "bot_type",
+          "config_manifest"
+        ],
+        "title": "BotCreateWithManifest",
+        "type": "object"
+      },
+      "BotCreateWithManifestAccepted": {
+        "description": "What submission answers with: an id, and where to send the user.\n\n**No state field, and that is structural rather than stylistic.** The state\nvocabulary lives on the poll's response only, so no terminal value can ever\nbe returned by submission — a caller that has just submitted is, by\nconstruction, awaiting authorization.",
+        "example": {
+          "bot_id": "20260813_a7k2m9p1",
+          "iframe_url": "https://auth.example.com/passport/consent?flow=f-1",
+          "redirect_url": ""
+        },
+        "properties": {
+          "bot_id": {
+            "description": "The allocated bot id. Poll the status endpoint with it.",
+            "title": "Bot Id",
+            "type": "string"
+          },
+          "iframe_url": {
+            "description": "Embeddable authorization URL, or empty. Passport returns this or `redirect_url`, and which one is not predictable — use whichever is non-empty.",
+            "title": "Iframe Url",
+            "type": "string"
+          },
+          "redirect_url": {
+            "description": "Full-page authorization URL, or empty. See `iframe_url`.",
+            "title": "Redirect Url",
+            "type": "string"
+          }
+        },
+        "required": [
+          "bot_id",
+          "iframe_url",
+          "redirect_url"
+        ],
+        "title": "BotCreateWithManifestAccepted",
+        "type": "object"
+      },
+      "BotCreateWithManifestStatus": {
+        "description": "Where a creation stands, and everything a caller needs at the end.\n\nThe terminal states carry **both** the report and the bot. The bot matters\nmost on `APPLY_FAILED`: a caller must be able to see that it exists and is\nrunning, rather than infer it from a word.",
+        "example": {
+          "bot_id": "20260813_a7k2m9p1",
+          "iframe_url": "",
+          "message": "",
+          "redirect_url": "",
+          "state": "READY"
+        },
+        "properties": {
+          "apply": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ConfigManifestApply"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The apply report, at both terminal states. Names every entry that did and did not land, across both phases — the pre-container phase's `script` is carried into it, so nothing looks as though it vanished."
+          },
+          "bot": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Bot"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The created bot, once it exists. Present at `READY` **and at `APPLY_FAILED`** — the manifest failing never touches the bot record, and the response says so rather than leaving it to be inferred."
+          },
+          "bot_id": {
+            "description": "The bot this creation is for.",
+            "title": "Bot Id",
+            "type": "string"
+          },
+          "iframe_url": {
+            "default": "",
+            "description": "Authorization URL while `AWAITING_AUTHORIZATION`; empty afterwards.",
+            "title": "Iframe Url",
+            "type": "string"
+          },
+          "message": {
+            "default": "",
+            "description": "Why, when a state needs saying more than naming — a provisioning failure, or an authorization the user declined.",
+            "title": "Message",
+            "type": "string"
+          },
+          "redirect_url": {
+            "default": "",
+            "description": "See `iframe_url`.",
+            "title": "Redirect Url",
+            "type": "string"
+          },
+          "state": {
+            "$ref": "#/components/schemas/CreationState",
+            "description": "Where the creation stands."
+          }
+        },
+        "required": [
+          "state",
+          "bot_id"
+        ],
+        "title": "BotCreateWithManifestStatus",
+        "type": "object"
+      },
       "BotEditorRequestCreated": {
         "description": "Work-order identity returned for a Bot editor request.",
         "properties": {
@@ -1664,13 +1848,21 @@
         "properties": {
           "bot_call_type": {
             "$ref": "#/components/schemas/CallerCallType",
-            "description": "Aggregate Bot identity: caller when any active MCP uses caller."
+            "description": "Aggregate Bot identity: caller when any active MCP or CLI uses caller."
           },
           "capability": {
             "const": "caller_identity.v1",
             "description": "Caller identity capability version supported by the Bot.",
             "title": "Capability",
             "type": "string"
+          },
+          "cli_call_types": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/CallerCallType"
+            },
+            "description": "Sparse Caller overrides keyed by CLI code; missing means owner.",
+            "title": "Cli Call Types",
+            "type": "object"
           },
           "editable": {
             "description": "Whether the current caller may edit the draft Caller identity.",
@@ -1681,7 +1873,7 @@
             "additionalProperties": {
               "$ref": "#/components/schemas/CallerCallType"
             },
-            "description": "Explicit Caller identity mode keyed by active MCP server code.",
+            "description": "Sparse Caller overrides keyed by MCP server code; missing means owner.",
             "title": "Mcp Call Types",
             "type": "object"
           },
@@ -1708,6 +1900,7 @@
           "publish_id",
           "bot_call_type",
           "mcp_call_types",
+          "cli_call_types",
           "editable"
         ],
         "title": "CallerContext",
@@ -1909,6 +2102,409 @@
           }
         },
         "title": "ChannelUpdate",
+        "type": "object"
+      },
+      "CliCallTypeResult": {
+        "description": "Applied identity for one AgentPass-authorized CLI.",
+        "properties": {
+          "bot_call_type": {
+            "$ref": "#/components/schemas/CallerCallType",
+            "description": "Aggregate Bot identity after applying the CLI update."
+          },
+          "call_type": {
+            "$ref": "#/components/schemas/CallerCallType",
+            "description": "Applied CLI execution identity."
+          },
+          "cli_code": {
+            "description": "Updated AgentPass CLI code.",
+            "title": "Cli Code",
+            "type": "string"
+          }
+        },
+        "required": [
+          "cli_code",
+          "call_type",
+          "bot_call_type"
+        ],
+        "title": "CliCallTypeResult",
+        "type": "object"
+      },
+      "ConfigManifest": {
+        "description": "A bot's stored configuration manifest. Every field but the document is\nserver-derived.",
+        "example": {
+          "bot_id": "20260813_a7k2m9p1",
+          "document": "schema_version: 1\nmanifest:\n  identity:\n    - type: SOUL.md\n      content: |\n        # Who I am\n",
+          "schema_version": 1,
+          "size_bytes": 84,
+          "updated_at": "2026-08-31T09:12:04+00:00",
+          "updated_by": "u_165137",
+          "warnings": []
+        },
+        "properties": {
+          "bot_id": {
+            "description": "The bot this manifest belongs to.",
+            "title": "Bot Id",
+            "type": "string"
+          },
+          "document": {
+            "description": "Empty when the bot has no stored manifest.",
+            "title": "Document",
+            "type": "string"
+          },
+          "schema_version": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Null only when the bot has no stored manifest.",
+            "title": "Schema Version"
+          },
+          "size_bytes": {
+            "description": "Size of the stored document in bytes; 0 when none is stored.",
+            "title": "Size Bytes",
+            "type": "integer"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Null only when the bot has no stored manifest.",
+            "title": "Updated At"
+          },
+          "updated_by": {
+            "description": "Empty when the bot has no stored manifest.",
+            "title": "Updated By",
+            "type": "string"
+          },
+          "warnings": {
+            "description": "Non-fatal notes about the document just written — for example a source declared under `sources` that nothing references. Always empty on a read.",
+            "items": {
+              "type": "string"
+            },
+            "title": "Warnings",
+            "type": "array"
+          }
+        },
+        "required": [
+          "bot_id",
+          "document",
+          "size_bytes",
+          "updated_by"
+        ],
+        "title": "ConfigManifest",
+        "type": "object"
+      },
+      "ConfigManifestApply": {
+        "description": "One apply's report — what was delivered, and what was not.",
+        "example": {
+          "apply_id": "9c1f4ae2b83d4f6a9e1c7d5b2a8f0e34",
+          "bot_id": "20260813_a7k2m9p1",
+          "categories": [
+            {
+              "aborted": false,
+              "category": "mcp",
+              "removed": [
+                "mcp.old"
+              ]
+            }
+          ],
+          "entries": [
+            {
+              "action": "created",
+              "category": "mcp",
+              "name": "mcp.ant.homistudio.meetmcp"
+            }
+          ],
+          "finished_at": "2026-08-31T09:12:06+00:00",
+          "result": "SUCCEEDED",
+          "sources": [],
+          "started_at": "2026-08-31T09:12:04+00:00",
+          "trigger": "explicit"
+        },
+        "properties": {
+          "apply_id": {
+            "description": "Empty when the bot has never been applied.",
+            "title": "Apply Id",
+            "type": "string"
+          },
+          "bot_id": {
+            "description": "The bot this apply targeted.",
+            "title": "Bot Id",
+            "type": "string"
+          },
+          "categories": {
+            "description": "One summary per category the document declared. A category the document did not mention does not appear, because it was not touched.",
+            "items": {
+              "$ref": "#/components/schemas/ConfigManifestApplyCategory"
+            },
+            "title": "Categories",
+            "type": "array"
+          },
+          "entries": {
+            "description": "One row per declared entry, across every category. Removals are not here — they have no declared entry, so they are reported under the category's `removed`.",
+            "items": {
+              "$ref": "#/components/schemas/ConfigManifestApplyEntry"
+            },
+            "title": "Entries",
+            "type": "array"
+          },
+          "finished_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Null exactly while `result` is `RUNNING`.",
+            "title": "Finished At"
+          },
+          "result": {
+            "description": "`RUNNING` while the work is in flight, then `SUCCEEDED` / `PARTIAL` / `FAILED`, derived from the entries below.",
+            "title": "Result",
+            "type": "string"
+          },
+          "sources": {
+            "description": "Provenance for the manifest's named remote sources: what each `source` name actually resolved to, including the exact `resolved_sha`, since a moving `ref` like `main` means something different next week. Always empty in this release — nothing is fetched yet — and filled once remote sources are supported. A credential appears by name only, never by value.",
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "title": "Sources",
+            "type": "array"
+          },
+          "started_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "When the apply began. Null when the bot has never been applied.",
+            "title": "Started At"
+          },
+          "trigger": {
+            "description": "What started it; `explicit` for this API.",
+            "title": "Trigger",
+            "type": "string"
+          }
+        },
+        "required": [
+          "apply_id",
+          "bot_id",
+          "trigger",
+          "result"
+        ],
+        "title": "ConfigManifestApply",
+        "type": "object"
+      },
+      "ConfigManifestApplyAccepted": {
+        "description": "The 202 body: a handle, and the state the apply starts in.\n\nDeliberately not a report. The work has not happened yet — that is the point\nof the shape — so returning anything report-shaped would invite a caller to\nread outcomes that do not exist.",
+        "example": {
+          "apply_id": "9c1f4ae2b83d4f6a9e1c7d5b2a8f0e34",
+          "result": "RUNNING"
+        },
+        "properties": {
+          "apply_id": {
+            "description": "Poll this apply with `GET .../config-manifest/applies/{apply_id}`.",
+            "title": "Apply Id",
+            "type": "string"
+          },
+          "result": {
+            "description": "Always `RUNNING` here.",
+            "title": "Result",
+            "type": "string"
+          }
+        },
+        "required": [
+          "apply_id",
+          "result"
+        ],
+        "title": "ConfigManifestApplyAccepted",
+        "type": "object"
+      },
+      "ConfigManifestApplyCategory": {
+        "description": "One category's summary, including what overwriting it removed.",
+        "properties": {
+          "aborted": {
+            "description": "True when the category did not converge, because at least one declared entry could not be materialized. Read it together with `partially_written`: on its own it does not promise the area is untouched.",
+            "title": "Aborted",
+            "type": "boolean"
+          },
+          "category": {
+            "description": "The category or section.",
+            "title": "Category",
+            "type": "string"
+          },
+          "partially_written": {
+            "default": false,
+            "description": "True when the failure happened partway through writing, so part of the category's area may already have changed. `aborted` with this false means nothing was written and there is nothing to undo; with this true, re-apply to converge the area.",
+            "title": "Partially Written",
+            "type": "boolean"
+          },
+          "removed": {
+            "description": "Entries that existed in this category's area and are no longer declared, so overwriting removed them. Reported separately from `entries` because a removal has no declared entry.",
+            "items": {
+              "type": "string"
+            },
+            "title": "Removed",
+            "type": "array"
+          }
+        },
+        "required": [
+          "category",
+          "aborted"
+        ],
+        "title": "ConfigManifestApplyCategory",
+        "type": "object"
+      },
+      "ConfigManifestApplyEntry": {
+        "description": "What happened to one declared entry.",
+        "properties": {
+          "action": {
+            "description": "`created` / `updated` / `unchanged` / `skipped` / `failed`. `skipped` means the entry was not written because its category was aborted — never that it was optional.",
+            "title": "Action",
+            "type": "string"
+          },
+          "category": {
+            "description": "The category or section this entry is in.",
+            "title": "Category",
+            "type": "string"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Why, when `action` is `failed` or `skipped`.",
+            "title": "Error"
+          },
+          "name": {
+            "description": "How the entry names itself — a skill `name`, an identity `type`, a resource `path`, an mcp `server_code`.",
+            "title": "Name",
+            "type": "string"
+          },
+          "note": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Something true of a successful entry a caller would otherwise have to infer — today, when a `script` actually executes.",
+            "title": "Note"
+          }
+        },
+        "required": [
+          "category",
+          "name",
+          "action"
+        ],
+        "title": "ConfigManifestApplyEntry",
+        "type": "object"
+      },
+      "ConfigManifestCapabilities": {
+        "description": "Which manifest constructs a bot accepts.\n\nAnswered from the same resolver the write path refuses with, so this can\nnever claim support for something a `PUT` then rejects.",
+        "example": {
+          "bot_id": "20260813_a7k2m9p1",
+          "bot_type": "personal",
+          "constructs": [
+            {
+              "kind": "category",
+              "name": "identity",
+              "reason": "",
+              "supported": true
+            },
+            {
+              "kind": "source",
+              "name": "git",
+              "reason": "git sources are resolved by the named-and-git source work item (W7), which has not landed",
+              "supported": false
+            }
+          ],
+          "engine_type": "openclaw",
+          "schema_versions": [
+            1
+          ]
+        },
+        "properties": {
+          "bot_id": {
+            "description": "The bot these capabilities describe.",
+            "title": "Bot Id",
+            "type": "string"
+          },
+          "bot_type": {
+            "description": "The bot type the answer was computed for.",
+            "title": "Bot Type",
+            "type": "string"
+          },
+          "constructs": {
+            "description": "Every construct, supported or not, with its reason.",
+            "items": {
+              "$ref": "#/components/schemas/ManifestConstruct"
+            },
+            "title": "Constructs",
+            "type": "array"
+          },
+          "engine_type": {
+            "description": "The engine the answer was computed for.",
+            "title": "Engine Type",
+            "type": "string"
+          },
+          "schema_versions": {
+            "description": "The `schema_version` values this deployment accepts.",
+            "items": {
+              "type": "integer"
+            },
+            "title": "Schema Versions",
+            "type": "array"
+          }
+        },
+        "required": [
+          "bot_id",
+          "engine_type",
+          "bot_type",
+          "schema_versions",
+          "constructs"
+        ],
+        "title": "ConfigManifestCapabilities",
+        "type": "object"
+      },
+      "ConfigManifestWrite": {
+        "additionalProperties": false,
+        "description": "A configuration manifest submitted for storage.",
+        "properties": {
+          "document": {
+            "description": "The manifest document (YAML). Stored and returned byte for byte — the `script` body's quoting and whitespace are preserved exactly.",
+            "title": "Document",
+            "type": "string"
+          }
+        },
+        "required": [
+          "document"
+        ],
+        "title": "ConfigManifestWrite",
         "type": "object"
       },
       "Connection": {
@@ -2998,6 +3594,76 @@
         ],
         "title": "CreateWorkOrderEventRequest",
         "type": "object"
+      },
+      "CreationState": {
+        "description": "Where a creation stands. Reported by the status endpoint, and only there.",
+        "enum": [
+          "AWAITING_AUTHORIZATION",
+          "AUTHORIZATION_REJECTED",
+          "AUTHORIZATION_EXPIRED",
+          "CREATING",
+          "CREATE_FAILED",
+          "APPLYING",
+          "READY",
+          "APPLY_FAILED"
+        ],
+        "title": "CreationState",
+        "type": "string",
+        "x-enum-descriptions": [
+          "Waiting for the user to open the authorization link. Nothing has been created yet.",
+          "Terminal. The user declined, and no bot was created. The submitted manifest is deleted with the creation.",
+          "Terminal. Nobody responded within the authorization window, and no bot was created. Distinct from a rejection: nothing was decided.",
+          "Authorized. The bot record exists and its container is being provisioned.",
+          "Terminal. There is no usable bot — it could not be created, or no container ever came up. Nothing to do with the manifest.",
+          "The bot is up and the post-container part of the manifest is being applied.",
+          "Terminal. The bot is up and the whole manifest landed. The response carries the bot and the apply report.",
+          "Terminal. The bot is up and running, and part of its configuration did not land. The response carries the bot as well as the report, so this is visibly not the same as CREATE_FAILED. Fix the manifest and apply it again; nothing needs recreating."
+        ],
+        "x-enum-varnames": [
+          "AWAITING_AUTHORIZATION",
+          "AUTHORIZATION_REJECTED",
+          "AUTHORIZATION_EXPIRED",
+          "CREATING",
+          "CREATE_FAILED",
+          "APPLYING",
+          "READY",
+          "APPLY_FAILED"
+        ],
+        "x-enumNames": [
+          "AWAITING_AUTHORIZATION",
+          "AUTHORIZATION_REJECTED",
+          "AUTHORIZATION_EXPIRED",
+          "CREATING",
+          "CREATE_FAILED",
+          "APPLYING",
+          "READY",
+          "APPLY_FAILED"
+        ]
+      },
+      "CredentialType": {
+        "description": "The mechanism that presents this credential's secret.",
+        "enum": [
+          "header",
+          "oss_aksk",
+          "basic"
+        ],
+        "title": "CredentialType",
+        "type": "string",
+        "x-enum-descriptions": [
+          "The platform presents the secret in an HTTP header (header_name) while fetching — the only implemented mechanism.",
+          "Reserved for a future OSS AK/SK mechanism; refused at write today so the stored type is real from day one.",
+          "Reserved for a future HTTP Basic mechanism; refused at write today so the stored type is real from day one."
+        ],
+        "x-enum-varnames": [
+          "HEADER",
+          "OSS_AKSK",
+          "BASIC"
+        ],
+        "x-enumNames": [
+          "HEADER",
+          "OSS_AKSK",
+          "BASIC"
+        ]
       },
       "DataInitResult": {
         "description": "Public-safe cold-start data initialization state.",
@@ -5061,6 +5727,90 @@
         "title": "Envelope[BotAuthStatus]",
         "type": "object"
       },
+      "Envelope_BotCreateWithManifestAccepted_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
+        "properties": {
+          "code": {
+            "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
+            "title": "Code",
+            "type": "integer"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BotCreateWithManifestAccepted"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Response payload; present but null on errors or empty results."
+          },
+          "message": {
+            "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
+            "title": "Message",
+            "type": "string"
+          },
+          "request_id": {
+            "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
+            "title": "Request Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message",
+          "data",
+          "request_id"
+        ],
+        "title": "Envelope[BotCreateWithManifestAccepted]",
+        "type": "object"
+      },
+      "Envelope_BotCreateWithManifestStatus_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
+        "properties": {
+          "code": {
+            "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
+            "title": "Code",
+            "type": "integer"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BotCreateWithManifestStatus"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Response payload; present but null on errors or empty results."
+          },
+          "message": {
+            "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
+            "title": "Message",
+            "type": "string"
+          },
+          "request_id": {
+            "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
+            "title": "Request Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message",
+          "data",
+          "request_id"
+        ],
+        "title": "Envelope[BotCreateWithManifestStatus]",
+        "type": "object"
+      },
       "Envelope_BotEditorRequestCreated_": {
         "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
@@ -5437,6 +6187,216 @@
           "request_id"
         ],
         "title": "Envelope[Channel]",
+        "type": "object"
+      },
+      "Envelope_CliCallTypeResult_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
+        "properties": {
+          "code": {
+            "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
+            "title": "Code",
+            "type": "integer"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/CliCallTypeResult"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Response payload; present but null on errors or empty results."
+          },
+          "message": {
+            "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
+            "title": "Message",
+            "type": "string"
+          },
+          "request_id": {
+            "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
+            "title": "Request Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message",
+          "data",
+          "request_id"
+        ],
+        "title": "Envelope[CliCallTypeResult]",
+        "type": "object"
+      },
+      "Envelope_ConfigManifestApplyAccepted_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
+        "properties": {
+          "code": {
+            "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
+            "title": "Code",
+            "type": "integer"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ConfigManifestApplyAccepted"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Response payload; present but null on errors or empty results."
+          },
+          "message": {
+            "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
+            "title": "Message",
+            "type": "string"
+          },
+          "request_id": {
+            "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
+            "title": "Request Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message",
+          "data",
+          "request_id"
+        ],
+        "title": "Envelope[ConfigManifestApplyAccepted]",
+        "type": "object"
+      },
+      "Envelope_ConfigManifestApply_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
+        "properties": {
+          "code": {
+            "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
+            "title": "Code",
+            "type": "integer"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ConfigManifestApply"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Response payload; present but null on errors or empty results."
+          },
+          "message": {
+            "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
+            "title": "Message",
+            "type": "string"
+          },
+          "request_id": {
+            "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
+            "title": "Request Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message",
+          "data",
+          "request_id"
+        ],
+        "title": "Envelope[ConfigManifestApply]",
+        "type": "object"
+      },
+      "Envelope_ConfigManifestCapabilities_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
+        "properties": {
+          "code": {
+            "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
+            "title": "Code",
+            "type": "integer"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ConfigManifestCapabilities"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Response payload; present but null on errors or empty results."
+          },
+          "message": {
+            "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
+            "title": "Message",
+            "type": "string"
+          },
+          "request_id": {
+            "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
+            "title": "Request Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message",
+          "data",
+          "request_id"
+        ],
+        "title": "Envelope[ConfigManifestCapabilities]",
+        "type": "object"
+      },
+      "Envelope_ConfigManifest_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
+        "properties": {
+          "code": {
+            "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
+            "title": "Code",
+            "type": "integer"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ConfigManifest"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Response payload; present but null on errors or empty results."
+          },
+          "message": {
+            "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
+            "title": "Message",
+            "type": "string"
+          },
+          "request_id": {
+            "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
+            "title": "Request Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message",
+          "data",
+          "request_id"
+        ],
+        "title": "Envelope[ConfigManifest]",
         "type": "object"
       },
       "Envelope_Connection_": {
@@ -10227,6 +11187,48 @@
         "title": "Envelope[Skill]",
         "type": "object"
       },
+      "Envelope_SourceCredentialDetail_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
+        "properties": {
+          "code": {
+            "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
+            "title": "Code",
+            "type": "integer"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SourceCredentialDetail"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Response payload; present but null on errors or empty results."
+          },
+          "message": {
+            "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
+            "title": "Message",
+            "type": "string"
+          },
+          "request_id": {
+            "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
+            "title": "Request Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message",
+          "data",
+          "request_id"
+        ],
+        "title": "Envelope[SourceCredentialDetail]",
+        "type": "object"
+      },
       "Envelope_SpaceCreated_": {
         "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
@@ -11634,6 +12636,52 @@
           "request_id"
         ],
         "title": "Envelope[list[SkillSetSkillItem]]",
+        "type": "object"
+      },
+      "Envelope_list_SourceCredential__": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
+        "properties": {
+          "code": {
+            "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
+            "title": "Code",
+            "type": "integer"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/SourceCredential"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Response payload; present but null on errors or empty results.",
+            "title": "Data"
+          },
+          "message": {
+            "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
+            "title": "Message",
+            "type": "string"
+          },
+          "request_id": {
+            "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
+            "title": "Request Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message",
+          "data",
+          "request_id"
+        ],
+        "title": "Envelope[list[SourceCredential]]",
         "type": "object"
       },
       "Envelope_list_dict_str__Any___": {
@@ -13103,6 +14151,39 @@
           "bot_id"
         ],
         "title": "LocalOpenFolderResult",
+        "type": "object"
+      },
+      "ManifestConstruct": {
+        "description": "One thing a manifest can declare, and whether this bot accepts it.",
+        "properties": {
+          "kind": {
+            "description": "`category` (one of the six under `manifest`), `section` (a top-level section such as `script`), or `source` (how an entry names its content).",
+            "title": "Kind",
+            "type": "string"
+          },
+          "name": {
+            "description": "The construct's name within its kind.",
+            "title": "Name",
+            "type": "string"
+          },
+          "reason": {
+            "description": "Empty when supported; otherwise names the cause.",
+            "title": "Reason",
+            "type": "string"
+          },
+          "supported": {
+            "description": "False when a document using this construct is refused.",
+            "title": "Supported",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "kind",
+          "name",
+          "supported",
+          "reason"
+        ],
+        "title": "ManifestConstruct",
         "type": "object"
       },
       "MarketFavoriteItem": {
@@ -15152,7 +16233,7 @@
             "type": "string"
           },
           "title": {
-            "description": "Display title of the notification.",
+            "description": "Canonical display title of the notification.",
             "title": "Title",
             "type": "string"
           },
@@ -19926,6 +21007,18 @@
       "SkillGrantItem": {
         "description": "One active OWNER or MANAGER Grant.",
         "properties": {
+          "display_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Current staff-directory display name.",
+            "title": "Display Name"
+          },
           "role": {
             "$ref": "#/components/schemas/SkillRole",
             "description": "Role held by the user for this Skill."
@@ -20960,6 +22053,137 @@
         "x-enumNames": [
           "CHAT"
         ]
+      },
+      "SourceCredential": {
+        "description": "Masked metadata for one named credential.\n\nThe secret never appears: read paths answer whether one is stored,\nunder which header it would be presented, and where it may be\npresented — never the value.",
+        "properties": {
+          "has_secret": {
+            "default": true,
+            "description": "Whether a secret is stored under this name.",
+            "title": "Has Secret",
+            "type": "boolean"
+          },
+          "name": {
+            "description": "Identifier of the credential, tenant-scoped. Nothing about it is derived — the name is caller-chosen and referenced from a manifest by that name alone.",
+            "title": "Name",
+            "type": "string"
+          },
+          "updated_at": {
+            "description": "Last write, server clock.",
+            "format": "date-time",
+            "title": "Updated At",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "updated_at"
+        ],
+        "title": "SourceCredential",
+        "type": "object"
+      },
+      "SourceCredentialDetail": {
+        "description": "Resolve-time shape for a named credential.",
+        "properties": {
+          "allowed_prefixes": {
+            "description": "Absolute HTTPS prefixes this credential's presentation is scoped to.",
+            "items": {
+              "type": "string"
+            },
+            "title": "Allowed Prefixes",
+            "type": "array"
+          },
+          "has_secret": {
+            "default": true,
+            "description": "Whether a secret is stored under this name.",
+            "title": "Has Secret",
+            "type": "boolean"
+          },
+          "header_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Header the secret presents under; null if the mechanism does not use one.",
+            "title": "Header Name"
+          },
+          "name": {
+            "description": "Identifier of the credential, tenant-scoped. Nothing about it is derived — the name is caller-chosen and referenced from a manifest by that name alone.",
+            "title": "Name",
+            "type": "string"
+          },
+          "owner_app_id": {
+            "description": "The owning application (registry id): the one whose PUT created this name. Rotation and delete are its calls alone; every application of the tenant may read this metadata.",
+            "title": "Owner App Id",
+            "type": "integer"
+          },
+          "type": {
+            "$ref": "#/components/schemas/CredentialType",
+            "description": "Authentication mechanism."
+          },
+          "updated_at": {
+            "description": "Last write, server clock.",
+            "format": "date-time",
+            "title": "Updated At",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "updated_at",
+          "type",
+          "header_name",
+          "allowed_prefixes",
+          "owner_app_id"
+        ],
+        "title": "SourceCredentialDetail",
+        "type": "object"
+      },
+      "SourceCredentialWrite": {
+        "additionalProperties": false,
+        "description": "Register or rotate one named credential.\n\nOne body schema for every mechanism the endpoint will ever carry: the\ndiscriminating key is the authentication mechanism (type), and the\nstorage type is not the source type (git/oss/url is a *source* axis).\nRotation is the same request under the same name — no apply runs and\nthe next fetch uses the new value. Fails (422) when the type is a\nreserved future mechanism or the input is invalid.",
+        "properties": {
+          "allowed_prefixes": {
+            "description": "Authorized presentation scopes: absolute HTTPS prefixes this credential may be presented to, matched on whole path segments (https://host/team/content authorizes that tree, not .../team/content-secret). At least one; empty list is a refusal.",
+            "items": {
+              "type": "string"
+            },
+            "title": "Allowed Prefixes",
+            "type": "array"
+          },
+          "header_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Header the secret is presented under, required when type is 'header' (e.g. PRIVATE-TOKEN for a git host token, Authorization for bearer-style tokens).",
+            "title": "Header Name"
+          },
+          "secret": {
+            "description": "The secret value itself — stored encrypted, never readable back through the API, never shown in logs or apply reports (only the credential name appears there).",
+            "title": "Secret",
+            "type": "string"
+          },
+          "type": {
+            "$ref": "#/components/schemas/CredentialType",
+            "default": "header",
+            "description": "Authentication mechanism for presenting the secret. 'header' is the only implemented mechanism; 'oss_aksk' and 'basic' are reserved for future support and are refused at write."
+          }
+        },
+        "required": [
+          "secret",
+          "allowed_prefixes"
+        ],
+        "title": "SourceCredentialWrite",
+        "type": "object"
       },
       "SpaceCreated": {
         "description": "Details returned after a Space is created.",
@@ -22246,47 +23470,6 @@
         "title": "TaskSpecDTO",
         "type": "object"
       },
-      "TemplateRunRequestDTO": {
-        "description": "运行仓内置静态模板;触发者身份从调用方上下文解析。\n\n触发者身份对称 dynamic execute:caller_bot_id 必填(触发执行的 bot id),\nowner_user_id/owner_account_id 由登录态 principal 解析后注入。",
-        "properties": {
-          "auto_advance": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "演示自驱开关:true=跳过真实派发用 mock 结果推进静态 DAG,false=强制真实派发,null=由服务端默认开关决定。",
-            "title": "Auto Advance"
-          },
-          "caller_bot_id": {
-            "description": "触发执行这条静态模板的 caller bot id(必填,对称 dynamic execute.owner_bot_id)",
-            "minLength": 1,
-            "title": "Caller Bot Id",
-            "type": "string"
-          },
-          "input": {
-            "additionalProperties": true,
-            "description": "模板输入键值,按模板 input_schema 规定填入",
-            "title": "Input",
-            "type": "object"
-          },
-          "template_id": {
-            "description": "仓内置静态模板标识,如 okr-implementation",
-            "minLength": 1,
-            "title": "Template Id",
-            "type": "string"
-          }
-        },
-        "required": [
-          "template_id",
-          "caller_bot_id"
-        ],
-        "title": "TemplateRunRequestDTO",
-        "type": "object"
-      },
       "TransferSkillOwnerRequest": {
         "description": "Atomically move the unique OWNER slot to an active Space Member.",
         "properties": {
@@ -22562,7 +23745,7 @@
             "type": "string"
           },
           "title": {
-            "description": "Display title of the work order.",
+            "description": "Canonical display title of the work order.",
             "title": "Title",
             "type": "string"
           },
@@ -22970,16 +24153,9 @@
             "type": "string"
           },
           "title": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Notification title, when available.",
-            "title": "Title"
+            "description": "Canonical notification title.",
+            "title": "Title",
+            "type": "string"
           },
           "work_order_id": {
             "anyOf": [
@@ -23375,250 +24551,6 @@
         },
         "title": "UpdateSkillSetRequest",
         "type": "object"
-      },
-      "Envelope_SourceCredentialDetail_": {
-        "properties": {
-          "code": {
-            "type": "integer",
-            "title": "Code",
-            "description": "6-digit code: HTTP status (3) + business subcode (3).",
-            "example": 200000
-          },
-          "message": {
-            "type": "string",
-            "title": "Message",
-            "description": "Human-readable status; always English (e.g. \"OK\").",
-            "example": "OK"
-          },
-          "data": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/SourceCredentialDetail"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Response payload; present but null on errors or empty results."
-          },
-          "request_id": {
-            "type": "string",
-            "title": "Request Id",
-            "description": "Trace id; mirrors the X-Trace-Id response header.",
-            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-          }
-        },
-        "type": "object",
-        "required": [
-          "code",
-          "message",
-          "data",
-          "request_id"
-        ],
-        "title": "Envelope[SourceCredentialDetail]",
-        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support."
-      },
-      "SourceCredentialDetail": {
-        "properties": {
-          "name": {
-            "type": "string",
-            "title": "Name",
-            "description": "Identifier of the credential, tenant-scoped. Nothing about it is derived — the name is caller-chosen and referenced from a manifest by that name alone."
-          },
-          "has_secret": {
-            "type": "boolean",
-            "title": "Has Secret",
-            "description": "Whether a secret is stored under this name.",
-            "default": true
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Updated At",
-            "description": "Last write, server clock."
-          },
-          "type": {
-            "$ref": "#/components/schemas/CredentialType",
-            "description": "Authentication mechanism."
-          },
-          "header_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Header Name",
-            "description": "Header the secret presents under; null if the mechanism does not use one."
-          },
-          "allowed_prefixes": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Allowed Prefixes",
-            "description": "Absolute HTTPS prefixes this credential's presentation is scoped to."
-          },
-          "owner_app_id": {
-            "type": "integer",
-            "title": "Owner App Id",
-            "description": "The owning application (registry id): the one whose PUT created this name. Rotation and delete are its calls alone; every application of the tenant may read this metadata."
-          }
-        },
-        "type": "object",
-        "required": [
-          "name",
-          "updated_at",
-          "type",
-          "header_name",
-          "allowed_prefixes",
-          "owner_app_id"
-        ],
-        "title": "SourceCredentialDetail",
-        "description": "Resolve-time shape for a named credential."
-      },
-      "SourceCredential": {
-        "properties": {
-          "name": {
-            "type": "string",
-            "title": "Name",
-            "description": "Identifier of the credential, tenant-scoped. Nothing about it is derived — the name is caller-chosen and referenced from a manifest by that name alone."
-          },
-          "has_secret": {
-            "type": "boolean",
-            "title": "Has Secret",
-            "description": "Whether a secret is stored under this name.",
-            "default": true
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Updated At",
-            "description": "Last write, server clock."
-          }
-        },
-        "type": "object",
-        "required": [
-          "name",
-          "updated_at"
-        ],
-        "title": "SourceCredential",
-        "description": "Masked metadata for one named credential.\n\nThe secret never appears: read paths answer whether one is stored,\nunder which header it would be presented, and where it may be\npresented — never the value."
-      },
-      "Envelope_list_SourceCredential__": {
-        "properties": {
-          "code": {
-            "type": "integer",
-            "title": "Code",
-            "description": "6-digit code: HTTP status (3) + business subcode (3).",
-            "example": 200000
-          },
-          "message": {
-            "type": "string",
-            "title": "Message",
-            "description": "Human-readable status; always English (e.g. \"OK\").",
-            "example": "OK"
-          },
-          "data": {
-            "anyOf": [
-              {
-                "items": {
-                  "$ref": "#/components/schemas/SourceCredential"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Data",
-            "description": "Response payload; present but null on errors or empty results."
-          },
-          "request_id": {
-            "type": "string",
-            "title": "Request Id",
-            "description": "Trace id; mirrors the X-Trace-Id response header.",
-            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-          }
-        },
-        "type": "object",
-        "required": [
-          "code",
-          "message",
-          "data",
-          "request_id"
-        ],
-        "title": "Envelope[list[SourceCredential]]",
-        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support."
-      },
-      "CredentialType": {
-        "type": "string",
-        "enum": [
-          "header",
-          "oss_aksk",
-          "basic"
-        ],
-        "title": "CredentialType",
-        "description": "The mechanism that presents this credential's secret.",
-        "x-enum-descriptions": [
-          "The platform presents the secret in an HTTP header (header_name) while fetching — the only implemented mechanism.",
-          "Reserved for a future OSS AK/SK mechanism; refused at write today so the stored type is real from day one.",
-          "Reserved for a future HTTP Basic mechanism; refused at write today so the stored type is real from day one."
-        ],
-        "x-enum-varnames": [
-          "HEADER",
-          "OSS_AKSK",
-          "BASIC"
-        ],
-        "x-enumNames": [
-          "HEADER",
-          "OSS_AKSK",
-          "BASIC"
-        ]
-      },
-      "SourceCredentialWrite": {
-        "properties": {
-          "type": {
-            "$ref": "#/components/schemas/CredentialType",
-            "description": "Authentication mechanism for presenting the secret. 'header' is the only implemented mechanism; 'oss_aksk' and 'basic' are reserved for future support and are refused at write.",
-            "default": "header"
-          },
-          "header_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Header Name",
-            "description": "Header the secret is presented under, required when type is 'header' (e.g. PRIVATE-TOKEN for a git host token, Authorization for bearer-style tokens)."
-          },
-          "secret": {
-            "type": "string",
-            "title": "Secret",
-            "description": "The secret value itself — stored encrypted, never readable back through the API, never shown in logs or apply reports (only the credential name appears there)."
-          },
-          "allowed_prefixes": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Allowed Prefixes",
-            "description": "Authorized presentation scopes: absolute HTTPS prefixes this credential may be presented to, matched on whole path segments (https://host/team/content authorizes that tree, not .../team/content-secret). At least one; empty list is a refusal."
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "secret",
-          "allowed_prefixes"
-        ],
-        "title": "SourceCredentialWrite",
-        "description": "Register or rotate one named credential.\n\nOne body schema for every mechanism the endpoint will ever carry: the\ndiscriminating key is the authentication mechanism (type), and the\nstorage type is not the source type (git/oss/url is a *source* axis).\nRotation is the same request under the same name — no apply runs and\nthe next fetch uses the new value. Fails (422) when the type is a\nreserved future mechanism or the input is invalid."
       }
     }
   },
@@ -39438,6 +40370,619 @@
         ]
       }
     },
+    "/openapi/v1/bots/source-credentials": {
+      "get": {
+        "description": "Every credential in the caller's tenant, masked metadata only.\n\nSorted by name. The response never contains a secret or ciphertext —\nit is the metadata a calling application needs to rotate or reference:\nname, presence, last write.",
+        "operationId": "list_source_credentials_openapi_v1_bots_source_credentials_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_list_SourceCredential__"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 503000,
+                  "message": "Service Unavailable",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Temporarily unavailable"
+          }
+        },
+        "summary": "List Source Credentials",
+        "tags": [
+          "source-credentials"
+        ]
+      }
+    },
+    "/openapi/v1/bots/source-credentials/{name}": {
+      "delete": {
+        "description": "Remove the named credential. Idempotent succeeds on re-delete.\n\nThe delete is the owning application's alone (403 for any other\napplication of the tenant). Manifests referencing the deleted name\nfail their next fetch with the credential's name — removal does not\ntranslate into silent unauthenticated fetches. Storage never guesses\nthe reference graph.",
+        "operationId": "delete_source_credential_openapi_v1_bots_source_credentials__name__delete",
+        "parameters": [
+          {
+            "description": "Identifier of the credential, tenant-scoped. Nothing about it is derived — the name is caller-chosen and referenced from a manifest by that name alone.",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "description": "Identifier of the credential, tenant-scoped. Nothing about it is derived — the name is caller-chosen and referenced from a manifest by that name alone.",
+              "title": "Name",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_Deleted_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 503000,
+                  "message": "Service Unavailable",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Temporarily unavailable"
+          }
+        },
+        "summary": "Delete Source Credential",
+        "tags": [
+          "source-credentials"
+        ]
+      },
+      "get": {
+        "description": "One credential by name: masked metadata including its scopes.\n\n404 when no credential is registered under this name in the caller's\ntenant.",
+        "operationId": "get_source_credential_openapi_v1_bots_source_credentials__name__get",
+        "parameters": [
+          {
+            "description": "Identifier of the credential, tenant-scoped. Nothing about it is derived — the name is caller-chosen and referenced from a manifest by that name alone.",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "description": "Identifier of the credential, tenant-scoped. Nothing about it is derived — the name is caller-chosen and referenced from a manifest by that name alone.",
+              "title": "Name",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_SourceCredentialDetail_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 503000,
+                  "message": "Service Unavailable",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Temporarily unavailable"
+          }
+        },
+        "summary": "Get Source Credential",
+        "tags": [
+          "source-credentials"
+        ]
+      },
+      "put": {
+        "description": "Register or rotate the named credential. Takes effect on the next\nfetch that references it — no apply runs, ever.\n\nThe body validates before any persistence: HTTPS-pinned prefixes,\npath-segment scopes, reserved mechanism types refused, and — under a\nfail-closed deployment (production profile) — writes refused entirely\nwhen the platform's master key is not resolvable, so a misconfigured\nkey store surfaces as a loud 503 rather than plaintext tenant secrets\nat rest.\n\nRegistering a free name makes the calling application its owner;\nrotating an existing one is the owner's call alone (403 for any other\napplication of the tenant), because a rotation replaces the whole row\nevery manifest citation of that name depends on.",
+        "operationId": "put_source_credential_openapi_v1_bots_source_credentials__name__put",
+        "parameters": [
+          {
+            "description": "Identifier of the credential, tenant-scoped. Nothing about it is derived — the name is caller-chosen and referenced from a manifest by that name alone.",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "description": "Identifier of the credential, tenant-scoped. Nothing about it is derived — the name is caller-chosen and referenced from a manifest by that name alone.",
+              "title": "Name",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SourceCredentialWrite"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_SourceCredentialDetail_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 503000,
+                  "message": "Service Unavailable",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Temporarily unavailable"
+          }
+        },
+        "summary": "Put Source Credential",
+        "tags": [
+          "source-credentials"
+        ]
+      }
+    },
     "/openapi/v1/bots/spaces": {
       "get": {
         "operationId": "list_spaces_openapi_v1_bots_spaces_get",
@@ -48469,6 +50014,187 @@
         ]
       }
     },
+    "/openapi/v1/bots/with-manifest": {
+      "post": {
+        "description": "Create a bot and its configuration in one request. Always `202`.\n\n**Submit the manifest once.** The status endpoint never accepts it again, so\nthe document that was validated here is necessarily the document that gets\napplied — there is no second copy for a caller to change underneath the one\nthat passed.\n\n**The manifest is validated before anything is spent.** An invalid document\nis a `422` naming every violation at once, with no `bot_id` minted, no\nPassport application made and nothing stored. You never authorize a bot only\nto be told your configuration was wrong.\n\nOne rule beyond what `PUT .../config-manifest` enforces: a category no\nmaterializer in this build can apply is **refused here** rather than stored\ninert. Accepting it would mean authorizing, creating and only then failing to\nconfigure. Refusal names the category; create the bot first and `PUT` the\nmanifest once the materializer has landed.\n\n**Iteration 1: a `script` must not depend on anything else the manifest\ndeclares.** On a first boot the script is baked into the start command and\nruns before any other category has been delivered — a script that expects an\nMCP server or a skill from the same document will not find it. Tracked by\n#1508, which delivers every category before the container starts.\n\nThen send the user to `iframe_url` or `redirect_url` (whichever is non-empty)\nand poll `GET /openapi/v1/bots/{bot_id}/with-manifest/status`. Nothing is\ncreated until they authorize, and nothing here waits for them.\n\nThis endpoint is ARCA-only. A teclaw bot is configured by the artifact\ncomposed when its container is provisioned, which is a different mechanism\nfrom this pre/post-container delivery; it is refused, naming W8 (#1476).",
+        "operationId": "create_bot_with_manifest",
+        "parameters": [
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BotCreateWithManifest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_BotCreateWithManifestAccepted_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 503000,
+                  "message": "Service Unavailable",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Temporarily unavailable"
+          }
+        },
+        "summary": "Create Bot With Manifest",
+        "tags": [
+          "bots"
+        ]
+      }
+    },
     "/openapi/v1/bots/work-order-notifications/read-all": {
       "post": {
         "operationId": "mark_all_notifications_read_openapi_v1_bots_work_order_notifications_read_all_post",
@@ -52974,7 +54700,7 @@
     },
     "/openapi/v1/bots/{bot_id}/caller-context": {
       "get": {
-        "description": "Return aggregate and per-MCP Caller identity for one Bot runtime.",
+        "description": "Return aggregate and per-resource Caller overrides for one Bot runtime.",
         "operationId": "get_caller_context_openapi_v1_bots__bot_id__caller_context_get",
         "parameters": [
           {
@@ -55216,6 +56942,1719 @@
         "summary": "Get Bot Chat",
         "tags": [
           "bot-chats"
+        ]
+      }
+    },
+    "/openapi/v1/bots/{bot_id}/clis/{cli_code}/call-type": {
+      "patch": {
+        "description": "Update one authorized Default CLI's AgentPass identity mode.",
+        "operationId": "update_cli_call_type_openapi_v1_bots__bot_id__clis__cli_code__call_type_patch",
+        "parameters": [
+          {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
+            "in": "path",
+            "name": "bot_id",
+            "required": true,
+            "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
+              "title": "Bot Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Opaque AgentPass CLI identifier.",
+            "in": "path",
+            "name": "cli_code",
+            "required": true,
+            "schema": {
+              "description": "Opaque AgentPass CLI identifier.",
+              "title": "Cli Code",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+            "in": "query",
+            "name": "owner_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+              "title": "Owner Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/McpCallTypeUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_CliCallTypeResult_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "423": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 423000,
+                  "message": "Edit lock required",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "A Bot with collaborators requires the caller to hold its edit lock."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 503000,
+                  "message": "Service Unavailable",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Temporarily unavailable"
+          }
+        },
+        "summary": "Update Cli Call Type",
+        "tags": [
+          "Caller identity"
+        ]
+      }
+    },
+    "/openapi/v1/bots/{bot_id}/config-manifest": {
+      "delete": {
+        "description": "Clear a bot's configuration manifest. Idempotent.\n\nEntities a previous apply produced are **not** removed: this clears the\ndeclaration, not the assets it named.",
+        "operationId": "delete_bot_config_manifest",
+        "parameters": [
+          {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
+            "in": "path",
+            "name": "bot_id",
+            "required": true,
+            "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
+              "title": "Bot Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+            "in": "query",
+            "name": "owner_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+              "title": "Owner Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_Deleted_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 503000,
+                  "message": "Service Unavailable",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Temporarily unavailable"
+          }
+        },
+        "summary": "Delete Bot Config Manifest",
+        "tags": [
+          "bots"
+        ]
+      },
+      "get": {
+        "description": "Read a bot's configuration manifest.\n\nA bot that has never had one reads as an **empty document**, not an error —\na 404 here would make \"has none\" indistinguishable from \"no such bot\".\n\nThe document is returned exactly as it was written, byte for byte, including\nthe `script` body's quoting and whitespace.",
+        "operationId": "get_bot_config_manifest",
+        "parameters": [
+          {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
+            "in": "path",
+            "name": "bot_id",
+            "required": true,
+            "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
+              "title": "Bot Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+            "in": "query",
+            "name": "owner_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+              "title": "Owner Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_ConfigManifest_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 503000,
+                  "message": "Service Unavailable",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Temporarily unavailable"
+          }
+        },
+        "summary": "Get Bot Config Manifest",
+        "tags": [
+          "bots"
+        ]
+      },
+      "put": {
+        "description": "Set or replace a bot's configuration manifest.\n\n**All-or-nothing.** A document is stored only if every part of it is valid\nand supported for this bot: one unsupported category refuses the whole\ndocument, nothing is written, and the `422` carries the full list of reasons\nwith the offending entry named in each. Fixing a document is one pass, not a\nqueue.\n\nDeclaring a category this bot's engine cannot be given — or a source form\nthe platform cannot yet resolve — is refused rather than stored, because a\nstored declaration nothing can act on is a silent no-op the caller would\nreasonably read as success. `GET …/config-manifest/capabilities` answers\nfrom the same rules, so it can never promise what this refuses.\n\nStoring a manifest applies nothing yet.",
+        "operationId": "update_bot_config_manifest",
+        "parameters": [
+          {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
+            "in": "path",
+            "name": "bot_id",
+            "required": true,
+            "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
+              "title": "Bot Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+            "in": "query",
+            "name": "owner_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+              "title": "Owner Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConfigManifestWrite"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_ConfigManifest_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "413": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 413000,
+                  "message": "Config manifest exceeds the 65536-byte limit",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Manifest document exceeds the size limit."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Config manifest is invalid",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The document was refused; `data.violations` names every reason, each with the entry it applies to."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 503000,
+                  "message": "Service Unavailable",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Temporarily unavailable"
+          }
+        },
+        "summary": "Update Bot Config Manifest",
+        "tags": [
+          "bots"
+        ]
+      }
+    },
+    "/openapi/v1/bots/{bot_id}/config-manifest/applies/{apply_id}": {
+      "get": {
+        "description": "Read one apply's report, whether it is still running or finished.\n\n`result` is `RUNNING` until the work ends, then `SUCCEEDED`, `PARTIAL` or\n`FAILED` — derived from the per-entry outcomes, which say exactly what was\ndelivered and what was not.\n\nAn `apply_id` that belongs to a different bot is not found here: the id is a\nhandle for polling, not something that grants access.",
+        "operationId": "get_bot_config_manifest_apply",
+        "parameters": [
+          {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
+            "in": "path",
+            "name": "bot_id",
+            "required": true,
+            "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
+              "title": "Bot Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The id returned by `POST .../config-manifest/apply`.",
+            "in": "path",
+            "name": "apply_id",
+            "required": true,
+            "schema": {
+              "description": "The id returned by `POST .../config-manifest/apply`.",
+              "title": "Apply Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+            "in": "query",
+            "name": "owner_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+              "title": "Owner Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_ConfigManifestApply_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 503000,
+                  "message": "Service Unavailable",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Temporarily unavailable"
+          }
+        },
+        "summary": "Get Bot Config Manifest Apply",
+        "tags": [
+          "bots"
+        ]
+      }
+    },
+    "/openapi/v1/bots/{bot_id}/config-manifest/apply": {
+      "post": {
+        "description": "Apply this bot's stored manifest. Returns immediately with an id to poll.\n\n**This does not wait for the apply.** Applying writes to a bot's device and,\nin later releases, fetches over the network; the response is a `202` carrying\nan `apply_id`, and the work continues in the background. Poll it with\n`GET .../config-manifest/applies/{apply_id}`, or read the newest with\n`GET .../config-manifest/last-apply`.\n\nWhat can be answered immediately is answered immediately, **before** an id\nexists: a `409` if another apply is already running for this bot, and a `422`\nif the stored document no longer validates for it. You never hold an id for\nan apply that did not start.\n\n**A declared category is overwritten to equal the declaration.** Anything in\nthat category's area that the manifest does not declare is **removed** —\nincluding MCP servers enabled by hand through the console. A category the\nmanifest does not mention is not touched at all, and deleting a manifest\ntherefore deletes nothing.\n\n**A category is written all-or-nothing.** Permission and platform-default\nownership are checked before the first write, so if a declared entry fails\neither, that whole category is left exactly as it was and its other entries\nreport `skipped` — a momentary failure never deletes something that was\nworking. Categories do not affect each other.\n\nA write can still fail for a reason not checked up front — the underlying\nservice is down, a concurrent change lands, or the server is owned by one of\nthe bot's SkillSets, which is refused at write time and not yet preflighted.\nThere is no transaction spanning those calls to roll back, so such a\ncategory reports `partially_written` and re-applying converges it. That flag\nis the one case where `aborted` does not mean \"nothing changed\".\n\nA bot with no stored manifest applies nothing and reports nothing applied.\nThat is not an error.",
+        "operationId": "apply_bot_config_manifest",
+        "parameters": [
+          {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
+            "in": "path",
+            "name": "bot_id",
+            "required": true,
+            "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
+              "title": "Bot Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Return the plan without performing it. Synchronous; it applies no part of your manifest and writes no apply record, so it mints no `apply_id` and appears in no history. Two caveats, both by design: a declared source MAY really be fetched (a preview that cannot tell you whether your sources are reachable and your digests match is a weak preview), bounded by the same per-apply fetch ledger a real apply uses — and the bytes acquired are kept as the platform's own copy, because that audit trail records acquisition, not delivery; and reading a bot's installed MCP set reconciles platform-managed installation rows against SkillSet membership, which any read of that state does. Nothing your manifest declares is applied to the bot.",
+            "in": "query",
+            "name": "dry_run",
+            "required": false,
+            "schema": {
+              "default": false,
+              "description": "Return the plan without performing it. Synchronous; it applies no part of your manifest and writes no apply record, so it mints no `apply_id` and appears in no history. Two caveats, both by design: a declared source MAY really be fetched (a preview that cannot tell you whether your sources are reachable and your digests match is a weak preview), bounded by the same per-apply fetch ledger a real apply uses — and the bytes acquired are kept as the platform's own copy, because that audit trail records acquisition, not delivery; and reading a bot's installed MCP set reconciles platform-managed installation rows against SkillSet membership, which any read of that state does. Nothing your manifest declares is applied to the bot.",
+              "title": "Dry Run",
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+            "in": "query",
+            "name": "owner_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+              "title": "Owner Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_ConfigManifestApply_"
+                }
+              }
+            },
+            "description": "A dry run's plan, computed without performing it."
+          },
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_ConfigManifestApplyAccepted_"
+                }
+              }
+            },
+            "description": "The apply has started; poll it with the returned id."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "423": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 423000,
+                  "message": "Edit lock required",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "A Bot with collaborators requires the caller to hold its edit lock."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 503000,
+                  "message": "Service Unavailable",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Temporarily unavailable"
+          }
+        },
+        "summary": "Apply Bot Config Manifest",
+        "tags": [
+          "bots"
+        ]
+      }
+    },
+    "/openapi/v1/bots/{bot_id}/config-manifest/capabilities": {
+      "get": {
+        "description": "Which manifest constructs this bot accepts, and why not when it does not.\n\nAnswered by the same resolver `PUT` refuses with, so this can never claim\nsupport for something the next write rejects. A construct is a category, a\ntop-level section (`script`), or a source form — a source with no resolver\nfails exactly the way an unsupported category does, so both are listed.\n\nAn unrecognised engine supports nothing.",
+        "operationId": "get_bot_config_manifest_capabilities",
+        "parameters": [
+          {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
+            "in": "path",
+            "name": "bot_id",
+            "required": true,
+            "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
+              "title": "Bot Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+            "in": "query",
+            "name": "owner_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+              "title": "Owner Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_ConfigManifestCapabilities_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 503000,
+                  "message": "Service Unavailable",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Temporarily unavailable"
+          }
+        },
+        "summary": "Get Bot Config Manifest Capabilities",
+        "tags": [
+          "bots"
+        ]
+      }
+    },
+    "/openapi/v1/bots/{bot_id}/config-manifest/last-apply": {
+      "get": {
+        "description": "The most recent apply for this bot.\n\nThis is the authoritative answer to \"did my manifest take effect?\".\n\nA bot that has never been applied reads as an **empty report**, not an error\n— the same rule that makes a bot with no manifest read as an empty document.",
+        "operationId": "get_bot_config_manifest_last_apply",
+        "parameters": [
+          {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
+            "in": "path",
+            "name": "bot_id",
+            "required": true,
+            "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
+              "title": "Bot Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+            "in": "query",
+            "name": "owner_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+              "title": "Owner Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_ConfigManifestApply_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 503000,
+                  "message": "Service Unavailable",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Temporarily unavailable"
+          }
+        },
+        "summary": "Get Bot Config Manifest Last Apply",
+        "tags": [
+          "bots"
         ]
       }
     },
@@ -83656,6 +87095,188 @@
         ]
       }
     },
+    "/openapi/v1/bots/{bot_id}/with-manifest/status": {
+      "get": {
+        "description": "Where a creation stands. Takes a `bot_id` and nothing else.\n\n**A pure read.** No manifest, no creation attributes, no query parameters —\nthe server already holds everything the creation was for. It calls no\nexternal service, starts no work and writes nothing, so polling it faster\nchanges nothing and a caller that stops polling loses nothing: the creation\nruns to its own end either way.\n\nThe states, and what each one promises about the bot:\n\n- `AWAITING_AUTHORIZATION` — nothing exists yet. Send the user to the URL.\n- `AUTHORIZATION_REJECTED` / `AUTHORIZATION_EXPIRED` — terminal, and **no\n  bot was created**. The stored manifest is deleted with the creation, so\n  nothing is left behind to find later.\n- `CREATING` — authorized; the bot record exists and its container is being\n  provisioned.\n- `CREATE_FAILED` — terminal, and there is **no usable bot**. Nothing to do\n  with the manifest.\n- `APPLYING` — the bot is up and the post-container phase is running.\n- `READY` — terminal; the bot is up and the whole manifest landed.\n- `APPLY_FAILED` — terminal; **the bot is up and running**, and part of its\n  configuration did not land. The `apply` report names every entry, and the\n  response carries the `bot` so this is visibly not the same as\n  `CREATE_FAILED`. Fix the manifest and `POST .../config-manifest/apply`;\n  nothing needs recreating.\n\nA `PARTIAL` apply reports `APPLY_FAILED`, not `READY`: under the manifest's\ncategory overwrite a partial category can have *removed* entries it then\nfailed to replace, so it is a state to act on rather than a success with a\nfootnote.\n\nThe report at `READY` and `APPLY_FAILED` covers **both** phases — the\npre-container `script` is carried into it, so nothing that was applied looks\nas though it vanished.\n\n`404` when no create-with-manifest was submitted for this `bot_id`, which\nincludes a bot created through the ordinary endpoint.",
+        "operationId": "get_bot_create_with_manifest_status",
+        "parameters": [
+          {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
+            "in": "path",
+            "name": "bot_id",
+            "required": true,
+            "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
+              "title": "Bot Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_BotCreateWithManifestStatus_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 503000,
+                  "message": "Service Unavailable",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Temporarily unavailable"
+          }
+        },
+        "summary": "Get Bot Create With Manifest Status",
+        "tags": [
+          "bots"
+        ]
+      }
+    },
     "/openapi/v1/collaboration/bots/{bot_uuid}/public": {
       "post": {
         "description": "Publish a bot to users or agents — opens a botpublish approval ticket.\n\nbot_uuid is the BCS bot identity the gateway forwards verbatim; the service\nsplits it internally to reverse-lookup the backend bot record.",
@@ -84701,187 +88322,6 @@
         ]
       }
     },
-    "/openapi/v1/collaboration/tasks/run-template": {
-      "post": {
-        "description": "运行预置静态模板;owner 由公开面鉴权 + user_id 自确认决定。\n\nuser_id 经 require_user_id 自确认(与签名 principal 不符→403);owner_user_id=user_id。\n触发执行 bot 由请求体提供并交由任务服务处理。",
-        "operationId": "run_template_openapi_v1_collaboration_tasks_run_template_post",
-        "parameters": [
-          {
-            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
-            "in": "query",
-            "name": "user_id",
-            "required": true,
-            "schema": {
-              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
-              "minLength": 1,
-              "title": "User Id",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/TemplateRunRequestDTO"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Envelope_TaskOpResultDTO_"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 400000,
-                  "message": "Bad Request",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Invalid request"
-          },
-          "401": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 401000,
-                  "message": "Unauthorized",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Missing or invalid credentials"
-          },
-          "403": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 403000,
-                  "message": "Forbidden",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "The user_id names a user the authenticated caller may not act for"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 404000,
-                  "message": "Not found",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Not found — also returned when the resource exists but does not belong to the caller"
-          },
-          "409": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 409000,
-                  "message": "Conflict",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Conflicts with current state"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 422000,
-                  "message": "Invalid request",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Request failed validation"
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 500000,
-                  "message": "Internal Server Error",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Internal error"
-          },
-          "502": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 502000,
-                  "message": "Bad Gateway",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Upstream service error"
-          },
-          "503": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 503000,
-                  "message": "Service Unavailable",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Temporarily unavailable"
-          }
-        },
-        "summary": "Run Template",
-        "tags": [
-          "task"
-        ]
-      }
-    },
     "/openapi/v1/org/dept": {
       "get": {
         "description": "Fuzzy-search the department directory by name.\n\nA tenant-wide catalogue read — the match set does not depend on which user\nis asking — so it takes no user id and admits any authenticated caller.\nReturns the matching departments; an empty list means nothing matched (200,\nnot a failure). A directory that is unreachable or errors raises and is\nanswered 5xx, distinct from \"no match\" the way \"no dept\" is distinct from\n\"directory down\".",
@@ -85193,619 +88633,6 @@
         "tags": [
           "org"
         ]
-      }
-    },
-    "/openapi/v1/bots/source-credentials": {
-      "get": {
-        "tags": [
-          "source-credentials"
-        ],
-        "summary": "List Source Credentials",
-        "description": "Every credential in the caller's tenant, masked metadata only.\n\nSorted by name. The response never contains a secret or ciphertext —\nit is the metadata a calling application needs to rotate or reference:\nname, presence, last write.",
-        "operationId": "list_source_credentials_openapi_v1_bots_source_credentials_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Envelope_list_SourceCredential__"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                },
-                "example": {
-                  "code": 400000,
-                  "message": "Bad Request",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Missing or invalid credentials",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                },
-                "example": {
-                  "code": 401000,
-                  "message": "Unauthorized",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not found — also returned when the resource exists but does not belong to the caller",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                },
-                "example": {
-                  "code": 404000,
-                  "message": "Not found",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "Conflicts with current state",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                },
-                "example": {
-                  "code": 409000,
-                  "message": "Conflict",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Request failed validation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                },
-                "example": {
-                  "code": 422000,
-                  "message": "Invalid request",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                },
-                "example": {
-                  "code": 500000,
-                  "message": "Internal Server Error",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                }
-              }
-            }
-          },
-          "502": {
-            "description": "Upstream service error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                },
-                "example": {
-                  "code": 502000,
-                  "message": "Bad Gateway",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "Temporarily unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                },
-                "example": {
-                  "code": 503000,
-                  "message": "Service Unavailable",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/openapi/v1/bots/source-credentials/{name}": {
-      "get": {
-        "tags": [
-          "source-credentials"
-        ],
-        "summary": "Get Source Credential",
-        "description": "One credential by name: masked metadata including its scopes.\n\n404 when no credential is registered under this name in the caller's\ntenant.",
-        "operationId": "get_source_credential_openapi_v1_bots_source_credentials__name__get",
-        "parameters": [
-          {
-            "name": "name",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "Identifier of the credential, tenant-scoped. Nothing about it is derived — the name is caller-chosen and referenced from a manifest by that name alone.",
-              "title": "Name"
-            },
-            "description": "Identifier of the credential, tenant-scoped. Nothing about it is derived — the name is caller-chosen and referenced from a manifest by that name alone."
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Envelope_SourceCredentialDetail_"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid request",
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 400000,
-                  "message": "Bad Request",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Missing or invalid credentials",
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 401000,
-                  "message": "Unauthorized",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not found — also returned when the resource exists but does not belong to the caller",
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 404000,
-                  "message": "Not found",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "Conflicts with current state",
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 409000,
-                  "message": "Conflict",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Request failed validation",
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 422000,
-                  "message": "Invalid request",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal error",
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 500000,
-                  "message": "Internal Server Error",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            }
-          },
-          "502": {
-            "description": "Upstream service error",
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 502000,
-                  "message": "Bad Gateway",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "Temporarily unavailable",
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 503000,
-                  "message": "Service Unavailable",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "source-credentials"
-        ],
-        "summary": "Put Source Credential",
-        "description": "Register or rotate the named credential. Takes effect on the next\nfetch that references it — no apply runs, ever.\n\nThe body validates before any persistence: HTTPS-pinned prefixes,\npath-segment scopes, reserved mechanism types refused, and — under a\nfail-closed deployment (production profile) — writes refused entirely\nwhen the platform's master key is not resolvable, so a misconfigured\nkey store surfaces as a loud 503 rather than plaintext tenant secrets\nat rest.\n\nRegistering a free name makes the calling application its owner;\nrotating an existing one is the owner's call alone (403 for any other\napplication of the tenant), because a rotation replaces the whole row\nevery manifest citation of that name depends on.",
-        "operationId": "put_source_credential_openapi_v1_bots_source_credentials__name__put",
-        "parameters": [
-          {
-            "name": "name",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "Identifier of the credential, tenant-scoped. Nothing about it is derived — the name is caller-chosen and referenced from a manifest by that name alone.",
-              "title": "Name"
-            },
-            "description": "Identifier of the credential, tenant-scoped. Nothing about it is derived — the name is caller-chosen and referenced from a manifest by that name alone."
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SourceCredentialWrite"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Envelope_SourceCredentialDetail_"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid request",
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 400000,
-                  "message": "Bad Request",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Missing or invalid credentials",
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 401000,
-                  "message": "Unauthorized",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not found — also returned when the resource exists but does not belong to the caller",
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 404000,
-                  "message": "Not found",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "Conflicts with current state",
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 409000,
-                  "message": "Conflict",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Request failed validation",
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 422000,
-                  "message": "Invalid request",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal error",
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 500000,
-                  "message": "Internal Server Error",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            }
-          },
-          "502": {
-            "description": "Upstream service error",
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 502000,
-                  "message": "Bad Gateway",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "Temporarily unavailable",
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 503000,
-                  "message": "Service Unavailable",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "source-credentials"
-        ],
-        "summary": "Delete Source Credential",
-        "description": "Remove the named credential. Idempotent succeeds on re-delete.\n\nThe delete is the owning application's alone (403 for any other\napplication of the tenant). Manifests referencing the deleted name\nfail their next fetch with the credential's name — removal does not\ntranslate into silent unauthenticated fetches. Storage never guesses\nthe reference graph.",
-        "operationId": "delete_source_credential_openapi_v1_bots_source_credentials__name__delete",
-        "parameters": [
-          {
-            "name": "name",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "Identifier of the credential, tenant-scoped. Nothing about it is derived — the name is caller-chosen and referenced from a manifest by that name alone.",
-              "title": "Name"
-            },
-            "description": "Identifier of the credential, tenant-scoped. Nothing about it is derived — the name is caller-chosen and referenced from a manifest by that name alone."
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Envelope_Deleted_"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid request",
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 400000,
-                  "message": "Bad Request",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Missing or invalid credentials",
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 401000,
-                  "message": "Unauthorized",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not found — also returned when the resource exists but does not belong to the caller",
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 404000,
-                  "message": "Not found",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "Conflicts with current state",
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 409000,
-                  "message": "Conflict",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Request failed validation",
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 422000,
-                  "message": "Invalid request",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal error",
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 500000,
-                  "message": "Internal Server Error",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            }
-          },
-          "502": {
-            "description": "Upstream service error",
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 502000,
-                  "message": "Bad Gateway",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "Temporarily unavailable",
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 503000,
-                  "message": "Service Unavailable",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            }
-          }
-        }
       }
     }
   }


### PR DESCRIPTION
## 修复内容

- 历史 Skill 共同编辑工单列表按申请人工号查询花名，展示为 `用户「花名」(工号)`；不回写历史通知数据。
- Skill grants 的 owner/managers 新增兼容字段 `display_name`，保留 `user_id`、`role`；花名查询失败时降级为 `null`。
- 重新生成 `src/gateway/configs/schemas/bots.openapi.json`，并验证生成结果可复现。

## 验证

- 196 项贴近改动的单测、合同测试、接口契约与架构门禁通过。
- Standards/Spec 双轴 review 的代码问题已修复。

## 已知发布门禁

OpenAPI 兼容门禁仍检测到 `REL20260904` 基线已有的 3 项无关破坏性差异：`run-template` 接口/`TemplateRunRequestDTO` 移除，以及 `CallerContext.cli_call_types` 变为必填。本 PR 未使用 `--allow-breaking` 绕过。