### PR TITLE
feat(ci): add TaskRunner pre-push design guard

### DIFF
--- a/.github/workflows/task-design-guard.yml
+++ b/.github/workflows/task-design-guard.yml
@@ -1,0 +1,159 @@
+name: Task Design Guard
+
+on:
+  pull_request_target:
+    branches:
+      - dev
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: read
+  statuses: write
+
+concurrency:
+  group: task-design-guard-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  task-design-guard:
+    name: Publish TaskRunner design guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Mark TaskRunner design guard pending
+        uses: actions/github-script@v7
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        with:
+          script: |
+            await github.rest.repos.createCommitStatus({
+              ...context.repo,
+              sha: process.env.HEAD_SHA,
+              state: "pending",
+              context: "TaskRunner design guard",
+              description: "Inspecting protected TaskRunner structure",
+            });
+
+      # pull_request_target checks out the trusted target revision. Never check
+      # out or execute code from the pull request head in this workflow.
+      - name: Check out trusted dev revision
+        id: trusted-checkout
+        continue-on-error: true
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Evaluate protected TaskRunner structure
+        id: evaluate
+        if: always()
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          CHECKOUT_OUTCOME: ${{ steps.trusted-checkout.outcome }}
+        run: |
+          set -u
+
+          degraded() {
+            local reason="$1"
+            echo "::warning title=TaskRunner design guard degraded::$reason"
+            {
+              echo "### ⚠️ TaskRunner design guard degraded"
+              echo
+              echo "$reason"
+              echo
+              echo "The check was allowed to pass by the approved fail-open policy."
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "state=success" >> "$GITHUB_OUTPUT"
+            echo "description=Degraded (fail-open); inspect the workflow summary" >> "$GITHUB_OUTPUT"
+          }
+
+          if [[ "$CHECKOUT_OUTCOME" != "success" ]]; then
+            degraded "Could not check out the trusted dev revision."
+            exit 0
+          fi
+
+          set +e
+          git fetch --no-tags --force origin \
+            "+refs/pull/${PR_NUMBER}/head:refs/remotes/pull/${PR_NUMBER}/head"
+          fetch_status=$?
+          set -e
+          if [[ "$fetch_status" -ne 0 ]]; then
+            degraded "Could not fetch the pull request head for static inspection."
+            exit 0
+          fi
+
+          set +e
+          fetched_head="$(git rev-parse "refs/remotes/pull/${PR_NUMBER}/head")"
+          resolve_status=$?
+          set -e
+          if [[ "$resolve_status" -ne 0 ]]; then
+            degraded "Could not resolve the fetched pull request head."
+            exit 0
+          fi
+          if [[ "$fetched_head" != "$HEAD_SHA" ]]; then
+            degraded "The fetched pull request head did not match the event head SHA."
+            exit 0
+          fi
+
+          set +e
+          python3 scripts/ci/task_design_guard.py \
+            --base "$BASE_SHA" \
+            --head "$HEAD_SHA" \
+            --actor "$PR_AUTHOR"
+          guard_status=$?
+          set -e
+
+          case "$guard_status" in
+            0)
+              echo "state=success" >> "$GITHUB_OUTPUT"
+              echo "description=Protected TaskRunner structure is accepted" >> "$GITHUB_OUTPUT"
+              exit 0
+              ;;
+            1)
+              echo "state=failure" >> "$GITHUB_OUTPUT"
+              echo "description=Protected TaskRunner structure was changed" >> "$GITHUB_OUTPUT"
+              exit 0
+              ;;
+            2)
+              degraded "The trusted guard could not complete its evaluation. See the log above."
+              exit 0
+              ;;
+            *)
+              degraded "The trusted guard returned unexpected status ${guard_status}."
+              exit 0
+              ;;
+          esac
+
+      - name: Publish TaskRunner design guard result on PR head
+        if: always()
+        uses: actions/github-script@v7
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          STATUS_STATE: ${{ steps.evaluate.outputs.state }}
+          STATUS_DESCRIPTION: ${{ steps.evaluate.outputs.description }}
+        with:
+          script: |
+            const state = process.env.STATUS_STATE || "success";
+            const description = process.env.STATUS_DESCRIPTION ||
+              "Degraded before evaluation (fail-open); inspect workflow logs";
+            await github.rest.repos.createCommitStatus({
+              ...context.repo,
+              sha: process.env.HEAD_SHA,
+              state,
+              context: "TaskRunner design guard",
+              description,
+            });
+
+      - name: Reject protected design change
+        if: steps.evaluate.outputs.state == 'failure'
+        run: exit 1

--- a/docs/arch/task-design-guard-submitters.json
+++ b/docs/arch/task-design-guard-submitters.json
@@ -1,0 +1,9 @@
+{
+  "version": 1,
+  "guarded_submitters": [
+    "jiangj0627",
+    "msjbear",
+    "WEN6Lev57q4",
+    "guok974-dot"
+  ]
+}

--- a/docs/superpowers/specs/2026-09-03-task-runner-pre-push-design-guard.md
+++ b/docs/superpowers/specs/2026-09-03-task-runner-pre-push-design-guard.md
@@ -1,384 +1,227 @@
-# TaskRunner Pre-Push Design Guard
+# TaskRunner Pull-Request Design Guard
 
 - **Status:** Implemented
-- **Phase:** 1 — local developer guard
-- **Date:** 2026-09-03
-- **Target baseline:** `origin/dev`, unless the repository's existing pre-push
-  merge-target configuration selects another `<remote>/<branch>`
-- **Protected owner identity:** local Git email `regrecall@gmail.com`
+- **Phase:** 1 — GitHub PR required check
+- **Target branch:** `dev`
+- **Owner identity:** GitHub login `regrecall`
+
+The filename is retained from the original pre-push prototype so existing links
+remain valid. This document supersedes that prototype: the guard no longer runs
+from `scripts/ci/pre_push.sh` and does not intercept personal branch pushes.
 
 ## 1. Decision Summary
 
-Add a small, deterministic AST guard to the repository's existing pre-push
-pipeline. The guard protects selected structural surfaces of `TaskRunner` and
-rejects a normal `git push` when a committed change modifies those surfaces.
+The repository protects selected structural surfaces of `TaskRunner` when a
+pull request targets `dev`. GitHub runs a deterministic AST comparison as the
+`TaskRunner design guard` status check. Repository administrators must mark
+that status as required for `dev`; a workflow file alone cannot disable the
+Merge button.
 
-Phase 1 is deliberately a local development aid, not a security boundary or a
-server CI gate. Git hooks are installed per worktree and can be bypassed with
-`git push --no-verify`. The configured owner email is also locally mutable.
-Those limitations are accepted for this phase and must remain explicit in user
-documentation and diagnostics.
+The workflow uses `pull_request_target` with `contents: read` and
+`statuses: write`. The write permission is used only to publish the
+`TaskRunner design guard` commit status on the pull request head SHA; it does
+not grant permission to change code, approve, or merge a pull request. The
+workflow checks out the pull request's trusted base SHA and fetches the head
+only as a Git object. It never checks out, imports, or executes pull-request
+code. The checker, manifest, and submitter policy therefore come from the
+already accepted `dev` revision and cannot be weakened by the pull request
+being evaluated.
 
-Phase 1 does not call Codex, inspect pull requests, validate GitHub approvals,
-or support waivers. Those capabilities belong to a later server-side phase.
+## 2. Trigger Boundary
 
-## 2. Problem
+The workflow responds only to these `pull_request_target` activities when the
+base branch is `dev`:
 
-The Backend Task framework contains structural seams that downstream callers
-and integrations already rely on. In particular, `TaskRunner` is the execution
-boundary used to inject delivery behavior and start a batch of dispatched task
-nodes. Casual changes to its class shape or selected method signatures can
-propagate into the orchestration engine, dependency wiring, test doubles, and
-production integrations.
+- `opened`
+- `synchronize`
+- `reopened`
+- `ready_for_review`
 
-The repository already has a pre-push pipeline, but it currently selects broad
-module gates from changed paths. It does not distinguish a flexible method-body
-refactor from a structural change to an explicitly protected class or method.
+There is no `push`, `workflow_dispatch`, or path filter. Draft pull requests
+run the lightweight check immediately and rerun after each pushed commit.
+Personal branch pushes do not trigger the guard.
 
-The first increment needs a fast local signal at push time without expanding
-the existing heavy-test default or requiring a model, network service, or new
-developer credential.
+Direct pushes to `dev` are outside this policy. Contributors with direct-push
+permission can bypass the PR guard; this is an explicitly accepted limitation.
 
-## 3. Goals
+## 3. Identity Policy
 
-1. Reject a normal push when a committed change modifies the protected
-   `TaskRunner` class structure or one of its protected method interfaces.
-2. Permit implementation-only edits inside method bodies.
-3. Reuse the existing immutable merge-base and head SHAs supplied by the
-   pre-push hook.
-4. Run in both lint-only and full-CI pre-push modes.
-5. Produce deterministic, English diagnostics that identify the protected
-   symbol and the structural difference.
-6. Allow the configured local owner identity to skip only this new guard.
-7. Fail open on guard configuration, extraction, or parser errors, while making
-   the degraded result visible as a warning.
+The pull request author's GitHub login is the identity authority. Git commit
+names, author emails, committer emails, and local Git configuration are not
+used because contributors can set them locally.
 
-## 4. Non-Goals
+Decision order:
 
-- An unbypassable repository policy.
-- Protection against a contributor changing their local Git email.
-- Protection against `git push --no-verify` or an uninstalled hook.
-- Pull-request review, GitHub branch protection, or required status checks.
-- Codex or another model participating in the Phase 1 decision.
-- Waiver creation, approval, expiry, or verification.
-- Detecting semantic behavior changes inside method bodies.
-- Discovering omitted protected classes or methods automatically.
-- Reviewing other files in the Backend Task package.
-- Self-protection against a local contributor editing the guard, its manifest,
-  or the hook before pushing.
+1. `regrecall` bypasses this guard.
+2. A non-owner modifying a guard control file is rejected.
+3. A non-owner absent from the guarded-submitter policy skips the structural
+   comparison and passes.
+4. A guarded submitter receives the full TaskRunner structural comparison.
 
-## 5. Existing Pre-Push Contract
+Login comparison is case-insensitive.
 
-The implementation must extend, rather than replace, the current flow:
-
-1. `.githooks/pre-push` resolves the configured merge target. Its precedence
-   remains `AVERNET_PRE_PUSH_MERGE_TARGET`, Git configuration, then
-   `origin/dev`.
-2. The hook fetches the target and resolves it to an immutable commit.
-3. For each non-deletion ref, it computes `git merge-base <local> <target>`.
-4. It calls `scripts/ci/pre_push.sh --base <base> --head <local>`.
-5. The dispatcher continues to own the existing SAST, test, coverage, and
-   singlebox selection behavior.
-
-The TaskRunner guard consumes the already resolved `base` and `head`. It must
-not independently select a different comparison range or fall back to the root
-commit.
-
-This means every pushed branch is compared with the intended merge target, not
-only a direct push to `dev`.
-
-## 6. Protected-Surface Manifest
-
-The machine-readable source of truth should be a versioned JSON document. JSON
-keeps the guard on Python's standard library and avoids adding a YAML parser to
-the default pre-push path. The
-initial content is logically equivalent to:
+The guarded-submitter policy is
+`docs/arch/task-design-guard-submitters.json`. Its schema is:
 
 ```json
 {
   "version": 1,
-  "packages": [
-    {
-      "package": "agentclaw.community.core.task.task_runner",
-      "classes": [
-        {
-          "class": "agentclaw.community.core.task.task_runner.task_runner.TaskRunner",
-          "methods": ["__init__", "set_delivery", "start_run"]
-        }
-      ]
-    }
+  "guarded_submitters": [
+    "github-login"
   ]
 }
 ```
 
-The manifest identifies symbols only. It does not duplicate parameter lists,
-return annotations, decorators, or source text. Those facts are extracted from
-the base and head revisions.
+The list must be non-empty, contain valid GitHub logins, and contain no
+case-insensitive duplicates. Only a pull request authored by `regrecall` may
+change it. A policy update takes effect only after it is merged into `dev`.
 
-Phase 1 does not enforce authorship of manifest changes. Repository-level
-ownership enforcement is deferred because the local identity signal is not a
-trustworthy authorization mechanism.
+## 4. Guard Control Files
 
-## 7. Structural Rules
+A non-owner pull request is rejected with `TRG900` if it changes any of:
 
-### 7.1 Protected class
+- `.github/workflows/task-design-guard.yml`
+- `docs/arch/task-design-guard-submitters.json`
+- `docs/superpowers/specs/2026-09-03-task-runner-pre-push-design-guard.md`
+- `scripts/ci/task_design_guard.json`
+- `scripts/ci/task_design_guard.py`
 
-For `TaskRunner`, reject the push when the head revision:
+This check runs before submitter-list membership, so an unlisted account cannot
+skip the guard and alter its controls in the same pull request.
+
+## 5. Protected Surface
+
+The protected-surface manifest remains
+`scripts/ci/task_design_guard.json`. The initial policy protects:
+
+```text
+agentclaw.community.core.task.task_runner.task_runner.TaskRunner
+  __init__
+  set_delivery
+  start_run
+```
+
+The manifest identifies symbols only. Parameter lists, annotations,
+decorators, fields, and source text are extracted from the trusted base and PR
+head revisions.
+
+## 6. Structural Rules
+
+For `TaskRunner`, reject a guarded submitter's pull request when the head:
 
 - removes or renames the class;
-- changes its base classes;
-- changes its class decorators;
-- adds, removes, or changes a class-level assigned or annotated field; or
+- changes its base classes or class decorators;
+- adds, removes, or changes a directly declared class field; or
 - adds any directly declared method, including private and dunder methods.
 
-Changing only the body of an existing, non-protected method is allowed.
-Deleting an unprotected method is not independently guarded in Phase 1. A
-rename of an unprotected method is rejected because it introduces a new method
-name on the protected class.
-
-"Class-level field" means an `Assign` or `AnnAssign` node directly inside the
-class body. Instance attributes assigned inside `__init__` or another method
-are method-body implementation details and are not compared in Phase 1.
-
-### 7.2 Protected methods
-
-For `__init__`, `set_delivery`, and `start_run`, reject the push when the head
-revision:
+For `__init__`, `set_delivery`, and `start_run`, reject when the head:
 
 - removes or renames the method;
 - changes `def` to `async def` or the reverse;
-- changes method decorators;
-- changes parameter names, order, positional/keyword kind, variadic kind,
-  default values, or annotations; or
+- changes decorators;
+- changes parameter names, order, kinds, defaults, or annotations; or
 - changes the return annotation.
 
-The method fingerprint excludes the executable body and docstring. Comments,
-whitespace, formatting, local variables, control flow, called functions, and
-other body-only changes are allowed by this guard.
+Method bodies and docstrings are excluded from fingerprints. Comments,
+whitespace, local variables, control flow, and called functions may change.
 
-### 7.3 Missing symbols
+The checker uses Python's standard-library `ast` module and never imports the
+Backend module. Normalized AST rendering excludes source locations so
+formatting movement does not create a violation.
 
-Missing symbols have asymmetric handling:
+## 7. Result Contract
 
-- If a protected symbol is absent from the base revision, emit a configuration
-  warning and pass this guard. This is a fail-open response to a stale manifest.
-- If the symbol exists in the base revision but is absent from the head
-  revision, treat it as a protected deletion or rename and reject the push.
+The checker has three exit statuses:
 
-## 8. AST Comparison Model
+| Status | Meaning | Workflow result |
+| --- | --- | --- |
+| `0` | passed, owner bypass, or unlisted-author skip | pass |
+| `1` | confirmed structural violation, control-file violation, or PR-head parse failure | fail |
+| `2` | trusted policy, checker, or recoverable Git/environment failure | warn and pass |
 
-The guard should use Python's standard-library `ast` module and require no new
-third-party dependency.
+A syntax error introduced in the protected PR-head source is `TRG901`, not an
+internal failure. This prevents a guarded submitter from bypassing comparison
+by making the file unparsable.
 
-For each protected source module:
+Exit status `2` implements the approved fail-open policy. The workflow writes
+an Actions warning and a prominent warning to `$GITHUB_STEP_SUMMARY`, then
+publishes a successful status whose description identifies the degraded run.
+The workflow first publishes `pending`, then replaces it with `success` or
+`failure` after evaluation. It publishes the status explicitly on
+`github.event.pull_request.head.sha`; the `pull_request_target` workflow run
+itself is associated with the trusted base revision and must not be selected as
+the required check. If GitHub never schedules the workflow, no repository code
+can apply fail-open; the required status remains missing until GitHub recovers
+or an administrator intervenes.
 
-1. Read the base and head blobs with `git show <sha>:<path>`.
-2. Parse both blobs with `ast.parse`.
-3. Resolve the configured top-level class and its directly declared methods.
-4. Build normalized structural records with location metadata removed.
-5. Compare the records according to Section 7.
-6. Report all violations in one run rather than stopping at the first one.
+## 8. Required GitHub Configuration
 
-Normalized AST rendering must exclude `lineno`, `col_offset`, `end_lineno`, and
-`end_col_offset` so formatting-only movement does not change a fingerprint.
-Default values, annotations, bases, fields, and decorators retain their AST
-shape because they are protected structure.
+After the bootstrap pull request is merged and the workflow has completed at
+least once, a repository administrator must configure the `dev` ruleset:
 
-The guard must not import or execute either revision of the Backend module.
-Static parsing avoids import-time side effects and missing runtime dependencies.
+1. Open **Settings → Rules → Rulesets** (or the repository's branch protection
+   page).
+2. Create or edit the rule targeting `dev`.
+3. Enable **Require status checks to pass**.
+4. Add the exact status check **TaskRunner design guard**.
+5. If GitHub offers an expected-source selector, choose **GitHub Actions**.
+6. Enable **Require branches to be up to date before merging**.
+7. Leave direct-push policy unchanged, per the accepted limitation.
 
-## 9. Owner Bypass
+Select the custom commit status named `TaskRunner design guard`, not the
+workflow job named `Publish TaskRunner design guard`.
 
-Before running the TaskRunner comparison, read:
+The first workflow PR cannot protect itself because its trusted base does not
+yet contain the workflow. It must be authored and manually verified by
+`regrecall`. Required-check configuration happens immediately after that first
+successful run.
 
-```bash
-git config user.email
-```
+## 9. Diagnostics
 
-If and only if its exact output is `regrecall@gmail.com`, skip the TaskRunner
-guard and produce no TaskRunner-specific output. The bypass is intentionally
-silent.
-
-The bypass must not exit the complete pre-push dispatcher. Existing Backend
-SAST, unit-test, coverage, singlebox, and other module gates continue normally.
-
-This is a cooperative convenience, not authentication. Any local user can
-change the value, and the design makes no stronger security claim.
-
-## 10. Failure Semantics
-
-The guard has two result categories:
-
-### Policy violation
-
-A successfully extracted and compared protected structure differs according to
-Section 7. The guard exits non-zero. `scripts/ci/pre_push.sh` treats the command
-as required and prevents the normal push.
-
-The error must include:
-
-- the source path;
-- the fully qualified class and method, where applicable;
-- a stable rule identifier;
-- a concise old-versus-new structural summary; and
-- a reminder that `TaskRunner` is a protected design surface.
-
-### Guard failure
-
-Manifest loading, Git blob extraction, JSON validation, AST parsing, or an
-unexpected internal exception fails. The guard writes an English warning to
-stderr and exits zero, allowing the push to continue.
-
-A syntax error may still be rejected independently by the repository's
-existing Python SAST/lint gate. The TaskRunner guard must not change that
-behavior.
-
-## 11. Integration Point
-
-`scripts/ci/pre_push.sh` should invoke the guard as an always-on lightweight
-required step, passing its existing `--base` and `--head` values. The invocation
-must not be placed behind `run_heavy` and must not depend on
-`OCB_PRE_PUSH_RUN_CI=1`.
-
-The guard may return immediately when neither the protected source file nor the
-manifest is present in the committed diff. Calling it unconditionally keeps
-dispatch behavior simple while preserving a cheap fast path internally.
-
-The new invocation must not replace or weaken the existing Backend gate. A
-Backend change continues through SAST and, when selected, the existing heavy
-checks after the TaskRunner decision.
-
-### 11.1 Expected implementation files
-
-The later implementation should remain a small CI-tooling change:
-
-- add `scripts/ci/task_design_guard.py` for manifest loading, Git blob
-  extraction, AST normalization, comparison, diagnostics, and exit semantics;
-- add `scripts/ci/task_design_guard.json` for the protected-surface manifest;
-- add `scripts/ci/tests/test_task_design_guard.py` for comparator and command
-  behavior;
-- update `scripts/ci/pre_push.sh` to invoke the guard with its resolved base and
-  head; and
-- extend the existing pre-push dispatcher or hook tests only where integration
-  behavior needs coverage.
-
-No production Backend package should import the guard. It is repository tooling
-and must remain outside `agentclaw` runtime code.
-
-## 12. User Experience
-
-Allowed change:
+Allowed structural change:
 
 ```text
 TaskRunner design guard passed: protected structure is unchanged
+```
+
+Unlisted author:
+
+```text
+TaskRunner design guard skipped: @user is not in the guarded submitter policy
 ```
 
 Blocked change:
 
 ```text
 TaskRunner design guard failed
-TRG003 agentclaw.community.core.task.task_runner.task_runner.TaskRunner.start_run
-parameter structure changed: (toDoTaskList: list[TaskNode]) -> (nodes: Sequence[TaskNode])
-TaskRunner is a protected design surface; revert the structural change before pushing.
+TRG104 agentclaw.community.core.task.task_runner.task_runner.TaskRunner.start_run
+  parameter structure changed: ...
+TaskRunner is a protected design surface; revert the structural change before merging into dev.
 ```
 
-Guard failure:
+There is no waiver flow in Phase 1.
 
-```text
-warning: TaskRunner design guard could not parse the head revision; guard skipped
-```
+## 10. Verification
 
-No waiver instructions should appear in Phase 1 because Phase 1 has no waiver
-mechanism.
+Tests must cover:
 
-## 13. Test Strategy
+- all existing class and protected-method AST rules;
+- method-body changes passing;
+- `regrecall` bypass;
+- guarded, unlisted, and case-insensitive submitter behavior;
+- non-owner control-file changes failing before membership checks;
+- trusted manifest and submitter policy being read from the base revision;
+- malformed PR-head source returning `1`;
+- trusted configuration or base-source failures returning `2`;
+- uncommitted working-tree changes being ignored;
+- removal of the pre-push invocation; and
+- workflow trigger, least-privilege permission, trusted-checkout constraints,
+  and explicit publication to the pull request head SHA.
 
-### 13.1 Comparator unit tests
-
-Use small source fixtures to prove that the normalized comparison:
-
-- allows method-body, local-variable, comment, whitespace, and formatting
-  changes;
-- rejects a new public, private, or dunder method;
-- rejects class removal or rename;
-- rejects base-class and class-decorator changes;
-- rejects class-level field name, annotation, or value changes;
-- rejects protected-method removal or rename;
-- rejects parameter name, order, kind, default, and annotation changes;
-- rejects return-annotation, sync/async, and method-decorator changes;
-- warns and passes when the protected class or method is already absent from
-  the base revision; and
-- rejects a symbol present in base but absent in head.
-
-### 13.2 Command tests
-
-Exercise the command against temporary Git repositories to prove that it:
-
-- compares the supplied immutable base and head revisions;
-- does not inspect uncommitted working-tree changes;
-- reports all detected violations;
-- exits non-zero only for confirmed policy violations;
-- warns and exits zero for invalid manifest, Git extraction, and AST failures;
-  and
-- silently returns success when `git config user.email` is exactly
-  `regrecall@gmail.com`.
-
-### 13.3 Pre-push integration tests
-
-Extend the existing pre-push dispatcher tests to prove that:
-
-- the TaskRunner guard runs in lint-only mode;
-- the TaskRunner guard runs in full-CI mode;
-- an owner bypass skips only the new guard;
-- existing Backend SAST dispatch remains active after an owner bypass;
-- a rejected guard result prevents the push; and
-- unrelated module dispatch behavior is unchanged.
-
-## 14. Acceptance Criteria
-
-Phase 1 is complete when:
-
-- the manifest identifies exactly `TaskRunner`, `__init__`, `set_delivery`, and
-  `start_run`;
-- every structural rule in Section 7 has a passing regression test;
-- a body-only edit to any protected method can be pushed normally;
-- a protected structural edit is rejected in the default lint-only pre-push
-  mode;
-- `regrecall@gmail.com` silently bypasses only the TaskRunner guard;
-- guard failures warn and allow the push;
-- the existing hook and dispatcher tests remain green; and
-- the hook installation documentation still accurately states that hooks are
-  installed per worktree and may be skipped by Git.
-
-## 15. Architecture Alignment and Limitations
+## 11. Architecture Alignment
 
 This guard supports Architecture Constitution Rules 16 and 17 by distinguishing
 a selected constrained surface from flexible implementation details and by
-making structural changes visible before push. It also follows the existing
-pre-push merge-base contract instead of inventing a conflicting change range.
-
-It does not satisfy the constitution's CI, conformance-test, structural-review,
-or waiver requirements by itself. Because it is local, bypassable, and
-fail-open on internal errors, it must not be presented as proof that a pull
-request is architecture-compliant.
-
-Protecting a concrete class is an intentionally narrow Phase 1 policy. It does
-not reclassify `TaskRunner` as a Service API or Plugin API, and it does not
-replace the existing `DeliveryPort` or Task service contracts.
-
-## 16. Deferred Phase 2
-
-A later design may move enforcement to pull requests and add:
-
-- a required GitHub status check for PRs targeting `dev`;
-- Codex review through the official Codex GitHub Action;
-- a protected, owner-maintained contract manifest;
-- GitHub identity and approval verification for `@regrecall`;
-- structured, head-bound waivers;
-- sticky PR review comments and source annotations;
-- fail-closed configuration validation; and
-- protection against local hook bypass and guard self-modification.
-
-Phase 2 must be reviewed as a separate security and governance boundary. It
-must not silently inherit the cooperative identity or fail-open assumptions of
-Phase 1.
+making structural changes visible before they enter `dev`. It remains a narrow
+governance policy for a concrete class; it does not reclassify `TaskRunner` as
+a Service API or Plugin API and does not replace conformance tests.

--- a/docs/superpowers/specs/2026-09-03-task-runner-pre-push-design-guard.md
+++ b/docs/superpowers/specs/2026-09-03-task-runner-pre-push-design-guard.md
@@ -1,0 +1,384 @@
+# TaskRunner Pre-Push Design Guard
+
+- **Status:** Implemented
+- **Phase:** 1 — local developer guard
+- **Date:** 2026-09-03
+- **Target baseline:** `origin/dev`, unless the repository's existing pre-push
+  merge-target configuration selects another `<remote>/<branch>`
+- **Protected owner identity:** local Git email `regrecall@gmail.com`
+
+## 1. Decision Summary
+
+Add a small, deterministic AST guard to the repository's existing pre-push
+pipeline. The guard protects selected structural surfaces of `TaskRunner` and
+rejects a normal `git push` when a committed change modifies those surfaces.
+
+Phase 1 is deliberately a local development aid, not a security boundary or a
+server CI gate. Git hooks are installed per worktree and can be bypassed with
+`git push --no-verify`. The configured owner email is also locally mutable.
+Those limitations are accepted for this phase and must remain explicit in user
+documentation and diagnostics.
+
+Phase 1 does not call Codex, inspect pull requests, validate GitHub approvals,
+or support waivers. Those capabilities belong to a later server-side phase.
+
+## 2. Problem
+
+The Backend Task framework contains structural seams that downstream callers
+and integrations already rely on. In particular, `TaskRunner` is the execution
+boundary used to inject delivery behavior and start a batch of dispatched task
+nodes. Casual changes to its class shape or selected method signatures can
+propagate into the orchestration engine, dependency wiring, test doubles, and
+production integrations.
+
+The repository already has a pre-push pipeline, but it currently selects broad
+module gates from changed paths. It does not distinguish a flexible method-body
+refactor from a structural change to an explicitly protected class or method.
+
+The first increment needs a fast local signal at push time without expanding
+the existing heavy-test default or requiring a model, network service, or new
+developer credential.
+
+## 3. Goals
+
+1. Reject a normal push when a committed change modifies the protected
+   `TaskRunner` class structure or one of its protected method interfaces.
+2. Permit implementation-only edits inside method bodies.
+3. Reuse the existing immutable merge-base and head SHAs supplied by the
+   pre-push hook.
+4. Run in both lint-only and full-CI pre-push modes.
+5. Produce deterministic, English diagnostics that identify the protected
+   symbol and the structural difference.
+6. Allow the configured local owner identity to skip only this new guard.
+7. Fail open on guard configuration, extraction, or parser errors, while making
+   the degraded result visible as a warning.
+
+## 4. Non-Goals
+
+- An unbypassable repository policy.
+- Protection against a contributor changing their local Git email.
+- Protection against `git push --no-verify` or an uninstalled hook.
+- Pull-request review, GitHub branch protection, or required status checks.
+- Codex or another model participating in the Phase 1 decision.
+- Waiver creation, approval, expiry, or verification.
+- Detecting semantic behavior changes inside method bodies.
+- Discovering omitted protected classes or methods automatically.
+- Reviewing other files in the Backend Task package.
+- Self-protection against a local contributor editing the guard, its manifest,
+  or the hook before pushing.
+
+## 5. Existing Pre-Push Contract
+
+The implementation must extend, rather than replace, the current flow:
+
+1. `.githooks/pre-push` resolves the configured merge target. Its precedence
+   remains `AVERNET_PRE_PUSH_MERGE_TARGET`, Git configuration, then
+   `origin/dev`.
+2. The hook fetches the target and resolves it to an immutable commit.
+3. For each non-deletion ref, it computes `git merge-base <local> <target>`.
+4. It calls `scripts/ci/pre_push.sh --base <base> --head <local>`.
+5. The dispatcher continues to own the existing SAST, test, coverage, and
+   singlebox selection behavior.
+
+The TaskRunner guard consumes the already resolved `base` and `head`. It must
+not independently select a different comparison range or fall back to the root
+commit.
+
+This means every pushed branch is compared with the intended merge target, not
+only a direct push to `dev`.
+
+## 6. Protected-Surface Manifest
+
+The machine-readable source of truth should be a versioned JSON document. JSON
+keeps the guard on Python's standard library and avoids adding a YAML parser to
+the default pre-push path. The
+initial content is logically equivalent to:
+
+```json
+{
+  "version": 1,
+  "packages": [
+    {
+      "package": "agentclaw.community.core.task.task_runner",
+      "classes": [
+        {
+          "class": "agentclaw.community.core.task.task_runner.task_runner.TaskRunner",
+          "methods": ["__init__", "set_delivery", "start_run"]
+        }
+      ]
+    }
+  ]
+}
+```
+
+The manifest identifies symbols only. It does not duplicate parameter lists,
+return annotations, decorators, or source text. Those facts are extracted from
+the base and head revisions.
+
+Phase 1 does not enforce authorship of manifest changes. Repository-level
+ownership enforcement is deferred because the local identity signal is not a
+trustworthy authorization mechanism.
+
+## 7. Structural Rules
+
+### 7.1 Protected class
+
+For `TaskRunner`, reject the push when the head revision:
+
+- removes or renames the class;
+- changes its base classes;
+- changes its class decorators;
+- adds, removes, or changes a class-level assigned or annotated field; or
+- adds any directly declared method, including private and dunder methods.
+
+Changing only the body of an existing, non-protected method is allowed.
+Deleting an unprotected method is not independently guarded in Phase 1. A
+rename of an unprotected method is rejected because it introduces a new method
+name on the protected class.
+
+"Class-level field" means an `Assign` or `AnnAssign` node directly inside the
+class body. Instance attributes assigned inside `__init__` or another method
+are method-body implementation details and are not compared in Phase 1.
+
+### 7.2 Protected methods
+
+For `__init__`, `set_delivery`, and `start_run`, reject the push when the head
+revision:
+
+- removes or renames the method;
+- changes `def` to `async def` or the reverse;
+- changes method decorators;
+- changes parameter names, order, positional/keyword kind, variadic kind,
+  default values, or annotations; or
+- changes the return annotation.
+
+The method fingerprint excludes the executable body and docstring. Comments,
+whitespace, formatting, local variables, control flow, called functions, and
+other body-only changes are allowed by this guard.
+
+### 7.3 Missing symbols
+
+Missing symbols have asymmetric handling:
+
+- If a protected symbol is absent from the base revision, emit a configuration
+  warning and pass this guard. This is a fail-open response to a stale manifest.
+- If the symbol exists in the base revision but is absent from the head
+  revision, treat it as a protected deletion or rename and reject the push.
+
+## 8. AST Comparison Model
+
+The guard should use Python's standard-library `ast` module and require no new
+third-party dependency.
+
+For each protected source module:
+
+1. Read the base and head blobs with `git show <sha>:<path>`.
+2. Parse both blobs with `ast.parse`.
+3. Resolve the configured top-level class and its directly declared methods.
+4. Build normalized structural records with location metadata removed.
+5. Compare the records according to Section 7.
+6. Report all violations in one run rather than stopping at the first one.
+
+Normalized AST rendering must exclude `lineno`, `col_offset`, `end_lineno`, and
+`end_col_offset` so formatting-only movement does not change a fingerprint.
+Default values, annotations, bases, fields, and decorators retain their AST
+shape because they are protected structure.
+
+The guard must not import or execute either revision of the Backend module.
+Static parsing avoids import-time side effects and missing runtime dependencies.
+
+## 9. Owner Bypass
+
+Before running the TaskRunner comparison, read:
+
+```bash
+git config user.email
+```
+
+If and only if its exact output is `regrecall@gmail.com`, skip the TaskRunner
+guard and produce no TaskRunner-specific output. The bypass is intentionally
+silent.
+
+The bypass must not exit the complete pre-push dispatcher. Existing Backend
+SAST, unit-test, coverage, singlebox, and other module gates continue normally.
+
+This is a cooperative convenience, not authentication. Any local user can
+change the value, and the design makes no stronger security claim.
+
+## 10. Failure Semantics
+
+The guard has two result categories:
+
+### Policy violation
+
+A successfully extracted and compared protected structure differs according to
+Section 7. The guard exits non-zero. `scripts/ci/pre_push.sh` treats the command
+as required and prevents the normal push.
+
+The error must include:
+
+- the source path;
+- the fully qualified class and method, where applicable;
+- a stable rule identifier;
+- a concise old-versus-new structural summary; and
+- a reminder that `TaskRunner` is a protected design surface.
+
+### Guard failure
+
+Manifest loading, Git blob extraction, JSON validation, AST parsing, or an
+unexpected internal exception fails. The guard writes an English warning to
+stderr and exits zero, allowing the push to continue.
+
+A syntax error may still be rejected independently by the repository's
+existing Python SAST/lint gate. The TaskRunner guard must not change that
+behavior.
+
+## 11. Integration Point
+
+`scripts/ci/pre_push.sh` should invoke the guard as an always-on lightweight
+required step, passing its existing `--base` and `--head` values. The invocation
+must not be placed behind `run_heavy` and must not depend on
+`OCB_PRE_PUSH_RUN_CI=1`.
+
+The guard may return immediately when neither the protected source file nor the
+manifest is present in the committed diff. Calling it unconditionally keeps
+dispatch behavior simple while preserving a cheap fast path internally.
+
+The new invocation must not replace or weaken the existing Backend gate. A
+Backend change continues through SAST and, when selected, the existing heavy
+checks after the TaskRunner decision.
+
+### 11.1 Expected implementation files
+
+The later implementation should remain a small CI-tooling change:
+
+- add `scripts/ci/task_design_guard.py` for manifest loading, Git blob
+  extraction, AST normalization, comparison, diagnostics, and exit semantics;
+- add `scripts/ci/task_design_guard.json` for the protected-surface manifest;
+- add `scripts/ci/tests/test_task_design_guard.py` for comparator and command
+  behavior;
+- update `scripts/ci/pre_push.sh` to invoke the guard with its resolved base and
+  head; and
+- extend the existing pre-push dispatcher or hook tests only where integration
+  behavior needs coverage.
+
+No production Backend package should import the guard. It is repository tooling
+and must remain outside `agentclaw` runtime code.
+
+## 12. User Experience
+
+Allowed change:
+
+```text
+TaskRunner design guard passed: protected structure is unchanged
+```
+
+Blocked change:
+
+```text
+TaskRunner design guard failed
+TRG003 agentclaw.community.core.task.task_runner.task_runner.TaskRunner.start_run
+parameter structure changed: (toDoTaskList: list[TaskNode]) -> (nodes: Sequence[TaskNode])
+TaskRunner is a protected design surface; revert the structural change before pushing.
+```
+
+Guard failure:
+
+```text
+warning: TaskRunner design guard could not parse the head revision; guard skipped
+```
+
+No waiver instructions should appear in Phase 1 because Phase 1 has no waiver
+mechanism.
+
+## 13. Test Strategy
+
+### 13.1 Comparator unit tests
+
+Use small source fixtures to prove that the normalized comparison:
+
+- allows method-body, local-variable, comment, whitespace, and formatting
+  changes;
+- rejects a new public, private, or dunder method;
+- rejects class removal or rename;
+- rejects base-class and class-decorator changes;
+- rejects class-level field name, annotation, or value changes;
+- rejects protected-method removal or rename;
+- rejects parameter name, order, kind, default, and annotation changes;
+- rejects return-annotation, sync/async, and method-decorator changes;
+- warns and passes when the protected class or method is already absent from
+  the base revision; and
+- rejects a symbol present in base but absent in head.
+
+### 13.2 Command tests
+
+Exercise the command against temporary Git repositories to prove that it:
+
+- compares the supplied immutable base and head revisions;
+- does not inspect uncommitted working-tree changes;
+- reports all detected violations;
+- exits non-zero only for confirmed policy violations;
+- warns and exits zero for invalid manifest, Git extraction, and AST failures;
+  and
+- silently returns success when `git config user.email` is exactly
+  `regrecall@gmail.com`.
+
+### 13.3 Pre-push integration tests
+
+Extend the existing pre-push dispatcher tests to prove that:
+
+- the TaskRunner guard runs in lint-only mode;
+- the TaskRunner guard runs in full-CI mode;
+- an owner bypass skips only the new guard;
+- existing Backend SAST dispatch remains active after an owner bypass;
+- a rejected guard result prevents the push; and
+- unrelated module dispatch behavior is unchanged.
+
+## 14. Acceptance Criteria
+
+Phase 1 is complete when:
+
+- the manifest identifies exactly `TaskRunner`, `__init__`, `set_delivery`, and
+  `start_run`;
+- every structural rule in Section 7 has a passing regression test;
+- a body-only edit to any protected method can be pushed normally;
+- a protected structural edit is rejected in the default lint-only pre-push
+  mode;
+- `regrecall@gmail.com` silently bypasses only the TaskRunner guard;
+- guard failures warn and allow the push;
+- the existing hook and dispatcher tests remain green; and
+- the hook installation documentation still accurately states that hooks are
+  installed per worktree and may be skipped by Git.
+
+## 15. Architecture Alignment and Limitations
+
+This guard supports Architecture Constitution Rules 16 and 17 by distinguishing
+a selected constrained surface from flexible implementation details and by
+making structural changes visible before push. It also follows the existing
+pre-push merge-base contract instead of inventing a conflicting change range.
+
+It does not satisfy the constitution's CI, conformance-test, structural-review,
+or waiver requirements by itself. Because it is local, bypassable, and
+fail-open on internal errors, it must not be presented as proof that a pull
+request is architecture-compliant.
+
+Protecting a concrete class is an intentionally narrow Phase 1 policy. It does
+not reclassify `TaskRunner` as a Service API or Plugin API, and it does not
+replace the existing `DeliveryPort` or Task service contracts.
+
+## 16. Deferred Phase 2
+
+A later design may move enforcement to pull requests and add:
+
+- a required GitHub status check for PRs targeting `dev`;
+- Codex review through the official Codex GitHub Action;
+- a protected, owner-maintained contract manifest;
+- GitHub identity and approval verification for `@regrecall`;
+- structured, head-bound waivers;
+- sticky PR review comments and source annotations;
+- fail-closed configuration validation; and
+- protection against local hook bypass and guard self-modification.
+
+Phase 2 must be reviewed as a separate security and governance boundary. It
+must not silently inherit the cooperative identity or fail-open assumptions of
+Phase 1.

--- a/scripts/ci/pre_push.sh
+++ b/scripts/ci/pre_push.sh
@@ -125,12 +125,6 @@ if [[ -z "$changed_files" ]]; then
   exit 0
 fi
 
-# TaskRunner design guard is a lightweight, always-on pre-push check. It is
-# intentionally outside run_heavy so the protected structure is checked in the
-# default lint-only mode as well as in full CI mode.
-run_required python3 "$repo_root/scripts/ci/task_design_guard.py" \
-  --base "$base" --head "$head"
-
 if matches_any '^src/backend/'; then
   # Backend 默认强卡点:
   # 1) python_sast_local.sh 近似线上 python-sast block 规则,且只扫本次变更 Python 文件

--- a/scripts/ci/pre_push.sh
+++ b/scripts/ci/pre_push.sh
@@ -125,6 +125,12 @@ if [[ -z "$changed_files" ]]; then
   exit 0
 fi
 
+# TaskRunner design guard is a lightweight, always-on pre-push check. It is
+# intentionally outside run_heavy so the protected structure is checked in the
+# default lint-only mode as well as in full CI mode.
+run_required python3 "$repo_root/scripts/ci/task_design_guard.py" \
+  --base "$base" --head "$head"
+
 if matches_any '^src/backend/'; then
   # Backend 默认强卡点:
   # 1) python_sast_local.sh 近似线上 python-sast block 规则,且只扫本次变更 Python 文件

--- a/scripts/ci/task_design_guard.json
+++ b/scripts/ci/task_design_guard.json
@@ -1,0 +1,18 @@
+{
+  "version": 1,
+  "packages": [
+    {
+      "package": "agentclaw.community.core.task.task_runner",
+      "classes": [
+        {
+          "class": "agentclaw.community.core.task.task_runner.task_runner.TaskRunner",
+          "methods": [
+            "__init__",
+            "set_delivery",
+            "start_run"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/ci/task_design_guard.py
+++ b/scripts/ci/task_design_guard.py
@@ -1,0 +1,486 @@
+#!/usr/bin/env python3
+"""Protect selected Task module class structure during pre-push."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+from collections import Counter
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+from typing import Any, NamedTuple, Sequence
+
+
+OWNER_EMAIL = "regrecall@gmail.com"
+DEFAULT_MANIFEST = "scripts/ci/task_design_guard.json"
+BACKEND_SOURCE_ROOT = Path("src/backend/src")
+
+
+class GuardFailure(RuntimeError):
+    """The guard could not establish a reliable comparison."""
+
+
+class ProtectedClass(NamedTuple):
+    package: str
+    qualified_name: str
+    module: str
+    name: str
+    methods: tuple[str, ...]
+    source_path: str
+
+
+class Violation(NamedTuple):
+    rule: str
+    symbol: str
+    detail: str
+
+
+class Comparison(NamedTuple):
+    violations: tuple[Violation, ...]
+    warnings: tuple[str, ...]
+
+
+def _clean_git_environment() -> dict[str, str]:
+    environment = os.environ.copy()
+    for name in ("GIT_DIR", "GIT_WORK_TREE", "GIT_PREFIX", "GIT_INDEX_FILE"):
+        environment.pop(name, None)
+    return environment
+
+
+def _git(
+    repository: Path, arguments: Sequence[str], *, required: bool = True
+) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        ["git", *arguments],
+        cwd=repository,
+        env=_clean_git_environment(),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if required and result.returncode != 0:
+        message = result.stderr.strip() or result.stdout.strip() or "unknown Git error"
+        raise GuardFailure(f"git {' '.join(arguments)} failed: {message}")
+    return result
+
+
+def find_repository_root(start: Path) -> Path:
+    result = _git(start, ["rev-parse", "--show-toplevel"])
+    return Path(result.stdout.strip()).resolve()
+
+
+def configured_email(repository: Path) -> str | None:
+    result = _git(repository, ["config", "--get", "user.email"], required=False)
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def _read_blob(repository: Path, revision: str, path: str) -> str | None:
+    result = _git(repository, ["show", f"{revision}:{path}"], required=False)
+    if result.returncode == 0:
+        return result.stdout
+    missing_markers = (
+        "does not exist in",
+        "exists on disk, but not in",
+        "path '",
+    )
+    if any(marker in result.stderr for marker in missing_markers):
+        return None
+    message = result.stderr.strip() or result.stdout.strip() or "unknown Git error"
+    raise GuardFailure(f"could not read {path} at {revision}: {message}")
+
+
+def _expect_string(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise GuardFailure(f"manifest field {field} must be a non-empty string")
+    return value
+
+
+def _expect_list(value: Any, field: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise GuardFailure(f"manifest field {field} must be a list")
+    return value
+
+
+def load_manifest(text: str) -> tuple[ProtectedClass, ...]:
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as error:
+        raise GuardFailure(f"manifest is not valid JSON: {error}") from error
+    if not isinstance(payload, dict) or payload.get("version") != 1:
+        raise GuardFailure("manifest version must be 1")
+
+    protected: list[ProtectedClass] = []
+    seen_classes: set[str] = set()
+    for package_index, package_entry in enumerate(
+        _expect_list(payload.get("packages"), "packages")
+    ):
+        if not isinstance(package_entry, dict):
+            raise GuardFailure(f"packages[{package_index}] must be an object")
+        package = _expect_string(
+            package_entry.get("package"), f"packages[{package_index}].package"
+        )
+        classes = _expect_list(
+            package_entry.get("classes"), f"packages[{package_index}].classes"
+        )
+        for class_index, class_entry in enumerate(classes):
+            prefix = f"packages[{package_index}].classes[{class_index}]"
+            if not isinstance(class_entry, dict):
+                raise GuardFailure(f"{prefix} must be an object")
+            qualified_name = _expect_string(class_entry.get("class"), f"{prefix}.class")
+            if qualified_name in seen_classes:
+                raise GuardFailure(f"duplicate protected class: {qualified_name}")
+            module, separator, class_name = qualified_name.rpartition(".")
+            if not separator or not module.startswith(package):
+                raise GuardFailure(
+                    f"protected class {qualified_name} is outside package {package}"
+                )
+            raw_methods = _expect_list(class_entry.get("methods"), f"{prefix}.methods")
+            methods = tuple(
+                _expect_string(method, f"{prefix}.methods[{index}]")
+                for index, method in enumerate(raw_methods)
+            )
+            if len(set(methods)) != len(methods):
+                raise GuardFailure(f"duplicate protected method in {qualified_name}")
+            source_path = str(
+                (BACKEND_SOURCE_ROOT / Path(*module.split("."))).with_suffix(".py")
+            )
+            protected.append(
+                ProtectedClass(
+                    package=package,
+                    qualified_name=qualified_name,
+                    module=module,
+                    name=class_name,
+                    methods=methods,
+                    source_path=source_path,
+                )
+            )
+            seen_classes.add(qualified_name)
+    if not protected:
+        raise GuardFailure("manifest must protect at least one class")
+    return tuple(protected)
+
+
+def _parse(source: str, label: str) -> ast.Module:
+    try:
+        return ast.parse(source, filename=label)
+    except SyntaxError as error:
+        raise GuardFailure(f"could not parse {label}: {error}") from error
+
+
+def _find_class(tree: ast.Module, name: str) -> ast.ClassDef | None:
+    return next(
+        (node for node in tree.body if isinstance(node, ast.ClassDef) and node.name == name),
+        None,
+    )
+
+
+def _methods(node: ast.ClassDef) -> list[ast.FunctionDef | ast.AsyncFunctionDef]:
+    return [
+        child
+        for child in node.body
+        if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef))
+    ]
+
+
+def _find_method(
+    node: ast.ClassDef, name: str
+) -> ast.FunctionDef | ast.AsyncFunctionDef | None:
+    return next((method for method in _methods(node) if method.name == name), None)
+
+
+def _dump(node: ast.AST | None) -> str | None:
+    return None if node is None else ast.dump(node, include_attributes=False)
+
+
+def _dump_many(nodes: Sequence[ast.AST]) -> tuple[str, ...]:
+    return tuple(ast.dump(node, include_attributes=False) for node in nodes)
+
+
+def _class_bases(node: ast.ClassDef) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    bases = _dump_many(node.bases) + _method_type_parameters(node)
+    keywords = tuple(
+        f"{keyword.arg}={ast.dump(keyword.value, include_attributes=False)}"
+        for keyword in node.keywords
+    )
+    return bases, keywords
+
+
+def _class_fields(node: ast.ClassDef) -> tuple[str, ...]:
+    fields: list[str] = []
+    for child in node.body:
+        if isinstance(child, ast.Assign):
+            targets = ",".join(
+                ast.dump(target, include_attributes=False) for target in child.targets
+            )
+            value = ast.dump(child.value, include_attributes=False)
+            fields.append(f"assign:{targets}={value}:type_comment={child.type_comment!r}")
+        elif isinstance(child, ast.AnnAssign):
+            target = ast.dump(child.target, include_attributes=False)
+            annotation = ast.dump(child.annotation, include_attributes=False)
+            value = _dump(child.value)
+            fields.append(
+                f"annotated:{target}:{annotation}={value}:simple={child.simple}"
+            )
+    return tuple(sorted(fields))
+
+
+def _method_kind(node: ast.FunctionDef | ast.AsyncFunctionDef) -> str:
+    return "async" if isinstance(node, ast.AsyncFunctionDef) else "sync"
+
+
+def _method_type_parameters(node: ast.AST) -> tuple[str, ...]:
+    return _dump_many(getattr(node, "type_params", ()))
+
+
+def _short(value: object, limit: int = 360) -> str:
+    rendered = repr(value)
+    return rendered if len(rendered) <= limit else rendered[: limit - 3] + "..."
+
+
+def compare_class_sources(
+    base_source: str,
+    head_source: str,
+    protected: ProtectedClass,
+) -> Comparison:
+    base_tree = _parse(base_source, f"base:{protected.source_path}")
+    head_tree = _parse(head_source, f"head:{protected.source_path}")
+    base_class = _find_class(base_tree, protected.name)
+    head_class = _find_class(head_tree, protected.name)
+
+    if base_class is None:
+        return Comparison(
+            violations=(),
+            warnings=(
+                f"protected class {protected.qualified_name} is absent from the base revision; guard skipped",
+            ),
+        )
+    if head_class is None:
+        return Comparison(
+            violations=(
+                Violation(
+                    "TRG001",
+                    protected.qualified_name,
+                    "protected class was removed or renamed",
+                ),
+            ),
+            warnings=(),
+        )
+
+    violations: list[Violation] = []
+    warnings: list[str] = []
+    base_bases = _class_bases(base_class)
+    head_bases = _class_bases(head_class)
+    if base_bases != head_bases:
+        violations.append(
+            Violation(
+                "TRG002",
+                protected.qualified_name,
+                f"base classes changed: {_short(base_bases)} -> {_short(head_bases)}",
+            )
+        )
+
+    base_decorators = _dump_many(base_class.decorator_list)
+    head_decorators = _dump_many(head_class.decorator_list)
+    if base_decorators != head_decorators:
+        violations.append(
+            Violation(
+                "TRG003",
+                protected.qualified_name,
+                "class decorators changed: "
+                f"{_short(base_decorators)} -> {_short(head_decorators)}",
+            )
+        )
+
+    base_fields = _class_fields(base_class)
+    head_fields = _class_fields(head_class)
+    if base_fields != head_fields:
+        violations.append(
+            Violation(
+                "TRG004",
+                protected.qualified_name,
+                f"class fields changed: {_short(base_fields)} -> {_short(head_fields)}",
+            )
+        )
+
+    base_method_counts = Counter(method.name for method in _methods(base_class))
+    head_method_counts = Counter(method.name for method in _methods(head_class))
+    for method_name in sorted(head_method_counts):
+        added = head_method_counts[method_name] - base_method_counts[method_name]
+        if added > 0:
+            violations.append(
+                Violation(
+                    "TRG005",
+                    f"{protected.qualified_name}.{method_name}",
+                    "method was added to the protected class",
+                )
+            )
+
+    for method_name in protected.methods:
+        symbol = f"{protected.qualified_name}.{method_name}"
+        base_method = _find_method(base_class, method_name)
+        head_method = _find_method(head_class, method_name)
+        if base_method is None:
+            warnings.append(
+                f"protected method {symbol} is absent from the base revision; method guard skipped"
+            )
+            continue
+        if head_method is None:
+            violations.append(
+                Violation(
+                    "TRG101", symbol, "protected method was removed or renamed"
+                )
+            )
+            continue
+
+        base_kind = _method_kind(base_method)
+        head_kind = _method_kind(head_method)
+        if base_kind != head_kind:
+            violations.append(
+                Violation(
+                    "TRG102",
+                    symbol,
+                    f"method kind changed: {base_kind} -> {head_kind}",
+                )
+            )
+
+        base_method_decorators = _dump_many(base_method.decorator_list)
+        head_method_decorators = _dump_many(head_method.decorator_list)
+        if base_method_decorators != head_method_decorators:
+            violations.append(
+                Violation(
+                    "TRG103",
+                    symbol,
+                    "method decorators changed: "
+                    f"{_short(base_method_decorators)} -> {_short(head_method_decorators)}",
+                )
+            )
+
+        base_arguments = (_dump(base_method.args), base_method.type_comment)
+        head_arguments = (_dump(head_method.args), head_method.type_comment)
+        base_type_parameters = _method_type_parameters(base_method)
+        head_type_parameters = _method_type_parameters(head_method)
+        if (base_arguments, base_type_parameters) != (
+            head_arguments,
+            head_type_parameters,
+        ):
+            violations.append(
+                Violation(
+                    "TRG104",
+                    symbol,
+                    "parameter structure changed: "
+                    f"{_short((base_arguments, base_type_parameters))} -> "
+                    f"{_short((head_arguments, head_type_parameters))}",
+                )
+            )
+
+        base_return = _dump(base_method.returns)
+        head_return = _dump(head_method.returns)
+        if base_return != head_return:
+            violations.append(
+                Violation(
+                    "TRG105",
+                    symbol,
+                    f"return annotation changed: {_short(base_return)} -> {_short(head_return)}",
+                )
+            )
+
+    return Comparison(tuple(violations), tuple(warnings))
+
+
+def changed_files(repository: Path, base: str, head: str) -> set[str]:
+    result = _git(repository, ["diff", "--name-only", base, head, "--"])
+    return {line for line in result.stdout.splitlines() if line}
+
+
+def evaluate(
+    repository: Path,
+    base: str,
+    head: str,
+    manifest_path: str = DEFAULT_MANIFEST,
+) -> tuple[Comparison, bool]:
+    manifest_text = _read_blob(repository, head, manifest_path)
+    if manifest_text is None:
+        raise GuardFailure(f"manifest {manifest_path} is absent from {head}")
+    protected_classes = load_manifest(manifest_text)
+    changed = changed_files(repository, base, head)
+    relevant_paths = {manifest_path, *(item.source_path for item in protected_classes)}
+    if changed.isdisjoint(relevant_paths):
+        return Comparison((), ()), False
+
+    violations: list[Violation] = []
+    warnings: list[str] = []
+    for protected in protected_classes:
+        if protected.source_path not in changed and manifest_path not in changed:
+            continue
+        base_source = _read_blob(repository, base, protected.source_path)
+        if base_source is None:
+            warnings.append(
+                f"protected source {protected.source_path} is absent from the base revision; guard skipped"
+            )
+            continue
+        head_source = _read_blob(repository, head, protected.source_path)
+        if head_source is None:
+            violations.append(
+                Violation(
+                    "TRG001",
+                    protected.qualified_name,
+                    f"protected source {protected.source_path} was removed",
+                )
+            )
+            continue
+        result = compare_class_sources(base_source, head_source, protected)
+        violations.extend(result.violations)
+        warnings.extend(result.warnings)
+    return Comparison(tuple(violations), tuple(warnings)), True
+
+
+def _print_violations(violations: Sequence[Violation]) -> None:
+    print("TaskRunner design guard failed", file=sys.stderr)
+    for violation in violations:
+        print(
+            f"{violation.rule} {violation.symbol}\n  {violation.detail}",
+            file=sys.stderr,
+        )
+    print(
+        "TaskRunner is a protected design surface; revert the structural change before pushing.",
+        file=sys.stderr,
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", required=True)
+    parser.add_argument("--head", required=True)
+    parser.add_argument("--manifest", default=DEFAULT_MANIFEST)
+    arguments = parser.parse_args(argv)
+
+    try:
+        repository = find_repository_root(Path.cwd())
+        if configured_email(repository) == OWNER_EMAIL:
+            return 0
+        comparison, relevant = evaluate(
+            repository,
+            arguments.base,
+            arguments.head,
+            arguments.manifest,
+        )
+        for warning in comparison.warnings:
+            print(f"warning: {warning}", file=sys.stderr)
+        if comparison.violations:
+            _print_violations(comparison.violations)
+            return 1
+        if relevant:
+            print("TaskRunner design guard passed: protected structure is unchanged")
+        return 0
+    except Exception as error:  # Fail open by explicit Phase 1 policy.
+        print(f"warning: TaskRunner design guard skipped: {error}", file=sys.stderr)
+        return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/task_design_guard.py
+++ b/scripts/ci/task_design_guard.py
@@ -1,26 +1,41 @@
-#!/usr/bin/env python3
-"""Protect selected Task module class structure during pre-push."""
+"""Protect selected Task module structure on pull requests targeting dev."""
 
 from __future__ import annotations
 
 import argparse
 import ast
-from collections import Counter
 import json
 import os
-from pathlib import Path
+import re
 import subprocess
 import sys
-from typing import Any, NamedTuple, Sequence
+from collections import Counter
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any, NamedTuple
 
-
-OWNER_EMAIL = "regrecall@gmail.com"
+OWNER_LOGIN = "regrecall"
 DEFAULT_MANIFEST = "scripts/ci/task_design_guard.json"
+DEFAULT_SUBMITTERS = "docs/arch/task-design-guard-submitters.json"
 BACKEND_SOURCE_ROOT = Path("src/backend/src")
+PROTECTED_CONTROL_PATHS = frozenset(
+    {
+        ".github/workflows/task-design-guard.yml",
+        "docs/arch/task-design-guard-submitters.json",
+        "docs/superpowers/specs/2026-09-03-task-runner-pre-push-design-guard.md",
+        "scripts/ci/task_design_guard.json",
+        "scripts/ci/task_design_guard.py",
+    }
+)
+GITHUB_LOGIN = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$")
 
 
 class GuardFailure(RuntimeError):
-    """The guard could not establish a reliable comparison."""
+    """The trusted guard could not establish a reliable comparison."""
+
+
+class HeadPolicyFailure(RuntimeError):
+    """The pull request made the protected source impossible to validate."""
 
 
 class ProtectedClass(NamedTuple):
@@ -43,6 +58,12 @@ class Comparison(NamedTuple):
     warnings: tuple[str, ...]
 
 
+class Evaluation(NamedTuple):
+    comparison: Comparison
+    relevant: bool
+    skipped_reason: str | None
+
+
 def _clean_git_environment() -> dict[str, str]:
     environment = os.environ.copy()
     for name in ("GIT_DIR", "GIT_WORK_TREE", "GIT_PREFIX", "GIT_INDEX_FILE"):
@@ -57,9 +78,9 @@ def _git(
         ["git", *arguments],
         cwd=repository,
         env=_clean_git_environment(),
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
         text=True,
+        check=False,
     )
     if required and result.returncode != 0:
         message = result.stderr.strip() or result.stdout.strip() or "unknown Git error"
@@ -70,13 +91,6 @@ def _git(
 def find_repository_root(start: Path) -> Path:
     result = _git(start, ["rev-parse", "--show-toplevel"])
     return Path(result.stdout.strip()).resolve()
-
-
-def configured_email(repository: Path) -> str | None:
-    result = _git(repository, ["config", "--get", "user.email"], required=False)
-    if result.returncode != 0:
-        return None
-    return result.stdout.strip()
 
 
 def _read_blob(repository: Path, revision: str, path: str) -> str | None:
@@ -165,16 +179,55 @@ def load_manifest(text: str) -> tuple[ProtectedClass, ...]:
     return tuple(protected)
 
 
-def _parse(source: str, label: str) -> ast.Module:
+def load_guarded_submitters(text: str) -> frozenset[str]:
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as error:
+        raise GuardFailure(f"submitter policy is not valid JSON: {error}") from error
+    if not isinstance(payload, dict):
+        raise GuardFailure("submitter policy must be an object")
+    expected_keys = {"version", "guarded_submitters"}
+    if set(payload) != expected_keys:
+        raise GuardFailure(
+            "submitter policy must contain exactly version and guarded_submitters"
+        )
+    if payload.get("version") != 1:
+        raise GuardFailure("submitter policy version must be 1")
+    raw_submitters = payload.get("guarded_submitters")
+    if not isinstance(raw_submitters, list) or not raw_submitters:
+        raise GuardFailure("guarded_submitters must be a non-empty list")
+
+    submitters: set[str] = set()
+    for index, login in enumerate(raw_submitters):
+        if not isinstance(login, str) or not GITHUB_LOGIN.fullmatch(login):
+            raise GuardFailure(
+                f"guarded_submitters[{index}] must be a valid GitHub login"
+            )
+        normalized = login.casefold()
+        if normalized in submitters:
+            raise GuardFailure(f"duplicate guarded submitter: {login}")
+        submitters.add(normalized)
+    return frozenset(submitters)
+
+
+def _parse(
+    source: str,
+    label: str,
+    failure_type: type[GuardFailure | HeadPolicyFailure] = GuardFailure,
+) -> ast.Module:
     try:
         return ast.parse(source, filename=label)
     except SyntaxError as error:
-        raise GuardFailure(f"could not parse {label}: {error}") from error
+        raise failure_type(f"could not parse {label}: {error}") from error
 
 
 def _find_class(tree: ast.Module, name: str) -> ast.ClassDef | None:
     return next(
-        (node for node in tree.body if isinstance(node, ast.ClassDef) and node.name == name),
+        (
+            node
+            for node in tree.body
+            if isinstance(node, ast.ClassDef) and node.name == name
+        ),
         None,
     )
 
@@ -218,7 +271,9 @@ def _class_fields(node: ast.ClassDef) -> tuple[str, ...]:
                 ast.dump(target, include_attributes=False) for target in child.targets
             )
             value = ast.dump(child.value, include_attributes=False)
-            fields.append(f"assign:{targets}={value}:type_comment={child.type_comment!r}")
+            fields.append(
+                f"assign:{targets}={value}:type_comment={child.type_comment!r}"
+            )
         elif isinstance(child, ast.AnnAssign):
             target = ast.dump(child.target, include_attributes=False)
             annotation = ast.dump(child.annotation, include_attributes=False)
@@ -246,9 +301,15 @@ def compare_class_sources(
     base_source: str,
     head_source: str,
     protected: ProtectedClass,
+    *,
+    head_failure_type: type[GuardFailure | HeadPolicyFailure] = GuardFailure,
 ) -> Comparison:
     base_tree = _parse(base_source, f"base:{protected.source_path}")
-    head_tree = _parse(head_source, f"head:{protected.source_path}")
+    head_tree = _parse(
+        head_source,
+        f"head:{protected.source_path}",
+        head_failure_type,
+    )
     base_class = _find_class(base_tree, protected.name)
     head_class = _find_class(head_tree, protected.name)
 
@@ -256,7 +317,7 @@ def compare_class_sources(
         return Comparison(
             violations=(),
             warnings=(
-                f"protected class {protected.qualified_name} is absent from the base revision; guard skipped",
+                f"protected class {protected.qualified_name} is absent from the base revision",
             ),
         )
     if head_class is None:
@@ -326,14 +387,12 @@ def compare_class_sources(
         head_method = _find_method(head_class, method_name)
         if base_method is None:
             warnings.append(
-                f"protected method {symbol} is absent from the base revision; method guard skipped"
+                f"protected method {symbol} is absent from the base revision"
             )
             continue
         if head_method is None:
             violations.append(
-                Violation(
-                    "TRG101", symbol, "protected method was removed or renamed"
-                )
+                Violation("TRG101", symbol, "protected method was removed or renamed")
             )
             continue
 
@@ -397,32 +456,30 @@ def changed_files(repository: Path, base: str, head: str) -> set[str]:
     return {line for line in result.stdout.splitlines() if line}
 
 
-def evaluate(
+def evaluate_structure(
     repository: Path,
     base: str,
     head: str,
     manifest_path: str = DEFAULT_MANIFEST,
 ) -> tuple[Comparison, bool]:
-    manifest_text = _read_blob(repository, head, manifest_path)
+    manifest_text = _read_blob(repository, base, manifest_path)
     if manifest_text is None:
-        raise GuardFailure(f"manifest {manifest_path} is absent from {head}")
+        raise GuardFailure(f"trusted manifest {manifest_path} is absent from {base}")
     protected_classes = load_manifest(manifest_text)
     changed = changed_files(repository, base, head)
-    relevant_paths = {manifest_path, *(item.source_path for item in protected_classes)}
+    relevant_paths = {item.source_path for item in protected_classes}
     if changed.isdisjoint(relevant_paths):
         return Comparison((), ()), False
 
     violations: list[Violation] = []
-    warnings: list[str] = []
     for protected in protected_classes:
-        if protected.source_path not in changed and manifest_path not in changed:
+        if protected.source_path not in changed:
             continue
         base_source = _read_blob(repository, base, protected.source_path)
         if base_source is None:
-            warnings.append(
-                f"protected source {protected.source_path} is absent from the base revision; guard skipped"
+            raise GuardFailure(
+                f"trusted protected source {protected.source_path} is absent from {base}"
             )
-            continue
         head_source = _read_blob(repository, head, protected.source_path)
         if head_source is None:
             violations.append(
@@ -433,10 +490,65 @@ def evaluate(
                 )
             )
             continue
-        result = compare_class_sources(base_source, head_source, protected)
+        result = compare_class_sources(
+            base_source,
+            head_source,
+            protected,
+            head_failure_type=HeadPolicyFailure,
+        )
+        if result.warnings:
+            raise GuardFailure("; ".join(result.warnings))
         violations.extend(result.violations)
-        warnings.extend(result.warnings)
-    return Comparison(tuple(violations), tuple(warnings)), True
+    return Comparison(tuple(violations), ()), True
+
+
+def evaluate_pull_request(
+    repository: Path,
+    base: str,
+    head: str,
+    actor: str,
+    manifest_path: str = DEFAULT_MANIFEST,
+    submitters_path: str = DEFAULT_SUBMITTERS,
+) -> Evaluation:
+    normalized_actor = actor.strip().casefold()
+    if not normalized_actor:
+        raise GuardFailure("pull request actor must be a non-empty GitHub login")
+    if normalized_actor == OWNER_LOGIN.casefold():
+        return Evaluation(Comparison((), ()), False, f"owner @{actor} bypass")
+
+    changed = changed_files(repository, base, head)
+    changed_controls = sorted(changed.intersection(PROTECTED_CONTROL_PATHS))
+    if changed_controls:
+        violations = tuple(
+            Violation(
+                "TRG900",
+                path,
+                f"guard control file may only be changed by @{OWNER_LOGIN}",
+            )
+            for path in changed_controls
+        )
+        return Evaluation(Comparison(violations, ()), True, None)
+
+    submitters_text = _read_blob(repository, base, submitters_path)
+    if submitters_text is None:
+        raise GuardFailure(
+            f"trusted submitter policy {submitters_path} is absent from {base}"
+        )
+    guarded_submitters = load_guarded_submitters(submitters_text)
+    if normalized_actor not in guarded_submitters:
+        return Evaluation(
+            Comparison((), ()),
+            False,
+            f"@{actor} is not in the guarded submitter policy",
+        )
+
+    comparison, relevant = evaluate_structure(
+        repository,
+        base,
+        head,
+        manifest_path,
+    )
+    return Evaluation(comparison, relevant, None)
 
 
 def _print_violations(violations: Sequence[Violation]) -> None:
@@ -447,7 +559,7 @@ def _print_violations(violations: Sequence[Violation]) -> None:
             file=sys.stderr,
         )
     print(
-        "TaskRunner is a protected design surface; revert the structural change before pushing.",
+        "TaskRunner is a protected design surface; revert the structural change before merging into dev.",
         file=sys.stderr,
     )
 
@@ -456,30 +568,37 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--base", required=True)
     parser.add_argument("--head", required=True)
+    parser.add_argument("--actor", required=True)
     parser.add_argument("--manifest", default=DEFAULT_MANIFEST)
+    parser.add_argument("--submitters", default=DEFAULT_SUBMITTERS)
     arguments = parser.parse_args(argv)
 
     try:
         repository = find_repository_root(Path.cwd())
-        if configured_email(repository) == OWNER_EMAIL:
-            return 0
-        comparison, relevant = evaluate(
+        evaluation = evaluate_pull_request(
             repository,
             arguments.base,
             arguments.head,
+            arguments.actor,
             arguments.manifest,
+            arguments.submitters,
         )
-        for warning in comparison.warnings:
-            print(f"warning: {warning}", file=sys.stderr)
-        if comparison.violations:
-            _print_violations(comparison.violations)
+        if evaluation.comparison.violations:
+            _print_violations(evaluation.comparison.violations)
             return 1
-        if relevant:
+        if evaluation.skipped_reason:
+            print(f"TaskRunner design guard skipped: {evaluation.skipped_reason}")
+        elif evaluation.relevant:
             print("TaskRunner design guard passed: protected structure is unchanged")
+        else:
+            print("TaskRunner design guard passed: no protected source changes")
         return 0
-    except Exception as error:  # Fail open by explicit Phase 1 policy.
-        print(f"warning: TaskRunner design guard skipped: {error}", file=sys.stderr)
-        return 0
+    except HeadPolicyFailure as error:
+        _print_violations((Violation("TRG901", "pull request head", str(error)),))
+        return 1
+    except Exception as error:  # noqa: BLE001 - fail-open is the policy boundary.
+        print(f"warning: TaskRunner design guard degraded: {error}", file=sys.stderr)
+        return 2
 
 
 if __name__ == "__main__":

--- a/scripts/ci/tests/test_task_design_guard.py
+++ b/scripts/ci/tests/test_task_design_guard.py
@@ -1,0 +1,362 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = REPO_ROOT / "scripts/ci/task_design_guard.py"
+SPEC = importlib.util.spec_from_file_location("task_design_guard", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+GUARD = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = GUARD
+SPEC.loader.exec_module(GUARD)
+
+QUALIFIED_CLASS = (
+    "agentclaw.community.core.task.task_runner.task_runner.TaskRunner"
+)
+SOURCE_PATH = (
+    "src/backend/src/agentclaw/community/core/task/task_runner/task_runner.py"
+)
+PROTECTED = GUARD.ProtectedClass(
+    package="agentclaw.community.core.task.task_runner",
+    qualified_name=QUALIFIED_CLASS,
+    module="agentclaw.community.core.task.task_runner.task_runner",
+    name="TaskRunner",
+    methods=("__init__", "set_delivery", "start_run"),
+    source_path=SOURCE_PATH,
+)
+
+BASE_SOURCE = '''\
+@class_decorator
+class TaskRunner(BaseRunner):
+    _DELIVER_CONCURRENCY: int = 8
+
+    def __init__(self, graph, execution_backend=None) -> None:
+        self._graph = graph
+
+    def set_delivery(self, mode: str, port: DeliveryPort) -> None:
+        self._deliveries[mode] = port
+
+    async def start_run(self, nodes: list[TaskNode]) -> list[bool]:
+        return [True for _node in nodes]
+
+    def query_status(self, task_id: str) -> Status:
+        return self._graph.status(task_id)
+'''
+
+
+def _rules(head_source: str) -> set[str]:
+    result = GUARD.compare_class_sources(BASE_SOURCE, head_source, PROTECTED)
+    return {violation.rule for violation in result.violations}
+
+
+def test_method_body_and_docstring_changes_are_allowed() -> None:
+    head = BASE_SOURCE.replace(
+        "        self._graph = graph\n",
+        '        """Updated constructor docs."""\n        self._graph = normalize(graph)\n',
+    ).replace(
+        "        return [True for _node in nodes]\n",
+        "        results = await deliver(nodes)\n        return list(results)\n",
+    )
+
+    result = GUARD.compare_class_sources(BASE_SOURCE, head, PROTECTED)
+
+    assert result.violations == ()
+    assert result.warnings == ()
+
+
+@pytest.mark.parametrize(
+    ("head_source", "expected_rule"),
+    [
+        (BASE_SOURCE.replace("BaseRunner", "OtherBase"), "TRG002"),
+        (BASE_SOURCE.replace("@class_decorator", "@replacement_decorator"), "TRG003"),
+        (BASE_SOURCE.replace("= 8", "= 16"), "TRG004"),
+        (
+            BASE_SOURCE.replace(
+                "    def query_status",
+                "    def _new_helper(self) -> None:\n        pass\n\n    def query_status",
+            ),
+            "TRG005",
+        ),
+        (
+            BASE_SOURCE.replace(
+                "    def query_status",
+                "    def __new_hook__(self) -> None:\n        pass\n\n    def query_status",
+            ),
+            "TRG005",
+        ),
+        (BASE_SOURCE.replace("class TaskRunner", "class RenamedTaskRunner"), "TRG001"),
+    ],
+)
+def test_protected_class_structure_changes_are_rejected(
+    head_source: str, expected_rule: str
+) -> None:
+    assert expected_rule in _rules(head_source)
+
+
+@pytest.mark.parametrize(
+    ("old", "new", "expected_rule"),
+    [
+        ("async def start_run", "def start_run", "TRG102"),
+        (
+            "async def start_run(self, nodes: list[TaskNode])",
+            "async def start_run(self, tasks: list[TaskNode])",
+            "TRG104",
+        ),
+        (
+            "async def start_run(self, nodes: list[TaskNode])",
+            "async def start_run(self, nodes: tuple[TaskNode, ...])",
+            "TRG104",
+        ),
+        (
+            "async def start_run(self, nodes: list[TaskNode])",
+            "async def start_run(self, nodes: list[TaskNode] = [])",
+            "TRG104",
+        ),
+        ("-> list[bool]", "-> tuple[bool, ...]", "TRG105"),
+        (
+            "    async def start_run",
+            "    @protected_method\n    async def start_run",
+            "TRG103",
+        ),
+    ],
+)
+def test_protected_method_interface_changes_are_rejected(
+    old: str, new: str, expected_rule: str
+) -> None:
+    assert expected_rule in _rules(BASE_SOURCE.replace(old, new))
+
+
+def test_removed_protected_method_is_rejected() -> None:
+    start = BASE_SOURCE.index("    def set_delivery")
+    end = BASE_SOURCE.index("    async def start_run")
+    head = BASE_SOURCE[:start] + BASE_SOURCE[end:]
+
+    assert "TRG101" in _rules(head)
+
+
+def test_protected_symbol_missing_from_base_warns_and_passes() -> None:
+    result = GUARD.compare_class_sources(
+        "class SomethingElse:\n    pass\n", BASE_SOURCE, PROTECTED
+    )
+
+    assert result.violations == ()
+    assert "absent from the base revision" in result.warnings[0]
+
+
+def test_repository_manifest_resolves_current_task_runner() -> None:
+    protected_classes = GUARD.load_manifest(
+        (REPO_ROOT / "scripts/ci/task_design_guard.json").read_text(encoding="utf-8")
+    )
+    protected = protected_classes[0]
+    source = (REPO_ROOT / protected.source_path).read_text(encoding="utf-8")
+
+    result = GUARD.compare_class_sources(source, source, protected)
+
+    assert protected.qualified_name == QUALIFIED_CLASS
+    assert protected.methods == ("__init__", "set_delivery", "start_run")
+    assert result == GUARD.Comparison((), ())
+
+
+def _git(repository: Path, *arguments: str) -> str:
+    return subprocess.run(
+        ["git", *arguments],
+        cwd=repository,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    ).stdout.strip()
+
+
+def _write(repository: Path, relative_path: str, content: str) -> None:
+    path = repository / relative_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _manifest() -> str:
+    return json.dumps(
+        {
+            "version": 1,
+            "packages": [
+                {
+                    "package": "agentclaw.community.core.task.task_runner",
+                    "classes": [
+                        {
+                            "class": QUALIFIED_CLASS,
+                            "methods": ["__init__", "set_delivery", "start_run"],
+                        }
+                    ],
+                }
+            ],
+        }
+    )
+
+
+def _repository(tmp_path: Path) -> tuple[Path, str]:
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    _git(repository, "init", "--initial-branch", "dev")
+    _git(repository, "config", "user.name", "Guard Test")
+    _git(repository, "config", "user.email", "guard-test@example.com")
+    _write(repository, SOURCE_PATH, BASE_SOURCE)
+    _write(repository, "scripts/ci/task_design_guard.json", _manifest())
+    _git(repository, "add", ".")
+    _git(repository, "commit", "-m", "baseline")
+    return repository, _git(repository, "rev-parse", "HEAD")
+
+
+def _run_guard(repository: Path, base: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--base",
+            base,
+            "--head",
+            "HEAD",
+            "--manifest",
+            "scripts/ci/task_design_guard.json",
+        ],
+        cwd=repository,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+
+def test_command_rejects_confirmed_structural_change(tmp_path: Path) -> None:
+    repository, base = _repository(tmp_path)
+    _write(
+        repository,
+        SOURCE_PATH,
+        BASE_SOURCE.replace("nodes: list[TaskNode]", "tasks: list[TaskNode]"),
+    )
+    _git(repository, "add", ".")
+    _git(repository, "commit", "-m", "change protected parameter")
+
+    result = _run_guard(repository, base)
+
+    assert result.returncode == 1
+    assert "TaskRunner design guard failed" in result.stderr
+    assert "TRG104" in result.stderr
+
+
+def test_command_owner_email_bypasses_silently(tmp_path: Path) -> None:
+    repository, base = _repository(tmp_path)
+    _write(
+        repository,
+        SOURCE_PATH,
+        BASE_SOURCE.replace("nodes: list[TaskNode]", "tasks: list[TaskNode]"),
+    )
+    _git(repository, "add", ".")
+    _git(repository, "commit", "-m", "change protected parameter")
+    _git(repository, "config", "user.email", "regrecall@gmail.com")
+
+    result = _run_guard(repository, base)
+
+    assert result.returncode == 0
+    assert result.stdout == ""
+    assert result.stderr == ""
+
+
+def test_command_invalid_manifest_warns_and_fails_open(tmp_path: Path) -> None:
+    repository, base = _repository(tmp_path)
+    _write(repository, "scripts/ci/task_design_guard.json", "not-json\n")
+    _write(
+        repository,
+        SOURCE_PATH,
+        BASE_SOURCE.replace("nodes: list[TaskNode]", "tasks: list[TaskNode]"),
+    )
+    _git(repository, "add", ".")
+    _git(repository, "commit", "-m", "break manifest and protected parameter")
+
+    result = _run_guard(repository, base)
+
+    assert result.returncode == 0
+    assert "warning: TaskRunner design guard skipped" in result.stderr
+    assert "not valid JSON" in result.stderr
+
+
+def test_command_ignores_uncommitted_structural_change(tmp_path: Path) -> None:
+    repository, base = _repository(tmp_path)
+    _write(repository, "README.md", "committed unrelated change\n")
+    _git(repository, "add", ".")
+    _git(repository, "commit", "-m", "unrelated change")
+    _write(
+        repository,
+        SOURCE_PATH,
+        BASE_SOURCE.replace("nodes: list[TaskNode]", "tasks: list[TaskNode]"),
+    )
+
+    result = _run_guard(repository, base)
+
+    assert result.returncode == 0
+    assert result.stdout == ""
+    assert result.stderr == ""
+
+
+def test_pre_push_dispatcher_runs_guard_in_lint_only_mode(tmp_path: Path) -> None:
+    repository, base = _repository(tmp_path)
+    dispatcher = repository / "scripts/ci/pre_push.sh"
+    dispatcher.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(REPO_ROOT / "scripts/ci/pre_push.sh", dispatcher)
+    dispatcher.chmod(0o755)
+    _write(repository, "src/bcs/feature.rs", "// unrelated BCS change\n")
+    _git(repository, "add", ".")
+    _git(repository, "commit", "-m", "change BCS")
+
+    result = subprocess.run(
+        [str(dispatcher), "--base", base, "--head", "HEAD", "--dry-run"],
+        cwd=repository,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    assert "mode: lint-only" in result.stdout
+    assert "scripts/ci/task_design_guard.py" in result.stdout
+
+
+def test_owner_bypass_keeps_backend_sast_gate_active(tmp_path: Path) -> None:
+    repository, base = _repository(tmp_path)
+    dispatcher = repository / "scripts/ci/pre_push.sh"
+    guard = repository / "scripts/ci/task_design_guard.py"
+    sast = repository / "scripts/ci/python_sast_local.sh"
+    dispatcher.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(REPO_ROOT / "scripts/ci/pre_push.sh", dispatcher)
+    shutil.copy2(SCRIPT, guard)
+    dispatcher.chmod(0o755)
+    sast.write_text("#!/usr/bin/env bash\necho BACKEND_SAST_RAN\n", encoding="utf-8")
+    sast.chmod(0o755)
+    _write(
+        repository,
+        SOURCE_PATH,
+        BASE_SOURCE.replace("nodes: list[TaskNode]", "tasks: list[TaskNode]"),
+    )
+    _git(repository, "add", ".")
+    _git(repository, "commit", "-m", "change protected parameter")
+    _git(repository, "config", "user.email", "regrecall@gmail.com")
+
+    result = subprocess.run(
+        [str(dispatcher), "--base", base, "--head", "HEAD"],
+        cwd=repository,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    assert "BACKEND_SAST_RAN" in result.stdout
+    assert "TaskRunner design guard passed" not in result.stdout
+    assert "TaskRunner design guard" not in result.stderr

--- a/scripts/ci/tests/test_task_design_guard.py
+++ b/scripts/ci/tests/test_task_design_guard.py
@@ -2,13 +2,11 @@ from __future__ import annotations
 
 import importlib.util
 import json
-from pathlib import Path
-import shutil
 import subprocess
 import sys
+from pathlib import Path
 
 import pytest
-
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 SCRIPT = REPO_ROOT / "scripts/ci/task_design_guard.py"
@@ -18,12 +16,10 @@ GUARD = importlib.util.module_from_spec(SPEC)
 sys.modules[SPEC.name] = GUARD
 SPEC.loader.exec_module(GUARD)
 
-QUALIFIED_CLASS = (
-    "agentclaw.community.core.task.task_runner.task_runner.TaskRunner"
-)
-SOURCE_PATH = (
-    "src/backend/src/agentclaw/community/core/task/task_runner/task_runner.py"
-)
+QUALIFIED_CLASS = "agentclaw.community.core.task.task_runner.task_runner.TaskRunner"
+SOURCE_PATH = "src/backend/src/agentclaw/community/core/task/task_runner/task_runner.py"
+MANIFEST_PATH = "scripts/ci/task_design_guard.json"
+SUBMITTERS_PATH = "docs/arch/task-design-guard-submitters.json"
 PROTECTED = GUARD.ProtectedClass(
     package="agentclaw.community.core.task.task_runner",
     qualified_name=QUALIFIED_CLASS,
@@ -33,7 +29,7 @@ PROTECTED = GUARD.ProtectedClass(
     source_path=SOURCE_PATH,
 )
 
-BASE_SOURCE = '''\
+BASE_SOURCE = """\
 @class_decorator
 class TaskRunner(BaseRunner):
     _DELIVER_CONCURRENCY: int = 8
@@ -49,7 +45,7 @@ class TaskRunner(BaseRunner):
 
     def query_status(self, task_id: str) -> Status:
         return self._graph.status(task_id)
-'''
+"""
 
 
 def _rules(head_source: str) -> set[str]:
@@ -68,8 +64,7 @@ def test_method_body_and_docstring_changes_are_allowed() -> None:
 
     result = GUARD.compare_class_sources(BASE_SOURCE, head, PROTECTED)
 
-    assert result.violations == ()
-    assert result.warnings == ()
+    assert result == GUARD.Comparison((), ())
 
 
 @pytest.mark.parametrize(
@@ -142,7 +137,7 @@ def test_removed_protected_method_is_rejected() -> None:
     assert "TRG101" in _rules(head)
 
 
-def test_protected_symbol_missing_from_base_warns_and_passes() -> None:
+def test_protected_symbol_missing_from_base_is_reported() -> None:
     result = GUARD.compare_class_sources(
         "class SomethingElse:\n    pass\n", BASE_SOURCE, PROTECTED
     )
@@ -153,7 +148,7 @@ def test_protected_symbol_missing_from_base_warns_and_passes() -> None:
 
 def test_repository_manifest_resolves_current_task_runner() -> None:
     protected_classes = GUARD.load_manifest(
-        (REPO_ROOT / "scripts/ci/task_design_guard.json").read_text(encoding="utf-8")
+        (REPO_ROOT / MANIFEST_PATH).read_text(encoding="utf-8")
     )
     protected = protected_classes[0]
     source = (REPO_ROOT / protected.source_path).read_text(encoding="utf-8")
@@ -165,13 +160,40 @@ def test_repository_manifest_resolves_current_task_runner() -> None:
     assert result == GUARD.Comparison((), ())
 
 
+def test_repository_submitter_policy_is_valid() -> None:
+    submitters = GUARD.load_guarded_submitters(
+        (REPO_ROOT / SUBMITTERS_PATH).read_text(encoding="utf-8")
+    )
+
+    assert submitters == {
+        "jiangj0627",
+        "msjbear",
+        "wen6lev57q4",
+        "guok974-dot",
+    }
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "not-json",
+        json.dumps({"version": 1, "guarded_submitters": []}),
+        json.dumps({"version": 1, "guarded_submitters": ["bad_login!"]}),
+        json.dumps({"version": 1, "guarded_submitters": ["Same", "same"]}),
+        json.dumps({"version": 1, "guarded_submitters": ["msjbear"], "extra": True}),
+    ],
+)
+def test_submitter_policy_rejects_invalid_content(payload: str) -> None:
+    with pytest.raises(GUARD.GuardFailure):
+        GUARD.load_guarded_submitters(payload)
+
+
 def _git(repository: Path, *arguments: str) -> str:
     return subprocess.run(
         ["git", *arguments],
         cwd=repository,
         check=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
         text=True,
     ).stdout.strip()
 
@@ -201,20 +223,41 @@ def _manifest() -> str:
     )
 
 
-def _repository(tmp_path: Path) -> tuple[Path, str]:
+def _submitters() -> str:
+    return json.dumps({"version": 1, "guarded_submitters": ["msjbear", "WEN6Lev57q4"]})
+
+
+def _repository(
+    tmp_path: Path,
+    *,
+    base_source: str = BASE_SOURCE,
+    submitters: str | None = None,
+) -> tuple[Path, str]:
     repository = tmp_path / "repository"
     repository.mkdir()
     _git(repository, "init", "--initial-branch", "dev")
     _git(repository, "config", "user.name", "Guard Test")
     _git(repository, "config", "user.email", "guard-test@example.com")
-    _write(repository, SOURCE_PATH, BASE_SOURCE)
-    _write(repository, "scripts/ci/task_design_guard.json", _manifest())
+    _write(repository, SOURCE_PATH, base_source)
+    _write(repository, MANIFEST_PATH, _manifest())
+    _write(repository, SUBMITTERS_PATH, submitters or _submitters())
     _git(repository, "add", ".")
     _git(repository, "commit", "-m", "baseline")
     return repository, _git(repository, "rev-parse", "HEAD")
 
 
-def _run_guard(repository: Path, base: str) -> subprocess.CompletedProcess[str]:
+def _commit(repository: Path, path: str, content: str, message: str) -> None:
+    _write(repository, path, content)
+    _git(repository, "add", path)
+    _git(repository, "commit", "-m", message)
+
+
+def _run_guard(
+    repository: Path,
+    base: str,
+    *,
+    actor: str = "msjbear",
+) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         [
             sys.executable,
@@ -223,26 +266,28 @@ def _run_guard(repository: Path, base: str) -> subprocess.CompletedProcess[str]:
             base,
             "--head",
             "HEAD",
+            "--actor",
+            actor,
             "--manifest",
-            "scripts/ci/task_design_guard.json",
+            MANIFEST_PATH,
+            "--submitters",
+            SUBMITTERS_PATH,
         ],
         cwd=repository,
         check=False,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
         text=True,
     )
 
 
-def test_command_rejects_confirmed_structural_change(tmp_path: Path) -> None:
+def test_guarded_pr_author_is_blocked_on_structural_change(tmp_path: Path) -> None:
     repository, base = _repository(tmp_path)
-    _write(
+    _commit(
         repository,
         SOURCE_PATH,
         BASE_SOURCE.replace("nodes: list[TaskNode]", "tasks: list[TaskNode]"),
+        "change protected parameter",
     )
-    _git(repository, "add", ".")
-    _git(repository, "commit", "-m", "change protected parameter")
 
     result = _run_guard(repository, base)
 
@@ -251,47 +296,99 @@ def test_command_rejects_confirmed_structural_change(tmp_path: Path) -> None:
     assert "TRG104" in result.stderr
 
 
-def test_command_owner_email_bypasses_silently(tmp_path: Path) -> None:
+def test_owner_login_bypasses_silently_before_control_file_check(
+    tmp_path: Path,
+) -> None:
     repository, base = _repository(tmp_path)
-    _write(
-        repository,
-        SOURCE_PATH,
-        BASE_SOURCE.replace("nodes: list[TaskNode]", "tasks: list[TaskNode]"),
-    )
-    _git(repository, "add", ".")
-    _git(repository, "commit", "-m", "change protected parameter")
-    _git(repository, "config", "user.email", "regrecall@gmail.com")
+    _commit(repository, MANIFEST_PATH, "not-json\n", "owner changes policy")
 
-    result = _run_guard(repository, base)
+    result = _run_guard(repository, base, actor="RegRecall")
 
     assert result.returncode == 0
-    assert result.stdout == ""
+    assert "owner @RegRecall bypass" in result.stdout
     assert result.stderr == ""
 
 
-def test_command_invalid_manifest_warns_and_fails_open(tmp_path: Path) -> None:
+def test_unlisted_pr_author_skips_structural_check(tmp_path: Path) -> None:
     repository, base = _repository(tmp_path)
-    _write(repository, "scripts/ci/task_design_guard.json", "not-json\n")
-    _write(
+    _commit(
         repository,
         SOURCE_PATH,
         BASE_SOURCE.replace("nodes: list[TaskNode]", "tasks: list[TaskNode]"),
+        "change protected parameter",
     )
-    _git(repository, "add", ".")
-    _git(repository, "commit", "-m", "break manifest and protected parameter")
+
+    result = _run_guard(repository, base, actor="unlisted-user")
+
+    assert result.returncode == 0
+    assert "not in the guarded submitter policy" in result.stdout
+
+
+def test_guarded_submitter_matching_is_case_insensitive(tmp_path: Path) -> None:
+    repository, base = _repository(tmp_path)
+    _commit(
+        repository,
+        SOURCE_PATH,
+        BASE_SOURCE.replace("nodes: list[TaskNode]", "tasks: list[TaskNode]"),
+        "change protected parameter",
+    )
+
+    result = _run_guard(repository, base, actor="wen6LEV57Q4")
+
+    assert result.returncode == 1
+    assert "TRG104" in result.stderr
+
+
+@pytest.mark.parametrize("actor", ["msjbear", "unlisted-user"])
+def test_non_owner_cannot_change_guard_control_files(
+    tmp_path: Path, actor: str
+) -> None:
+    repository, base = _repository(tmp_path)
+    _commit(repository, MANIFEST_PATH, "not-json\n", "tamper with guard policy")
+
+    result = _run_guard(repository, base, actor=actor)
+
+    assert result.returncode == 1
+    assert "TRG900" in result.stderr
+    assert MANIFEST_PATH in result.stderr
+
+
+def test_head_syntax_error_is_a_blocking_policy_failure(tmp_path: Path) -> None:
+    repository, base = _repository(tmp_path)
+    _commit(repository, SOURCE_PATH, "class TaskRunner(:\n", "break protected source")
 
     result = _run_guard(repository, base)
 
-    assert result.returncode == 0
-    assert "warning: TaskRunner design guard skipped" in result.stderr
+    assert result.returncode == 1
+    assert "TRG901" in result.stderr
+
+
+def test_trusted_submitter_policy_failure_returns_degraded_status(
+    tmp_path: Path,
+) -> None:
+    repository, base = _repository(tmp_path, submitters="not-json\n")
+    _commit(repository, "README.md", "unrelated\n", "unrelated change")
+
+    result = _run_guard(repository, base)
+
+    assert result.returncode == 2
+    assert "design guard degraded" in result.stderr
     assert "not valid JSON" in result.stderr
 
 
-def test_command_ignores_uncommitted_structural_change(tmp_path: Path) -> None:
+def test_trusted_base_syntax_error_returns_degraded_status(tmp_path: Path) -> None:
+    repository, base = _repository(tmp_path, base_source="class TaskRunner(:\n")
+    _commit(repository, SOURCE_PATH, "class TaskRunner(:\n# still invalid\n", "change")
+
+    result = _run_guard(repository, base)
+
+    assert result.returncode == 2
+    assert "design guard degraded" in result.stderr
+
+
+def test_guard_ignores_uncommitted_structural_change(tmp_path: Path) -> None:
     repository, base = _repository(tmp_path)
-    _write(repository, "README.md", "committed unrelated change\n")
-    _git(repository, "add", ".")
-    _git(repository, "commit", "-m", "unrelated change")
+    _commit(repository, "README.md", "committed unrelated change\n", "unrelated")
     _write(
         repository,
         SOURCE_PATH,
@@ -301,62 +398,34 @@ def test_command_ignores_uncommitted_structural_change(tmp_path: Path) -> None:
     result = _run_guard(repository, base)
 
     assert result.returncode == 0
-    assert result.stdout == ""
-    assert result.stderr == ""
+    assert "no protected source changes" in result.stdout
 
 
-def test_pre_push_dispatcher_runs_guard_in_lint_only_mode(tmp_path: Path) -> None:
-    repository, base = _repository(tmp_path)
-    dispatcher = repository / "scripts/ci/pre_push.sh"
-    dispatcher.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copy2(REPO_ROOT / "scripts/ci/pre_push.sh", dispatcher)
-    dispatcher.chmod(0o755)
-    _write(repository, "src/bcs/feature.rs", "// unrelated BCS change\n")
-    _git(repository, "add", ".")
-    _git(repository, "commit", "-m", "change BCS")
+def test_pre_push_dispatcher_does_not_run_task_design_guard() -> None:
+    dispatcher = (REPO_ROOT / "scripts/ci/pre_push.sh").read_text(encoding="utf-8")
 
-    result = subprocess.run(
-        [str(dispatcher), "--base", base, "--head", "HEAD", "--dry-run"],
-        cwd=repository,
-        check=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
+    assert "task_design_guard.py" not in dispatcher
+
+
+def test_workflow_only_targets_pull_requests_to_dev() -> None:
+    workflow = (REPO_ROOT / ".github/workflows/task-design-guard.yml").read_text(
+        encoding="utf-8"
     )
 
-    assert "mode: lint-only" in result.stdout
-    assert "scripts/ci/task_design_guard.py" in result.stdout
-
-
-def test_owner_bypass_keeps_backend_sast_gate_active(tmp_path: Path) -> None:
-    repository, base = _repository(tmp_path)
-    dispatcher = repository / "scripts/ci/pre_push.sh"
-    guard = repository / "scripts/ci/task_design_guard.py"
-    sast = repository / "scripts/ci/python_sast_local.sh"
-    dispatcher.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copy2(REPO_ROOT / "scripts/ci/pre_push.sh", dispatcher)
-    shutil.copy2(SCRIPT, guard)
-    dispatcher.chmod(0o755)
-    sast.write_text("#!/usr/bin/env bash\necho BACKEND_SAST_RAN\n", encoding="utf-8")
-    sast.chmod(0o755)
-    _write(
-        repository,
-        SOURCE_PATH,
-        BASE_SOURCE.replace("nodes: list[TaskNode]", "tasks: list[TaskNode]"),
-    )
-    _git(repository, "add", ".")
-    _git(repository, "commit", "-m", "change protected parameter")
-    _git(repository, "config", "user.email", "regrecall@gmail.com")
-
-    result = subprocess.run(
-        [str(dispatcher), "--base", base, "--head", "HEAD"],
-        cwd=repository,
-        check=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-    )
-
-    assert "BACKEND_SAST_RAN" in result.stdout
-    assert "TaskRunner design guard passed" not in result.stdout
-    assert "TaskRunner design guard" not in result.stderr
+    assert "pull_request_target:" in workflow
+    assert "      - dev" in workflow
+    assert "  push:" not in workflow
+    assert "workflow_dispatch:" not in workflow
+    assert "paths:" not in workflow
+    assert "contents: read" in workflow
+    assert "statuses: write" in workflow
+    assert "persist-credentials: false" in workflow
+    assert "continue-on-error: true" in workflow
+    assert "CHECKOUT_OUTCOME" in workflow
+    assert "name: Publish TaskRunner design guard" in workflow
+    assert workflow.count('context: "TaskRunner design guard"') == 2
+    assert "github.event.pull_request.head.sha" in workflow
+    assert "github.rest.repos.createCommitStatus" in workflow
+    assert 'state: "pending"' in workflow
+    assert "steps.evaluate.outputs.state" in workflow
+    assert '--actor "$PR_AUTHOR"' in workflow

--- a/src/backend/tests/community/core/task/task_runner/test_runner.py
+++ b/src/backend/tests/community/core/task/task_runner/test_runner.py
@@ -89,6 +89,12 @@ def _node_output(svc: TaskGraphService, node_id: str) -> dict:
 
 # ===== start_run 三模态 =====
 class TestStartRun:
+    def test_empty_batch_is_noop(self, svc):
+        runner = TaskRunner(svc)
+
+        assert _run(runner.start_run([])) == []
+        assert runner._run_log == []
+
     def test_single_bot_dispatched(self, svc, graph):
         runner = TaskRunner(svc)
         _dispatch(svc, graph, ["c1"], run_mode="single_bot", assignee="bot_market")


### PR DESCRIPTION
## Problem

`TaskRunner` 是 Backend Task 模块的核心设计接口，但当前缺少本地门禁来阻止贡献者在不知情的情况下修改其类结构或核心方法签名。

此类变化可能破坏模块边界和调用方约定，并且通常要到 PR Review 或 CI 阶段才能被发现。

## Solution

新增基于 Python AST 的 pre-push 设计门禁，保护：

- `agentclaw.community.core.task.task_runner.task_runner.TaskRunner`
- `__init__`
- `set_delivery`
- `start_run`

门禁会阻止：

- 删除、重命名或移动受保护类
- 修改类继承、装饰器或类字段
- 向受保护类新增方法
- 删除或重命名核心方法
- 修改核心方法的同步/异步类型
- 修改方法参数、默认值、类型注解或返回值注解
- 修改方法装饰器

方法体实现、注释和格式调整不会触发门禁。

保护范围由 `scripts/ci/task_design_guard.json` 声明，检查器接入现有 `scripts/ci/pre_push.sh`，在 lint-only 和完整 CI 模式下都会执行。

当本地 Git 邮箱为 `regrecall@gmail.com` 时，跳过该设计门禁。第一期不支持 waiver；其他开发者触发规则后会直接阻止 push，并提示其修改了受保护的设计接口。

采用 AST 结构比较，而不是文本 diff，以避免格式化、注释和方法体实现变化产生误报。

## Validation

已完成以下验证：

- `scripts/ci/tests/test_task_design_guard.py`：`22 passed`
- `python3 -m py_compile scripts/ci/task_design_guard.py`：通过
- `bash -n scripts/ci/pre_push.sh`：通过
- `git diff --check`：通过
- TaskRunner 门禁基线自检：通过
- 实际执行 pre-push hook：通过
- Backend 本地 SAST：通过

本次 push 使用默认 lint-only 模式，因此未运行完整 Backend 单测、覆盖率和 Singlebox E2E。

## Compatibility and risk

不修改 Backend 运行时代码、公开 API、数据结构或配置格式。

主要风险是 AST 门禁规则可能阻止合法的 TaskRunner 设计调整。需要调整接口时，可由拥有最高权限的维护者处理并同步更新门禁清单。

如果检查器本身发生无法读取 Git revision、清单错误或 Python 解析异常，会输出警告并跳过门禁，避免因工具内部故障永久阻塞开发者 push。

回滚方式是移除 `scripts/ci/pre_push.sh` 中的门禁调用，并删除对应检查器、清单和测试。

## Spec

实现以下设计文档：

`docs/superpowers/specs/2026-09-03-task-runner-pre-push-design-guard.md`