### PR TITLE
normalize friend approval result notifications

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/app.py
+++ b/src/backend/src/agentclaw/community/adapters/http/app.py
@@ -70,7 +70,6 @@ if get_current_env() in ("pre", "prod"):
     eager_check_critical_bindings(injector)
 # ──────────────────────────────────────────────────────────────────────────
 
-
 # =============================================================================
 # Pre-import side effects: AGENTCLAW_CONFIG_PATH + OpenClaw DB config
 # =============================================================================
@@ -94,9 +93,7 @@ def _set_openclaw_config_path():
     except Exception as e:
         logging.warning(f"Could not set AGENTCLAW_CONFIG_PATH: {e}")
 
-
 _set_openclaw_config_path()  # noqa: FLA010 — composition root, must run at import time before OpenClaw imports below read AGENTCLAW_CONFIG_PATH
-
 
 # =============================================================================
 # Router imports (post-DI-bootstrap)
@@ -625,7 +622,10 @@ async def _validation_error_handler(
             ],
             exc_info=exc,
         )
-        return error_response(422, "Invalid request", request)
+        message = "缺少必填字段text" if any(
+            "缺少必填字段text" in str(error.get("msg", "")) for error in exc.errors()
+        ) else "Invalid request"
+        return error_response(422, message, request)
     # Internal routes keep FastAPI's ``{"detail": [...]}`` body, whose default
     # handler logs nothing. Same treatment as above: log, then delegate. The
     # ``input`` each error carries is the caller's raw payload, so only

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/work_orders/converter.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/work_orders/converter.py
@@ -10,6 +10,8 @@ from agentclaw.community.core.work_orders.models import (
     WorkOrderMessageTitle,
     WorkOrderStatus,
     WorkOrderTitleKey,
+    notification_summary_for,
+    notification_title_for,
 )
 
 JsonObject = dict[str, Any]
@@ -39,10 +41,14 @@ _TITLE_KEY_BY_STATUS = {
 def display_title(
     stored_title: str | None,
     *,
+    event_type: str | None = None,
     biz_type: str | None = None,
     status: WorkOrderStatus | None = None,
-) -> str | None:
-    """Translate known persisted title formats and preserve unknown titles."""
+) -> str:
+    """Resolve titles from the event contract with legacy compatibility."""
+
+    if event_type is not None:
+        return notification_title_for(event_type, stored_title)
 
     key = _TITLE_KEY_BY_STORED_VALUE.get(stored_title or "")
     if key is not None:
@@ -52,6 +58,11 @@ def display_title(
     if biz_type == WorkOrderBizType.SPACE_JOIN.value and status is not None:
         return _TITLE_BY_KEY[_TITLE_KEY_BY_STATUS[status]]
     return stored_title
+
+
+def display_summary(event_type: str | None) -> str:
+    """Return the stable list/detail summary for an event."""
+    return notification_summary_for(event_type)
 
 
 def json_object(raw: str | None) -> JsonObject | None:

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/work_orders/converter.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/work_orders/converter.py
@@ -1,4 +1,4 @@
-"""Presentation compatibility for persisted work-order JSON and title codes."""
+"""Presentation compatibility for persisted work-order content and titles."""
 
 from __future__ import annotations
 
@@ -7,6 +7,7 @@ from typing import Any
 
 from agentclaw.community.core.work_orders.models import (
     WorkOrderBizType,
+    WorkOrderEventType,
     WorkOrderMessageTitle,
     WorkOrderStatus,
     WorkOrderTitleKey,
@@ -15,6 +16,7 @@ from agentclaw.community.core.work_orders.models import (
 )
 
 JsonObject = dict[str, Any]
+ContentValue = str | JsonObject | None
 
 _TITLE_KEY_BY_STORED_VALUE = {
     WorkOrderTitleKey.SPACE_JOIN_PENDING.value: WorkOrderTitleKey.SPACE_JOIN_PENDING,
@@ -31,10 +33,44 @@ _TITLE_BY_KEY = {
     WorkOrderTitleKey.SPACE_JOIN_APPROVED: WorkOrderMessageTitle.SPACE_JOIN_APPROVED.value,
     WorkOrderTitleKey.SPACE_JOIN_REJECTED: WorkOrderMessageTitle.SPACE_JOIN_REJECTED.value,
 }
-_TITLE_KEY_BY_STATUS = {
-    WorkOrderStatus.PENDING: WorkOrderTitleKey.SPACE_JOIN_PENDING,
-    WorkOrderStatus.APPROVED: WorkOrderTitleKey.SPACE_JOIN_APPROVED,
-    WorkOrderStatus.REJECTED: WorkOrderTitleKey.SPACE_JOIN_REJECTED,
+_TITLE_BY_BIZ_STATUS = {
+    (WorkOrderBizType.SPACE_JOIN.value, WorkOrderStatus.PENDING): WorkOrderMessageTitle.SPACE_JOIN_PENDING.value,
+    (WorkOrderBizType.SPACE_JOIN.value, WorkOrderStatus.APPROVED): WorkOrderMessageTitle.SPACE_JOIN_APPROVED.value,
+    (WorkOrderBizType.SPACE_JOIN.value, WorkOrderStatus.REJECTED): WorkOrderMessageTitle.SPACE_JOIN_REJECTED.value,
+    (WorkOrderBizType.BOT_COLLABORATOR.value, WorkOrderStatus.PENDING): WorkOrderMessageTitle.BOT_COLLABORATOR_PENDING.value,
+    (WorkOrderBizType.BOT_COLLABORATOR.value, WorkOrderStatus.APPROVED): WorkOrderMessageTitle.BOT_COLLABORATOR_APPROVED.value,
+    (WorkOrderBizType.BOT_COLLABORATOR.value, WorkOrderStatus.REJECTED): WorkOrderMessageTitle.BOT_COLLABORATOR_REJECTED.value,
+    (WorkOrderBizType.SKILL_COLLABORATOR.value, WorkOrderStatus.PENDING): WorkOrderMessageTitle.SKILL_COLLABORATOR_PENDING.value,
+    (WorkOrderBizType.SKILL_COLLABORATOR.value, WorkOrderStatus.APPROVED): WorkOrderMessageTitle.SKILL_COLLABORATOR_APPROVED.value,
+    (WorkOrderBizType.SKILL_COLLABORATOR.value, WorkOrderStatus.REJECTED): WorkOrderMessageTitle.SKILL_COLLABORATOR_REJECTED.value,
+    (WorkOrderBizType.BOT_FRIEND.value, WorkOrderStatus.PENDING): "好友申请待审批",
+    (WorkOrderBizType.BOT_FRIEND.value, WorkOrderStatus.APPROVED): "好友申请已通过",
+    (WorkOrderBizType.BOT_FRIEND.value, WorkOrderStatus.REJECTED): "好友申请未通过",
+}
+_SUMMARY_BY_BIZ_TYPE = {
+    WorkOrderBizType.SPACE_JOIN.value: "有新的空间加入申请，请及时处理。",
+    WorkOrderBizType.BOT_COLLABORATOR.value: "有新的 Bot 共同编辑申请，请及时处理。",
+    WorkOrderBizType.SKILL_COLLABORATOR.value: "有新的 Skill 共同编辑申请，请及时处理。",
+    WorkOrderBizType.BOT_FRIEND.value: "有新的好友申请，请及时处理。",
+}
+_GENERIC_SUMMARY = "你有一条新的通知，请查看详情。"
+_REVIEWED_TITLE_BY_EVENT_STATUS = {
+    (
+        WorkOrderEventType.HUMAN2BOT_FRIEND_REVIEWED.value,
+        WorkOrderStatus.APPROVED,
+    ): WorkOrderMessageTitle.HUMAN_FRIEND_APPROVED.value,
+    (
+        WorkOrderEventType.HUMAN2BOT_FRIEND_REVIEWED.value,
+        WorkOrderStatus.REJECTED,
+    ): WorkOrderMessageTitle.HUMAN_FRIEND_REJECTED.value,
+    (
+        WorkOrderEventType.BOT2BOT_FRIEND_REVIEWED.value,
+        WorkOrderStatus.APPROVED,
+    ): WorkOrderMessageTitle.BOT_FRIEND_APPROVED.value,
+    (
+        WorkOrderEventType.BOT2BOT_FRIEND_REVIEWED.value,
+        WorkOrderStatus.REJECTED,
+    ): WorkOrderMessageTitle.BOT_FRIEND_REJECTED.value,
 }
 
 
@@ -44,34 +80,79 @@ def display_title(
     event_type: str | None = None,
     biz_type: str | None = None,
     status: WorkOrderStatus | None = None,
-) -> str:
-    """Resolve titles from the event contract with legacy compatibility."""
+) -> str | None:
+    """Resolve canonical titles while retaining legacy persisted values."""
 
     if event_type is not None:
+        reviewed_title = _REVIEWED_TITLE_BY_EVENT_STATUS.get((event_type, status))
+        if reviewed_title is not None:
+            return reviewed_title
         return notification_title_for(event_type, stored_title)
 
     key = _TITLE_KEY_BY_STORED_VALUE.get(stored_title or "")
     if key is not None:
         return _TITLE_BY_KEY[key]
-    if stored_title:
+    derived = _TITLE_BY_BIZ_STATUS.get((biz_type or "", status))
+    if derived is not None:
+        return derived
+    if stored_title and stored_title != "新的系统通知":
         return stored_title
-    if biz_type == WorkOrderBizType.SPACE_JOIN.value and status is not None:
-        return _TITLE_BY_KEY[_TITLE_KEY_BY_STATUS[status]]
-    return stored_title
+    return None
 
 
-def display_summary(event_type: str | None) -> str:
-    """Return the stable list/detail summary for an event."""
-    return notification_summary_for(event_type)
+def _parse_content(raw: Any) -> Any:
+    if isinstance(raw, str):
+        try:
+            return json.loads(raw)
+        except (TypeError, ValueError):
+            return raw
+    return raw
+
+
+def preserve_content(raw: Any) -> ContentValue:
+    """Expose content without reshaping historical strings or JSON objects."""
+
+    parsed = _parse_content(raw)
+    if parsed is None or isinstance(parsed, (str, dict)):
+        return parsed
+    # Preserve unsupported historical JSON values as their original database
+    # text rather than changing their shape or representation.
+    return raw if isinstance(raw, str) else str(parsed)
+
+
+def extract_content_text(raw: Any) -> str | None:
+    """Extract user-facing text from legacy text and structured content."""
+
+    parsed = _parse_content(raw)
+    if isinstance(parsed, str):
+        return parsed or None
+    if not isinstance(parsed, dict):
+        return None
+    for key in ("text", "legacy_value"):
+        value = parsed.get(key)
+        if isinstance(value, str) and value.strip():
+            return value
+    return None
+
+
+def display_summary(
+    event_type: str | None,
+    content: Any = None,
+    *,
+    biz_type: str | None = None,
+) -> str:
+    """Return content text first, then the event/business default summary."""
+
+    content_text = extract_content_text(content)
+    if content_text is not None:
+        return content_text
+    if event_type is not None:
+        return notification_summary_for(event_type)
+    return _SUMMARY_BY_BIZ_TYPE.get(biz_type or "", _GENERIC_SUMMARY)
 
 
 def json_object(raw: str | None) -> JsonObject | None:
-    """Decode stored JSON objects and safely expose historical scalar text.
-
-    New API writes always store JSON objects. Historical rows may contain raw
-    text or another JSON scalar, so they are exposed under ``legacy_value`` to
-    keep the response contract object-shaped without losing the old value.
-    """
+    """Legacy object-shaped decoder retained for business-data responses."""
 
     if raw is None:
         return None

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/work_orders/converter.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/work_orders/converter.py
@@ -128,7 +128,7 @@ def extract_content_text(raw: Any) -> str | None:
         return parsed or None
     if not isinstance(parsed, dict):
         return None
-    for key in ("text", "legacy_value"):
+    for key in ("text", "legacy_value", "workitem_name"):
         value = parsed.get(key)
         if isinstance(value, str) and value.strip():
             return value

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/work_orders/converter.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/work_orders/converter.py
@@ -48,12 +48,20 @@ _TITLE_BY_BIZ_STATUS = {
     (WorkOrderBizType.BOT_FRIEND.value, WorkOrderStatus.REJECTED): "好友申请未通过",
 }
 _SUMMARY_BY_BIZ_TYPE = {
-    WorkOrderBizType.SPACE_JOIN.value: "有新的空间加入申请，请及时处理。",
-    WorkOrderBizType.BOT_COLLABORATOR.value: "有新的 Bot 共同编辑申请，请及时处理。",
-    WorkOrderBizType.SKILL_COLLABORATOR.value: "有新的 Skill 共同编辑申请，请及时处理。",
-    WorkOrderBizType.BOT_FRIEND.value: "有新的好友申请，请及时处理。",
+    (WorkOrderBizType.SPACE_JOIN.value, WorkOrderStatus.PENDING): "有新的空间加入申请，请及时处理。",
+    (WorkOrderBizType.SPACE_JOIN.value, WorkOrderStatus.APPROVED): "空间加入申请已通过。",
+    (WorkOrderBizType.SPACE_JOIN.value, WorkOrderStatus.REJECTED): "空间加入申请未通过。",
+    (WorkOrderBizType.BOT_COLLABORATOR.value, WorkOrderStatus.PENDING): "有新的 Bot 共同编辑申请，请及时处理。",
+    (WorkOrderBizType.BOT_COLLABORATOR.value, WorkOrderStatus.APPROVED): "Bot 共同编辑申请已通过。",
+    (WorkOrderBizType.BOT_COLLABORATOR.value, WorkOrderStatus.REJECTED): "Bot 共同编辑申请未通过。",
+    (WorkOrderBizType.SKILL_COLLABORATOR.value, WorkOrderStatus.PENDING): "有新的 Skill 共同编辑申请，请及时处理。",
+    (WorkOrderBizType.SKILL_COLLABORATOR.value, WorkOrderStatus.APPROVED): "Skill 共同编辑申请已通过。",
+    (WorkOrderBizType.SKILL_COLLABORATOR.value, WorkOrderStatus.REJECTED): "Skill 共同编辑申请未通过。",
+    (WorkOrderBizType.BOT_FRIEND.value, WorkOrderStatus.PENDING): "有新的好友申请，请及时处理。",
+    (WorkOrderBizType.BOT_FRIEND.value, WorkOrderStatus.APPROVED): "好友申请已通过。",
+    (WorkOrderBizType.BOT_FRIEND.value, WorkOrderStatus.REJECTED): "好友申请未通过。",
 }
-_GENERIC_SUMMARY = "你有一条新的通知，请查看详情。"
+_GENERIC_SUMMARY = "你有一条新的通知"
 _REVIEWED_TITLE_BY_EVENT_STATUS = {
     (
         WorkOrderEventType.HUMAN2BOT_FRIEND_REVIEWED.value,
@@ -140,6 +148,7 @@ def display_summary(
     content: Any = None,
     *,
     biz_type: str | None = None,
+    status: WorkOrderStatus | None = None,
 ) -> str:
     """Return content text first, then the event/business default summary."""
 
@@ -147,8 +156,15 @@ def display_summary(
     if content_text is not None:
         return content_text
     if event_type is not None:
-        return notification_summary_for(event_type)
-    return _SUMMARY_BY_BIZ_TYPE.get(biz_type or "", _GENERIC_SUMMARY)
+        event_summary = notification_summary_for(event_type)
+        # Unknown/legacy event types should still use the work-order state
+        # when it provides a more specific fallback.
+        if event_summary != _GENERIC_SUMMARY:
+            return event_summary
+    return _SUMMARY_BY_BIZ_TYPE.get(
+        (biz_type or "", status),
+        _GENERIC_SUMMARY,
+    )
 
 
 def json_object(raw: str | None) -> JsonObject | None:

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/work_orders/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/work_orders/router.py
@@ -136,7 +136,10 @@ def _list_item(item: DomainListItem) -> WorkOrderListItem:
             event_type=notification.event_type,
             title=display_title(notification.title, event_type=notification.event_type) or "新的系统通知",
             summary=display_summary(
-                notification.event_type, notification.content, biz_type=notification.biz_type
+                notification.event_type,
+                notification.content,
+                biz_type=notification.biz_type,
+                status=(work_order.status if work_order is not None else None),
             ),
             content=preserve_content(notification.content),
             status=None,
@@ -174,6 +177,7 @@ def _list_item(item: DomainListItem) -> WorkOrderListItem:
         event_type,
         notification.content if notification is not None else None,
         biz_type=work_order.biz_type,
+        status=work_order.status,
     )
     content = preserve_content(notification.content) if notification is not None else None
     return WorkOrderListItem(
@@ -376,7 +380,10 @@ async def get_work_order(
                 status=work_order.status,
             ) or "新的系统通知",
             summary=display_summary(
-                detail.event_type, detail.content, biz_type=work_order.biz_type
+                detail.event_type,
+                detail.content,
+                biz_type=work_order.biz_type,
+                status=work_order.status,
             ),
             content=preserve_content(detail.content),
             status=work_order.status,
@@ -536,7 +543,10 @@ async def get_notification(
                 status=detail.work_order_status,
             ) or "新的系统通知",
             summary=display_summary(
-                record.event_type, record.content, biz_type=record.biz_type
+                record.event_type,
+                record.content,
+                biz_type=record.biz_type,
+                status=detail.work_order_status,
             ),
             content=preserve_content(record.content),
             is_read=record.is_read,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/work_orders/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/work_orders/router.py
@@ -49,6 +49,7 @@ from agentclaw.community.adapters.http.openapi_v1.work_orders.converter import (
     display_summary,
     display_title,
     json_object,
+    preserve_content,
 )
 from agentclaw.community.adapters.http.work_orders.converter import (
     create_work_order_event_data,
@@ -134,8 +135,10 @@ def _list_item(item: DomainListItem) -> WorkOrderListItem:
             recipient_user_id=notification.recipient_user_id,
             event_type=notification.event_type,
             title=display_title(notification.title, event_type=notification.event_type) or "新的系统通知",
-            summary=display_summary(notification.event_type),
-            content=json_object(notification.content),
+            summary=display_summary(
+                notification.event_type, notification.content, biz_type=notification.biz_type
+            ),
+            content=preserve_content(notification.content),
             status=None,
             is_read=notification.is_read,
             read_at=notification.read_at,
@@ -167,8 +170,12 @@ def _list_item(item: DomainListItem) -> WorkOrderListItem:
         biz_type=work_order.biz_type,
         status=work_order.status,
     ) or "新的系统通知"
-    summary = display_summary(event_type)
-    content = json_object(notification.content) if notification is not None else None
+    summary = display_summary(
+        event_type,
+        notification.content if notification is not None else None,
+        biz_type=work_order.biz_type,
+    )
+    content = preserve_content(notification.content) if notification is not None else None
     return WorkOrderListItem(
         item_id=(
             f"NOTIFICATION_{notification.id}"
@@ -368,8 +375,10 @@ async def get_work_order(
                 biz_type=work_order.biz_type,
                 status=work_order.status,
             ) or "新的系统通知",
-            summary=display_summary(detail.event_type),
-            content=json_object(detail.content),
+            summary=display_summary(
+                detail.event_type, detail.content, biz_type=work_order.biz_type
+            ),
+            content=preserve_content(detail.content),
             status=work_order.status,
             reviewer_user_id=work_order.reviewer_user_id,
             reviewer_user_name=detail.reviewer_user_name,
@@ -526,8 +535,10 @@ async def get_notification(
                 biz_type=record.biz_type,
                 status=detail.work_order_status,
             ) or "新的系统通知",
-            summary=display_summary(record.event_type),
-            content=json_object(record.content),
+            summary=display_summary(
+                record.event_type, record.content, biz_type=record.biz_type
+            ),
+            content=preserve_content(record.content),
             is_read=record.is_read,
             work_order_status=detail.work_order_status,
             can_approve=detail.can_approve,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/work_orders/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/work_orders/router.py
@@ -46,6 +46,7 @@ from agentclaw.community.adapters.http.openapi_v1.work_orders.schemas import (
     WorkOrderLegacyReviewResponse,
 )
 from agentclaw.community.adapters.http.openapi_v1.work_orders.converter import (
+    display_summary,
     display_title,
     json_object,
 )
@@ -132,7 +133,8 @@ def _list_item(item: DomainListItem) -> WorkOrderListItem:
             reviewed_at=None,
             recipient_user_id=notification.recipient_user_id,
             event_type=notification.event_type,
-            title=display_title(notification.title),
+            title=display_title(notification.title, event_type=notification.event_type) or "新的系统通知",
+            summary=display_summary(notification.event_type),
             content=json_object(notification.content),
             status=None,
             is_read=notification.is_read,
@@ -158,11 +160,14 @@ def _list_item(item: DomainListItem) -> WorkOrderListItem:
         if category is not None
         else WorkOrderItemType.APPROVAL
     )
+    event_type = notification.event_type if notification is not None else None
     title = display_title(
         notification.title if notification is not None else None,
+        event_type=event_type,
         biz_type=work_order.biz_type,
         status=work_order.status,
-    )
+    ) or "新的系统通知"
+    summary = display_summary(event_type)
     content = json_object(notification.content) if notification is not None else None
     return WorkOrderListItem(
         item_id=(
@@ -185,8 +190,9 @@ def _list_item(item: DomainListItem) -> WorkOrderListItem:
         recipient_user_id=notification.recipient_user_id
         if notification is not None
         else None,
-        event_type=notification.event_type if notification is not None else None,
+        event_type=event_type,
         title=title,
+        summary=summary,
         content=content,
         status=work_order.status,
         is_read=notification.is_read if notification is not None else None,
@@ -358,12 +364,15 @@ async def get_work_order(
             event_type=detail.event_type,
             title=display_title(
                 detail.title,
+                event_type=detail.event_type,
                 biz_type=work_order.biz_type,
                 status=work_order.status,
-            ),
+            ) or "新的系统通知",
+            summary=display_summary(detail.event_type),
             content=json_object(detail.content),
             status=work_order.status,
             reviewer_user_id=work_order.reviewer_user_id,
+            reviewer_user_name=detail.reviewer_user_name,
             review_remark=work_order.review_remark,
             reviewed_at=work_order.reviewed_at,
             biz_data=json_object(work_order.biz_data),
@@ -513,9 +522,11 @@ async def get_notification(
             event_type=record.event_type,
             title=display_title(
                 record.title,
+                event_type=record.event_type,
                 biz_type=record.biz_type,
                 status=detail.work_order_status,
-            ),
+            ) or "新的系统通知",
+            summary=display_summary(record.event_type),
             content=json_object(record.content),
             is_read=record.is_read,
             work_order_status=detail.work_order_status,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/work_orders/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/work_orders/schemas.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, Field, field_serializer, field_validator
+from pydantic import BaseModel, Field, field_serializer
 
 from agentclaw.community.adapters.http.openapi_v1.enums import _DocumentedEnum
 
@@ -116,24 +116,6 @@ class CreateWorkOrderEventRequest(BaseModel):
         default=None,
         description="JSON object stored as notification content without business reshaping.",
     )
-
-    @field_validator("content", mode="before")
-    @classmethod
-    def validate_content(cls, value: Any) -> dict[str, Any] | None:
-        if value is None:
-            return None
-        if not isinstance(value, dict):
-            raise ValueError("缺少必填字段text")
-        workitem_name = value.get("workitem_name")
-        has_workitem_name = isinstance(workitem_name, str) and bool(workitem_name.strip())
-        if "text" not in value:
-            if has_workitem_name:
-                return value
-            raise ValueError("缺少必填字段text")
-        text = value["text"]
-        if not isinstance(text, str) or not text.strip():
-            raise ValueError("缺少必填字段text")
-        return value
     apply_reason: str | None = Field(
         default=None,
         max_length=512,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/work_orders/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/work_orders/schemas.py
@@ -374,8 +374,8 @@ class WorkOrderListItem(_UtcResponseModel):
     )
     title: str = Field(description="Canonical notification title.")
     summary: str = Field(default="你有一条新的通知，请查看详情。", description="Stable notification summary.")
-    content: dict[str, Any] | None = Field(
-        description="Notification JSON object, or null when unavailable."
+    content: str | dict[str, Any] | None = Field(
+        description="Original notification content, either text or a JSON object."
     )
     status: WorkOrderStatus | None = Field(
         description="Related work-order status, when one exists."
@@ -410,8 +410,8 @@ class WorkOrderDetailResponse(_UtcResponseModel):
     )
     title: str = Field(description="Canonical display title of the work order.")
     summary: str = Field(default="你有一条新的通知，请查看详情。", description="Stable notification summary.")
-    content: dict[str, Any] | None = Field(
-        default=None, description="Notification JSON object, when available."
+    content: str | dict[str, Any] | None = Field(
+        default=None, description="Original notification content, when available."
     )
     biz_data: dict[str, Any] | None = Field(
         default=None, description="Work-order business JSON object, when available."
@@ -447,8 +447,8 @@ class NotificationDetailResponse(BaseModel):
     event_type: str = Field(description="Legacy event represented by the notification.")
     title: str = Field(description="Canonical display title of the notification.")
     summary: str = Field(default="你有一条新的通知，请查看详情。", description="Stable notification summary.")
-    content: dict[str, Any] | None = Field(
-        description="Notification JSON object, when present."
+    content: str | dict[str, Any] | None = Field(
+        description="Original notification content, either text or a JSON object."
     )
     is_read: bool = Field(
         description="Whether the recipient has read the notification."

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/work_orders/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/work_orders/schemas.py
@@ -373,7 +373,7 @@ class WorkOrderListItem(_UtcResponseModel):
         description="Originating event, or null when no notification is attached."
     )
     title: str = Field(description="Canonical notification title.")
-    summary: str = Field(default="你有一条新的通知，请查看详情。", description="Stable notification summary.")
+    summary: str = Field(default="你有一条新的通知", description="Stable notification summary.")
     content: str | dict[str, Any] | None = Field(
         description="Original notification content, either text or a JSON object."
     )
@@ -409,7 +409,7 @@ class WorkOrderDetailResponse(_UtcResponseModel):
         default=None, description="Legacy originating event, when available."
     )
     title: str = Field(description="Canonical display title of the work order.")
-    summary: str = Field(default="你有一条新的通知，请查看详情。", description="Stable notification summary.")
+    summary: str = Field(default="你有一条新的通知", description="Stable notification summary.")
     content: str | dict[str, Any] | None = Field(
         default=None, description="Original notification content, when available."
     )
@@ -446,7 +446,7 @@ class NotificationDetailResponse(BaseModel):
     )
     event_type: str = Field(description="Legacy event represented by the notification.")
     title: str = Field(description="Canonical display title of the notification.")
-    summary: str = Field(default="你有一条新的通知，请查看详情。", description="Stable notification summary.")
+    summary: str = Field(default="你有一条新的通知", description="Stable notification summary.")
     content: str | dict[str, Any] | None = Field(
         description="Original notification content, either text or a JSON object."
     )

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/work_orders/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/work_orders/schemas.py
@@ -372,7 +372,8 @@ class WorkOrderListItem(_UtcResponseModel):
     event_type: str | None = Field(
         description="Originating event, or null when no notification is attached."
     )
-    title: str | None = Field(description="Notification title, when available.")
+    title: str = Field(description="Canonical notification title.")
+    summary: str = Field(default="你有一条新的通知，请查看详情。", description="Stable notification summary.")
     content: dict[str, Any] | None = Field(
         description="Notification JSON object, or null when unavailable."
     )
@@ -407,7 +408,8 @@ class WorkOrderDetailResponse(_UtcResponseModel):
     event_type: str | None = Field(
         default=None, description="Legacy originating event, when available."
     )
-    title: str = Field(description="Display title of the work order.")
+    title: str = Field(description="Canonical display title of the work order.")
+    summary: str = Field(default="你有一条新的通知，请查看详情。", description="Stable notification summary.")
     content: dict[str, Any] | None = Field(
         default=None, description="Notification JSON object, when available."
     )
@@ -417,6 +419,9 @@ class WorkOrderDetailResponse(_UtcResponseModel):
     status: WorkOrderStatus = Field(description="Current work-order status.")
     reviewer_user_id: str | None = Field(
         description="Identifier of the reviewer after processing, otherwise null."
+    )
+    reviewer_user_name: str | None = Field(
+        description="Display name of the reviewer after processing, otherwise null."
     )
     review_remark: str | None = Field(
         description="Review comment after processing, otherwise null."
@@ -440,7 +445,8 @@ class NotificationDetailResponse(BaseModel):
         description="Presentation category of the notification."
     )
     event_type: str = Field(description="Legacy event represented by the notification.")
-    title: str = Field(description="Display title of the notification.")
+    title: str = Field(description="Canonical display title of the notification.")
+    summary: str = Field(default="你有一条新的通知，请查看详情。", description="Stable notification summary.")
     content: dict[str, Any] | None = Field(
         description="Notification JSON object, when present."
     )

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/work_orders/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/work_orders/schemas.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, Field, field_serializer
+from pydantic import BaseModel, Field, field_serializer, field_validator
 
 from agentclaw.community.adapters.http.openapi_v1.enums import _DocumentedEnum
 
@@ -116,6 +116,24 @@ class CreateWorkOrderEventRequest(BaseModel):
         default=None,
         description="JSON object stored as notification content without business reshaping.",
     )
+
+    @field_validator("content", mode="before")
+    @classmethod
+    def validate_content(cls, value: Any) -> dict[str, Any] | None:
+        if value is None:
+            return None
+        if not isinstance(value, dict):
+            raise ValueError("缺少必填字段text")
+        workitem_name = value.get("workitem_name")
+        has_workitem_name = isinstance(workitem_name, str) and bool(workitem_name.strip())
+        if "text" not in value:
+            if has_workitem_name:
+                return value
+            raise ValueError("缺少必填字段text")
+        text = value["text"]
+        if not isinstance(text, str) or not text.strip():
+            raise ValueError("缺少必填字段text")
+        return value
     apply_reason: str | None = Field(
         default=None,
         max_length=512,

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill_editor_request.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill_editor_request.py
@@ -392,7 +392,7 @@ class SkillEditorRequestRepository(SkillEditorRequestRepositoryProtocol):
                         WorkOrderEventType.SKILL_COLLABORATOR_REVIEWED.value,
                         notification.title,
                     ),
-                    content=notification.content,
+                    content=json.dumps(notification.content, ensure_ascii=False),
                     env=env,
                 )
             )

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill_editor_request.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill_editor_request.py
@@ -34,6 +34,7 @@ from agentclaw.community.core.work_orders.models import (
     WorkOrderNotificationDraft,
     WorkOrderReviewResult,
     WorkOrderStatus,
+    notification_title_for,
 )
 from agentclaw.community.core.work_orders.repository.models import (
     WorkOrderApproverModel,
@@ -205,7 +206,9 @@ class SkillEditorRequestRepository(SkillEditorRequestRepositoryProtocol):
                     event_type=WorkOrderEventType.SKILL_COLLABORATOR_APPLIED.value,
                     biz_type=WorkOrderBizType.SKILL_COLLABORATOR.value,
                     biz_id=str(skill_id),
-                    title=title,
+                    title=notification_title_for(
+                        WorkOrderEventType.SKILL_COLLABORATOR_APPLIED.value, title
+                    ),
                     content=content,
                     env=env,
                 )
@@ -381,7 +384,10 @@ class SkillEditorRequestRepository(SkillEditorRequestRepositoryProtocol):
                     event_type=WorkOrderEventType.SKILL_COLLABORATOR_REVIEWED.value,
                     biz_type=WorkOrderBizType.SKILL_COLLABORATOR.value,
                     biz_id=str(skill_id),
-                    title=notification.title,
+                    title=notification_title_for(
+                        WorkOrderEventType.SKILL_COLLABORATOR_REVIEWED.value,
+                        notification.title,
+                    ),
                     content=notification.content,
                     env=env,
                 )

--- a/src/backend/src/agentclaw/community/core/repository/implementations/work_orders/bot_editor.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/work_orders/bot_editor.py
@@ -33,6 +33,7 @@ from agentclaw.community.core.work_orders.models import (
     WorkOrderNotificationDraft,
     WorkOrderReviewResult,
     WorkOrderStatus,
+    notification_title_for,
 )
 from agentclaw.community.core.work_orders.repository.models import (
     WorkOrderApproverModel,
@@ -193,7 +194,9 @@ class _BotEditorWorkOrderRepository:
                     event_type=WorkOrderEventType.BOT_COLLABORATOR_APPLIED.value,
                     biz_type=WorkOrderBizType.BOT_COLLABORATOR.value,
                     biz_id=bot_id,
-                    title=title,
+                    title=notification_title_for(
+                        WorkOrderEventType.BOT_COLLABORATOR_APPLIED.value, title
+                    ),
                     content=content,
                     env=env,
                 )
@@ -331,7 +334,10 @@ class _BotEditorWorkOrderRepository:
                         notification.biz_type, "value", notification.biz_type
                     ),
                     biz_id=notification.biz_id,
-                    title=notification.title,
+                    title=notification_title_for(
+                        getattr(notification.event_type, "value", notification.event_type),
+                        notification.title,
+                    ),
                     content=notification.content,
                     env=env,
                 )

--- a/src/backend/src/agentclaw/community/core/repository/implementations/work_orders/bot_editor.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/work_orders/bot_editor.py
@@ -338,7 +338,7 @@ class _BotEditorWorkOrderRepository:
                         getattr(notification.event_type, "value", notification.event_type),
                         notification.title,
                     ),
-                    content=notification.content,
+                    content=json.dumps(notification.content, ensure_ascii=False),
                     env=env,
                 )
             )

--- a/src/backend/src/agentclaw/community/core/repository/implementations/work_orders/creation.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/work_orders/creation.py
@@ -24,6 +24,7 @@ from agentclaw.community.core.work_orders.models import (
     WorkOrderEventType,
     WorkOrderMessageContent,
     WorkOrderTitleKey,
+    notification_title_for,
 )
 from agentclaw.community.core.work_orders.repository.models import (
     WorkOrderApproverModel,
@@ -112,7 +113,7 @@ class _WorkOrderCreationRepository:
                     event_type=event_type,
                     biz_type=biz_type,
                     biz_id=biz_id,
-                    title=title,
+                    title=notification_title_for(event_type, title),
                     content=content,
                     env=env,
                 )
@@ -275,7 +276,9 @@ class _WorkOrderCreationRepository:
                         event_type=WorkOrderEventType.SPACE_JOIN_APPLIED.value,
                         biz_type=WorkOrderBizType.SPACE_JOIN.value,
                         biz_id=str(space_id),
-                        title=title,
+                        title=notification_title_for(
+                            WorkOrderEventType.SPACE_JOIN_APPLIED.value, title
+                        ),
                         content=content,
                         env=env,
                     )

--- a/src/backend/src/agentclaw/community/core/repository/implementations/work_orders/creation.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/work_orders/creation.py
@@ -105,6 +105,11 @@ class _WorkOrderCreationRepository:
                     )
 
             notifications = []
+            persisted_title = (
+                title
+                if event_type == WorkOrderEventType.SPACE_JOIN_APPLIED.value
+                else notification_title_for(event_type, title)
+            )
             for user_id in recipients:
                 notification = self._Notification(
                     work_order_id=work_order_id,
@@ -113,7 +118,7 @@ class _WorkOrderCreationRepository:
                     event_type=event_type,
                     biz_type=biz_type,
                     biz_id=biz_id,
-                    title=notification_title_for(event_type, title),
+                    title=persisted_title,
                     content=content,
                     env=env,
                 )
@@ -276,9 +281,7 @@ class _WorkOrderCreationRepository:
                         event_type=WorkOrderEventType.SPACE_JOIN_APPLIED.value,
                         biz_type=WorkOrderBizType.SPACE_JOIN.value,
                         biz_id=str(space_id),
-                        title=notification_title_for(
-                            WorkOrderEventType.SPACE_JOIN_APPLIED.value, title
-                        ),
+                        title=title,
                         content=content,
                         env=env,
                     )

--- a/src/backend/src/agentclaw/community/core/repository/implementations/work_orders/creation.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/work_orders/creation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from datetime import datetime, timezone
 from uuid import uuid4
 
@@ -255,8 +256,13 @@ class _WorkOrderCreationRepository:
             db.add(row)
             db.flush()
             title = "空间加入申请待审批"
-            content = WorkOrderMessageContent.SPACE_JOIN_PENDING.value.format(
-                applicant_name=applicant_name, space_name=space.name
+            content = json.dumps(
+                {
+                    "text": WorkOrderMessageContent.SPACE_JOIN_PENDING.value.format(
+                        applicant_name=applicant_name, space_name=space.name
+                    )
+                },
+                ensure_ascii=False,
             )
             for (owner_id,) in owners:
                 db.add(

--- a/src/backend/src/agentclaw/community/core/repository/implementations/work_orders/creation.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/work_orders/creation.py
@@ -23,7 +23,6 @@ from agentclaw.community.core.work_orders.models import (
     WorkOrderStatus,
     WorkOrderEventType,
     WorkOrderMessageContent,
-    WorkOrderTitleKey,
     notification_title_for,
 )
 from agentclaw.community.core.work_orders.repository.models import (
@@ -105,11 +104,6 @@ class _WorkOrderCreationRepository:
                     )
 
             notifications = []
-            persisted_title = (
-                title
-                if event_type == WorkOrderEventType.SPACE_JOIN_APPLIED.value
-                else notification_title_for(event_type, title)
-            )
             for user_id in recipients:
                 notification = self._Notification(
                     work_order_id=work_order_id,
@@ -118,7 +112,7 @@ class _WorkOrderCreationRepository:
                     event_type=event_type,
                     biz_type=biz_type,
                     biz_id=biz_id,
-                    title=persisted_title,
+                    title=notification_title_for(event_type, title),
                     content=content,
                     env=env,
                 )
@@ -260,7 +254,7 @@ class _WorkOrderCreationRepository:
             )
             db.add(row)
             db.flush()
-            title = WorkOrderTitleKey.SPACE_JOIN_PENDING.value
+            title = "空间加入申请待审批"
             content = WorkOrderMessageContent.SPACE_JOIN_PENDING.value.format(
                 applicant_name=applicant_name, space_name=space.name
             )
@@ -281,7 +275,9 @@ class _WorkOrderCreationRepository:
                         event_type=WorkOrderEventType.SPACE_JOIN_APPLIED.value,
                         biz_type=WorkOrderBizType.SPACE_JOIN.value,
                         biz_id=str(space_id),
-                        title=title,
+                        title=notification_title_for(
+                            WorkOrderEventType.SPACE_JOIN_APPLIED.value, title
+                        ),
                         content=content,
                         env=env,
                     )

--- a/src/backend/src/agentclaw/community/core/repository/implementations/work_orders/work_order.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/work_orders/work_order.py
@@ -51,7 +51,9 @@ from agentclaw.community.core.work_orders.models import (
     WorkOrderDecision,
     WorkOrderApproverStatus,
     WorkOrderEventCreatedResult,
+    WorkOrderEventType,
     reviewed_event_type_for,
+    notification_title_for,
 )
 from agentclaw.community.core.work_orders.repository.models import (
     WorkOrderModel,
@@ -822,7 +824,10 @@ class WorkOrderRepository(WorkOrderRepositoryProtocol):
                         notification.biz_type, "value", notification.biz_type
                     ),
                     biz_id=notification.biz_id,
-                    title=WorkOrderTitleKey[f"SPACE_JOIN_{target_status.value}"].value,
+                    title=notification_title_for(
+                        WorkOrderEventType.SPACE_JOIN_REVIEWED.value,
+                        notification.title,
+                    ),
                     content=notification.content,
                     env=env,
                 )

--- a/src/backend/src/agentclaw/community/core/repository/implementations/work_orders/work_order.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/work_orders/work_order.py
@@ -53,7 +53,6 @@ from agentclaw.community.core.work_orders.models import (
     WorkOrderEventCreatedResult,
     WorkOrderEventType,
     reviewed_event_type_for,
-    notification_title_for,
 )
 from agentclaw.community.core.work_orders.repository.models import (
     WorkOrderModel,
@@ -643,14 +642,11 @@ class WorkOrderRepository(WorkOrderRepositoryProtocol):
                 .first()
                 is not None
             )
-            event_type = (
-                notification.event_type
-                if notification is not None
-                else work_order.biz_type
-            )
-            title = (
-                notification.title if notification is not None else work_order.biz_type
-            )
+            # A work order without a notification has no originating event.
+            # Keep these fields empty so the delivery adapter can derive a
+            # compatible title from the business type and current status.
+            event_type = notification.event_type if notification is not None else None
+            title = notification.title if notification is not None else None
             return WorkOrderDetail(
                 work_order=work_order.to_record(),
                 event_type=event_type,
@@ -824,9 +820,10 @@ class WorkOrderRepository(WorkOrderRepositoryProtocol):
                         notification.biz_type, "value", notification.biz_type
                     ),
                     biz_id=notification.biz_id,
-                    title=notification_title_for(
-                        WorkOrderEventType.SPACE_JOIN_REVIEWED.value,
-                        notification.title,
+                    title=(
+                        WorkOrderTitleKey.SPACE_JOIN_APPROVED.value
+                        if target_status is WorkOrderStatus.APPROVED
+                        else WorkOrderTitleKey.SPACE_JOIN_REJECTED.value
                     ),
                     content=notification.content,
                     env=env,

--- a/src/backend/src/agentclaw/community/core/repository/implementations/work_orders/work_order.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/work_orders/work_order.py
@@ -866,7 +866,7 @@ class WorkOrderRepository(WorkOrderRepositoryProtocol):
                         WorkOrderEventType.SPACE_JOIN_REVIEWED.value,
                         notification.title,
                     ),
-                    content=notification.content,
+                    content=json.dumps(notification.content, ensure_ascii=False),
                     env=env,
                 )
             )

--- a/src/backend/src/agentclaw/community/core/repository/implementations/work_orders/work_order.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/work_orders/work_order.py
@@ -51,6 +51,8 @@ from agentclaw.community.core.work_orders.models import (
     WorkOrderApproverStatus,
     WorkOrderEventCreatedResult,
     WorkOrderEventType,
+    WorkOrderMessageContent,
+    WorkOrderMessageTitle,
     reviewed_event_type_for,
     notification_title_for,
 )
@@ -339,6 +341,50 @@ class WorkOrderRepository(WorkOrderRepositoryProtocol):
                 source_event_type=source_event_type,
                 biz_type=order.biz_type,
             )
+            result_title = notification_title_for(
+                reviewed_event_type, f"{order.biz_type} {target.value}"
+            )
+            result_content = review_remark
+            if (
+                order.biz_type == WorkOrderBizType.BOT_FRIEND.value
+                and reviewed_event_type
+                in {
+                    WorkOrderEventType.HUMAN2BOT_FRIEND_REVIEWED.value,
+                    WorkOrderEventType.BOT2BOT_FRIEND_REVIEWED.value,
+                }
+            ):
+                is_human_friend = (
+                    reviewed_event_type
+                    == WorkOrderEventType.HUMAN2BOT_FRIEND_REVIEWED.value
+                )
+                if target is WorkOrderStatus.APPROVED:
+                    result_title = (
+                        WorkOrderMessageTitle.HUMAN_FRIEND_APPROVED.value
+                        if is_human_friend
+                        else WorkOrderMessageTitle.BOT_FRIEND_APPROVED.value
+                    )
+                    result_text = (
+                        WorkOrderMessageContent.HUMAN_FRIEND_APPROVED.value
+                        if is_human_friend
+                        else WorkOrderMessageContent.BOT_FRIEND_APPROVED.value
+                    )
+                else:
+                    result_title = (
+                        WorkOrderMessageTitle.HUMAN_FRIEND_REJECTED.value
+                        if is_human_friend
+                        else WorkOrderMessageTitle.BOT_FRIEND_REJECTED.value
+                    )
+                    result_text = (
+                        WorkOrderMessageContent.HUMAN_FRIEND_REJECTED.value
+                        if is_human_friend
+                        else WorkOrderMessageContent.BOT_FRIEND_REJECTED.value
+                    )
+                result_payload = {"text": result_text}
+                if review_remark is not None:
+                    result_payload["review_remark"] = review_remark
+                result_content = json.dumps(
+                    result_payload, ensure_ascii=False
+                )
             db.add(
                 self._Notification(
                     work_order_id=work_order_id,
@@ -347,10 +393,8 @@ class WorkOrderRepository(WorkOrderRepositoryProtocol):
                     event_type=reviewed_event_type,
                     biz_type=order.biz_type,
                     biz_id=order.biz_id,
-                    title=notification_title_for(
-                        reviewed_event_type, f"{order.biz_type} {target.value}"
-                    ),
-                    content=review_remark,
+                    title=result_title,
+                    content=result_content,
                     env=env,
                 )
             )

--- a/src/backend/src/agentclaw/community/core/repository/implementations/work_orders/work_order.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/work_orders/work_order.py
@@ -47,12 +47,12 @@ from agentclaw.community.core.work_orders.models import (
     WorkOrderQueryType,
     WorkOrderReviewResult,
     WorkOrderStatus,
-    WorkOrderTitleKey,
     WorkOrderDecision,
     WorkOrderApproverStatus,
     WorkOrderEventCreatedResult,
     WorkOrderEventType,
     reviewed_event_type_for,
+    notification_title_for,
 )
 from agentclaw.community.core.work_orders.repository.models import (
     WorkOrderModel,
@@ -347,10 +347,8 @@ class WorkOrderRepository(WorkOrderRepositoryProtocol):
                     event_type=reviewed_event_type,
                     biz_type=order.biz_type,
                     biz_id=order.biz_id,
-                    title=(
-                        WorkOrderTitleKey[f"SPACE_JOIN_{target.value}"].value
-                        if order.biz_type == WorkOrderBizType.SPACE_JOIN.value
-                        else f"{order.biz_type} {target.value}"
+                    title=notification_title_for(
+                        reviewed_event_type, f"{order.biz_type} {target.value}"
                     ),
                     content=review_remark,
                     env=env,
@@ -820,10 +818,9 @@ class WorkOrderRepository(WorkOrderRepositoryProtocol):
                         notification.biz_type, "value", notification.biz_type
                     ),
                     biz_id=notification.biz_id,
-                    title=(
-                        WorkOrderTitleKey.SPACE_JOIN_APPROVED.value
-                        if target_status is WorkOrderStatus.APPROVED
-                        else WorkOrderTitleKey.SPACE_JOIN_REJECTED.value
+                    title=notification_title_for(
+                        WorkOrderEventType.SPACE_JOIN_REVIEWED.value,
+                        notification.title,
                     ),
                     content=notification.content,
                     env=env,

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_collaborator_approval_handler.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_collaborator_approval_handler.py
@@ -71,7 +71,7 @@ class SkillCollaboratorApprovalHandler(SkillCollaboratorApprovalHandlerProtocol)
             biz_type=WorkOrderBizType.SKILL_COLLABORATOR,
             biz_id=detail.work_order.biz_id,
             title=title,
-            content=content,
+            content={"text": content},
         )
         return self._repository.review_skill_editor_request(
             work_order_id=detail.work_order.id,

--- a/src/backend/src/agentclaw/community/core/spaces/services/space_member_service.py
+++ b/src/backend/src/agentclaw/community/core/spaces/services/space_member_service.py
@@ -149,7 +149,7 @@ class SpaceMemberService(SpaceMemberServiceProtocol):
                 WorkOrderMessageTitle.SPACE_MEMBER_REMOVED.value,
             ),
             content={
-                "legacy_value": WorkOrderMessageContent.SPACE_MEMBER_REMOVED.format(
+                "text": WorkOrderMessageContent.SPACE_MEMBER_REMOVED.format(
                     space_name=space.name
                 )
             },

--- a/src/backend/src/agentclaw/community/core/spaces/services/space_member_service.py
+++ b/src/backend/src/agentclaw/community/core/spaces/services/space_member_service.py
@@ -27,6 +27,7 @@ from agentclaw.community.core.work_orders.models import (
     WorkOrderEventType,
     WorkOrderMessageContent,
     WorkOrderMessageTitle,
+    notification_title_for,
 )
 from agentclaw.community.log import get_logger
 from agentclaw.community.plugin_api.staff_dept import (
@@ -143,7 +144,10 @@ class SpaceMemberService(SpaceMemberServiceProtocol):
             applicant_user_id=None,
             approver_user_ids=[],
             recipient_user_ids=[normalized],
-            title=WorkOrderMessageTitle.SPACE_MEMBER_REMOVED.value,
+            title=notification_title_for(
+                WorkOrderEventType.SPACE_MEMBER_REMOVED.value,
+                WorkOrderMessageTitle.SPACE_MEMBER_REMOVED.value,
+            ),
             content={
                 "legacy_value": WorkOrderMessageContent.SPACE_MEMBER_REMOVED.format(
                     space_name=space.name

--- a/src/backend/src/agentclaw/community/core/work_orders/models.py
+++ b/src/backend/src/agentclaw/community/core/work_orders/models.py
@@ -56,48 +56,132 @@ class WorkOrderItemType(StrEnum):
 
 
 class WorkOrderEventType(StrEnum):
-    SPACE_JOIN_APPLIED = "SPACE_JOIN_APPLIED"
-    SPACE_JOIN_REVIEWED = "SPACE_JOIN_REVIEWED"
-    SPACE_MEMBER_ADDED = "SPACE_MEMBER_ADDED"
-    BOT_COLLABORATOR_APPLIED = "BOT_COLLABORATOR_APPLIED"
-    BOT_COLLABORATOR_REVIEWED = "BOT_COLLABORATOR_REVIEWED"
-    BOT_MEMBER_ADDED = "BOT_MEMBER_ADDED"
-    SKILL_COLLABORATOR_APPLIED = "SKILL_COLLABORATOR_APPLIED"
-    SKILL_COLLABORATOR_REVIEWED = "SKILL_COLLABORATOR_REVIEWED"
-    SKILL_MEMBER_ADDED = "SKILL_MEMBER_ADDED"
-    HUMAN2BOT_FRIEND_APPLIED = "HUMAN2BOT_FRIEND_APPLIED"
-    HUMAN2BOT_FRIEND_REVIEWED = "HUMAN2BOT_FRIEND_REVIEWED"
-    BOT2BOT_FRIEND_APPLIED = "BOT2BOT_FRIEND_APPLIED"
-    BOT2BOT_FRIEND_REVIEWED = "BOT2BOT_FRIEND_REVIEWED"
-    HUMAN2BOT_PUBLIC_ORDER_CREATED = "HUMAN2BOT_PUBLIC_ORDER_CREATED"
-    HUMAN2BOT_PUBLIC_ORDER_COMPLETED = "HUMAN2BOT_PUBLIC_ORDER_COMPLETED"
-    BOT2BOT_PUBLIC_ORDER_CREATED = "BOT2BOT_PUBLIC_ORDER_CREATED"
-    BOT2BOT_PUBLIC_ORDER_COMPLETED = "BOT2BOT_PUBLIC_ORDER_COMPLETED"
-    SPACE_MEMBER_REMOVED = "SPACE_MEMBER_REMOVED"
-    TASK_DISCOVERED = "TASK_DISCOVERED"
+    """Known notification events and their complete display contract.
+
+    Keeping the category, title, and summary beside the event value prevents
+    the event catalogue and presentation mappings from drifting apart.
+    """
+
+    def __new__(
+        cls,
+        value: str,
+        category: NotificationCategory,
+        title: str,
+        summary: str,
+    ):
+        member = str.__new__(cls, value)
+        member._value_ = value
+        member.notification_category = category
+        member.title = title
+        member.summary = summary
+        return member
+
+    SPACE_JOIN_APPLIED = (
+        "SPACE_JOIN_APPLIED", NotificationCategory.APPROVAL,
+        "空间加入申请待审批", "有新的空间加入申请，请及时处理。",
+    )
+    SPACE_JOIN_REVIEWED = (
+        "SPACE_JOIN_REVIEWED", NotificationCategory.NOTICE,
+        "空间加入申请已处理", "空间加入申请已有处理结果，请查看详情。",
+    )
+    SPACE_MEMBER_ADDED = (
+        "SPACE_MEMBER_ADDED", NotificationCategory.NOTICE,
+        "你已被添加到空间", "你已加入一个新的空间，请查看详情。",
+    )
+    SPACE_MEMBER_REMOVED = (
+        "SPACE_MEMBER_REMOVED", NotificationCategory.NOTICE,
+        "你已被移出空间", "你已被移出一个空间，请查看详情。",
+    )
+    BOT_COLLABORATOR_APPLIED = (
+        "BOT_COLLABORATOR_APPLIED", NotificationCategory.APPROVAL,
+        "Bot 共同编辑申请待审批", "有新的 Bot 共同编辑申请，请及时处理。",
+    )
+    BOT_COLLABORATOR_REVIEWED = (
+        "BOT_COLLABORATOR_REVIEWED", NotificationCategory.NOTICE,
+        "Bot 共同编辑申请已处理", "Bot 共同编辑申请已有处理结果，请查看详情。",
+    )
+    BOT_MEMBER_ADDED = (
+        "BOT_MEMBER_ADDED", NotificationCategory.NOTICE,
+        "你已被添加为 Bot 协作者", "你已获得一个 Bot 的协作权限，请查看详情。",
+    )
+    SKILL_COLLABORATOR_APPLIED = (
+        "SKILL_COLLABORATOR_APPLIED", NotificationCategory.APPROVAL,
+        "Skill 共同编辑申请待审批", "有新的 Skill 共同编辑申请，请及时处理。",
+    )
+    SKILL_COLLABORATOR_REVIEWED = (
+        "SKILL_COLLABORATOR_REVIEWED", NotificationCategory.NOTICE,
+        "Skill 共同编辑申请已处理", "Skill 共同编辑申请已有处理结果，请查看详情。",
+    )
+    SKILL_MEMBER_ADDED = (
+        "SKILL_MEMBER_ADDED", NotificationCategory.NOTICE,
+        "你已被添加为 Skill 协作者", "你已获得一个 Skill 的协作权限，请查看详情。",
+    )
+    HUMAN2BOT_FRIEND_APPLIED = (
+        "HUMAN2BOT_FRIEND_APPLIED", NotificationCategory.APPROVAL,
+        "人机好友申请待审批", "有新的人机好友申请，请及时处理。",
+    )
+    HUMAN2BOT_FRIEND_REVIEWED = (
+        "HUMAN2BOT_FRIEND_REVIEWED", NotificationCategory.NOTICE,
+        "人机好友申请已处理", "人机好友申请已有处理结果，请查看详情。",
+    )
+    BOT2BOT_FRIEND_APPLIED = (
+        "BOT2BOT_FRIEND_APPLIED", NotificationCategory.APPROVAL,
+        "Bot 好友申请待审批", "有新的 Bot 好友申请，请及时处理。",
+    )
+    BOT2BOT_FRIEND_REVIEWED = (
+        "BOT2BOT_FRIEND_REVIEWED", NotificationCategory.NOTICE,
+        "Bot 好友申请已处理", "Bot 好友申请已有处理结果，请查看详情。",
+    )
+    HUMAN2BOT_PUBLIC_ORDER_CREATED = (
+        "HUMAN2BOT_PUBLIC_ORDER_CREATED", NotificationCategory.NOTICE,
+        "人机公开订单已创建", "你有一条新的人机公开订单，请查看详情。",
+    )
+    HUMAN2BOT_PUBLIC_ORDER_COMPLETED = (
+        "HUMAN2BOT_PUBLIC_ORDER_COMPLETED", NotificationCategory.NOTICE,
+        "人机公开订单已完成", "一条人机公开订单已完成，请查看详情。",
+    )
+    BOT2BOT_PUBLIC_ORDER_CREATED = (
+        "BOT2BOT_PUBLIC_ORDER_CREATED", NotificationCategory.NOTICE,
+        "Bot 公开订单已创建", "你有一条新的 Bot 公开订单，请查看详情。",
+    )
+    BOT2BOT_PUBLIC_ORDER_COMPLETED = (
+        "BOT2BOT_PUBLIC_ORDER_COMPLETED", NotificationCategory.NOTICE,
+        "Bot 公开订单已完成", "一条 Bot 公开订单已完成，请查看详情。",
+    )
+    TASK_DISCOVERED = (
+        "TASK_DISCOVERED", NotificationCategory.NOTICE,
+        "发现新任务", "发现一条新任务，请查看详情。",
+    )
 
 
 EVENT_CATEGORIES: dict[WorkOrderEventType, NotificationCategory] = {
-    WorkOrderEventType.SPACE_JOIN_APPLIED: NotificationCategory.APPROVAL,
-    WorkOrderEventType.SPACE_JOIN_REVIEWED: NotificationCategory.NOTICE,
-    WorkOrderEventType.SPACE_MEMBER_ADDED: NotificationCategory.NOTICE,
-    WorkOrderEventType.BOT_COLLABORATOR_APPLIED: NotificationCategory.APPROVAL,
-    WorkOrderEventType.BOT_COLLABORATOR_REVIEWED: NotificationCategory.NOTICE,
-    WorkOrderEventType.BOT_MEMBER_ADDED: NotificationCategory.NOTICE,
-    WorkOrderEventType.SKILL_COLLABORATOR_APPLIED: NotificationCategory.APPROVAL,
-    WorkOrderEventType.SKILL_COLLABORATOR_REVIEWED: NotificationCategory.NOTICE,
-    WorkOrderEventType.SKILL_MEMBER_ADDED: NotificationCategory.NOTICE,
-    WorkOrderEventType.HUMAN2BOT_FRIEND_APPLIED: NotificationCategory.APPROVAL,
-    WorkOrderEventType.HUMAN2BOT_FRIEND_REVIEWED: NotificationCategory.NOTICE,
-    WorkOrderEventType.BOT2BOT_FRIEND_APPLIED: NotificationCategory.APPROVAL,
-    WorkOrderEventType.BOT2BOT_FRIEND_REVIEWED: NotificationCategory.NOTICE,
-    WorkOrderEventType.HUMAN2BOT_PUBLIC_ORDER_CREATED: NotificationCategory.NOTICE,
-    WorkOrderEventType.HUMAN2BOT_PUBLIC_ORDER_COMPLETED: NotificationCategory.NOTICE,
-    WorkOrderEventType.BOT2BOT_PUBLIC_ORDER_CREATED: NotificationCategory.NOTICE,
-    WorkOrderEventType.BOT2BOT_PUBLIC_ORDER_COMPLETED: NotificationCategory.NOTICE,
-    WorkOrderEventType.SPACE_MEMBER_REMOVED: NotificationCategory.NOTICE,
-    WorkOrderEventType.TASK_DISCOVERED: NotificationCategory.NOTICE,
+    event_type: event_type.notification_category for event_type in WorkOrderEventType
 }
+
+
+def event_type_definition(event_type: str | None) -> WorkOrderEventType | None:
+    """Return the canonical definition, or ``None`` for external/legacy values."""
+    try:
+        return WorkOrderEventType(event_type) if event_type else None
+    except ValueError:
+        return None
+
+
+def notification_title_for(
+    event_type: str | None, fallback_title: str | None = None
+) -> str:
+    """Return the canonical title while retaining a useful legacy fallback."""
+    definition = event_type_definition(event_type)
+    if definition is not None:
+        return definition.title
+    return fallback_title or "新的系统通知"
+
+
+def notification_summary_for(event_type: str | None) -> str:
+    """Return a non-empty summary for every known and unknown event."""
+    definition = event_type_definition(event_type)
+    return definition.summary if definition is not None else "你有一条新的通知，请查看详情。"
+
 
 # Approval events are extracted from the single classification table so new
 # event values only need one category entry above.
@@ -277,6 +361,7 @@ class WorkOrderDetail(BaseModel):
     space_id: int
     space_name: str
     applicant_name: str
+    reviewer_user_name: str | None = None
     can_approve: bool
 
 

--- a/src/backend/src/agentclaw/community/core/work_orders/models.py
+++ b/src/backend/src/agentclaw/community/core/work_orders/models.py
@@ -355,8 +355,8 @@ class WorkOrderListItem(BaseModel):
 
 class WorkOrderDetail(BaseModel):
     work_order: WorkOrderRecord
-    event_type: str
-    title: str
+    event_type: str | None
+    title: str | None
     content: str | None = None
     space_id: int
     space_name: str

--- a/src/backend/src/agentclaw/community/core/work_orders/models.py
+++ b/src/backend/src/agentclaw/community/core/work_orders/models.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from enum import StrEnum
+from typing import Any
 
 from pydantic import BaseModel
 
@@ -350,7 +351,7 @@ class WorkOrderNotificationDraft(BaseModel):
     biz_type: str
     biz_id: str
     title: str
-    content: str
+    content: dict[str, Any]
 
 
 class WorkOrderNotificationDetail(BaseModel):

--- a/src/backend/src/agentclaw/community/core/work_orders/models.py
+++ b/src/backend/src/agentclaw/community/core/work_orders/models.py
@@ -250,6 +250,10 @@ class WorkOrderMessageTitle(StrEnum):
     SKILL_COLLABORATOR_PENDING = "Skill 共同编辑申请待审批"
     SKILL_COLLABORATOR_APPROVED = "Skill 共同编辑申请已通过"
     SKILL_COLLABORATOR_REJECTED = "Skill 共同编辑申请未通过"
+    HUMAN_FRIEND_APPROVED = "人机好友申请已通过"
+    HUMAN_FRIEND_REJECTED = "人机好友申请未通过"
+    BOT_FRIEND_APPROVED = "Bot 好友申请已通过"
+    BOT_FRIEND_REJECTED = "Bot 好友申请未通过"
 
 
 class WorkOrderMessageContent(StrEnum):
@@ -276,6 +280,10 @@ class WorkOrderMessageContent(StrEnum):
     SKILL_COLLABORATOR_REJECTED = (
         "你共同编辑 Skill「{skill_name}」的申请未通过。拒绝原因：{review_remark}"
     )
+    HUMAN_FRIEND_APPROVED = "你的 Bot 好友申请已通过。"
+    HUMAN_FRIEND_REJECTED = "你的 Bot 好友申请未通过。"
+    BOT_FRIEND_APPROVED = "你的 Bot 好友申请已通过。"
+    BOT_FRIEND_REJECTED = "你的 Bot 好友申请未通过。"
 
 
 def skill_collaborator_applicant_display(

--- a/src/backend/src/agentclaw/community/core/work_orders/models.py
+++ b/src/backend/src/agentclaw/community/core/work_orders/models.py
@@ -83,15 +83,15 @@ class WorkOrderEventType(StrEnum):
     )
     SPACE_JOIN_REVIEWED = (
         "SPACE_JOIN_REVIEWED", NotificationCategory.NOTICE,
-        "空间加入申请已处理", "空间加入申请已有处理结果，请查看详情。",
+        "空间加入申请已处理", "空间加入申请已有处理结果。",
     )
     SPACE_MEMBER_ADDED = (
         "SPACE_MEMBER_ADDED", NotificationCategory.NOTICE,
-        "你已被添加到空间", "你已加入一个新的空间，请查看详情。",
+        "你已被添加到空间", "你已加入一个新的空间。",
     )
     SPACE_MEMBER_REMOVED = (
         "SPACE_MEMBER_REMOVED", NotificationCategory.NOTICE,
-        "你已被移出空间", "你已被移出一个空间，请查看详情。",
+        "你已被移出空间", "你已被移出一个空间。",
     )
     BOT_COLLABORATOR_APPLIED = (
         "BOT_COLLABORATOR_APPLIED", NotificationCategory.APPROVAL,
@@ -99,11 +99,11 @@ class WorkOrderEventType(StrEnum):
     )
     BOT_COLLABORATOR_REVIEWED = (
         "BOT_COLLABORATOR_REVIEWED", NotificationCategory.NOTICE,
-        "Bot 共同编辑申请已处理", "Bot 共同编辑申请已有处理结果，请查看详情。",
+        "Bot 共同编辑申请已处理", "Bot 共同编辑申请已有处理结果。",
     )
     BOT_MEMBER_ADDED = (
         "BOT_MEMBER_ADDED", NotificationCategory.NOTICE,
-        "你已被添加为 Bot 协作者", "你已获得一个 Bot 的协作权限，请查看详情。",
+        "你已被添加为 Bot 协作者", "你已获得一个 Bot 的协作权限。",
     )
     SKILL_COLLABORATOR_APPLIED = (
         "SKILL_COLLABORATOR_APPLIED", NotificationCategory.APPROVAL,
@@ -111,11 +111,11 @@ class WorkOrderEventType(StrEnum):
     )
     SKILL_COLLABORATOR_REVIEWED = (
         "SKILL_COLLABORATOR_REVIEWED", NotificationCategory.NOTICE,
-        "Skill 共同编辑申请已处理", "Skill 共同编辑申请已有处理结果，请查看详情。",
+        "Skill 共同编辑申请已处理", "Skill 共同编辑申请已有处理结果。",
     )
     SKILL_MEMBER_ADDED = (
         "SKILL_MEMBER_ADDED", NotificationCategory.NOTICE,
-        "你已被添加为 Skill 协作者", "你已获得一个 Skill 的协作权限，请查看详情。",
+        "你已被添加为 Skill 协作者", "你已获得一个 Skill 的协作权限。",
     )
     HUMAN2BOT_FRIEND_APPLIED = (
         "HUMAN2BOT_FRIEND_APPLIED", NotificationCategory.APPROVAL,
@@ -123,7 +123,7 @@ class WorkOrderEventType(StrEnum):
     )
     HUMAN2BOT_FRIEND_REVIEWED = (
         "HUMAN2BOT_FRIEND_REVIEWED", NotificationCategory.NOTICE,
-        "人机好友申请已处理", "人机好友申请已有处理结果，请查看详情。",
+        "人机好友申请已处理", "人机好友申请已有处理结果。",
     )
     BOT2BOT_FRIEND_APPLIED = (
         "BOT2BOT_FRIEND_APPLIED", NotificationCategory.APPROVAL,
@@ -131,27 +131,27 @@ class WorkOrderEventType(StrEnum):
     )
     BOT2BOT_FRIEND_REVIEWED = (
         "BOT2BOT_FRIEND_REVIEWED", NotificationCategory.NOTICE,
-        "Bot 好友申请已处理", "Bot 好友申请已有处理结果，请查看详情。",
+        "Bot 好友申请已处理", "Bot 好友申请已有处理结果。",
     )
     HUMAN2BOT_PUBLIC_ORDER_CREATED = (
         "HUMAN2BOT_PUBLIC_ORDER_CREATED", NotificationCategory.NOTICE,
-        "人机公开订单已创建", "你有一条新的人机公开订单，请查看详情。",
+        "Bot 公开工单审批已创建", "Bot 公开工单审批已创建",
     )
     HUMAN2BOT_PUBLIC_ORDER_COMPLETED = (
         "HUMAN2BOT_PUBLIC_ORDER_COMPLETED", NotificationCategory.NOTICE,
-        "人机公开订单已完成", "一条人机公开订单已完成，请查看详情。",
+        "Bot 公开工单审批已结束", "Bot 公开工单审批已结束",
     )
     BOT2BOT_PUBLIC_ORDER_CREATED = (
         "BOT2BOT_PUBLIC_ORDER_CREATED", NotificationCategory.NOTICE,
-        "Bot 公开订单已创建", "你有一条新的 Bot 公开订单，请查看详情。",
+        "Bot 公开工单审批已创建", "Bot 公开工单审批已创建",
     )
     BOT2BOT_PUBLIC_ORDER_COMPLETED = (
         "BOT2BOT_PUBLIC_ORDER_COMPLETED", NotificationCategory.NOTICE,
-        "Bot 公开订单已完成", "一条 Bot 公开订单已完成，请查看详情。",
+        "Bot 公开工单审批已结束", "Bot 公开工单审批已结束",
     )
     TASK_DISCOVERED = (
         "TASK_DISCOVERED", NotificationCategory.NOTICE,
-        "发现新任务", "发现一条新任务，请查看详情。",
+        "发现新任务", "发现一条新任务。",
     )
 
 
@@ -181,7 +181,7 @@ def notification_title_for(
 def notification_summary_for(event_type: str | None) -> str:
     """Return a non-empty summary for every known and unknown event."""
     definition = event_type_definition(event_type)
-    return definition.summary if definition is not None else "你有一条新的通知，请查看详情。"
+    return definition.summary if definition is not None else "你有一条新的通知"
 
 
 # Approval events are extracted from the single classification table so new

--- a/src/backend/src/agentclaw/community/core/work_orders/services/work_order_service.py
+++ b/src/backend/src/agentclaw/community/core/work_orders/services/work_order_service.py
@@ -646,17 +646,21 @@ class WorkOrderNotificationService(WorkOrderNotificationServiceProtocol):
     ) -> WorkOrderNotificationDraft:
         if target_status is WorkOrderStatus.APPROVED:
             title = WorkOrderTitleKey.SPACE_JOIN_APPROVED.value
-            content = WorkOrderMessageContent.SPACE_JOIN_APPROVED.value.format(
-                space_name=detail.space_name
-            )
+            content = {
+                "text": WorkOrderMessageContent.SPACE_JOIN_APPROVED.value.format(
+                    space_name=detail.space_name
+                )
+            }
         elif target_status is WorkOrderStatus.REJECTED:
             if review_remark is None:
                 raise WorkOrderInvalidRemarkError("review remark is required")
             title = WorkOrderTitleKey.SPACE_JOIN_REJECTED.value
-            content = WorkOrderMessageContent.SPACE_JOIN_REJECTED.value.format(
-                space_name=detail.space_name,
-                review_remark=review_remark,
-            )
+            content = {
+                "text": WorkOrderMessageContent.SPACE_JOIN_REJECTED.value.format(
+                    space_name=detail.space_name,
+                    review_remark=review_remark,
+                )
+            }
         else:
             raise ValueError(f"unsupported review status: {target_status}")
 
@@ -700,7 +704,7 @@ class WorkOrderNotificationService(WorkOrderNotificationServiceProtocol):
             biz_type=WorkOrderBizType.BOT_COLLABORATOR,
             biz_id=detail.work_order.biz_id,
             title=title,
-            content=content,
+            content={"text": content},
         )
 
     def get_detail(self, *, notification_id: int, actor_id: str):

--- a/src/backend/src/agentclaw/community/core/work_orders/services/work_order_service.py
+++ b/src/backend/src/agentclaw/community/core/work_orders/services/work_order_service.py
@@ -448,6 +448,24 @@ class WorkOrderService(WorkOrderServiceProtocol):
         nickname = (profile.nick_name or "").strip()
         return nickname[:128] or applicant_user_id
 
+    def _get_reviewer_name(self, *, reviewer_user_id: str | None) -> str | None:
+        if not reviewer_user_id:
+            return None
+        try:
+            profile = self._staff_dept.get_profile_by_work_no(
+                work_no=normalize_work_no_for_lookup(reviewer_user_id)
+            )
+        except StaffProfileLookupError:
+            logger.warning(
+                "failed to resolve reviewer nickname",
+                extra={"user_id": reviewer_user_id},
+                exc_info=True,
+            )
+            return None
+
+        nickname = (profile.nick_name or "").strip()
+        return nickname[:128] or None
+
     def list_items(
         self,
         *,
@@ -478,7 +496,13 @@ class WorkOrderService(WorkOrderServiceProtocol):
         )
         if detail is None:
             raise WorkOrderNotFoundError("work order not found")
-        return detail
+        return detail.model_copy(
+            update={
+                "reviewer_user_name": self._get_reviewer_name(
+                    reviewer_user_id=detail.work_order.reviewer_user_id
+                )
+            }
+        )
 
     def approve(self, *, work_order_id: int, actor_id: str, review_remark: str | None):
         normalized_remark = (review_remark or "").strip() or None

--- a/src/backend/tests/community/adapters/http/openapi_v1/work_orders/test_work_order_contract.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/work_orders/test_work_order_contract.py
@@ -411,13 +411,15 @@ def test_list_work_orders_maps_plain_and_notification_items(client, work_order_s
     assert items[0]["item_type"] == "APPROVAL"
     assert items[0]["notification_id"] is None
     assert items[0]["title"] == "空间加入申请待审批"
+    assert items[0]["summary"] == "你有一条新的通知，请查看详情。"
     assert items[0]["content"] is None
     assert items[0]["gmt_created"] == "2026-08-18T01:02:03"
     assert items[0]["gmt_modified"] == "2026-08-18T02:03:04"
     assert items[1]["item_id"] == "NOTIFICATION_21"
     assert items[1]["item_type"] == "NOTICE"
     assert items[1]["notification_id"] == 21
-    assert items[1]["title"] == "空间加入申请已通过"
+    assert items[1]["title"] == "空间加入申请已处理"
+    assert items[1]["summary"] == "空间加入申请已有处理结果，请查看详情。"
     assert items[1]["content"] == {"message": "approved"}
     assert items[1]["gmt_created"] == "2026-08-18T01:02:03"
     assert items[1]["gmt_modified"] == "2026-08-18T03:04:05"
@@ -464,23 +466,20 @@ def test_list_work_orders_derives_space_title_without_notification(
 
 
 @pytest.mark.parametrize(
-    ("stored_title", "expected"),
+    ("event_type", "stored_title", "expected"),
     [
-        ("空间加入申请待审批", "空间加入申请待审批"),
-        ("空间加入申请已通过", "空间加入申请已通过"),
-        ("空间加入申请未通过", "空间加入申请未通过"),
-        ("SPACE_JOIN APPROVED", "空间加入申请已通过"),
-        ("SPACE_JOIN REJECTED", "空间加入申请未通过"),
-        ("SPACE_JOIN_PENDING", "空间加入申请待审批"),
-        ("SPACE_JOIN_APPROVED", "空间加入申请已通过"),
-        ("SPACE_JOIN_REJECTED", "空间加入申请未通过"),
-        ("custom title", "custom title"),
+        (WorkOrderEventType.SPACE_JOIN_REVIEWED, None, "空间加入申请已处理"),
+        (WorkOrderEventType.SKILL_COLLABORATOR_APPLIED, None, "Skill 共同编辑申请待审批"),
+        (WorkOrderEventType.BOT2BOT_FRIEND_REVIEWED, "BOT_FRIEND APPROVED", "Bot 好友申请已处理"),
+        ("EXTERNAL_EVENT", "custom title", "custom title"),
     ],
 )
-def test_list_work_orders_translates_compatible_titles(
-    client, work_order_service, stored_title, expected
+def test_list_work_orders_uses_event_type_display_contract(
+    client, work_order_service, event_type, stored_title, expected
 ):
-    notification = _notification().model_copy(update={"title": stored_title})
+    notification = _notification().model_copy(
+        update={"event_type": event_type, "title": stored_title}
+    )
     work_order_service.list_items.return_value = (
         1,
         [
@@ -495,7 +494,9 @@ def test_list_work_orders_translates_compatible_titles(
     response = client.get("/openapi/v1/bots/work-orders")
 
     assert response.status_code == 200
-    assert response.json()["data"]["items"][0]["title"] == expected
+    item = response.json()["data"]["items"][0]
+    assert item["title"] == expected
+    assert item["summary"]
 
 
 def test_get_work_order_maps_nested_content(client, work_order_service):
@@ -667,7 +668,8 @@ def test_notification_detail_and_mark_read(client, notification_service):
         "work_order_id": 11,
         "notification_category": "APPROVAL",
         "event_type": "SPACE_JOIN_REVIEWED",
-        "title": "空间加入申请已通过",
+        "title": "空间加入申请已处理",
+        "summary": "空间加入申请已有处理结果，请查看详情。",
         "content": {"message": "approved"},
         "is_read": False,
         "work_order_status": "PENDING",
@@ -701,7 +703,8 @@ def test_notification_detail_wraps_historical_plain_text(client, notification_se
     response = client.get("/openapi/v1/bots/work-order-notifications/21")
 
     assert response.status_code == 200
-    assert response.json()["data"]["title"] == "空间加入申请已通过"
+    assert response.json()["data"]["title"] == "空间加入申请已处理"
+    assert response.json()["data"]["summary"] == "空间加入申请已有处理结果，请查看详情。"
     assert response.json()["data"]["content"] == {"legacy_value": "approved"}
 
 

--- a/src/backend/tests/community/adapters/http/openapi_v1/work_orders/test_work_order_contract.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/work_orders/test_work_order_contract.py
@@ -329,8 +329,12 @@ def test_create_work_order_event_accepts_json_objects(
     "content",
     [
         None,
+        {},
         {"text": "display"},
         {"text": "display", "legacy_value": "legacy"},
+        {"message": "成员已加入空间", "space_id": 7},
+        {"display_content": "...", "metadata": {"source": "bcs"}},
+        {"review_remark": "审批备注"},
         {"workitem_name": "历史任务"},
     ],
 )
@@ -365,16 +369,6 @@ def test_create_work_order_event_accepts_supported_content(content, client, work
         [],
         123,
         True,
-        {},
-        {"legacy_value": "历史内容"},
-        {"text": ""},
-        {"text": "   "},
-        {"text": None},
-        {"text": 123},
-        {"text": None, "workitem_name": "历史任务"},
-        {"workitem_name": ""},
-        {"workitem_name": "   "},
-        {"workitem_name": 123},
     ],
 )
 def test_create_work_order_event_rejects_invalid_content(content, client, work_order_service):
@@ -391,7 +385,7 @@ def test_create_work_order_event_rejects_invalid_content(content, client, work_o
     response = client.post("/openapi/v1/bots/work-orders/events", json=payload)
 
     assert response.status_code == 422
-    assert "缺少必填字段text" in response.text
+    assert "Invalid request" in response.text
     work_order_service.create_work_order_event.assert_not_called()
 
 

--- a/src/backend/tests/community/adapters/http/openapi_v1/work_orders/test_work_order_contract.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/work_orders/test_work_order_contract.py
@@ -452,7 +452,7 @@ def test_list_work_orders_maps_plain_and_notification_items(client, work_order_s
     assert items[1]["item_type"] == "NOTICE"
     assert items[1]["notification_id"] == 21
     assert items[1]["title"] == "空间加入申请已处理"
-    assert items[1]["summary"] == "空间加入申请已有处理结果，请查看详情。"
+    assert items[1]["summary"] == "空间加入申请已有处理结果。"
     assert items[1]["content"] == {"message": "approved"}
     assert items[1]["gmt_created"] == "2026-08-18T01:02:03"
     assert items[1]["gmt_modified"] == "2026-08-18T03:04:05"
@@ -752,7 +752,7 @@ def test_notification_detail_and_mark_read(client, notification_service):
         "notification_category": "APPROVAL",
         "event_type": "SPACE_JOIN_REVIEWED",
         "title": "空间加入申请已处理",
-        "summary": "空间加入申请已有处理结果，请查看详情。",
+        "summary": "空间加入申请已有处理结果。",
         "content": {"message": "approved"},
         "is_read": False,
         "work_order_status": "PENDING",
@@ -912,4 +912,34 @@ def test_content_presentation_supports_all_legacy_shapes():
     assert extract_content_text(json.dumps({"workitem_name": "workitem"})) == "workitem"
     assert extract_content_text(json.dumps({"other": "value"})) is None
     assert extract_content_text(json.dumps(["not", "an", "object"])) is None
-    assert display_summary(None, biz_type="UNKNOWN") == "你有一条新的通知，请查看详情。"
+    assert display_summary(None, biz_type="UNKNOWN") == "你有一条新的通知"
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [
+        (WorkOrderStatus.PENDING, "有新的 Skill 共同编辑申请，请及时处理。"),
+        (WorkOrderStatus.APPROVED, "Skill 共同编辑申请已通过。"),
+        (WorkOrderStatus.REJECTED, "Skill 共同编辑申请未通过。"),
+    ],
+)
+def test_display_summary_uses_work_order_status_without_notification(status, expected):
+    assert (
+        display_summary(
+            None,
+            biz_type=WorkOrderBizType.SKILL_COLLABORATOR.value,
+            status=status,
+        )
+        == expected
+    )
+
+
+def test_display_summary_unknown_event_falls_back_to_business_status():
+    assert (
+        display_summary(
+            "LEGACY_SKILL_EVENT",
+            biz_type=WorkOrderBizType.SKILL_COLLABORATOR.value,
+            status=WorkOrderStatus.REJECTED,
+        )
+        == "Skill 共同编辑申请未通过。"
+    )

--- a/src/backend/tests/community/adapters/http/openapi_v1/work_orders/test_work_order_contract.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/work_orders/test_work_order_contract.py
@@ -11,8 +11,11 @@ from injector import Injector, Module
 
 from agentclaw.community.adapters.http.openapi_v1.dependencies import require_principal
 from agentclaw.community.adapters.http.openapi_v1.work_orders.converter import (
+    display_summary,
     display_title,
+    extract_content_text,
     json_object,
+    preserve_content,
 )
 from agentclaw.community.adapters.http.openapi_v1.work_orders.router import router
 from agentclaw.community.api.work_order_service import (
@@ -411,7 +414,7 @@ def test_list_work_orders_maps_plain_and_notification_items(client, work_order_s
     assert items[0]["item_type"] == "APPROVAL"
     assert items[0]["notification_id"] is None
     assert items[0]["title"] == "空间加入申请待审批"
-    assert items[0]["summary"] == "你有一条新的通知，请查看详情。"
+    assert items[0]["summary"] == "有新的空间加入申请，请及时处理。"
     assert items[0]["content"] is None
     assert items[0]["gmt_created"] == "2026-08-18T01:02:03"
     assert items[0]["gmt_modified"] == "2026-08-18T02:03:04"
@@ -470,7 +473,7 @@ def test_list_work_orders_derives_space_title_without_notification(
     [
         (WorkOrderEventType.SPACE_JOIN_REVIEWED, None, "空间加入申请已处理"),
         (WorkOrderEventType.SKILL_COLLABORATOR_APPLIED, None, "Skill 共同编辑申请待审批"),
-        (WorkOrderEventType.BOT2BOT_FRIEND_REVIEWED, "BOT_FRIEND APPROVED", "Bot 好友申请已处理"),
+        (WorkOrderEventType.BOT2BOT_FRIEND_REVIEWED, "BOT_FRIEND APPROVED", "Bot 好友申请已通过"),
         ("EXTERNAL_EVENT", "custom title", "custom title"),
     ],
 )
@@ -497,6 +500,33 @@ def test_list_work_orders_uses_event_type_display_contract(
     item = response.json()["data"]["items"][0]
     assert item["title"] == expected
     assert item["summary"]
+
+
+def test_list_work_orders_uses_rejected_friend_status_for_title(
+    client, work_order_service
+):
+    notification = _notification().model_copy(
+        update={
+            "event_type": WorkOrderEventType.BOT2BOT_FRIEND_REVIEWED,
+            "title": "BOT_FRIEND REJECTED",
+        }
+    )
+    work_order_service.list_items.return_value = (
+        1,
+        [
+            WorkOrderListItem(
+                work_order=_work_order(WorkOrderStatus.REJECTED),
+                notification=notification,
+                can_approve=False,
+            )
+        ],
+    )
+
+    response = client.get("/openapi/v1/bots/work-orders")
+
+    assert response.status_code == 200
+    item = response.json()["data"]["items"][0]
+    assert item["title"] == "Bot 好友申请未通过"
 
 
 def test_get_work_order_maps_nested_content(client, work_order_service):
@@ -546,7 +576,7 @@ def test_get_work_order_without_notification_uses_business_status_title(
     data = response.json()["data"]
     assert data["event_type"] is None
     assert data["title"] == "空间加入申请待审批"
-    assert data["summary"] == "你有一条新的通知，请查看详情。"
+    assert data["summary"] == "有新的空间加入申请，请及时处理。"
 
 
 def test_get_bot_editor_work_order_maps_business_content(client, work_order_service):
@@ -727,8 +757,8 @@ def test_notification_detail_wraps_historical_plain_text(client, notification_se
 
     assert response.status_code == 200
     assert response.json()["data"]["title"] == "空间加入申请已处理"
-    assert response.json()["data"]["summary"] == "空间加入申请已有处理结果，请查看详情。"
-    assert response.json()["data"]["content"] == {"legacy_value": "approved"}
+    assert response.json()["data"]["summary"] == "approved"
+    assert response.json()["data"]["content"] == "approved"
 
 
 def test_domain_error_is_mapped_to_public_work_order_contract(
@@ -766,4 +796,88 @@ def test_request_validation_rejects_invalid_contract(client, path, method, paylo
 
 def test_presentation_helpers_preserve_empty_values() -> None:
     assert display_title(None, biz_type="CUSTOM", status=None) is None
+    assert display_title("SPACE_JOIN_PENDING") == "空间加入申请待审批"
+    assert display_title("custom title") == "custom title"
     assert json_object(None) is None
+    assert json_object("not-json") == {"legacy_value": "not-json"}
+
+
+def test_notification_content_text_has_priority_and_is_preserved(client, notification_service):
+    notification_service.get_detail.return_value = WorkOrderNotificationDetail(
+        notification=_notification().model_copy(
+            update={
+                "content": json.dumps({"legacy_value": "legacy", "text": "display"}),
+            }
+        ),
+        work_order_status=WorkOrderStatus.APPROVED,
+        can_approve=False,
+    )
+
+    response = client.get("/openapi/v1/bots/work-order-notifications/21")
+
+    assert response.status_code == 200
+    assert response.json()["data"]["content"] == {
+        "legacy_value": "legacy",
+        "text": "display",
+    }
+    assert response.json()["data"]["summary"] == "display"
+
+
+def test_work_order_content_summary_falls_back_to_legacy_value(
+    client, work_order_service
+):
+    work_order_service.get_detail.return_value = WorkOrderDetail(
+        work_order=_work_order(),
+        event_type=WorkOrderEventType.SPACE_JOIN_APPLIED,
+        title="pending",
+        content=json.dumps({"legacy_value": "legacy display"}),
+        space_id=7,
+        space_name="Team",
+        applicant_name="Applicant",
+        can_approve=True,
+    )
+
+    response = client.get("/openapi/v1/bots/work-orders/11")
+
+    assert response.status_code == 200
+    assert response.json()["data"]["summary"] == "legacy display"
+    assert response.json()["data"]["content"] == {"legacy_value": "legacy display"}
+
+
+@pytest.mark.parametrize(
+    ("biz_type", "expected"),
+    [
+        (WorkOrderBizType.BOT_COLLABORATOR, "Bot 共同编辑申请待审批"),
+        (WorkOrderBizType.SKILL_COLLABORATOR, "Skill 共同编辑申请待审批"),
+        (WorkOrderBizType.BOT_FRIEND, "好友申请待审批"),
+    ],
+)
+def test_list_work_orders_derives_collaborator_title_without_notification(
+    client, work_order_service, biz_type, expected
+):
+    work_order = _work_order().model_copy(update={"biz_type": biz_type})
+    work_order_service.list_items.return_value = (
+        1, [WorkOrderListItem(work_order=work_order, notification=None, can_approve=True)]
+    )
+
+    response = client.get("/openapi/v1/bots/work-orders")
+
+    assert response.status_code == 200
+    item = response.json()["data"]["items"][0]
+    assert item["title"] == expected
+    assert item["summary"]
+    assert item["content"] is None
+
+
+def test_content_presentation_supports_all_legacy_shapes():
+    assert preserve_content(None) is None
+    assert preserve_content("plain text") == "plain text"
+    assert preserve_content(json.dumps({"text": "structured"})) == {"text": "structured"}
+    assert preserve_content(json.dumps(["legacy", 1])) == "[\"legacy\", 1]"
+
+    assert extract_content_text("plain text") == "plain text"
+    assert extract_content_text(json.dumps({"text": "  ", "legacy_value": "legacy"})) == "legacy"
+    assert extract_content_text(json.dumps({"text": "display", "legacy_value": "legacy"})) == "display"
+    assert extract_content_text(json.dumps({"other": "value"})) is None
+    assert extract_content_text(json.dumps(["not", "an", "object"])) is None
+    assert display_summary(None, biz_type="UNKNOWN") == "你有一条新的通知，请查看详情。"

--- a/src/backend/tests/community/adapters/http/openapi_v1/work_orders/test_work_order_contract.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/work_orders/test_work_order_contract.py
@@ -296,7 +296,7 @@ def test_create_work_order_event_accepts_json_objects(
         "approver_user_ids": ["approver-1"],
         "recipient_user_ids": [],
         "title": "ignored display title",
-        "content": {"message": "apply", "items": [1, True]},
+        "content": {"text": "apply", "items": [1, True]},
         "biz_data": {"space_id": 7, "meta": {"source": "web"}},
     }
 
@@ -318,7 +318,7 @@ def test_create_work_order_event_accepts_json_objects(
         approver_user_ids=["approver-1"],
         recipient_user_ids=[],
         title="ignored display title",
-        content={"message": "apply", "items": [1, True]},
+        content={"text": "apply", "items": [1, True]},
         apply_reason=None,
         biz_data={"space_id": 7, "meta": {"source": "web"}},
         actor_id="owner-1",
@@ -326,36 +326,72 @@ def test_create_work_order_event_accepts_json_objects(
 
 
 @pytest.mark.parametrize(
-    ("field", "value"),
+    "content",
     [
-        ("content", [1, 2, 3]),
-        ("content", "text"),
-        ("content", 123),
-        ("content", True),
-        ("biz_data", [1, 2, 3]),
-        ("biz_data", "text"),
-        ("biz_data", 123),
-        ("biz_data", True),
+        None,
+        {"text": "display"},
+        {"text": "display", "legacy_value": "legacy"},
+        {"workitem_name": "历史任务"},
     ],
 )
-def test_create_work_order_event_rejects_non_object_json(
-    client, work_order_service, field, value
-):
+def test_create_work_order_event_accepts_supported_content(content, client, work_order_service):
+    work_order_service.create_work_order_event.return_value = WorkOrderEventCreatedResult(
+        event_category=NotificationCategory.NOTICE,
+        work_order_id=None,
+        work_order_no=None,
+        notification_ids=[21],
+        status=WorkOrderEventStatus.CREATED,
+    )
     payload = {
-        "event_category": "APPROVAL",
-        "biz_type": "SPACE_JOIN",
-        "biz_id": "7",
-        "event_type": "SPACE_JOIN_APPLIED",
-        "applicant_user_id": "owner-1",
-        "approver_user_ids": ["approver-1"],
-        "recipient_user_ids": [],
-        "title": "title",
-        field: value,
+        "event_category": "NOTICE",
+        "biz_type": "SPACE",
+        "biz_id": "space-1",
+        "event_type": "SPACE_MEMBER_ADDED",
+        "recipient_user_ids": ["owner-1"],
+        "title": "Member added",
+        "content": content,
+    }
+
+    response = client.post("/openapi/v1/bots/work-orders/events", json=payload)
+
+    assert response.status_code == 201
+    assert work_order_service.create_work_order_event.call_args.kwargs["content"] == content
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        "普通字符串",
+        [],
+        123,
+        True,
+        {},
+        {"legacy_value": "历史内容"},
+        {"text": ""},
+        {"text": "   "},
+        {"text": None},
+        {"text": 123},
+        {"text": None, "workitem_name": "历史任务"},
+        {"workitem_name": ""},
+        {"workitem_name": "   "},
+        {"workitem_name": 123},
+    ],
+)
+def test_create_work_order_event_rejects_invalid_content(content, client, work_order_service):
+    payload = {
+        "event_category": "NOTICE",
+        "biz_type": "SPACE",
+        "biz_id": "space-1",
+        "event_type": "SPACE_MEMBER_ADDED",
+        "recipient_user_ids": ["owner-1"],
+        "title": "Member added",
+        "content": content,
     }
 
     response = client.post("/openapi/v1/bots/work-orders/events", json=payload)
 
     assert response.status_code == 422
+    assert "缺少必填字段text" in response.text
     work_order_service.create_work_order_event.assert_not_called()
 
 
@@ -877,7 +913,9 @@ def test_content_presentation_supports_all_legacy_shapes():
 
     assert extract_content_text("plain text") == "plain text"
     assert extract_content_text(json.dumps({"text": "  ", "legacy_value": "legacy"})) == "legacy"
-    assert extract_content_text(json.dumps({"text": "display", "legacy_value": "legacy"})) == "display"
+    assert extract_content_text(json.dumps({"text": "display", "legacy_value": "legacy", "workitem_name": "workitem"})) == "display"
+    assert extract_content_text(json.dumps({"legacy_value": "legacy", "workitem_name": "workitem"})) == "legacy"
+    assert extract_content_text(json.dumps({"workitem_name": "workitem"})) == "workitem"
     assert extract_content_text(json.dumps({"other": "value"})) is None
     assert extract_content_text(json.dumps(["not", "an", "object"])) is None
     assert display_summary(None, biz_type="UNKNOWN") == "你有一条新的通知，请查看详情。"

--- a/src/backend/tests/community/adapters/http/openapi_v1/work_orders/test_work_order_contract.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/work_orders/test_work_order_contract.py
@@ -526,6 +526,29 @@ def test_get_work_order_maps_nested_content(client, work_order_service):
     )
 
 
+def test_get_work_order_without_notification_uses_business_status_title(
+    client, work_order_service
+):
+    work_order_service.get_detail.return_value = WorkOrderDetail(
+        work_order=_work_order(WorkOrderStatus.PENDING),
+        event_type=None,
+        title=None,
+        content=None,
+        space_id=7,
+        space_name="Team",
+        applicant_name="Applicant",
+        can_approve=True,
+    )
+
+    response = client.get("/openapi/v1/bots/work-orders/11")
+
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert data["event_type"] is None
+    assert data["title"] == "空间加入申请待审批"
+    assert data["summary"] == "你有一条新的通知，请查看详情。"
+
+
 def test_get_bot_editor_work_order_maps_business_content(client, work_order_service):
     record = _work_order(
         biz_data=json.dumps(

--- a/src/backend/tests/community/adapters/http/work_orders/test_router.py
+++ b/src/backend/tests/community/adapters/http/work_orders/test_router.py
@@ -120,7 +120,7 @@ def _approval_payload() -> dict[str, object]:
         "approver_user_ids": ["approver-1"],
         "recipient_user_ids": [],
         "title": "Join request",
-        "content": {"message": "apply", "items": [1, True]},
+        "content": {"text": "apply", "items": [1, True]},
         "apply_reason": "please approve",
         "biz_data": {"space_id": 7, "meta": {"source": "web"}},
     }
@@ -206,7 +206,7 @@ def test_create_approval_event_uses_authenticated_actor_and_shared_contract(
         approver_user_ids=["approver-1"],
         recipient_user_ids=[],
         title="Join request",
-        content={"message": "apply", "items": [1, True]},
+        content={"text": "apply", "items": [1, True]},
         apply_reason="please approve",
         biz_data={"space_id": 7, "meta": {"source": "web"}},
         actor_id="staff-1",
@@ -285,7 +285,6 @@ def test_mapped_business_errors_use_existing_envelope_codes(
     "payload",
     [
         {},
-        _approval_payload() | {"content": [1, 2]},
         _approval_payload() | {"biz_data": "not-an-object"},
     ],
 )

--- a/src/backend/tests/community/core/repository/implementations/test_space_market_work_order_repositories.py
+++ b/src/backend/tests/community/core/repository/implementations/test_space_market_work_order_repositories.py
@@ -1409,17 +1409,72 @@ def test_friend_approval_context_and_reviewed_event_use_original_applied_event(
     )
 
     with db.orm_session() as session:
-        result_event_type = (
-            session.query(WorkOrderNotificationModel.event_type)
+        result = (
+            session.query(
+                WorkOrderNotificationModel.event_type,
+                WorkOrderNotificationModel.title,
+                WorkOrderNotificationModel.content,
+            )
             .filter(
                 WorkOrderNotificationModel.work_order_id == created.work_order_id,
                 WorkOrderNotificationModel.recipient_user_id == "applicant-friend",
                 WorkOrderNotificationModel.notification_category
                 == NotificationCategory.NOTICE.value,
             )
-            .scalar()
+            .one()
         )
-    assert result_event_type == WorkOrderEventType.BOT2BOT_FRIEND_REVIEWED.value
+    assert result.event_type == WorkOrderEventType.BOT2BOT_FRIEND_REVIEWED.value
+    assert result.title == "Bot 好友申请已通过"
+    assert json.loads(result.content) == {"text": "你的 Bot 好友申请已通过。"}
+
+
+def test_friend_rejection_persists_status_specific_content(db) -> None:
+    repository = WorkOrderRepository(db, _skill_editor_requests(db))
+    created = repository.create_work_order_event(
+        event_category=NotificationCategory.APPROVAL,
+        biz_type=WorkOrderBizType.BOT_FRIEND.value,
+        biz_id="legacy-id-reject",
+        event_type=WorkOrderEventType.BOT2BOT_FRIEND_APPLIED.value,
+        applicant_user_id="applicant-reject",
+        approver_user_ids=["reviewer-reject"],
+        recipient_user_ids=[],
+        title="friend approval",
+        content=None,
+        apply_reason=None,
+        biz_data=json.dumps({"request_ids": ["request-reject"]}),
+        env="dev",
+    )
+    assert created.work_order_id is not None
+
+    repository.process_approval(
+        work_order_id=created.work_order_id,
+        reviewer_user_id="reviewer-reject",
+        decision=WorkOrderDecision.REJECTED,
+        review_remark="审批备注",
+        env="dev",
+    )
+
+    with db.orm_session() as session:
+        result = (
+            session.query(
+                WorkOrderNotificationModel.event_type,
+                WorkOrderNotificationModel.title,
+                WorkOrderNotificationModel.content,
+            )
+            .filter(
+                WorkOrderNotificationModel.work_order_id == created.work_order_id,
+                WorkOrderNotificationModel.recipient_user_id == "applicant-reject",
+                WorkOrderNotificationModel.notification_category
+                == NotificationCategory.NOTICE.value,
+            )
+            .one()
+        )
+    assert result.event_type == WorkOrderEventType.BOT2BOT_FRIEND_REVIEWED.value
+    assert result.title == "Bot 好友申请未通过"
+    assert json.loads(result.content) == {
+        "text": "你的 Bot 好友申请未通过。",
+        "review_remark": "审批备注",
+    }
 
 
 def test_get_approval_context_rejects_missing_order(db) -> None:

--- a/src/backend/tests/community/core/repository/implementations/test_space_market_work_order_repositories.py
+++ b/src/backend/tests/community/core/repository/implementations/test_space_market_work_order_repositories.py
@@ -50,7 +50,6 @@ from agentclaw.community.core.work_orders.models import (
     WorkOrderNotificationDraft,
     WorkOrderQueryType,
     WorkOrderStatus,
-    WorkOrderTitleKey,
 )
 from agentclaw.community.core.work_orders.repository.models import (
     WorkOrderApproverModel,
@@ -1046,7 +1045,7 @@ def test_work_order_repository_approve_and_notification_lifecycle(db) -> None:
     )
 
     notification = pending[0].notification
-    assert notification.title == "SPACE_JOIN_PENDING"
+    assert notification.title == "空间加入申请待审批"
     assert repository.count_unread(recipient_user_id="owner-1", env="dev") == 1
     owner_badge = repository.get_notification_badge_summary(
         recipient_user_id="owner-1", env="dev"
@@ -1168,7 +1167,7 @@ def test_work_order_repository_approve_and_notification_lifecycle(db) -> None:
     )
     assert applicant_total == 1
     applicant_notification = applicant_items[0].notification
-    assert applicant_notification.title == "SPACE_JOIN_APPROVED"
+    assert applicant_notification.title == "空间加入申请已处理"
     assert applicant_notification.content == approved_notification.content
     assert (
         repository.list_items(
@@ -1294,7 +1293,7 @@ def test_work_order_repository_rejects_and_requires_reviewer(db) -> None:
     )
     assert (
         applicant_items[0].notification.title
-        == "SPACE_JOIN_REJECTED"
+        == "空间加入申请已处理"
     )
     assert applicant_items[0].notification.content == "custom rejected content"
 
@@ -1332,33 +1331,6 @@ def test_badge_counts_distinct_pending_work_orders(db) -> None:
     assert summary.unread_count == 2
     assert summary.pending_approval_count == 1
     assert summary.badge_count == 1
-
-
-def test_space_join_event_persists_stable_title_key(db) -> None:
-    repository = WorkOrderRepository(db, _skill_editor_requests(db))
-
-    created = repository.create_work_order_event(
-        event_category=NotificationCategory.APPROVAL,
-        biz_type=WorkOrderBizType.SPACE_JOIN.value,
-        biz_id="space-join-1",
-        event_type=WorkOrderEventType.SPACE_JOIN_APPLIED.value,
-        applicant_user_id="applicant-space",
-        approver_user_ids=["reviewer-space"],
-        recipient_user_ids=[],
-        title=WorkOrderTitleKey.SPACE_JOIN_PENDING.value,
-        content="pending",
-        apply_reason=None,
-        biz_data=None,
-        env="dev",
-    )
-
-    with db.orm_session() as session:
-        assert (
-            session.query(WorkOrderNotificationModel.title)
-            .filter(WorkOrderNotificationModel.id == created.notification_ids[0])
-            .scalar()
-            == WorkOrderTitleKey.SPACE_JOIN_PENDING.value
-        )
 
 
 def test_friend_approval_context_and_reviewed_event_use_original_applied_event(

--- a/src/backend/tests/community/core/repository/implementations/test_space_market_work_order_repositories.py
+++ b/src/backend/tests/community/core/repository/implementations/test_space_market_work_order_repositories.py
@@ -99,7 +99,7 @@ def _review_notification(
         biz_type=WorkOrderBizType.SPACE_JOIN,
         biz_id=str(space_id),
         title=title,
-        content=content,
+        content={"text": content},
     )
 
 
@@ -113,7 +113,7 @@ def _bot_review_notification(
         biz_type=WorkOrderBizType.BOT_COLLABORATOR,
         biz_id=bot_id,
         title="Bot 共同编辑申请已通过",
-        content="approved",
+        content={"text": "approved"},
     )
 
 
@@ -127,7 +127,7 @@ def _skill_review_notification(
         biz_type=WorkOrderBizType.SKILL_COLLABORATOR,
         biz_id=str(skill_id),
         title="Skill 共同编辑申请已通过" if approved else "Skill 共同编辑申请未通过",
-        content="reviewed",
+        content={"text": "reviewed"},
     )
 
 
@@ -1205,7 +1205,7 @@ def test_work_order_repository_approve_and_notification_lifecycle(db) -> None:
     assert applicant_total == 1
     applicant_notification = applicant_items[0].notification
     assert applicant_notification.title == "空间加入申请已处理"
-    assert applicant_notification.content == approved_notification.content
+    assert json.loads(applicant_notification.content) == approved_notification.content
     assert (
         repository.list_items(
             actor_id="applicant-1",
@@ -1332,7 +1332,7 @@ def test_work_order_repository_rejects_and_requires_reviewer(db) -> None:
         applicant_items[0].notification.title
         == "空间加入申请已处理"
     )
-    assert applicant_items[0].notification.content == "custom rejected content"
+    assert json.loads(applicant_items[0].notification.content) == {"text": "custom rejected content"}
 
 
 def test_badge_counts_distinct_pending_work_orders(db) -> None:

--- a/src/backend/tests/community/core/repository/implementations/test_space_market_work_order_repositories.py
+++ b/src/backend/tests/community/core/repository/implementations/test_space_market_work_order_repositories.py
@@ -50,7 +50,6 @@ from agentclaw.community.core.work_orders.models import (
     WorkOrderNotificationDraft,
     WorkOrderQueryType,
     WorkOrderStatus,
-    WorkOrderTitleKey,
 )
 from agentclaw.community.core.work_orders.repository.models import (
     WorkOrderApproverModel,
@@ -1044,7 +1043,7 @@ def test_work_order_repository_approve_and_notification_lifecycle(db) -> None:
     )
 
     notification = pending[0].notification
-    assert notification.title == WorkOrderTitleKey.SPACE_JOIN_PENDING.value
+    assert notification.title == "空间加入申请待审批"
     assert repository.count_unread(recipient_user_id="owner-1", env="dev") == 1
     owner_badge = repository.get_notification_badge_summary(
         recipient_user_id="owner-1", env="dev"
@@ -1166,7 +1165,7 @@ def test_work_order_repository_approve_and_notification_lifecycle(db) -> None:
     )
     assert applicant_total == 1
     applicant_notification = applicant_items[0].notification
-    assert applicant_notification.title == WorkOrderTitleKey.SPACE_JOIN_APPROVED.value
+    assert applicant_notification.title == "空间加入申请已处理"
     assert applicant_notification.content == approved_notification.content
     assert (
         repository.list_items(
@@ -1292,7 +1291,7 @@ def test_work_order_repository_rejects_and_requires_reviewer(db) -> None:
     )
     assert (
         applicant_items[0].notification.title
-        == WorkOrderTitleKey.SPACE_JOIN_REJECTED.value
+        == "空间加入申请已处理"
     )
     assert applicant_items[0].notification.content == "custom rejected content"
 

--- a/src/backend/tests/community/core/repository/implementations/test_space_market_work_order_repositories.py
+++ b/src/backend/tests/community/core/repository/implementations/test_space_market_work_order_repositories.py
@@ -50,6 +50,7 @@ from agentclaw.community.core.work_orders.models import (
     WorkOrderNotificationDraft,
     WorkOrderQueryType,
     WorkOrderStatus,
+    WorkOrderTitleKey,
 )
 from agentclaw.community.core.work_orders.repository.models import (
     WorkOrderApproverModel,
@@ -1033,6 +1034,8 @@ def test_work_order_repository_approve_and_notification_lifecycle(db) -> None:
     owner_detail = repository.get_detail(
         work_order_id=record.id, actor_id="owner-1", env="dev"
     )
+    assert owner_detail.event_type is not None
+    assert owner_detail.title is not None
     assert owner_detail.can_approve is True
     assert (
         repository.get_detail(work_order_id=record.id, actor_id="intruder", env="dev")
@@ -1043,7 +1046,7 @@ def test_work_order_repository_approve_and_notification_lifecycle(db) -> None:
     )
 
     notification = pending[0].notification
-    assert notification.title == "空间加入申请待审批"
+    assert notification.title == "SPACE_JOIN_PENDING"
     assert repository.count_unread(recipient_user_id="owner-1", env="dev") == 1
     owner_badge = repository.get_notification_badge_summary(
         recipient_user_id="owner-1", env="dev"
@@ -1165,7 +1168,7 @@ def test_work_order_repository_approve_and_notification_lifecycle(db) -> None:
     )
     assert applicant_total == 1
     applicant_notification = applicant_items[0].notification
-    assert applicant_notification.title == "空间加入申请已处理"
+    assert applicant_notification.title == "SPACE_JOIN_APPROVED"
     assert applicant_notification.content == approved_notification.content
     assert (
         repository.list_items(
@@ -1291,7 +1294,7 @@ def test_work_order_repository_rejects_and_requires_reviewer(db) -> None:
     )
     assert (
         applicant_items[0].notification.title
-        == "空间加入申请已处理"
+        == "SPACE_JOIN_REJECTED"
     )
     assert applicant_items[0].notification.content == "custom rejected content"
 
@@ -1329,6 +1332,33 @@ def test_badge_counts_distinct_pending_work_orders(db) -> None:
     assert summary.unread_count == 2
     assert summary.pending_approval_count == 1
     assert summary.badge_count == 1
+
+
+def test_space_join_event_persists_stable_title_key(db) -> None:
+    repository = WorkOrderRepository(db, _skill_editor_requests(db))
+
+    created = repository.create_work_order_event(
+        event_category=NotificationCategory.APPROVAL,
+        biz_type=WorkOrderBizType.SPACE_JOIN.value,
+        biz_id="space-join-1",
+        event_type=WorkOrderEventType.SPACE_JOIN_APPLIED.value,
+        applicant_user_id="applicant-space",
+        approver_user_ids=["reviewer-space"],
+        recipient_user_ids=[],
+        title=WorkOrderTitleKey.SPACE_JOIN_PENDING.value,
+        content="pending",
+        apply_reason=None,
+        biz_data=None,
+        env="dev",
+    )
+
+    with db.orm_session() as session:
+        assert (
+            session.query(WorkOrderNotificationModel.title)
+            .filter(WorkOrderNotificationModel.id == created.notification_ids[0])
+            .scalar()
+            == WorkOrderTitleKey.SPACE_JOIN_PENDING.value
+        )
 
 
 def test_friend_approval_context_and_reviewed_event_use_original_applied_event(

--- a/src/backend/tests/community/core/skill_center/services/test_skill_collaborator_approval_handler.py
+++ b/src/backend/tests/community/core/skill_center/services/test_skill_collaborator_approval_handler.py
@@ -69,4 +69,5 @@ def test_skill_collaborator_handler_delegates_atomic_approval() -> None:
     assert call["target_status"] is WorkOrderStatus.APPROVED
     assert call["notification"].recipient_user_id == "member-1"
     assert call["notification"].event_type == "SKILL_COLLABORATOR_REVIEWED"
+    assert call["notification"].content == {"text": "你共同编辑 Skill「Review Skill」的申请已通过。"}
     assert call["env"] == "test"

--- a/src/backend/tests/community/core/spaces/test_space_member_service.py
+++ b/src/backend/tests/community/core/spaces/test_space_member_service.py
@@ -274,7 +274,7 @@ def test_delete_member_returns_true_for_existing_non_creator() -> None:
         approver_user_ids=[],
         recipient_user_ids=["member-1"],
         title="你已被移出空间",
-        content={"legacy_value": "你已被移出空间「Team」。"},
+        content={"text": "你已被移出空间「Team」。"},
         apply_reason=None,
         biz_data=None,
         actor_id="owner-1",

--- a/src/backend/tests/community/core/work_orders/test_event_type_presentation.py
+++ b/src/backend/tests/community/core/work_orders/test_event_type_presentation.py
@@ -23,7 +23,7 @@ def test_every_known_event_has_complete_display_contract():
 def test_unknown_event_keeps_supplied_title_and_uses_generic_summary():
     assert notification_title_for("EXTERNAL_EVENT", "外部标题") == "外部标题"
     assert notification_title_for("EXTERNAL_EVENT") == "新的系统通知"
-    assert notification_summary_for("EXTERNAL_EVENT") == "你有一条新的通知，请查看详情。"
+    assert notification_summary_for("EXTERNAL_EVENT") == "你有一条新的通知"
 
 
 def test_known_event_overrides_historical_title():
@@ -33,3 +33,28 @@ def test_known_event_overrides_historical_title():
         )
         == "Skill 共同编辑申请待审批"
     )
+
+
+def test_public_order_events_use_common_bot_display_copy():
+    assert (
+        WorkOrderEventType.HUMAN2BOT_PUBLIC_ORDER_CREATED.title
+        == "Bot 公开工单审批已创建"
+    )
+    assert (
+        WorkOrderEventType.BOT2BOT_PUBLIC_ORDER_CREATED.title
+        == "Bot 公开工单审批已创建"
+    )
+    assert (
+        WorkOrderEventType.HUMAN2BOT_PUBLIC_ORDER_COMPLETED.title
+        == "Bot 公开工单审批已结束"
+    )
+    assert (
+        WorkOrderEventType.BOT2BOT_PUBLIC_ORDER_COMPLETED.title
+        == "Bot 公开工单审批已结束"
+    )
+
+
+def test_default_event_copy_does_not_include_detail_action():
+    for event_type in WorkOrderEventType:
+        assert "查看详情" not in event_type.summary
+    assert "查看详情" not in notification_summary_for("EXTERNAL_EVENT")

--- a/src/backend/tests/community/core/work_orders/test_event_type_presentation.py
+++ b/src/backend/tests/community/core/work_orders/test_event_type_presentation.py
@@ -1,0 +1,35 @@
+from agentclaw.community.core.work_orders.models import (
+    EVENT_CATEGORIES,
+    NotificationCategory,
+    WorkOrderEventType,
+    notification_summary_for,
+    notification_title_for,
+)
+
+
+def test_every_known_event_has_complete_display_contract():
+    assert set(EVENT_CATEGORIES) == set(WorkOrderEventType)
+    for event_type in WorkOrderEventType:
+        assert event_type.notification_category in (
+            NotificationCategory.APPROVAL,
+            NotificationCategory.NOTICE,
+        )
+        assert event_type.title
+        assert event_type.summary
+        assert notification_title_for(event_type.value) == event_type.title
+        assert notification_summary_for(event_type.value) == event_type.summary
+
+
+def test_unknown_event_keeps_supplied_title_and_uses_generic_summary():
+    assert notification_title_for("EXTERNAL_EVENT", "外部标题") == "外部标题"
+    assert notification_title_for("EXTERNAL_EVENT") == "新的系统通知"
+    assert notification_summary_for("EXTERNAL_EVENT") == "你有一条新的通知，请查看详情。"
+
+
+def test_known_event_overrides_historical_title():
+    assert (
+        notification_title_for(
+            WorkOrderEventType.SKILL_COLLABORATOR_APPLIED.value, "旧标题"
+        )
+        == "Skill 共同编辑申请待审批"
+    )

--- a/src/backend/tests/community/core/work_orders/test_work_order_service.py
+++ b/src/backend/tests/community/core/work_orders/test_work_order_service.py
@@ -333,7 +333,7 @@ def test_unified_approval_dispatches_bot_editor_side_effect() -> None:
         biz_type=WorkOrderBizType.BOT_COLLABORATOR,
         biz_id="bot-17",
         title="approved",
-        content="approved",
+        content={"text": "approved"},
     )
     notifications.build_bot_editor_review_result.return_value = notification
     expected = WorkOrderReviewResult(
@@ -848,7 +848,7 @@ def test_review_requires_owner_and_delegates(
         biz_type=WorkOrderBizType.SPACE_JOIN,
         biz_id="7",
         title="reviewed",
-        content="result",
+        content={"text": "result"},
     )
     notifications.build_space_join_review_result.return_value = notification
     expected = WorkOrderReviewResult(
@@ -893,7 +893,7 @@ def test_approve_accepts_missing_or_blank_remark(value: str | None) -> None:
         biz_type=WorkOrderBizType.SPACE_JOIN,
         biz_id="7",
         title="approved",
-        content="approved",
+        content={"text": "approved"},
     )
     notifications.build_space_join_review_result.return_value = notification
     expected = WorkOrderReviewResult(
@@ -984,7 +984,7 @@ def test_notification_service_builds_space_join_review_result(
         biz_type=WorkOrderBizType.SPACE_JOIN,
         biz_id="7",
         title=expected_title,
-        content=expected_content,
+        content={"text": expected_content},
     )
 
 

--- a/src/backend/tests/community/core/work_orders/test_work_order_service.py
+++ b/src/backend/tests/community/core/work_orders/test_work_order_service.py
@@ -733,6 +733,43 @@ def test_list_items_forwards_filters_and_normalizes_pagination() -> None:
     )
 
 
+def test_get_detail_resolves_reviewer_name_from_staff_directory() -> None:
+    staff_dept = MagicMock(spec=StaffDeptPlugin)
+    staff_dept.get_profile_by_work_no.return_value = StaffProfileInfo(
+        work_no="001234", nick_name=" Reviewer "
+    )
+    service, repository, *_ = _service(staff_dept=staff_dept)
+    repository.get_detail.return_value = _detail().model_copy(
+        update={
+            "work_order": _work_order().model_copy(
+                update={"reviewer_user_id": "1234"}
+            )
+        }
+    )
+
+    detail = service.get_detail(work_order_id=11, actor_id="owner-1")
+
+    assert detail.reviewer_user_name == "Reviewer"
+    staff_dept.get_profile_by_work_no.assert_called_once_with(work_no="001234")
+
+
+def test_get_detail_keeps_success_when_reviewer_lookup_fails() -> None:
+    staff_dept = MagicMock(spec=StaffDeptPlugin)
+    staff_dept.get_profile_by_work_no.side_effect = StaffProfileLookupError("down")
+    service, repository, *_ = _service(staff_dept=staff_dept)
+    repository.get_detail.return_value = _detail().model_copy(
+        update={
+            "work_order": _work_order().model_copy(
+                update={"reviewer_user_id": "1234"}
+            )
+        }
+    )
+
+    detail = service.get_detail(work_order_id=11, actor_id="owner-1")
+
+    assert detail.reviewer_user_name is None
+
+
 def test_get_detail_returns_record_and_missing_raises() -> None:
     service, repository, _, _, _ = _service()
     repository.get_detail.side_effect = [_detail(), None]

--- a/src/gateway/configs/schemas/bots.openapi.json
+++ b/src/gateway/configs/schemas/bots.openapi.json
@@ -15145,6 +15145,12 @@
             "title": "Notification Id",
             "type": "integer"
           },
+          "summary": {
+            "default": "你有一条新的通知，请查看详情。",
+            "description": "Stable notification summary.",
+            "title": "Summary",
+            "type": "string"
+          },
           "title": {
             "description": "Display title of the notification.",
             "title": "Title",
@@ -22533,9 +22539,27 @@
             "description": "Identifier of the reviewer after processing, otherwise null.",
             "title": "Reviewer User Id"
           },
+          "reviewer_user_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Display name of the reviewer after processing, otherwise null.",
+            "title": "Reviewer User Name"
+          },
           "status": {
             "$ref": "#/components/schemas/WorkOrderStatus",
             "description": "Current work-order status."
+          },
+          "summary": {
+            "default": "你有一条新的通知，请查看详情。",
+            "description": "Stable notification summary.",
+            "title": "Summary",
+            "type": "string"
           },
           "title": {
             "description": "Display title of the work order.",
@@ -22561,6 +22585,7 @@
           "title",
           "status",
           "reviewer_user_id",
+          "reviewer_user_name",
           "review_remark",
           "reviewed_at",
           "can_approve"
@@ -22937,6 +22962,12 @@
               }
             ],
             "description": "Related work-order status, when one exists."
+          },
+          "summary": {
+            "default": "你有一条新的通知，请查看详情。",
+            "description": "Stable notification summary.",
+            "title": "Summary",
+            "type": "string"
           },
           "title": {
             "anyOf": [

--- a/src/gateway/configs/schemas/bots.openapi.json
+++ b/src/gateway/configs/schemas/bots.openapi.json
@@ -16197,6 +16197,9 @@
           "content": {
             "anyOf": [
               {
+                "type": "string"
+              },
+              {
                 "additionalProperties": true,
                 "type": "object"
               },
@@ -16204,7 +16207,7 @@
                 "type": "null"
               }
             ],
-            "description": "Notification JSON object, when present.",
+            "description": "Original notification content, either text or a JSON object.",
             "title": "Content"
           },
           "event_type": {
@@ -23664,6 +23667,9 @@
           "content": {
             "anyOf": [
               {
+                "type": "string"
+              },
+              {
                 "additionalProperties": true,
                 "type": "object"
               },
@@ -23671,7 +23677,7 @@
                 "type": "null"
               }
             ],
-            "description": "Notification JSON object, when available.",
+            "description": "Original notification content, either text or a JSON object.",
             "title": "Content"
           },
           "event_type": {
@@ -23980,6 +23986,9 @@
           "content": {
             "anyOf": [
               {
+                "type": "string"
+              },
+              {
                 "additionalProperties": true,
                 "type": "object"
               },
@@ -23987,7 +23996,7 @@
                 "type": "null"
               }
             ],
-            "description": "Notification JSON object, or null when unavailable.",
+            "description": "Original notification content, either text or a JSON object.",
             "title": "Content"
           },
           "env": {


### PR DESCRIPTION
好友审批结果通知的 event_type、标题和内容展示不统一，部分历史数据会显示为 BOT_FRIEND APPROVED，审批结果内容也可能为空或无法正确区分通过、拒绝。

 - 保留现有 HUMAN2BOT_FRIEND_REVIEWED、BOT2BOT_FRIEND_REVIEWED 类型；
  - 根据工单状态区分审批通过和拒绝；
  - 新生成的审批结果通知统一使用 JSON 格式保存 content；
  - 增加 text 文案字段，并兼容历史 legacy_value 和字符串格式；
  - 统一工单列表、详情、通知详情的标题、摘要和内容返回；