### PR TITLE
refactor(baas): acquire distributed lock via single upsert instead of three-step insert

### DIFF
--- a/src/baas/src/secbaas/community/core/repository/distributed_lock/_orm_repository.py
+++ b/src/baas/src/secbaas/community/core/repository/distributed_lock/_orm_repository.py
@@ -6,6 +6,8 @@ Corresponds to ZdasDistributedLockRepository (ac_lock_table).
 
 from datetime import datetime
 
+from sqlalchemy import case, func, or_, select
+
 from secbaas.community.core.repository import OrmConnectionMixin, with_orm_session
 from secbaas.community.logger import get_logger
 
@@ -98,6 +100,82 @@ class OrmDistributedLockRepository(OrmConnectionMixin, DistributedLockRepository
         log.info("[distributed-lock:delete_lock] result: %s", result)
         return result
 
+    def _build_acquire_upsert(self, lock_name, lock_holder, expire_time, env, now):
+        """Build the dialect-specific atomic acquire upsert for ``ac_lock_table``.
+
+        Mirrors the ``arca_ttl`` dual-dialect upsert convention
+        (``mysql.dialects.insert().on_duplicate_key_update()`` /
+        ``sqlite.dialects.insert().on_conflict_do_update()``). A row is
+        treated as acquirable when the existing holder is the same caller,
+        the row has no ``expire_time``, or the row has already expired; in
+        those cases the holder / expiry / env are overwritten, otherwise the
+        upsert is a no-op that leaves the current holder untouched. Because a
+        dialect upsert does not apply ``Column.onupdate`` (arca_ttl Pitfall 2),
+        ``gmt_modified`` is set explicitly and only refreshed when the row is
+        actually acquired.
+
+        The expiry check compares ``expire_time`` against a caller-supplied
+        app-clock ``now`` rather than the DB ``NOW()``: ``expire_time`` is
+        written in the application's wall-clock domain, and SQLite
+        ``CURRENT_TIMESTAMP`` is UTC, so a DB-side comparison would misclassify
+        unexpired rows as expired (and vice versa) against locally-stamped
+        rows — the same clock-domain rationale arca_ttl documents for its
+        caller-supplied ``now`` gate.
+        """
+        from sqlalchemy.dialects.mysql import insert as mysql_insert
+        from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+
+        is_sqlite = self._session.bind.dialect.name == "sqlite"
+        values = {
+            "lock_name": lock_name,
+            "lock_holder": lock_holder,
+            "expire_time": expire_time,
+            "env": env,
+        }
+
+        if is_sqlite:
+            stmt = sqlite_insert(DistributedLockModel).values(**values)
+            acquirable = or_(
+                DistributedLockModel.lock_holder == stmt.excluded.lock_holder,
+                DistributedLockModel.expire_time.is_(None),
+                DistributedLockModel.expire_time <= now,
+            )
+            return stmt.on_conflict_do_update(
+                index_elements=["lock_name"],
+                set_={
+                    "lock_holder": stmt.excluded.lock_holder,
+                    "expire_time": stmt.excluded.expire_time,
+                    "env": stmt.excluded.env,
+                    "gmt_modified": func.now(),
+                },
+                where=acquirable,
+            )
+
+        stmt = mysql_insert(DistributedLockModel).values(**values)
+        acquirable = or_(
+            DistributedLockModel.lock_holder == stmt.inserted.lock_holder,
+            DistributedLockModel.expire_time.is_(None),
+            DistributedLockModel.expire_time <= now,
+        )
+        return stmt.on_duplicate_key_update(
+            lock_holder=case(
+                (acquirable, stmt.inserted.lock_holder),
+                else_=DistributedLockModel.lock_holder,
+            ),
+            expire_time=case(
+                (acquirable, stmt.inserted.expire_time),
+                else_=DistributedLockModel.expire_time,
+            ),
+            env=case(
+                (acquirable, stmt.inserted.env),
+                else_=DistributedLockModel.env,
+            ),
+            gmt_modified=case(
+                (acquirable, func.now()),
+                else_=DistributedLockModel.gmt_modified,
+            ),
+        )
+
     @with_orm_session
     def try_acquire_lock(
         self,
@@ -106,20 +184,21 @@ class OrmDistributedLockRepository(OrmConnectionMixin, DistributedLockRepository
         lock_holder: str,
         expire_time: datetime,
     ) -> bool:
-        """Atomically try to acquire a lock in a single session.
+        """Atomically try to acquire a lock with a single upsert.
 
-        Prefer conditional UPDATE over DELETE + INSERT. Existing lock rows are
-        treated as stable state: an expired row, a row with no expire_time, or
-        a row already held by the same holder can be acquired by updating its
-        holder and expiry. A missing row is initialized by INSERT.
+        Issues one atomic upsert keyed on ``uk_lock_name``: a missing row is
+        initialized by INSERT, while an existing row is overwritten only when
+        it is acquirable (same holder, no ``expire_time``, or expired) and left
+        untouched otherwise. A confirming read SELECT then decides whether the
+        caller now holds the lock.
 
-        Concurrent INSERT conflicts and OceanBase/MySQL-compatible lock wait
-        timeouts are normal lock contention for this try-acquire API and are
-        returned as ``False``.
+        Replacing the former ``UPDATE → SELECT → INSERT`` three-step flow with
+        a single upsert removes the concurrent INSERT that produced the
+        underlying ``uk_lock_name`` 1062 conflict. OceanBase/MySQL-compatible
+        lock wait timeouts (1205) remain normal lock contention for this
+        try-acquire API and are still returned as ``False``.
         """
-        from sqlalchemy import func, or_
         from sqlalchemy.exc import DatabaseError as SADatabaseError
-        from sqlalchemy.exc import IntegrityError as SAIntegrityError
 
         from secbaas.community.core.utils.env_utils import get_current_env
 
@@ -132,76 +211,38 @@ class OrmDistributedLockRepository(OrmConnectionMixin, DistributedLockRepository
         env = get_current_env()
 
         try:
-            updated = (
-                self._session.query(DistributedLockModel)
-                .filter(
-                    DistributedLockModel.lock_name == lock_name,
-                    or_(
-                        DistributedLockModel.lock_holder == lock_holder,
-                        DistributedLockModel.expire_time.is_(None),
-                        DistributedLockModel.expire_time <= now,
-                    ),
-                )
-                .update(
-                    {
-                        "lock_holder": lock_holder,
-                        "expire_time": expire_time,
-                        "gmt_modified": func.now(),
-                        "env": env,
-                    },
-                    synchronize_session=False,
+            self._session.execute(
+                self._build_acquire_upsert(
+                    lock_name, lock_holder, expire_time, env, now
                 )
             )
 
-            if int(updated) > 0:
+            row = self._session.execute(
+                select(DistributedLockModel).where(
+                    DistributedLockModel.lock_name == lock_name
+                )
+            ).scalar_one_or_none()
+
+            if row is None:
+                log.warning(
+                    "[distributed-lock:try_acquire_lock] upsert left no row: lock_name=%s",
+                    lock_name,
+                )
+                return False
+
+            if row.lock_holder == lock_holder:
                 log.info(
-                    "[distributed-lock:try_acquire_lock] acquired by update: lock_name=%s",
+                    "[distributed-lock:try_acquire_lock] acquired: lock_name=%s",
                     lock_name,
                 )
                 return True
 
-            row = (
-                self._session.query(DistributedLockModel)
-                .filter(DistributedLockModel.lock_name == lock_name)
-                .first()
-            )
-            if row is not None:
-                if row.lock_holder == lock_holder:
-                    log.info(
-                        "[distributed-lock:try_acquire_lock] reentrant already held: lock_name=%s",
-                        lock_name,
-                    )
-                    return True
-
-                log.info(
-                    "[distributed-lock:try_acquire_lock] lock held by %s, not acquired",
-                    row.lock_holder,
-                )
-                return False
-
-            new_row = DistributedLockModel(
-                lock_name=lock_name,
-                lock_holder=lock_holder,
-                expire_time=expire_time,
-                env=env,
-            )
-            self._session.add(new_row)
-            self._session.flush()
-
             log.info(
-                "[distributed-lock:try_acquire_lock] acquired by insert: lock_name=%s, id=%s",
-                lock_name,
-                new_row.id,
-            )
-            return True
-
-        except SAIntegrityError:
-            self._session.rollback()
-            log.warning(
-                "[distributed-lock:try_acquire_lock] concurrent INSERT conflict: lock_name=%s",
-                lock_name,
+                "[distributed-lock:try_acquire_lock] lock held by %s, not acquired",
+                row.lock_holder,
             )
             return False
+
         except SADatabaseError as exc:
             if _is_lock_wait_timeout(exc):
                 self._session.rollback()

--- a/src/baas/src/secbaas/community/core/repository/distributed_lock/_protocol.py
+++ b/src/baas/src/secbaas/community/core/repository/distributed_lock/_protocol.py
@@ -32,9 +32,13 @@ class DistributedLockRepository(Protocol):
         lock_holder: str,
         expire_time: datetime,
     ) -> bool:
-        """在单一事务中尝试获取锁（SELECT → DELETE expired → INSERT）。
+        """以单条原子 upsert 尝试获取锁。
+
+        使用基于 ``uk_lock_name`` 的单条 upsert：无行则 INSERT 初始化，
+        已有行仅在可获取（同 holder / 无 expire_time / 已过期）时覆盖更新，
+        否则 no-op 不偷锁；随后一次确认读 SELECT 判定调用方是否持锁。
 
         返回 True 表示加锁成功；False 表示锁被他人持有且未过期。
-        唯一索引冲突视为并发竞争，返回 False 而非抛异常。
+        OceanBase/MySQL 锁等待超时（1205）视为正常竞争，返回 False。
         """
         ...

--- a/src/baas/tests/integration/core/repository/test_distributed_lock_sqlite.py
+++ b/src/baas/tests/integration/core/repository/test_distributed_lock_sqlite.py
@@ -141,3 +141,34 @@ class TestDistributedLockSqliteOrmEquivalence:
     def test_delete_nonexistent_lock(self):
         repo = get_container().repository.distributed_lock_repository()
         assert repo.delete_lock(f"nonexistent_{_generate_uuid()}") is False
+
+    def test_concurrent_acquire_same_new_lock_no_conflict_raised(self):
+        """Two holders racing for the same brand-new lock must not raise and
+        must serialize via the upsert: exactly one acquires, the other gets
+        ``False``, and no IntegrityError escapes the repository (the upsert
+        path replaces the former three-step INSERT that produced 1062).
+        """
+        from concurrent.futures import ThreadPoolExecutor
+
+        repo = get_container().repository.distributed_lock_repository()
+        lock_name = f"race_{_generate_uuid()[:12]}"
+        expire_time = datetime.now() + timedelta(minutes=5)
+        holders = [f"holder-{_generate_uuid()[:6]}", f"holder-{_generate_uuid()[:6]}"]
+
+        def _bid(holder):
+            # Each thread uses its own holder; the repository yields bool and
+            # must never propagate a unique-constraint IntegrityError.
+            return repo.try_acquire_lock(
+                lock_name=lock_name, lock_holder=holder, expire_time=expire_time
+            )
+
+        with ThreadPoolExecutor(max_workers=2) as ex:
+            results = list(ex.map(_bid, holders))
+
+        assert all(isinstance(r, bool) for r in results)
+        assert sum(1 for r in results if r is True) == 1, results
+        assert sum(1 for r in results if r is False) == 1, results
+
+        record = repo.get_by_lock_name(lock_name)
+        assert record is not None
+        assert record.lock_holder in holders

--- a/src/baas/tests/unit/core/repository/distributed_lock/test_orm_distributed_lock_repository.py
+++ b/src/baas/tests/unit/core/repository/distributed_lock/test_orm_distributed_lock_repository.py
@@ -3,6 +3,12 @@ OrmDistributedLockRepository unit tests.
 
 Uses pytest + MagicMock SQLAlchemy ORM session pattern matching the existing
 test_orm_bot_run_repository.py.
+
+``try_acquire_lock`` is exercised through the dialect-specific upsert it now
+emits: each test asserts on the compiled SQLAlchemy statement (mysql default
+or sqlite branch) and the bound params, plus the confirming read that decides
+acquired/not-acquired (see ``arca_ttl`` unit tests for the SQL-assertion
+pattern).
 """
 
 from datetime import datetime
@@ -12,6 +18,7 @@ from datetime import timedelta as _timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
+from sqlalchemy.dialects import mysql, sqlite
 
 from secbaas.community.core.repository.distributed_lock import (
     DistributedLockRepository,
@@ -26,11 +33,36 @@ NOW = datetime.now()
 FUTURE = NOW + _timedelta(days=30)
 PAST = NOW - _timedelta(days=30)
 
+_SQLITE = "sqlite"
+
+
+def _make_repo(dialect: str = "mysql"):
+    """Create a repository with a mocked database session bound to dialect.
+
+    The session's ``bind.dialect.name`` selects the upsert branch: mysql
+    (default) renders ``ON DUPLICATE KEY UPDATE``, sqlite renders
+    ``ON CONFLICT DO UPDATE``.
+    """
+    mock_session = MagicMock()
+    mock_session.bind.dialect.name = dialect
+    mock_db = MagicMock()
+    mock_db.orm_session.return_value.__enter__.return_value = mock_session
+    mock_db.orm_session.return_value.__exit__ = MagicMock(return_value=False)
+    return OrmDistributedLockRepository(database=mock_db), mock_session
+
+
+def _make_exec_result(row):
+    """Build a mock Result exposing ``scalar_one_or_none`` -> row (or None)."""
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = row
+    return result
+
 
 @pytest.fixture
 def mock_session():
-    """Mock SQLAlchemy ORM session."""
+    """Mock SQLAlchemy ORM session (mysql dialect by default)."""
     session = MagicMock()
+    session.bind.dialect.name = "mysql"
     session.query.return_value.filter.return_value.update.return_value = 0
     return session
 
@@ -313,149 +345,179 @@ class TestDeleteLock:
 
 
 class TestTryAcquireLock:
-    """Tests for OrmDistributedLockRepository.try_acquire_lock()."""
+    """Tests for OrmDistributedLockRepository.try_acquire_lock().
 
-    def test_acquire_when_no_existing_lock(self, repository, mock_session):
-        mock_session.query.return_value.filter.return_value.first.return_value = None
+    The repository now emits a single dialect-specific upsert followed by a
+    confirming read SELECT. These tests assert on the compiled SQL/bind params
+    and on the confirming read's row, mirroring the arca_ttl SQL-assertion
+    unit-test pattern.
+    """
 
-        def _add_side_effect(model):
-            model.id = 1
+    def test_acquire_emits_mysql_upsert_with_bindparams(self):
+        repo, mock_session = _make_repo("mysql")
+        mock_session.execute.return_value = _make_exec_result(
+            _make_model(lock_holder="holder-A", expire_time=FUTURE)
+        )
 
-        mock_session.add.side_effect = _add_side_effect
-
-        result = repository.try_acquire_lock(
-            lock_name="new-lock",
-            lock_holder="holder-A",
-            expire_time=FUTURE,
+        result = repo.try_acquire_lock(
+            lock_name="new-lock", lock_holder="holder-A", expire_time=FUTURE
         )
 
         assert result is True
-        mock_session.add.assert_called_once()
-        mock_session.flush.assert_called()
+        assert mock_session.execute.call_count == 2
 
-    def test_acquire_reentrant_same_holder(self, repository, mock_session):
-        mock_session.query.return_value.filter.return_value.update.return_value = 1
+        upsert_stmt = mock_session.execute.call_args_list[0][0][0]
+        compiled = upsert_stmt.compile(dialect=mysql.dialect())
+        sql_text = str(compiled)
 
-        result = repository.try_acquire_lock(
-            lock_name="existing-lock",
-            lock_holder="holder-A",
-            expire_time=FUTURE,
+        assert "INSERT INTO ac_lock_table" in sql_text
+        assert "ON DUPLICATE KEY UPDATE" in sql_text
+        # Conditional overwrite via CASE WHEN ... THEN VALUES(...) ELSE <col>.
+        assert "CASE WHEN" in sql_text
+        assert "VALUES(lock_holder)" in sql_text
+        assert "gmt_modified" in sql_text
+        # The acquirable predicate must contain all three OR branches:
+        # same holder, null expire, and expired (<= app-clock now). Each CASE
+        # repeats it, so it appears multiple times.
+        assert "ac_lock_table.lock_holder = VALUES(lock_holder)" in sql_text
+        assert "ac_lock_table.expire_time IS NULL" in sql_text
+        assert "ac_lock_table.expire_time <=" in sql_text
+
+        params = compiled.params
+        assert params["lock_name"] == "new-lock"
+        assert params["lock_holder"] == "holder-A"
+        assert params["expire_time"] == FUTURE
+        assert params["env"] == "dev"
+        # The expiry branch binds the app-clock now, not DB NOW().
+        assert "expire_time_1" in params or any(
+            isinstance(v, datetime) for v in params.values()
+        )
+
+    def test_acquire_emits_sqlite_on_conflict_dialect(self):
+        repo, mock_session = _make_repo(_SQLITE)
+        mock_session.execute.return_value = _make_exec_result(
+            _make_model(lock_holder="holder-A", expire_time=FUTURE)
+        )
+
+        result = repo.try_acquire_lock(
+            lock_name="new-lock", lock_holder="holder-A", expire_time=FUTURE
         )
 
         assert result is True
-        mock_session.add.assert_not_called()
-        mock_session.delete.assert_not_called()
+        upsert_stmt = mock_session.execute.call_args_list[0][0][0]
+        compiled = upsert_stmt.compile(dialect=sqlite.dialect())
+        sql_text = str(compiled)
 
-    def test_acquire_fails_when_held_by_other(self, repository, mock_session):
-        mock_model = _make_model(
-            lock_name="held-lock",
-            lock_holder="holder-B",
-            expire_time=FUTURE,
-        )
-        mock_session.query.return_value.filter.return_value.first.return_value = (
-            mock_model
+        assert "INSERT INTO ac_lock_table" in sql_text
+        assert "ON CONFLICT (lock_name)" in sql_text
+        assert "DO UPDATE SET" in sql_text
+        assert "excluded.lock_holder" in sql_text
+        assert "gmt_modified" in sql_text
+        assert "ON DUPLICATE KEY UPDATE" not in sql_text
+        # The ON CONFLICT WHERE guard must contain all three acquirable branches
+        # and bind the app-clock now for the expiry comparison.
+        where_region = sql_text.split("WHERE", 1)[1]
+        assert "ac_lock_table.lock_holder = excluded.lock_holder" in where_region
+        assert "ac_lock_table.expire_time IS NULL" in where_region
+        assert "ac_lock_table.expire_time <=" in where_region
+
+    def test_acquire_runs_confirm_read_select_after_upsert(self):
+        repo, mock_session = _make_repo("mysql")
+        mock_session.execute.return_value = _make_exec_result(
+            _make_model(lock_holder="holder-A", expire_time=FUTURE)
         )
 
-        result = repository.try_acquire_lock(
-            lock_name="held-lock",
-            lock_holder="holder-A",
-            expire_time=FUTURE,
+        repo.try_acquire_lock(
+            lock_name="cf-lock", lock_holder="holder-A", expire_time=FUTURE
+        )
+
+        confirm_stmt = mock_session.execute.call_args_list[1][0][0]
+        compiled = confirm_stmt.compile(dialect=mysql.dialect())
+        assert "SELECT" in str(compiled)
+        assert "ac_lock_table" in str(compiled)
+
+    def test_acquire_returns_true_when_confirm_read_shows_self(self):
+        repo, mock_session = _make_repo("mysql")
+        mock_session.execute.return_value = _make_exec_result(
+            _make_model(lock_holder="holder-A", expire_time=FUTURE)
+        )
+
+        result = repo.try_acquire_lock(
+            lock_name="held-self", lock_holder="holder-A", expire_time=FUTURE
+        )
+
+        assert result is True
+
+    def test_acquire_returns_false_when_held_by_other(self):
+        repo, mock_session = _make_repo("mysql")
+        mock_session.execute.return_value = _make_exec_result(
+            _make_model(lock_holder="holder-B", expire_time=FUTURE)
+        )
+
+        result = repo.try_acquire_lock(
+            lock_name="held-other", lock_holder="holder-A", expire_time=FUTURE
+        )
+
+        assert result is False
+        # No rollback on a clean not-acquired outcome.
+        mock_session.rollback.assert_not_called()
+
+    def test_acquire_returns_false_when_confirm_read_missing(self):
+        repo, mock_session = _make_repo("mysql")
+        mock_session.execute.return_value = _make_exec_result(None)
+
+        result = repo.try_acquire_lock(
+            lock_name="gone", lock_holder="holder-A", expire_time=FUTURE
         )
 
         assert result is False
 
-    def test_acquire_reentrant_same_holder_after_zero_rowcount(
-        self, repository, mock_session
-    ):
-        mock_model = _make_model(
-            lock_name="existing-lock",
-            lock_holder="holder-A",
-            expire_time=FUTURE,
-        )
-        mock_session.query.return_value.filter.return_value.first.return_value = (
-            mock_model
+    def test_acquire_takes_over_expired_lock_via_confirm_read(self):
+        repo, mock_session = _make_repo("mysql")
+        # Confirming read shows the row already updated to the new holder by
+        # the upsert, so the repository reports success even though the input
+        # holder differs from the previous (expired) owner.
+        mock_session.execute.return_value = _make_exec_result(
+            _make_model(lock_holder="new-holder", expire_time=FUTURE)
         )
 
-        result = repository.try_acquire_lock(
-            lock_name="existing-lock",
-            lock_holder="holder-A",
-            expire_time=FUTURE,
+        result = repo.try_acquire_lock(
+            lock_name="expired-lock", lock_holder="new-holder", expire_time=FUTURE
         )
 
         assert result is True
-        mock_session.add.assert_not_called()
-        mock_session.delete.assert_not_called()
 
-    def test_acquire_takes_over_expired_lock(self, repository, mock_session):
-        mock_session.query.return_value.filter.return_value.update.return_value = 1
-
-        result = repository.try_acquire_lock(
-            lock_name="expired-lock",
-            lock_holder="new-holder",
-            expire_time=FUTURE,
-        )
-
-        assert result is True
-        mock_session.delete.assert_not_called()
-        mock_session.add.assert_not_called()
-
-    def test_acquire_handles_unique_constraint_conflict(self, repository, mock_session):
-        from sqlalchemy.exc import IntegrityError as SAIntegrityError
-
-        mock_session.query.return_value.filter.return_value.first.return_value = None
-
-        orig = MagicMock()
-        orig.args = ("1062", "Duplicate entry")
-        mock_session.flush.side_effect = SAIntegrityError("INSERT INTO ...", {}, orig)
-
-        result = repository.try_acquire_lock(
-            lock_name="conflict-lock",
-            lock_holder="holder-A",
-            expire_time=FUTURE,
-        )
-
-        assert result is False
-        mock_session.rollback.assert_called_once()
-
-    def test_acquire_new_lock_has_env_field(self, repository, mock_session):
-        mock_session.query.return_value.filter.return_value.first.return_value = None
-
-        def _add_side_effect(model):
-            model.id = 10
-
-        mock_session.add.side_effect = _add_side_effect
-
-        repository.try_acquire_lock(
-            lock_name="env-check-lock",
-            lock_holder="holder",
-            expire_time=FUTURE,
-        )
-
-        added_model = mock_session.add.call_args[0][0]
-        assert added_model.env == "dev"
-
-    def test_acquire_handles_oceanbase_lock_wait_timeout(
-        self, repository, mock_session
-    ):
+    def test_acquire_handles_oceanbase_lock_wait_timeout(self):
         from sqlalchemy.exc import DatabaseError as SADatabaseError
 
+        repo, mock_session = _make_repo("mysql")
         orig = MagicMock()
         orig.errno = 1205
         orig.__str__.return_value = (
             "Lock wait timeout exceeded; try restarting transaction"
         )
-        mock_session.query.return_value.filter.return_value.update.side_effect = (
-            SADatabaseError("UPDATE ...", {}, orig)
-        )
+        mock_session.execute.side_effect = SADatabaseError("INSERT ...", {}, orig)
 
-        result = repository.try_acquire_lock(
-            lock_name="busy-lock",
-            lock_holder="holder-A",
-            expire_time=FUTURE,
+        result = repo.try_acquire_lock(
+            lock_name="busy-lock", lock_holder="holder-A", expire_time=FUTURE
         )
 
         assert result is False
         mock_session.rollback.assert_called_once()
+
+    def test_acquire_reraises_unexpected_database_error(self):
+        from sqlalchemy.exc import DatabaseError as SADatabaseError
+
+        repo, mock_session = _make_repo("mysql")
+        orig = MagicMock()
+        orig.errno = 1146  # not a lock-wait-timeout
+        orig.__str__.return_value = "Table doesn't exist"
+        mock_session.execute.side_effect = SADatabaseError("INSERT ...", {}, orig)
+
+        with pytest.raises(SADatabaseError):
+            repo.try_acquire_lock(
+                lock_name="err-lock", lock_holder="holder-A", expire_time=FUTURE
+            )
 
 
 # ==================== DistributedLockRepository Protocol Tests ====================
@@ -503,12 +565,9 @@ class TestWithOrmSessionIntegration:
     def test_session_used_for_try_acquire(self, mock_database, mock_session):
         repo = OrmDistributedLockRepository(mock_database)
 
-        mock_session.query.return_value.filter.return_value.first.return_value = None
-
-        def _add_side_effect(model):
-            model.id = 1
-
-        mock_session.add.side_effect = _add_side_effect
+        mock_session.execute.return_value = _make_exec_result(
+            _make_model(lock_holder="holder", expire_time=FUTURE)
+        )
 
         repo.try_acquire_lock(
             lock_name="test-lock",
@@ -550,12 +609,9 @@ class TestMethodRoundTrips:
     """Tests covering multiple methods in sequence on the same repository."""
 
     def test_acquire_then_get_by_lock_name(self, repository, mock_session):
-        mock_session.query.return_value.filter.return_value.first.return_value = None
-
-        def _add_side_effect(model):
-            model.id = 55
-
-        mock_session.add.side_effect = _add_side_effect
+        mock_session.execute.return_value = _make_exec_result(
+            _make_model(lock_holder="holder-rt", expire_time=FUTURE)
+        )
 
         acquired = repository.try_acquire_lock(
             lock_name="roundtrip-lock",
@@ -565,12 +621,9 @@ class TestMethodRoundTrips:
         assert acquired is True
 
     def test_acquire_then_delete(self, repository, mock_session):
-        mock_session.query.return_value.filter.return_value.first.return_value = None
-
-        def _add_side_effect(model):
-            model.id = 10
-
-        mock_session.add.side_effect = _add_side_effect
+        mock_session.execute.return_value = _make_exec_result(
+            _make_model(lock_holder="holder", expire_time=FUTURE)
+        )
 
         repository.try_acquire_lock(
             lock_name="delete-lock",
@@ -583,13 +636,10 @@ class TestMethodRoundTrips:
         assert deleted is True
 
     def test_full_lock_lifecycle(self, repository, mock_session):
-        # Acquire
-        mock_session.query.return_value.filter.return_value.first.return_value = None
-
-        def _add_side_effect(model):
-            model.id = 1
-
-        mock_session.add.side_effect = _add_side_effect
+        # Acquire via upsert + confirm-read showing self as holder.
+        mock_session.execute.return_value = _make_exec_result(
+            _make_model(lock_holder="holder", expire_time=FUTURE)
+        )
 
         acquired = repository.try_acquire_lock(
             lock_name="lifecycle-lock",
@@ -651,14 +701,14 @@ class TestEdgeCases:
         assert result.lock_holder == ""
 
     def test_consecutive_try_acquire_different_names(self, repository, mock_session):
-        mock_session.query.return_value.filter.return_value.first.return_value = None
-
-        ids = iter([1, 2])
-
-        def _add_side_effect(model):
-            model.id = next(ids)
-
-        mock_session.add.side_effect = _add_side_effect
+        # Each try_acquire issues upsert + confirming read; both executes for
+        # one logical call report that call's caller as the holder.
+        mock_session.execute.side_effect = [
+            _make_exec_result(_make_model(lock_holder="h1", expire_time=FUTURE)),
+            _make_exec_result(_make_model(lock_holder="h1", expire_time=FUTURE)),
+            _make_exec_result(_make_model(lock_holder="h2", expire_time=FUTURE)),
+            _make_exec_result(_make_model(lock_holder="h2", expire_time=FUTURE)),
+        ]
 
         r1 = repository.try_acquire_lock(
             lock_name="lock-a", lock_holder="h1", expire_time=FUTURE


### PR DESCRIPTION
# refactor(baas): acquire distributed lock via single upsert

## Background

The distributed lock repository's `try_acquire_lock` previously used a
three-step `conditional UPDATE → SELECT → INSERT` flow. When two sessions
raced to acquire the same brand-new lock, both reached the INSERT step and
one INSERT hit the `uk_lock_name` unique constraint, producing an underlying
`INSERT ... failed, 1062` record in the DB audit log. The conflict was already
caught at the application layer (IntegrityError → rollback → `False`), so lock
semantics were correct, but the exception path was being used as a normal
contention control flow and it polluted audit/monitoring with real failure
records.

## Change

Rewrite `try_acquire_lock` to issue a **single dialect-specific atomic upsert**
keyed on `uk_lock_name`, followed by one confirming read SELECT that decides
whether the caller now holds the lock:

- MySQL/OceanBase: `INSERT ... ON DUPLICATE KEY UPDATE` with
  `CASE WHEN <acquirable> THEN VALUES(col) ELSE col END` conditional overwrite,
  so a held-but-unexpired row is a no-op while same-holder / expired / null
  rows are taken over.
- SQLite: `INSERT ... ON CONFLICT(lock_name) DO UPDATE ... WHERE <acquirable>`,
  skipping the update entirely when the row is not acquirable.

The `acquirable` predicate matches the former conditional UPDATE exactly:
`lock_holder == caller OR expire_time IS NULL OR expire_time <= now`. The expiry
check binds the application wall-clock `now` (not the DB `NOW()`) so it stays
in the same clock domain as the written `expire_time` (SQLite
`CURRENT_TIMESTAMP` is UTC). `gmt_modified` is set explicitly and only refreshed
when the row is actually acquired, since a dialect upsert does not apply
`Column.onupdate`.

The dedicated `IntegrityError` catch is removed from `try_acquire_lock` because
the upsert no longer raises the unique-conflict path. The OceanBase/MySQL
lock-wait-timeout (1205) handling (`SADatabaseError` → rollback → `False`) is
preserved, and non-1205 database errors are re-raised. The service-layer and
repository utility IntegrityError safety nets are intentionally retained as
inert safety nets.

This follows the existing dual-dialect upsert convention already used in the
`arca_ttl` repository.

## Semantics preserved

- New lock: upsert INSERT → confirm holder == self → `True`.
- Same holder (reentrant renewal): upsert overwrite branch → renew expiry → `True`.
- Expired / null `expire_time`: takeover → `True`.
- Held by another, unexpired: no-op → confirm holder != self → `False`.
- Lock wait timeout (1205): rollback → `False`.

## Interface compatibility

- `DistributedLockRepository` Protocol and `try_acquire_lock(*, lock_name,
  lock_holder, expire_time) -> bool` are unchanged; callers
  (`DistributedLockService`, `SerializingExecutor`) need no changes.
- No schema, unique-constraint, or data migration changes.

## Testing

- Unit tests rewritten to assert the compiled upsert SQL (MySQL
  `ON DUPLICATE KEY UPDATE` + `CASE WHEN` branches and SQLite `ON CONFLICT ...
  DO UPDATE ... WHERE`), the bound parameters (including `env`), and the
  confirming read SELECT; the 1205 path and re-raise of non-1205 errors are
  covered.
- SQLite integration tests cover all four scenarios and add a concurrent
  two-holder race asserting no IntegrityError escapes and exactly one winner.
- `arca_ttl` contract tests pass as a regression check on the shared upsert
  convention.

## Risk / rollback

Low risk: public interface and schema unchanged; behavior covered by unit and
SQLite integration tests. Real OceanBase/MySQL confirmation that the audit log
no longer records `ac_lock_table INSERT failed 1062` should be done in the
target environment (not reproducible in the hermetic test suite). Revert is a
single-file rollback of `try_acquire_lock` since the contract is unchanged.