### PR TITLE
fix(bot-inventory): grant engine_restart to running personal-cloud bots

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_inventory/policies/action_policy.py
+++ b/src/backend/src/agentclaw/community/core/bot_inventory/policies/action_policy.py
@@ -37,12 +37,16 @@ def actions_for(
 
     if kind is BotInventoryKind.PERSONAL_CLOUD:
         if display_state is DisplayState.RUNNING:
+            # ENGINE_RESTART relays the device engine daemon's process restart
+            # (POST /openapi/v1/bots/{bot_id}/engine/restart) — a lighter verb
+            # than the container re-provision RESTART names, granted beside it.
             return (
                 (
                     BotAction.VIEW,
                     BotAction.CHAT,
                     BotAction.EDIT,
                     BotAction.RESTART,
+                    BotAction.ENGINE_RESTART,
                     BotAction.DELETE,
                     BotAction.PASSPORT,
                     BotAction.ENGINE_CONFIG,
@@ -54,13 +58,16 @@ def actions_for(
             disabled[BotAction.CHAT.value] = "activate first"
             disabled[BotAction.EDIT.value] = "activate first"
             disabled[BotAction.RESTART.value] = "activate first"
+            disabled[BotAction.ENGINE_RESTART.value] = "activate first"
             return ((BotAction.VIEW, BotAction.ACTIVATE, BotAction.DELETE), disabled)
         if display_state is DisplayState.FAILED:
             disabled[BotAction.RESTART.value] = "bot provisioning failed"
+            disabled[BotAction.ENGINE_RESTART.value] = "bot provisioning failed"
             return ((BotAction.VIEW, BotAction.DELETE), disabled)
         disabled[BotAction.CHAT.value] = "bot not ready"
         disabled[BotAction.EDIT.value] = "bot not ready"
         disabled[BotAction.RESTART.value] = "bot not ready"
+        disabled[BotAction.ENGINE_RESTART.value] = "bot not ready"
         return ((BotAction.VIEW,), disabled)
 
     return ((BotAction.VIEW,), disabled)

--- a/src/backend/tests/community/core/bot_inventory/policies/test_action_policy.py
+++ b/src/backend/tests/community/core/bot_inventory/policies/test_action_policy.py
@@ -19,8 +19,8 @@ def _values(actions: tuple[BotAction, ...]) -> tuple[str, ...]:
             BotInventoryKind.PERSONAL_CLOUD,
             DisplayState.RUNNING,
             (
-                "view", "chat", "edit", "restart", "delete", "passport",
-                "engine_config", "data_init",
+                "view", "chat", "edit", "restart", "engine_restart", "delete",
+                "passport", "engine_config", "data_init",
             ),
             {},
         ),
@@ -28,19 +28,29 @@ def _values(actions: tuple[BotAction, ...]) -> tuple[str, ...]:
             BotInventoryKind.PERSONAL_CLOUD,
             DisplayState.DORMANT,
             ("view", "activate", "delete"),
-            {"chat": "activate first", "edit": "activate first", "restart": "activate first"},
+            {
+                "chat": "activate first",
+                "edit": "activate first",
+                "restart": "activate first",
+                "engine_restart": "activate first",
+            },
         ),
         (
             BotInventoryKind.PERSONAL_CLOUD,
             DisplayState.FAILED,
             ("view", "delete"),
-            {"restart": "bot provisioning failed"},
+            {"restart": "bot provisioning failed", "engine_restart": "bot provisioning failed"},
         ),
         (
             BotInventoryKind.PERSONAL_CLOUD,
             DisplayState.PENDING,
             ("view",),
-            {"chat": "bot not ready", "edit": "bot not ready", "restart": "bot not ready"},
+            {
+                "chat": "bot not ready",
+                "edit": "bot not ready",
+                "restart": "bot not ready",
+                "engine_restart": "bot not ready",
+            },
         ),
         (
             BotInventoryKind.LOCAL,


### PR DESCRIPTION
## Problem

The Bot Workshop renders the "重启引擎" menu item on every non-agent-coding card and enables it only when the inventory card's `actions` list contains `engine_restart` (BotManagementMenu). The backend endpoint `POST /openapi/v1/bots/{bot_id}/engine/restart` exists and works (route, `Check(MEMBER)` authorization, relay to the device engine daemon), but the action matrix (`actions_for`) never granted `ENGINE_RESTART` to any state — a running personal-cloud bot is returned `restart` without `engine_restart`, so the button renders greyed out. Verified from the pre-production list endpoint: the OpenClaw personal-cloud bot's actions contain `restart` but not `engine_restart`.

This is a declaration-side gap, not an execution-side one: the engine endpoint was added to the public surface on 2026-08-17 (component-qualified path, distinct from the bot-level container re-provision), but the action matrix was laid down from the 2026-08-11 personal/local inventory design whose personal-cloud rows predate the endpoint; the two design tracks never reconciled.

## Solution

- Grant `ENGINE_RESTART` in the `PERSONAL_CLOUD + RUNNING` branch of `action_policy.py`, beside `RESTART` (engine-process restart is granted with the state, engine-agnostic — the device daemon restarts whichever engine is active, same model as `engine_config`/`data_init`).
- Mirror `restart`'s disabled reasons for `engine_restart` in DORMANT / FAILED / PENDING ("activate first" / "bot provisioning failed" / "bot not ready"), matching the local branch's existing treatment so every state either grants or explains the action.

Out of scope, deliberately: service-bot cards (their action vocabulary is the publication lifecycle's, and the card-to-stage mapping is a separate design decision) and local bots ("not supported in this phase" stands).

## Validation

- `tests/community/core/bot_inventory/policies/test_action_policy.py` — matrix pinned for the four personal-cloud states, updated in lockstep with the implementation (TDD: red first).
- Affected surface on the REL20260904 base: `tests/community/core/bot_inventory` + `tests/community/adapters/http/openapi_v1/inventory` + `test_app_only_listings.py` — 152 passed.
- Full backend suite delegated to PR CI (changed lines are exhaustively covered by the parameterized matrix tests).
- OpenAPI contract files: no change needed — the `BotAction` enum already contains `engine_restart`; the `actions` field description is state-agnostic.

## Compatibility and risk

- No contract/schema/config change: the action values already existed in the published enum; this only makes a legitimate state grant one. Rollback is the single commit.
- Consumer impact: frontends that unconditionally render the menu item (BotManagementMenu / BotCard) get the button enabled for running personal-cloud bots — which is the feature working as built. `getInventoryActionAvailability`-style consumers additionally gain an explained disabled state for non-running cards.