### PR TITLE
fix(workspace): exclude pool skill-center from aicoding rsync snapshot

### DIFF
--- a/src/backend/src/agentclaw/community/core/workspace/engines/aicoding.py
+++ b/src/backend/src/agentclaw/community/core/workspace/engines/aicoding.py
@@ -40,6 +40,8 @@ _AICODING_RSYNC_EXCLUDES = [
     "workspace/skills/skills-center",
     "workspace/skills-pool/skills-repo",
     "workspace/skills-pool/.skills-repo*",
+    "workspace/skills-pool/skill-center",
+    "workspace/skills-pool/.skill-center*",
     "workspace/.repos/",
     "workspace/.prewarm_ready.json",
     "skills/*/.git/",

--- a/src/backend/tests/community/core/workspace/test_engine_sandbox_providers.py
+++ b/src/backend/tests/community/core/workspace/test_engine_sandbox_providers.py
@@ -229,6 +229,19 @@ class TestAICodingProvider:
         assert "workspace/.repos/" in plan.rsync_excludes
         assert "workspace/.prewarm_ready.json" in plan.rsync_excludes
 
+    def test_build_plan_excludes_pool_skill_center_symmetric_with_skills_repo(self):
+        # skill-center and skills-repo are both external read-only mounts under
+        # workspace/skills-pool/; both must be rsync-skipped (not copied) and
+        # re-mounted at image startup. Exclude entries must be symmetric:
+        # <name> + .<name>* sidecar guard.
+        provider = AICodingSandboxProvider(workspace=_workspace())
+        excludes = provider.get_build_plan().rsync_excludes
+
+        assert "workspace/skills-pool/skills-repo" in excludes
+        assert "workspace/skills-pool/.skills-repo*" in excludes
+        assert "workspace/skills-pool/skill-center" in excludes
+        assert "workspace/skills-pool/.skill-center*" in excludes
+
     def test_build_plan_keeps_extra_sync_from_claude(self):
         provider = AICodingSandboxProvider(workspace=_workspace())
         plan = provider.get_build_plan()


### PR DESCRIPTION
## What
Add symmetric rsync excludes for the AICoding pool `skill-center` mount, mirroring the existing `skills-repo` pair.

```diff
 _AICODING_RSYNC_EXCLUDES = [
     ...
     "workspace/skills/skills-center",
     "workspace/skills-pool/skills-repo",
     "workspace/skills-pool/.skills-repo*",
+    "workspace/skills-pool/skill-center",
+    "workspace/skills-pool/.skill-center*",
     ...
 ]
```

## Why
Per the Skill Center Service Artifact handoff: `skill-center` and `skills-repo` under `workspace/skills-pool/` are **both external read-only shared corpora**. The contract is:
- rsync must **skip** both (not copy the corpus into the Artifact snapshot);
- the image-startup script **mounts** both (OCB-owned);
- active-root **symlinks** pointing into the corpora are still **copied normally** via rsync `--links`.

AICoding was missing the `skill-center` pair while already excluding `skills-repo`/`.skills-repo*`, so the two mounts were handled asymmetrically. This makes them consistent and ensures the Center corpus is never copied into the snapshot (the build-time Probe-driven `shared_corpora` exclusion/proof dedups against these static entries, so this is a safe, complementary superset).

## Scope
- **Only the AICoding engine** (`engines/aicoding.py`).
- `openclaw` / `claude_code` untouched. **Hermes intentionally untouched** — it has an existing regression guard `assert all("skill-center" not in item for item in plan.rsync_excludes)` that deliberately excludes `skills-repo` but not `skill-center`.
- Pool center path is `skill-center` (singular), consistent with the layout validation at `service_bot/services/deploy/artifact_build_request.py` (`center.name != "skill-center"`).

## Test
- Added regression test `test_build_plan_excludes_pool_skill_center_symmetric_with_skills_repo` asserting the symmetric excludes for both `skills-repo` and `skill-center` pairs.
- Verified: `128 passed` across `test_engine_sandbox_providers.py`, `test_bot_build_service_rsync_excludes.py`, `test_repo_workspace_excludes.py`, `test_artifact_build_request.py`.
