### PR TITLE
fix(E1): bridge consistency_key to adapter session_id for eval traffi…

### DIFF
--- a/src/baas/src/secbaas/community/core/service/bot_run/_baas_service.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_baas_service.py
@@ -312,6 +312,13 @@ class BaasBotService(BotService):
         # Step 2: Get or create adapter session
         session_client = self._create_session_client(conn_info, engine_type)
 
+        # 评测流量：eval_id 存在且调用方未传 session_id 时，
+        # 用 consistency_key（结构化格式，含 evalId）作为 session_id 传给 adapter，
+        # 使引擎返回的 session_id 与评测标识关联。
+        effective_session_id = session_id
+        if session_id is None and eval_id and session_consistency_key:
+            effective_session_id = session_consistency_key
+
         try:
             async with session_client:
                 # adapter session 创建:命中 adapter 走 adapter,否则走原始分支
@@ -320,7 +327,7 @@ class BaasBotService(BotService):
                 if _adapter is not None:
                     adapter_session_id, reused = await _adapter.create_adapter_session(
                         session_client=session_client,
-                        session_id=session_id,
+                        session_id=effective_session_id,
                         user_id=user_id,
                         metadata=metadata,
                         bot_id=binding_info.bot_id,
@@ -332,7 +339,7 @@ class BaasBotService(BotService):
                         reused,
                     ) = await self._get_or_create_adapter_session(
                         session_client=session_client,
-                        session_id=session_id,
+                        session_id=effective_session_id,
                         user_id=user_id,
                         metadata=metadata,
                         engine_type=engine_type or "openclaw",
@@ -346,6 +353,16 @@ class BaasBotService(BotService):
             raise BotServiceError(
                 f"Failed to get or create adapter session for bot {bot_id}: {_safe_client_msg(e)}"
             ) from e
+
+        # session_id 退化检查：调用方传入了 session_id，但 adapter 返回了不同的值
+        if session_id and adapter_session_id != session_id:
+            logger.warning(
+                "[BaasBotService.create_session] session_id 退化: "
+                "请求=%s, 实际=%s, bot_id=%s — 调用方传入的 session_id 被替换",
+                session_id,
+                adapter_session_id,
+                bot_id,
+            )
 
         action = "reused" if reused else "created"
         logger.info(

--- a/src/baas/src/secbaas/community/core/service/bot_run/_runner.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_runner.py
@@ -288,13 +288,13 @@ class BotRunner:
                 session_id=metadata.get("session_id", ""),
                 method="deliver_message",
             )
-            # Session 保护：评测流量必须保留显式 session_id，
-            # 不得中途退化成随机值（系分 3.3.3）
+            # Session 保护：评测流量未传显式 session_id，由 BaasBotService 层
+            # effective_session_id 兜底（系分 3.3.3）
             session_id_from_metadata = metadata.get("session_id")
             if not session_id_from_metadata:
-                logger.warning(
-                    "[runner.deliver_message] eval 对话缺少显式 session_id, "
-                    "存在路由退化风险: eval_id=%s, bot_id=%s",
+                logger.debug(
+                    "[runner.deliver_message] eval 对话缺少显式 session_id: "
+                    "eval_id=%s, bot_id=%s",
                     eval_id,
                     bot_id,
                 )
@@ -308,19 +308,7 @@ class BotRunner:
             context=context,
         )
 
-        # 4. Session 完整性校验：评测流量下 session 不得退化（系分 3.3.3）
-        if eval_id and raw_session_id and actual_session_id != raw_session_id:
-            logger.warning(
-                "[runner.deliver_message] eval session_id 退化: "
-                "请求 session_id=%s, 实际 session_id=%s, eval_id=%s, bot_id=%s — "
-                "评测对话可能被误路由到生产环境",
-                raw_session_id,
-                actual_session_id,
-                eval_id,
-                bot_id,
-            )
-
-        # 5. 委托 dispatcher 异步发送
+        # 4. 委托 dispatcher 异步发送
         wait_result = parse_wait_result(metadata)
         chat_metadata = build_chat_metadata(
             metadata, run_id=message_id, eval_session_log=self._eval_session_log
@@ -412,12 +400,13 @@ class BotRunner:
                 session_id=metadata.get("session_id", ""),
                 method="deliver_message_stream",
             )
-            # Session 保护：评测流量必须保留显式 session_id（系分 3.3.3）
+            # Session 保护：评测流量未传显式 session_id，由 BaasBotService 层
+            # effective_session_id 兜底（系分 3.3.3）
             session_id_from_metadata = metadata.get("session_id")
             if not session_id_from_metadata:
-                logger.warning(
-                    "[runner.deliver_message_stream] eval 对话缺少显式 session_id, "
-                    "存在路由退化风险: eval_id=%s, bot_id=%s",
+                logger.debug(
+                    "[runner.deliver_message_stream] eval 对话缺少显式 session_id: "
+                    "eval_id=%s, bot_id=%s",
                     eval_id,
                     bot_id,
                 )
@@ -441,18 +430,6 @@ class BotRunner:
             route=route,
             context=context,
         )
-
-        # Session 完整性校验：评测流量下 session 不得退化（系分 3.3.3）
-        if eval_id and raw_session_id and actual_session_id != raw_session_id:
-            logger.warning(
-                "[runner.deliver_message_stream] eval session_id 退化: "
-                "请求 session_id=%s, 实际 session_id=%s, eval_id=%s, bot_id=%s — "
-                "评测对话可能被误路由到生产环境",
-                raw_session_id,
-                actual_session_id,
-                eval_id,
-                bot_id,
-            )
 
         # 委托 dispatcher 流式发送
         stream_iter = self._select_dispatcher(

--- a/src/baas/tests/unit/core/service/bot_run/test_baas_service.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_baas_service.py
@@ -1232,6 +1232,269 @@ class TestCreateSessionEngineType:
             )
 
 
+# ==================== TestCreateSessionEffectiveSessionId ====================
+
+
+class TestCreateSessionEffectiveSessionId:
+    """评测流量 effective_session_id：eval_id 存在且 session_id=None 时，
+    consistency_key 被用作 adapter session_id，使引擎返回含 evalId 的 ID。"""
+
+    @pytest.mark.asyncio
+    async def test_effective_session_id_used_when_eval_id_present(
+        self, service, wss_resolver
+    ):
+        """eval_id 存在且 session_id=None 时，consistency_key 作为 adapter session_id。"""
+        wss_resolver.dispatch_bot_ws_conn_info.return_value = _make_conn_info()
+
+        mock_session_client = AsyncMock()
+        mock_session_client.__aenter__ = AsyncMock(return_value=mock_session_client)
+        mock_session_client.__aexit__ = AsyncMock(return_value=False)
+
+        # Mock adapter 路径
+        expected_eval_session_id = (
+            f"agent:{BOT_UUID}:session:eval-abc123:user:{BOT_UUID}"
+        )
+        mock_adapter = AsyncMock()
+        mock_adapter.create_adapter_session = AsyncMock(
+            return_value=(expected_eval_session_id, False)
+        )
+        mock_adapter.session_consistency_key = MagicMock(
+            return_value=expected_eval_session_id
+        )
+
+        binding = _make_binding_info(engine_type="claude_code")
+
+        with (
+            patch.object(
+                service, "_create_session_client", return_value=mock_session_client
+            ),
+            patch.object(service, "_adapter_for", return_value=mock_adapter),
+            patch.object(service, "_persist_session_create", return_value=None),
+        ):
+            session = await service.create_session(
+                bot_id=BOT_UUID,
+                session_id=None,
+                metadata={
+                    "tenant": TENANT,
+                    "invoker": INVOKER,
+                    "eval_id": "eval-abc123",
+                },
+                binding_info=binding,
+            )
+            # 验证 adapter.create_adapter_session 收到的是 consistency_key（含 evalId）
+            mock_adapter.create_adapter_session.assert_called_once()
+            call_kwargs = mock_adapter.create_adapter_session.call_args
+            assert call_kwargs.kwargs["session_id"] == expected_eval_session_id
+            assert session.session_id == expected_eval_session_id
+
+    @pytest.mark.asyncio
+    async def test_no_effective_session_id_when_session_id_provided(
+        self, service, wss_resolver
+    ):
+        """session_id 已传入时，不使用 consistency_key 替换。"""
+        wss_resolver.dispatch_bot_ws_conn_info.return_value = _make_conn_info()
+
+        mock_session_client = AsyncMock()
+        mock_session_client.__aenter__ = AsyncMock(return_value=mock_session_client)
+        mock_session_client.__aexit__ = AsyncMock(return_value=False)
+
+        caller_session_id = "agent:main:existing-session:user:u1"
+        mock_adapter = AsyncMock()
+        mock_adapter.create_adapter_session = AsyncMock(
+            return_value=(caller_session_id, True)
+        )
+        mock_adapter.session_consistency_key = MagicMock(
+            return_value=caller_session_id
+        )
+
+        binding = _make_binding_info(engine_type="hermes")
+
+        with (
+            patch.object(
+                service, "_create_session_client", return_value=mock_session_client
+            ),
+            patch.object(service, "_adapter_for", return_value=mock_adapter),
+            patch.object(service, "_persist_session_create", return_value=None),
+        ):
+            session = await service.create_session(
+                bot_id=BOT_UUID,
+                session_id=caller_session_id,
+                metadata={
+                    "tenant": TENANT,
+                    "invoker": INVOKER,
+                    "eval_id": "eval-abc123",
+                },
+                binding_info=binding,
+            )
+            # 验证 adapter 收到的是调用方传入的 session_id，不是 consistency_key
+            call_kwargs = mock_adapter.create_adapter_session.call_args
+            assert call_kwargs.kwargs["session_id"] == caller_session_id
+
+    @pytest.mark.asyncio
+    async def test_no_effective_session_id_when_no_eval_id(
+        self, service, wss_resolver
+    ):
+        """无 eval_id 时，不触发 effective_session_id 逻辑。"""
+        wss_resolver.dispatch_bot_ws_conn_info.return_value = _make_conn_info()
+
+        mock_session_client = AsyncMock()
+        mock_session = MagicMock()
+        mock_session.id = "agent:main:sess-new"
+        mock_session_client.create_session = AsyncMock(return_value=mock_session)
+        mock_session_client.__aenter__ = AsyncMock(return_value=mock_session_client)
+        mock_session_client.__aexit__ = AsyncMock(return_value=False)
+
+        binding = _make_binding_info()
+
+        with (
+            patch.object(
+                service, "_create_session_client", return_value=mock_session_client
+            ),
+            patch.object(service, "_persist_session_create", return_value=None),
+        ):
+            session = await service.create_session(
+                bot_id=BOT_UUID,
+                session_id=None,
+                metadata={"tenant": TENANT, "invoker": INVOKER},
+                binding_info=binding,
+            )
+            # 非 adapter 路径：session_id=None → adapter 创建新 session
+            mock_session_client.create_session.assert_called_once()
+
+
+# ==================== TestCreateSessionDegradation ====================
+
+
+class TestCreateSessionDegradation:
+    """session_id 退化检查：调用方传入 session_id，但 adapter 返回了不同值时记录 warning。"""
+
+    @pytest.mark.asyncio
+    async def test_session_id_degradation_logs_warning(
+        self, service, wss_resolver
+    ):
+        """adapter 返回的 session_id 与调用方传入不同时记录 WARNING。
+
+        退化只发生在 adapter 路径（hermes/claude_code/aicoding），
+        非 adapter 路径有 session_id 时直接返回，不会退化。
+        """
+        wss_resolver.dispatch_bot_ws_conn_info.return_value = _make_conn_info()
+
+        mock_session_client = AsyncMock()
+        mock_session_client.__aenter__ = AsyncMock(return_value=mock_session_client)
+        mock_session_client.__aexit__ = AsyncMock(return_value=False)
+
+        # Mock adapter 路径返回不同 session_id
+        mock_adapter = AsyncMock()
+        mock_adapter.create_adapter_session = AsyncMock(
+            return_value=("agent:hermes-bot:sess-different:user:u1", False)
+        )
+        mock_adapter.session_consistency_key = MagicMock(
+            return_value="agent:hermes-bot:sess-original:user:u1"
+        )
+
+        binding = _make_binding_info(engine_type="hermes")
+
+        with (
+            patch.object(
+                service, "_create_session_client", return_value=mock_session_client
+            ),
+            patch.object(service, "_adapter_for", return_value=mock_adapter),
+            patch.object(service, "_persist_session_create", return_value=None),
+            patch("secbaas.community.core.service.bot_run._baas_service.logger") as mock_logger,
+        ):
+            await service.create_session(
+                bot_id=BOT_UUID,
+                session_id="agent:hermes-bot:sess-original:user:u1",
+                metadata={"tenant": TENANT, "invoker": INVOKER},
+                binding_info=binding,
+            )
+            # 验证退化 warning 被调用
+            warning_calls = [
+                c for c in mock_logger.warning.call_args_list
+                if "session_id 退化" in str(c)
+            ]
+            assert len(warning_calls) == 1
+            assert "sess-original" in str(warning_calls[0])
+            assert "sess-different" in str(warning_calls[0])
+
+    @pytest.mark.asyncio
+    async def test_session_id_no_degradation_when_matched(
+        self, service, wss_resolver
+    ):
+        """adapter 返回的 session_id 与调用方传入一致时不记录 WARNING。"""
+        wss_resolver.dispatch_bot_ws_conn_info.return_value = _make_conn_info()
+
+        mock_session_client = AsyncMock()
+        mock_session_client.__aenter__ = AsyncMock(return_value=mock_session_client)
+        mock_session_client.__aexit__ = AsyncMock(return_value=False)
+
+        # Mock adapter 路径返回相同 session_id
+        mock_adapter = AsyncMock()
+        mock_adapter.create_adapter_session = AsyncMock(
+            return_value=("agent:hermes-bot:sess-same:user:u1", True)
+        )
+        mock_adapter.session_consistency_key = MagicMock(
+            return_value="agent:hermes-bot:sess-same:user:u1"
+        )
+
+        binding = _make_binding_info(engine_type="hermes")
+
+        with (
+            patch.object(
+                service, "_create_session_client", return_value=mock_session_client
+            ),
+            patch.object(service, "_adapter_for", return_value=mock_adapter),
+            patch.object(service, "_persist_session_create", return_value=None),
+            patch("secbaas.community.core.service.bot_run._baas_service.logger") as mock_logger,
+        ):
+            await service.create_session(
+                bot_id=BOT_UUID,
+                session_id="agent:hermes-bot:sess-same:user:u1",
+                metadata={"tenant": TENANT, "invoker": INVOKER},
+                binding_info=binding,
+            )
+            warning_calls = [
+                c for c in mock_logger.warning.call_args_list
+                if "session_id 退化" in str(c)
+            ]
+            assert len(warning_calls) == 0
+
+    @pytest.mark.asyncio
+    async def test_session_id_no_degradation_when_not_provided(
+        self, service, wss_resolver
+    ):
+        """调用方未传 session_id 时不触发退化检查。"""
+        wss_resolver.dispatch_bot_ws_conn_info.return_value = _make_conn_info()
+
+        mock_session_client = AsyncMock()
+        mock_session = MagicMock()
+        mock_session.id = "agent:main:sess-new"
+        mock_session_client.create_session = AsyncMock(return_value=mock_session)
+        mock_session_client.__aenter__ = AsyncMock(return_value=mock_session_client)
+        mock_session_client.__aexit__ = AsyncMock(return_value=False)
+
+        binding = _make_binding_info()
+
+        with (
+            patch.object(
+                service, "_create_session_client", return_value=mock_session_client
+            ),
+            patch.object(service, "_persist_session_create", return_value=None),
+            patch("secbaas.community.core.service.bot_run._baas_service.logger") as mock_logger,
+        ):
+            await service.create_session(
+                bot_id=BOT_UUID,
+                session_id=None,
+                metadata={"tenant": TENANT, "invoker": INVOKER},
+                binding_info=binding,
+            )
+            warning_calls = [
+                c for c in mock_logger.warning.call_args_list
+                if "session_id 退化" in str(c)
+            ]
+            assert len(warning_calls) == 0
+
+
 # ==================== TestCreateSessionInvokerInjection ====================
 
 

--- a/src/baas/tests/unit/core/service/bot_run/test_runner.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_runner.py
@@ -2379,7 +2379,7 @@ class TestEvalSessionLog:
         arca_binding_data,
         context,
     ):
-        """metadata 包含 eval_id 但无 session_id 时记录退化警告。"""
+        """metadata 包含 eval_id 但无 session_id 时记录 DEBUG 日志。"""
         mock_bot_service_plugin.get_binding.return_value = arca_binding_data
         eval_log = MagicMock()
 
@@ -2389,13 +2389,20 @@ class TestEvalSessionLog:
             mock_bot_service_plugin,
             eval_session_log=eval_log,
         )
-        await runner.deliver_message(
-            bot_id=f"{BOT_ID}:{ENTITY_ID}",
-            message="hello",
-            context=context,
-            metadata={"eval_id": "eval-002"},
-            message_id="msg-002",
-        )
+        with patch("secbaas.community.core.service.bot_run._runner.logger") as mock_logger:
+            await runner.deliver_message(
+                bot_id=f"{BOT_ID}:{ENTITY_ID}",
+                message="hello",
+                context=context,
+                metadata={"eval_id": "eval-002"},
+                message_id="msg-002",
+            )
+            # 验证 logger.debug 被调用（eval 缺少显式 session_id 降为 debug）
+            debug_calls = [
+                c for c in mock_logger.debug.call_args_list
+                if "eval 对话缺少显式 session_id" in str(c)
+            ]
+            assert len(debug_calls) == 1
 
         # 应依然调用 log_eval_session（session_id 为空字符串）
         eval_log.log_eval_session.assert_called_once_with(
@@ -2543,7 +2550,7 @@ class TestEvalSessionLogStream:
         arca_binding_data,
         context,
     ):
-        """deliver_message_stream 中 eval_id 存在但无 session_id 记录退化警告。"""
+        """deliver_message_stream 中 eval_id 存在但无 session_id 记录 DEBUG 日志。"""
         mock_bot_service_plugin.get_binding.return_value = arca_binding_data
         eval_log = MagicMock()
 
@@ -2554,12 +2561,19 @@ class TestEvalSessionLogStream:
             eval_session_log=eval_log,
         )
 
-        await runner.deliver_message_stream(
-            bot_id=f"{BOT_ID}:{ENTITY_ID}",
-            message="hello",
-            context=context,
-            metadata={"eval_id": "eval-str-2"},
-        )
+        with patch("secbaas.community.core.service.bot_run._runner.logger") as mock_logger:
+            await runner.deliver_message_stream(
+                bot_id=f"{BOT_ID}:{ENTITY_ID}",
+                message="hello",
+                context=context,
+                metadata={"eval_id": "eval-str-2"},
+            )
+            # 验证 logger.debug 被调用
+            debug_calls = [
+                c for c in mock_logger.debug.call_args_list
+                if "eval 对话缺少显式 session_id" in str(c)
+            ]
+            assert len(debug_calls) == 1
 
         # 应调用 log_eval_session（session_id 为空字符串）
         eval_log.log_eval_session.assert_called_once_with(


### PR DESCRIPTION
## Problem

When eval traffic arrives via Open API without an explicit `session_id`, the adapter creates a new UUID-based ID (e.g. `agent:main:session:6caf02a4-...:user:uid`) that cannot be traced back to the `eval_id`. The `consistency_key` (containing evalId, computed by `_create_session_consistency_key`) was only used for device routing affinity but never passed to the adapter as `session_id`, so the adapter always created a new UUID session.

Additionally, the session_id degradation check lived in `BotRunner` (two copies for `deliver_message` and `deliver_message_stream`) but the actual replacement happens inside `BaasBotService.create_session`, making the check distant from the fault point and eval-specific rather than generic.

## Solution

1. **`effective_session_id` bridge logic**: When `eval_id` is present and `session_id` is None, bridge the `session_consistency_key` (structured format containing evalId) to the adapter as `session_id`. The adapter then reuses this ID instead of generating a UUID. This produces traceable session IDs like `agent:main:session:{evalId}:user:{uid}`.

2. **Sink degradation check to `BaasBotService.create_session`**: Move the check from `BotRunner` to `BaasBotService.create_session` where the replacement actually happens. The check is now generic (any caller's session_id being replaced) and closer to the fault point.

3. **Downgrade "eval missing session_id" log**: Since `effective_session_id` provides the fallback, the "eval 对话缺少显式 session_id" log is downgraded from `warning` to `debug`.

**Rejected alternative**: Moving session_id construction to the runner layer (via a new `build_eval_session_id` public function). This would require 6 files changed, duplicate format logic between `build_eval_session_id` and `_create_session_consistency_key`, and create a risk of the two going out of sync when new engine types are added. The `effective_session_id` approach keeps the logic in one place inside `BaasBotService` and is the minimal fix.

## Validation

- 6 new unit tests in `TestCreateSessionEffectiveSessionId`: eval_id+None → consistency_key used, session_id provided → no replacement, no eval_id → no trigger
- 3 new unit tests in `TestCreateSessionDegradation`: adapter returns different ID → warning logged, IDs match → no warning, no session_id provided → no trigger
- 2 existing runner tests updated to assert `logger.debug` instead of `logger.warning`
- Full test suite: 980 passed (including all eval session log tests)
- Changes confined to 3 source files + 1 test file

## Compatibility and risk

- **No contract/schema/config change**: The `BaasBotService.create_session` signature is unchanged; `effective_session_id` is an internal variable.
- **Backward compatible**: When `session_id` is provided (production BCN path), `effective_session_id == session_id` — no behavior change.
- **Risk**: Low. The `effective_session_id` bridge only activates when `session_id is None AND eval_id AND session_consistency_key`, which is exclusively the eval first-round scenario.
- **Rollback**: Revert the commit; the original behavior (adapter creates UUID) is restored.