### PR TITLE
ci(github): enforce pull request title convention

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,8 @@
 <!--
-Title format: <type>(<scope>): <concise outcome>
+Title format: <type>: <concise outcome> or <type>(<scope>): <concise outcome>
   e.g. feat(backend): add whitelist observed state
 Types: feat | fix | refactor | docs | test | ci | build | chore
+Scope is optional; include it when one module or area clearly owns the change.
 The title becomes the commit message on squash merge, so make it self-contained.
 See "Pull Request Conventions" in AGENTS.md.
 Delete the optional sections that do not apply.

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,33 @@
+name: PR Title
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-title-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Test PR title policy
+        run: python3 -m unittest scripts.ci.tests.test_check_pr_title
+
+      - name: Validate PR title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: python3 scripts/ci/check_pr_title.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,9 +101,10 @@ merged. Both must carry meaning on their own.
 
 ### Title
 
-Use `<type>(<scope>): <concise outcome>`:
+Use `<type>: <concise outcome>` or `<type>(<scope>): <concise outcome>`:
 
 ```text
+feat: add whitelist observed state
 feat(backend): add whitelist observed state
 fix(bcs): reject routing updates for unknown bot ids
 docs(arch): document plugin protocol conformance shape
@@ -120,9 +121,10 @@ docs(arch): document plugin protocol conformance shape
 | `build` | Build system or dependencies |
 | `chore` | Other maintenance |
 
-The scope is the module or area you touched, such as `backend`, `baas`,
-`engine`, `bcs`, `frontend`, `gateway`, `arch`, or `ci`. The outcome describes
-what the change accomplishes, not which files moved.
+The optional scope is the module or area you touched, such as `backend`,
+`baas`, `engine`, `bcs`, `frontend`, `gateway`, `arch`, or `ci`. Include it
+when one module or area clearly owns the change. The outcome describes what the
+change accomplishes, not which files moved.
 
 Do not use vague or context-free titles such as `fix bug`, `update code`,
 `sync`, a bare branch name, or an issue number with no summary.

--- a/docs/arch/ci.enforce.md
+++ b/docs/arch/ci.enforce.md
@@ -19,6 +19,7 @@ At minimum, CI must enforce:
 4. **Configuration schema validation**
 5. **Conformance test execution**
 6. **Structural PR checklist completion**
+7. **Pull request title convention**
 
 ---
 
@@ -141,6 +142,9 @@ Conformance tests are mandatory for boundary contracts.
 PRs affecting boundaries must include completed structural analysis.
 
 ### Required PR fields
+- title matching `<type>: <concise outcome>` or
+  `<type>(<scope>): <concise outcome>` with an allowed type from `feat`, `fix`,
+  `refactor`, `docs`, `test`, `ci`, `build`, or `chore`; scope is optional
 - whether a contract changed
 - if changed, what kind of contract
 - affected consumers
@@ -151,6 +155,10 @@ PRs affecting boundaries must include completed structural analysis.
 
 ### Enforcement
 - PR template required
+- `.github/workflows/pr-title.yml` validates every PR title and reports the
+  stable `Validate PR title` status check
+- protected-branch rulesets must require `Validate PR title`; the workflow
+  result alone does not block merging unless the status check is required
 - reviewer must confirm completion
 - bots may reject PRs missing required sections
 

--- a/scripts/ci/check_pr_title.py
+++ b/scripts/ci/check_pr_title.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import os
+import re
+
+
+ALLOWED_TYPES = (
+    "feat",
+    "fix",
+    "refactor",
+    "docs",
+    "test",
+    "ci",
+    "build",
+    "chore",
+)
+OPTIONAL_SCOPE = r"(?:\([^()\s](?:[^()\r\n]*[^()\s])?\))?"
+TITLE_PATTERN = re.compile(
+    rf"(?:{'|'.join(ALLOWED_TYPES)})"
+    rf"{OPTIONAL_SCOPE}: "
+    r"\S(?:.*\S)?"
+)
+
+
+def is_valid_pr_title(title: str) -> bool:
+    return TITLE_PATTERN.fullmatch(title) is not None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate the pull request title against the repository convention."
+    )
+    parser.add_argument(
+        "--title",
+        default=os.environ.get("PR_TITLE"),
+        help="PR title to validate; defaults to the PR_TITLE environment variable",
+    )
+    args = parser.parse_args()
+
+    if args.title is None:
+        parser.error("provide --title or set PR_TITLE")
+
+    if is_valid_pr_title(args.title):
+        print(f"OK: valid PR title: {args.title}")
+        return 0
+
+    allowed_types = " | ".join(ALLOWED_TYPES)
+    print(f"ERROR: invalid PR title: {args.title}")
+    print("Expected: <type>: <concise outcome>")
+    print("      or: <type>(<scope>): <concise outcome>")
+    print(f"Allowed types: {allowed_types}")
+    print("Scope is optional. When present, it must be non-empty and enclosed in ().")
+    print("Examples:")
+    print("  feat: add whitelist observed state")
+    print("  feat(backend): add whitelist observed state")
+    print("  fix(bcs): reject routing updates for unknown bot ids")
+    print("  docs(arch): document plugin protocol conformance shape")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/tests/test_check_pr_title.py
+++ b/scripts/ci/tests/test_check_pr_title.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+from scripts.ci.check_pr_title import is_valid_pr_title
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+WORKFLOW = REPO_ROOT / ".github/workflows/pr-title.yml"
+CHECKER = REPO_ROOT / "scripts/ci/check_pr_title.py"
+
+
+class PullRequestTitleTest(unittest.TestCase):
+    def test_accepts_repository_title_convention(self) -> None:
+        valid_titles = (
+            "feat: add whitelist observed state",
+            "fix: 修复沙箱环境变量配置丢失问题",
+            "feat(backend): add whitelist observed state",
+            "fix(aliyun_ack): 修复沙箱环境变量配置丢失问题",
+            "docs(bot-config-manifest): add Chinese user manual",
+            "feat(baas/bot_runtime): expose runtime status",
+            "feat(bcs,gateway): expose OpenAPI auth schema",
+            "fix(BCS): keep a legacy uppercase scope during transition",
+            "feat(bcs, gateway): coordinate multiple modules",
+            "build(deps-dev): bump test dependencies",
+        )
+
+        for title in valid_titles:
+            with self.subTest(title=title):
+                self.assertTrue(is_valid_pr_title(title))
+
+    def test_rejects_non_conforming_titles(self) -> None:
+        invalid_titles = (
+            "Dev haoqian 20260903",
+            "fix openapi iam-token aliyun model",
+            "perf(bcs): unsupported type",
+            "Feat(bcs): uppercase type",
+            "feat(): empty scope",
+            "feat( ): blank scope",
+            "feat(bcs: unclosed scope",
+            "fix(bcs):",
+            "fix(bcs):  extra space",
+            "fix(bcs): trailing space ",
+        )
+
+        for title in invalid_titles:
+            with self.subTest(title=title):
+                self.assertFalse(is_valid_pr_title(title))
+
+    def test_cli_reports_actionable_failure(self) -> None:
+        result = subprocess.run(
+            [sys.executable, str(CHECKER), "--title", "Dev haoqian 20260903"],
+            cwd=REPO_ROOT,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("Expected: <type>: <concise outcome>", result.stdout)
+        self.assertIn("or: <type>(<scope>): <concise outcome>", result.stdout)
+        self.assertIn(
+            "feat | fix | refactor | docs | test | ci | build | chore",
+            result.stdout,
+        )
+
+    def test_workflow_runs_for_every_pr_title_change(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn("  pull_request:\n", workflow)
+        self.assertIn("      - edited\n", workflow)
+        self.assertNotIn("    paths:", workflow)
+        self.assertIn("PR_TITLE: ${{ github.event.pull_request.title }}", workflow)
+        self.assertIn("python3 scripts/ci/check_pr_title.py", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

仓库已经在贡献规范和 PR 模板中约定标题格式，但 GitHub 上没有自动校验卡点，仍可能合入 `Dev haoqian 20260903` 等缺少类型和明确结果描述的标题。

由于 PR 标题会成为 squash merge 的提交信息，这类标题会降低提交历史的可读性和可检索性。

## Solution

- 新增 `PR Title` GitHub Actions Workflow，在 PR 创建、标题编辑、重新打开、推送新提交和转为 Ready 时执行校验。
- 支持以下标题格式：
  - `<type>: <concise outcome>`
  - `<type>(<scope>): <concise outcome>`
- scope 暂时可选；存在时仅要求非空且括号完整。
- type 限定为：
  - `feat`
  - `fix`
  - `refactor`
  - `docs`
  - `test`
  - `ci`
  - `build`
  - `chore`
- 为不规范标题提供允许类型、格式和示例等明确错误提示。
- 增加校验器单元测试，并同步更新 `AGENTS.md`、PR 模板和 CI Enforcement 文档。

Workflow 稳定输出 `Validate PR title` 检查。首次成功运行后，需要在 `dev` 分支 Ruleset 中将其配置为 Required status check，才能阻止不规范 PR 合入。

## Validation

- `python3 -m unittest scripts.ci.tests.test_check_pr_title`
  - 4 项测试全部通过。
- 验证 `ci: enforce pull request title convention` 可以通过。
- 验证 `ci(github): enforce pull request title convention` 可以通过。
- 验证 `Dev haoqian 20260903` 会被拒绝并输出修改提示。
- GitHub Actions Workflow YAML 解析通过。
- `git diff --check origin/dev...HEAD` 通过。

## Compatibility and risk

本次只修改 CI、贡献规范和 PR 模板，不影响生产运行时、API 或数据库。

scope 当前保持可选，以降低规范启用初期对现有协作方式的影响。该规则不会追溯修改已经合入的提交。

在 `Validate PR title` 被设置为 Required status check 之前，Workflow 失败只会展示检查结果，不会真正阻止合入。