### PR TITLE
fix(bcs): surface ignored friendship writes

### DIFF
--- a/src/bcs/crates/services/bcs-friend-store/src/lib.rs
+++ b/src/bcs/crates/services/bcs-friend-store/src/lib.rs
@@ -7,7 +7,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 use bcs_config::resolve_env_str as resolve_env;
 use bcs_db_api::{DbError, DbPlugin, DbRow, DbSqlFlavor, DbStatement, DbValue};
@@ -169,7 +169,24 @@ impl FriendRepoPort for DbFriendStore {
             .await?;
 
         if affected == 0 {
-            debug!(left_bot = %left, right_bot = %right, "Friendship already existed (DB)");
+            if !self.are_friends(bot_a, bot_b).await? {
+                error!(
+                    left_bot = %left,
+                    right_bot = %right,
+                    env = %env,
+                    "Friendship insert was ignored, but no matching row exists in the current environment"
+                );
+                return Err(ServiceError::InternalError(
+                    "添加好友失败，请稍后重试".to_string(),
+                ));
+            }
+
+            debug!(
+                left_bot = %left,
+                right_bot = %right,
+                env = %env,
+                "Friendship already existed (DB)"
+            );
             return Ok(());
         }
 
@@ -871,6 +888,49 @@ mod tests {
                 .await
                 .expect("are friends after remove")
         );
+    }
+
+    #[tokio::test]
+    async fn sqlite_ignored_insert_without_current_env_row_returns_error() {
+        let db = must_db(LocalSqliteDbPlugin::new());
+        must_db(
+            db.execute(DbStatement::new(
+                "CREATE TABLE bcs_friendships (
+                    left_bot TEXT NOT NULL,
+                    right_bot TEXT NOT NULL,
+                    env TEXT NOT NULL,
+                    gmt_create TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                    gmt_modified TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                    PRIMARY KEY (left_bot, right_bot)
+                )",
+            ))
+            .await,
+        );
+
+        let env = resolve_env();
+        let other_env = format!("{env}-other");
+        must_db(
+            db.execute(DbStatement::with_params(
+                "INSERT INTO bcs_friendships (left_bot, right_bot, env) VALUES (?, ?, ?)",
+                vec![
+                    DbValue::from("alice"),
+                    DbValue::from("bob"),
+                    DbValue::from(other_env),
+                ],
+            ))
+            .await,
+        );
+
+        let db_plugin: Arc<dyn DbPlugin> = Arc::new(db);
+        let friend_store = DbFriendStore::sqlite(db_plugin);
+        let result = friend_store.add_friendship("alice", "bob").await;
+
+        assert!(matches!(
+            result,
+            Err(ServiceError::InternalError(message))
+                if message == "添加好友失败，请稍后重试"
+        ));
+        assert!(!must_service(friend_store.are_friends("alice", "bob").await));
     }
 
     #[tokio::test]

--- a/src/bcs/crates/services/bcs-friend/src/core/friend_request_core.rs
+++ b/src/bcs/crates/services/bcs-friend/src/core/friend_request_core.rs
@@ -155,6 +155,10 @@ impl FriendRequestCoreService for FriendRequestCore {
         self.reject_human_human(&request.from_bot, &request.to_bot)
             .await?;
 
+        self.friend_service
+            .add_friendship(&request.from_bot, &request.to_bot)
+            .await?;
+
         self.repo
             .update_request_status(request_id, FriendRequestStatus::Accepted)
             .await?;
@@ -172,10 +176,6 @@ impl FriendRequestCoreService for FriendRequestCore {
                 warn!(from = %request.to_bot, to = %request.from_bot, error = %err, "Failed to auto-accept reverse pending request; B can manually accept later for consistency");
             }
         }
-
-        self.friend_service
-            .add_friendship(&request.from_bot, &request.to_bot)
-            .await?;
 
         info!(request_id = %request_id, from = %request.from_bot, to = %request.to_bot, "Friend request accepted");
         Ok(())

--- a/src/bcs/crates/services/bcs-friend/tests/conformance_friend_services.rs
+++ b/src/bcs/crates/services/bcs-friend/tests/conformance_friend_services.rs
@@ -168,6 +168,38 @@ async fn friend_request_core_accepts_reverse_pending_request_and_adds_friendship
 }
 
 #[tokio::test]
+async fn friend_request_core_keeps_request_pending_when_friendship_write_fails() {
+    let request_repo = Arc::new(MemoryFriendRequestRepo::new());
+    let requests = FriendRequestCore::with_repo(
+        request_repo.clone(),
+        Arc::new(FriendCore::with_repo(Arc::new(FailingFriendRepo))),
+        Arc::new(StaticRegistry::new(&[
+            ("alice", "protected", ActorKind::Bot),
+            ("bob", "protected", ActorKind::Bot),
+        ])),
+    );
+    let request = requests
+        .create_request("alice", "bob")
+        .await
+        .expect("create request");
+
+    let result = requests.accept_request(&request.id).await;
+
+    assert!(matches!(
+        result,
+        Err(ServiceError::InternalError(message)) if message == "friend store unavailable"
+    ));
+    assert_eq!(
+        request_repo
+            .get_request(&request.id)
+            .await
+            .expect("request remains readable")
+            .status,
+        FriendRequestStatus::Pending
+    );
+}
+
+#[tokio::test]
 async fn friend_request_core_reject_and_cancel_preserve_terminal_requests() {
     let (_friend, requests, repo) = core_fixture(&[
         ("alice", "protected", ActorKind::Bot),

--- a/src/bcs/scripts/e2e-test/friends.sh
+++ b/src/bcs/scripts/e2e-test/friends.sh
@@ -6,9 +6,59 @@ E2E_TESTS_FRIENDS=(
     "test_friend_auto_accept_public"
     "test_friend_request_accept_protected"
     "test_friend_request_reject_protected"
+    "test_friendship_insert_ignore_failure_is_visible_and_retryable"
     "test_list_friends"
     "test_friend_flow_via_cli"
 )
+
+# ============================================================================
+# Local persistence fault fixture
+# ============================================================================
+
+_friendship_ignore_fixture() {
+    local mode="$1" db_path="$2" bot_a="$3" bot_b="$4"
+    python3 -c '
+import sqlite3
+import sys
+
+mode, db_path, bot_a, bot_b = sys.argv[1:]
+left_bot, right_bot = sorted((bot_a, bot_b))
+trigger_name = "e2e_ignore_friendship_insert"
+
+connection = sqlite3.connect(db_path, timeout=10)
+try:
+    connection.execute(f"DROP TRIGGER IF EXISTS {trigger_name}")
+    if mode == "reset":
+        connection.execute(
+            "DELETE FROM bcs_friendships WHERE left_bot = ? AND right_bot = ?",
+            (left_bot, right_bot),
+        )
+        connection.execute(
+            "DELETE FROM bcs_friend_requests "
+            "WHERE (from_bot = ? AND to_bot = ?) OR (from_bot = ? AND to_bot = ?)",
+            (bot_a, bot_b, bot_b, bot_a),
+        )
+        connection.execute(
+            "DELETE FROM bcs_actor_relations "
+            "WHERE is_creator = 0 AND "
+            "((from_id = ? AND to_id = ?) OR (from_id = ? AND to_id = ?))",
+            (bot_a, bot_b, bot_b, bot_a),
+        )
+    elif mode == "arm":
+        quote = lambda value: "\x27" + value.replace("\x27", "\x27\x27") + "\x27"
+        connection.execute(
+            f"CREATE TRIGGER {trigger_name} "
+            "BEFORE INSERT ON bcs_friendships "
+            f"WHEN NEW.left_bot = {quote(left_bot)} AND NEW.right_bot = {quote(right_bot)} "
+            "BEGIN SELECT RAISE(IGNORE); END"
+        )
+    elif mode != "disarm":
+        raise ValueError(f"unsupported fixture mode: {mode}")
+    connection.commit()
+finally:
+    connection.close()
+' "$mode" "$db_path" "$bot_a" "$bot_b"
+}
 
 # ============================================================================
 # Tests
@@ -140,6 +190,118 @@ for r in data:
     TESTS_TOTAL=$((TESTS_TOTAL + 1))
     # Restore 客服 to public
     api_put "/bots/$BOT_CS_UUID/visibility" "{\"visibility\":\"public\"}"
+}
+
+# Persistence failure: accepting a pending request must not report success when
+# the friendship INSERT is ignored and no row exists. This case only runs
+# against the explicitly provided standalone SQLite database; it never mutates
+# a remote E2E target. The store unit test covers the real cross-env legacy-key
+# setup, while this story verifies the HTTP error and retry journey end to end.
+test_friendship_insert_ignore_failure_is_visible_and_retryable() {
+    info "Friends: ignored friendship insert is visible and retryable"
+
+    local db_path="${BCS_E2E_SQLITE_DB_PATH:-}"
+    if [[ -z "$db_path" || ! -f "$db_path" ]]; then
+        warn "SKIP: BCS_E2E_SQLITE_DB_PATH is not an available local database"
+        return 0
+    fi
+    case "$BCS_API_BASE_URL" in
+        http://127.0.0.1:*|http://localhost:*) ;;
+        *)
+            warn "SKIP: friendship persistence fault fixture requires a loopback BCS target"
+            return 0
+            ;;
+    esac
+
+    if ! _friendship_ignore_fixture reset "$db_path" "$BOT_QA_UUID" "$BOT_CS_UUID"; then
+        fail "reset ignored-insert friendship fixture"
+        TESTS_FAILED=$((TESTS_FAILED + 1)); TESTS_TOTAL=$((TESTS_TOTAL + 1))
+        return
+    fi
+
+    api_put "/bots/$BOT_CS_UUID/visibility" '{"visibility":"protected"}'
+    if [[ "$HTTP_STATUS" != "200" ]]; then
+        fail "set fault-fixture target to protected returns $HTTP_STATUS"
+        TESTS_FAILED=$((TESTS_FAILED + 1)); TESTS_TOTAL=$((TESTS_TOTAL + 1))
+        _friendship_ignore_fixture reset "$db_path" "$BOT_QA_UUID" "$BOT_CS_UUID" || true
+        return
+    fi
+
+    api_post "/friends/request" \
+        "{\"from_bot\":\"$BOT_QA_UUID\",\"to_bot\":\"$BOT_CS_UUID\"}"
+    if [[ "$HTTP_STATUS" != "200" && "$HTTP_STATUS" != "201" ]]; then
+        fail "create fault-fixture friend request returns $HTTP_STATUS"
+        TESTS_FAILED=$((TESTS_FAILED + 1)); TESTS_TOTAL=$((TESTS_TOTAL + 1))
+        _friendship_ignore_fixture reset "$db_path" "$BOT_QA_UUID" "$BOT_CS_UUID" || true
+        api_put "/bots/$BOT_CS_UUID/visibility" '{"visibility":"public"}'
+        return
+    fi
+
+    local request_id
+    request_id=$(json_path "$RESPONSE" "data.id")
+    if [[ -z "$request_id" ]]; then
+        fail "fault-fixture friend request returns an id"
+        TESTS_FAILED=$((TESTS_FAILED + 1)); TESTS_TOTAL=$((TESTS_TOTAL + 1))
+        _friendship_ignore_fixture reset "$db_path" "$BOT_QA_UUID" "$BOT_CS_UUID" || true
+        api_put "/bots/$BOT_CS_UUID/visibility" '{"visibility":"public"}'
+        return
+    fi
+
+    if ! _friendship_ignore_fixture arm "$db_path" "$BOT_QA_UUID" "$BOT_CS_UUID"; then
+        fail "arm ignored-insert friendship fixture"
+        TESTS_FAILED=$((TESTS_FAILED + 1)); TESTS_TOTAL=$((TESTS_TOTAL + 1))
+        _friendship_ignore_fixture reset "$db_path" "$BOT_QA_UUID" "$BOT_CS_UUID" || true
+        api_put "/bots/$BOT_CS_UUID/visibility" '{"visibility":"public"}'
+        return
+    fi
+
+    api_post "/friends/requests/$request_id/accept" '{}'
+    assert_eq "ignored friendship insert returns 500" "$HTTP_STATUS" "500"
+    assert_json_eq "ignored friendship insert reports failure" "$RESPONSE" "success" "false"
+    assert_contains "ignored friendship insert returns a user-readable error" \
+        "$RESPONSE" "添加好友失败，请稍后重试"
+
+    api_get "/friends/requests?bot_uuid=$BOT_CS_UUID&direction=received&status=pending"
+    assert_eq "failed acceptance keeps request queryable" "$HTTP_STATUS" "200"
+    local pending_status
+    pending_status=$(printf '%s' "$RESPONSE" | python3 -c '
+import json
+import sys
+
+request_id = sys.argv[1]
+data = json.load(sys.stdin).get("data", [])
+request = next((item for item in data if item.get("id") == request_id), {})
+print(request.get("status", ""))
+' "$request_id")
+    assert_eq "failed acceptance keeps request pending" "$pending_status" "pending"
+
+    api_get "/bots/$BOT_QA_UUID/friends"
+    assert_eq "friend list remains queryable after failed acceptance" "$HTTP_STATUS" "200"
+    if [[ "$RESPONSE" == *"$BOT_CS_UUID"* ]]; then
+        fail "failed acceptance must not expose a friendship"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    else
+        pass "failed acceptance does not expose a friendship"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    fi
+    TESTS_TOTAL=$((TESTS_TOTAL + 1))
+
+    if ! _friendship_ignore_fixture disarm "$db_path" "$BOT_QA_UUID" "$BOT_CS_UUID"; then
+        fail "disarm ignored-insert friendship fixture"
+        TESTS_FAILED=$((TESTS_FAILED + 1)); TESTS_TOTAL=$((TESTS_TOTAL + 1))
+    fi
+
+    api_post "/friends/requests/$request_id/accept" '{}'
+    assert_eq "friend request can be retried after persistence recovers" "$HTTP_STATUS" "200"
+    api_get "/bots/$BOT_QA_UUID/friends"
+    assert_eq "friend list is queryable after retry" "$HTTP_STATUS" "200"
+    assert_contains "successful retry establishes the friendship" "$RESPONSE" "$BOT_CS_UUID"
+
+    if ! _friendship_ignore_fixture reset "$db_path" "$BOT_QA_UUID" "$BOT_CS_UUID"; then
+        fail "clean ignored-insert friendship fixture"
+        TESTS_FAILED=$((TESTS_FAILED + 1)); TESTS_TOTAL=$((TESTS_TOTAL + 1))
+    fi
+    api_put "/bots/$BOT_CS_UUID/visibility" '{"visibility":"public"}'
 }
 
 # List friends: verify known friendship exists.

--- a/src/bcs/scripts/e2e-test/stories.sh
+++ b/src/bcs/scripts/e2e-test/stories.sh
@@ -309,19 +309,22 @@ _story_register_and_onboard_owned_agent() {
 #
 # Flow:
 #   Befriend a public agent -> request access to a protected agent -> accept it
-#   -> submit another protected request -> reject it -> inspect friends via API
-#   and CLI.
+#   -> submit another protected request -> reject it -> observe and retry a
+#   persistence failure -> inspect friends via API and CLI.
 #
 # Critical assertions:
 #   - Public friendship becomes visible without a pending approval step.
 #   - Protected requests expose a concrete pending request that can be accepted.
 #   - A rejected request never creates a friendship.
+#   - A failed friendship write is visible, remains retryable, and never exposes
+#     a relationship before persistence recovers.
 #   - API and CLI friend lists contain the expected agents after each decision.
 story_user_builds_trusted_team() {
     info "Story: agents establish, accept, reject, and inspect trust relationships"
     test_friend_auto_accept_public
     test_friend_request_accept_protected
     test_friend_request_reject_protected
+    test_friendship_insert_ignore_failure_is_visible_and_retryable
     test_list_friends
     test_friend_flow_via_cli
 }

--- a/src/bcs/scripts/e2e_coverage.sh
+++ b/src/bcs/scripts/e2e_coverage.sh
@@ -76,6 +76,18 @@ while [[ "$#" -gt 0 ]]; do
   esac
 done
 
+# The ignored-friendship-write user story uses a scoped SQLite trigger to
+# exercise the persistence failure through the real HTTP API. Expose the DB
+# path only for the controlled local stack; --skip-start callers without an
+# explicit standalone runtime remain black-box and skip the fault fixture.
+if [[ -z "${BCS_E2E_SQLITE_DB_PATH:-}" ]]; then
+  if [[ -n "${STANDALONE_RUNTIME_DIR:-}" ]]; then
+    export BCS_E2E_SQLITE_DB_PATH="${STANDALONE_RUNTIME_DIR}/bcs_data/bcs.db"
+  elif [[ "$skip_start" -eq 0 ]]; then
+    export BCS_E2E_SQLITE_DB_PATH="$repo_root/scripts/.dependencies/standalone/bcs_data/bcs.db"
+  fi
+fi
+
 # With --force-rebuild, rebuild the instrumented bcs even when a cached binary
 # exists. The pre-push gate uses this so an up-to-date binary reflecting the
 # pushed source is exercised; cargo build is incremental so a no-op rebuild


### PR DESCRIPTION
## Problem

`INSERT IGNORE` can return zero affected rows when a legacy unique key conflicts with a friendship from another environment. BCS previously treated this as success, potentially marking the friend request as accepted without creating the friendship in the current environment.

## Solution

- Verify that a current-environment friendship exists when an insert affects zero rows.
- Return a user-readable error and emit a contextual error log when no matching row exists.
- Persist the friendship before marking the request as accepted, keeping failed requests pending and retryable.
- Add store, service, and E2E regression coverage for the failure and recovery flow.

## Validation

- `cargo test -p bcs-friend-store -p bcs-friend` — 24 passed after rebasing onto the latest `origin/dev`
- Friendship HTTP integration test — passed
- New ignored-insert E2E case — 10 assertions passed
- Full trusted-team user story — 29 assertions passed
- Shell syntax checks and `git diff --check` — passed
- Repository pre-push gate — passed in its default lint-only mode

## Compatibility and risk

- Existing same-environment duplicate requests remain idempotent.
- No API contract or database schema changes are included.
- The E2E fault is injected only into the local SQLite database; MySQL/OceanBase-specific behavior is not integration-tested in this change.