### PR TITLE
ci(github): require pull request title scope

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,8 @@
 <!--
-Title format: <type>: <concise outcome> or <type>(<scope>): <concise outcome>
+Title format: <type>(<scope>): <concise outcome>
   e.g. feat(backend): add whitelist observed state
 Types: feat | fix | refactor | docs | test | ci | build | chore
-Scope is optional; include it when one module or area clearly owns the change.
+Scope is required and should identify the module or area the change touches.
 The title becomes the commit message on squash merge, so make it self-contained.
 See "Pull Request Conventions" in AGENTS.md.
 Delete the optional sections that do not apply.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,10 +101,9 @@ merged. Both must carry meaning on their own.
 
 ### Title
 
-Use `<type>: <concise outcome>` or `<type>(<scope>): <concise outcome>`:
+Use `<type>(<scope>): <concise outcome>`:
 
 ```text
-feat: add whitelist observed state
 feat(backend): add whitelist observed state
 fix(bcs): reject routing updates for unknown bot ids
 docs(arch): document plugin protocol conformance shape
@@ -121,10 +120,9 @@ docs(arch): document plugin protocol conformance shape
 | `build` | Build system or dependencies |
 | `chore` | Other maintenance |
 
-The optional scope is the module or area you touched, such as `backend`,
-`baas`, `engine`, `bcs`, `frontend`, `gateway`, `arch`, or `ci`. Include it
-when one module or area clearly owns the change. The outcome describes what the
-change accomplishes, not which files moved.
+The required scope is the module or area you touched, such as `backend`,
+`baas`, `engine`, `bcs`, `frontend`, `gateway`, `arch`, or `ci`. The outcome
+describes what the change accomplishes, not which files moved.
 
 Do not use vague or context-free titles such as `fix bug`, `update code`,
 `sync`, a bare branch name, or an issue number with no summary.

--- a/docs/arch/ci.enforce.md
+++ b/docs/arch/ci.enforce.md
@@ -142,9 +142,9 @@ Conformance tests are mandatory for boundary contracts.
 PRs affecting boundaries must include completed structural analysis.
 
 ### Required PR fields
-- title matching `<type>: <concise outcome>` or
-  `<type>(<scope>): <concise outcome>` with an allowed type from `feat`, `fix`,
-  `refactor`, `docs`, `test`, `ci`, `build`, or `chore`; scope is optional
+- title matching `<type>(<scope>): <concise outcome>` with an allowed type from
+  `feat`, `fix`, `refactor`, `docs`, `test`, `ci`, `build`, or `chore`; scope is
+  required
 - whether a contract changed
 - if changed, what kind of contract
 - affected consumers

--- a/scripts/ci/check_pr_title.py
+++ b/scripts/ci/check_pr_title.py
@@ -16,10 +16,10 @@ ALLOWED_TYPES = (
     "build",
     "chore",
 )
-OPTIONAL_SCOPE = r"(?:\([^()\s](?:[^()\r\n]*[^()\s])?\))?"
+REQUIRED_SCOPE = r"\([^()\s](?:[^()\r\n]*[^()\s])?\)"
 TITLE_PATTERN = re.compile(
     rf"(?:{'|'.join(ALLOWED_TYPES)})"
-    rf"{OPTIONAL_SCOPE}: "
+    rf"{REQUIRED_SCOPE}: "
     r"\S(?:.*\S)?"
 )
 
@@ -48,12 +48,10 @@ def main() -> int:
 
     allowed_types = " | ".join(ALLOWED_TYPES)
     print(f"ERROR: invalid PR title: {args.title}")
-    print("Expected: <type>: <concise outcome>")
-    print("      or: <type>(<scope>): <concise outcome>")
+    print("Expected: <type>(<scope>): <concise outcome>")
     print(f"Allowed types: {allowed_types}")
-    print("Scope is optional. When present, it must be non-empty and enclosed in ().")
+    print("Scope is required. It must be non-empty and enclosed in ().")
     print("Examples:")
-    print("  feat: add whitelist observed state")
     print("  feat(backend): add whitelist observed state")
     print("  fix(bcs): reject routing updates for unknown bot ids")
     print("  docs(arch): document plugin protocol conformance shape")

--- a/scripts/ci/tests/test_check_pr_title.py
+++ b/scripts/ci/tests/test_check_pr_title.py
@@ -16,8 +16,6 @@ CHECKER = REPO_ROOT / "scripts/ci/check_pr_title.py"
 class PullRequestTitleTest(unittest.TestCase):
     def test_accepts_repository_title_convention(self) -> None:
         valid_titles = (
-            "feat: add whitelist observed state",
-            "fix: 修复沙箱环境变量配置丢失问题",
             "feat(backend): add whitelist observed state",
             "fix(aliyun_ack): 修复沙箱环境变量配置丢失问题",
             "docs(bot-config-manifest): add Chinese user manual",
@@ -35,6 +33,8 @@ class PullRequestTitleTest(unittest.TestCase):
     def test_rejects_non_conforming_titles(self) -> None:
         invalid_titles = (
             "Dev haoqian 20260903",
+            "feat: add whitelist observed state",
+            "fix: 修复沙箱环境变量配置丢失问题",
             "fix openapi iam-token aliyun model",
             "perf(bcs): unsupported type",
             "Feat(bcs): uppercase type",
@@ -61,8 +61,10 @@ class PullRequestTitleTest(unittest.TestCase):
         )
 
         self.assertEqual(result.returncode, 1)
-        self.assertIn("Expected: <type>: <concise outcome>", result.stdout)
-        self.assertIn("or: <type>(<scope>): <concise outcome>", result.stdout)
+        self.assertIn(
+            "Expected: <type>(<scope>): <concise outcome>", result.stdout
+        )
+        self.assertIn("Scope is required.", result.stdout)
         self.assertIn(
             "feat | fix | refactor | docs | test | ci | build | chore",
             result.stdout,


### PR DESCRIPTION
## Problem

PR 标题校验目前允许省略 scope，与仓库约定的 `<type>(<scope>): <concise outcome>` 格式不一致，无法确保标题明确标识变更所属模块或领域。

## Solution

- 将 PR 标题中的 scope 改为必填。
- 保持 scope 内容规则相对宽松，仅要求非空且括号完整。
- 同步更新 PR 模板、贡献规范和 CI enforcement 文档。
- 更新单元测试，覆盖缺少 scope 时校验失败的场景。

## Validation

- `python3 -m unittest scripts.ci.tests.test_check_pr_title`：通过，4/4。
- 验证带 scope 的标题可以通过校验。
- 验证不带 scope 的标题会被拒绝。
- `git diff --check`：通过。

## Compatibility and risk

此前可以通过校验的无 scope PR 标题将不再合法，需要修改为 `<type>(<scope>): <concise outcome>` 格式。

本次修改仅影响 PR 标题 CI 校验，不涉及运行时逻辑、接口或数据结构。