### PR TITLE
fix(bcs): allow human owning a session participant bot to mint session invite links

### DIFF
--- a/src/bcs/crates/application/v1/bcs-app-invitation/src/lib.rs
+++ b/src/bcs/crates/application/v1/bcs-app-invitation/src/lib.rs
@@ -328,22 +328,42 @@ impl InvitationService for InvitationFriendshipServiceImpl {
             ));
         }
         // Minting is gated on session membership only: any participant of the
-        // session (any role) may create an invitation for it. Group-level
-        // roles (driver, originator, manager) are intentionally NOT required,
-        // mirroring the relaxed legacy `create_session_invite_token`.
-        if !session
-            .participants
-            .iter()
-            .any(|p| p.bot_uuid == principal.actor_id())
-        {
-            return Err(ApplicationError::forbidden(
-                "Only Session participants may create invitations for this Session",
+        // session (any role) may create an invitation for it. A Human caller
+        // also qualifies through any owned Bot that participates in the
+        // session. Group-level roles (driver, originator, manager) are
+        // intentionally NOT required, mirroring the relaxed legacy
+        // `create_session_invite_token`.
+        let is_member = |actor_id: &str| {
+            session
+                .participants
+                .iter()
+                .any(|p| p.bot_uuid == actor_id)
+        };
+        if is_member(&principal.actor_id()) {
+            return Ok(self.mint_invitation(
+                InvitationTargetType::Session,
+                &command.session_id,
+                command.expires_in_seconds,
             ));
         }
-        Ok(self.mint_invitation(
-            InvitationTargetType::Session,
-            &command.session_id,
-            command.expires_in_seconds,
+        if let Principal::Human(human) = principal {
+            let owned_bots = self
+                .registry
+                .try_list_bots_by_creator(&human.subject.id)
+                .await
+                .map_err(map_service_error)?;
+            if owned_bots.iter().any(|bot| {
+                bot.actor_kind == ActorKind::Bot && is_member(bot.bot_uuid.as_str())
+            }) {
+                return Ok(self.mint_invitation(
+                    InvitationTargetType::Session,
+                    &command.session_id,
+                    command.expires_in_seconds,
+                ));
+            }
+        }
+        Err(ApplicationError::forbidden(
+            "Only Session participants may create invitations for this Session",
         ))
     }
 

--- a/src/bcs/crates/application/v1/bcs-app-invitation/tests/v1_invitation_friendship_service.rs
+++ b/src/bcs/crates/application/v1/bcs-app-invitation/tests/v1_invitation_friendship_service.rs
@@ -565,10 +565,36 @@ async fn create_session_invitation_session_participant_ok() {
 }
 
 #[tokio::test]
+async fn create_session_invitation_human_owner_of_participant_bot_ok() {
+    // A Human caller who is not itself a session participant may still mint
+    // when one of the Human's owned Bots participates in the session.
+    // staff-1 owns bot-a (see `Fixture::bot_owner`), which is the session's
+    // driver participant.
+    let fx = Fixture::new().await;
+    fx.add_bot("bot-a").await;
+    fx.store_legacy_group("grp-1", "bot-a", "human_other")
+        .await;
+    let session_id = fx.create_session("grp-1", "bot-a").await;
+
+    let invitation = fx
+        .service
+        .create_session_invitation(CreateSessionInvitation {
+            caller: Fixture::human_principal("staff-1"),
+            session_id: session_id.clone(),
+            expires_in_seconds: None,
+        })
+        .await
+        .expect("owner of a participant Bot may create session invitation");
+
+    assert_eq!(invitation.target_type, InvitationTargetType::Session);
+    assert_eq!(invitation.target_id, session_id);
+}
+
+#[tokio::test]
 async fn create_session_invitation_non_participant_forbidden() {
-    // The owner of the group's driver Bot (and of the group via
-    // originator-ownership) is still NOT a session participant, and
-    // group-level privilege no longer substitutes for session membership.
+    // A Human caller with no session membership of its own and no owned Bot in
+    // the session is forbidden; group-level privilege does not substitute for
+    // session membership.
     let fx = Fixture::new().await;
     fx.add_bot("bot-a").await;
     fx.store_legacy_group("grp-1", "bot-a", "human_other")
@@ -578,12 +604,12 @@ async fn create_session_invitation_non_participant_forbidden() {
     let error = fx
         .service
         .create_session_invitation(CreateSessionInvitation {
-            caller: Fixture::human_principal("staff-1"),
+            caller: Fixture::human_principal("staff-9"),
             session_id: session_id.clone(),
             expires_in_seconds: None,
         })
         .await
-        .expect_err("non-participant is forbidden even when owning the driver Bot");
+        .expect_err("non-participant without a participant Bot is forbidden");
 
     assert!(
         matches!(error, ApplicationError::Forbidden(_)),

--- a/src/bcs/crates/services/bcs-group/src/application/invite.rs
+++ b/src/bcs/crates/services/bcs-group/src/application/invite.rs
@@ -73,10 +73,11 @@ impl InviteServiceImpl {
     }
 
     /// Session invite tokens are gated on session membership only: any
-    /// participant of the session (any role, bot or human) may mint one.
-    /// Group-level roles (driver, originator, manager) are intentionally NOT
-    /// required here.
-    fn ensure_session_member(
+    /// participant of the session (any role, bot or human) may mint one. A
+    /// Human caller also qualifies through any owned Bot that participates in
+    /// the session. Group-level roles (driver, originator, manager) are
+    /// intentionally NOT required here.
+    async fn ensure_session_member(
         &self,
         cmd: &CreateInviteTokenCommand,
         session: &bcs_service_api::Session,
@@ -88,6 +89,12 @@ impl InviteServiceImpl {
         }
         if let Some(staff_no) = cmd.caller_staff_no.as_deref() {
             if is_member(&format!("human_{}", staff_no)) {
+                return Ok(());
+            }
+            let owned = self.registry.list_bots_by_creator(staff_no).await;
+            if owned.iter().any(|bot| {
+                bot.actor_kind == ActorKind::Bot && is_member(bot.bot_uuid.as_str())
+            }) {
                 return Ok(());
             }
         }
@@ -213,7 +220,7 @@ impl InviteService for InviteServiceImpl {
             ));
         }
 
-        self.ensure_session_member(&cmd, &session)?;
+        self.ensure_session_member(&cmd, &session).await?;
         let (token, exp) = self.make_token(&cmd.target_id, cmd.ttl_seconds);
         let join_url = match &self.session_link_url {
             Some(url) => format!("{}/{}", url.trim_end_matches('/'), token),

--- a/src/bcs/crates/services/bcs-group/tests/invite.rs
+++ b/src/bcs/crates/services/bcs-group/tests/invite.rs
@@ -18,7 +18,8 @@ use bcs_service_api::application::invite::{
 use bcs_service_api::application::session::{CreateOrReactivateCommand, SessionManagementService};
 use bcs_service_api::port::repo::{GroupRepoPort, NewSessionParams, SessionRepoPort};
 use bcs_service_api::{
-    Group, GroupCoreService, GroupStrategy, Participant, ParticipantRole, SessionKind,
+    BotCapabilities, BotRegistryCoreService, Group, GroupCoreService, GroupStrategy, Participant,
+    ParticipantRole, SessionKind,
 };
 use bcs_session::SessionManagementServiceImpl;
 use bcs_session_store::MemorySessionRepo;
@@ -30,14 +31,15 @@ struct Fixture {
     service: InviteServiceImpl,
     groups: Arc<GroupCore>,
     sessions: Arc<SessionManagementServiceImpl>,
+    bots: Arc<BotCore>,
 }
 
 impl Fixture {
     async fn new() -> Self {
         let group_repo: Arc<dyn GroupRepoPort> = Arc::new(MemoryGroupRepo::new());
         let groups = Arc::new(GroupCore::with_repo(group_repo.clone()));
-        // The session invite path never consults the bot registry; BotCore is
-        // wired in only because the impl struct requires it.
+        // The session invite path consults the bot registry to grant Human
+        // callers whose owned Bot participates in the session.
         let bots = Arc::new(BotCore::memory());
         let session_repo: Arc<dyn SessionRepoPort> = Arc::new(MemorySessionRepo::new());
         let sessions = Arc::new(SessionManagementServiceImpl::new(
@@ -45,7 +47,7 @@ impl Fixture {
             group_repo.clone(),
         ));
         let service = InviteServiceImpl {
-            registry: bots,
+            registry: bots.clone(),
             group: groups.clone(),
             session: sessions.clone(),
             system_message: Arc::new(NoopSystemMessageService),
@@ -59,7 +61,26 @@ impl Fixture {
             service,
             groups,
             sessions,
+            bots,
         }
+    }
+
+    async fn add_owned_bot(&self, bot_uuid: &str, owner_staff_no: &str) {
+        self.bots
+            .register(
+                bot_uuid.to_string(),
+                BotCapabilities {
+                    name: Some(bot_uuid.to_string()),
+                    visibility: "public".into(),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("register bot");
+        self.bots
+            .save_created_by(bot_uuid, owner_staff_no, true)
+            .await
+            .expect("assign test Bot owner");
     }
 
     async fn store_group(&self, group_id: &str, driver: &str) {
@@ -216,6 +237,76 @@ async fn session_invite_token_rejects_non_participant() {
         .create_session_invite_token(fx.cmd(&session_id, Some("bot-b")))
         .await
         .expect_err("non-participant is forbidden");
+
+    assert!(
+        matches!(error, InviteUseCaseError::Forbidden(_)),
+        "expected Forbidden, got {error:?}",
+    );
+}
+
+#[tokio::test]
+async fn session_invite_token_allows_human_owner_of_participant_bot() {
+    // A Human caller who is not itself a session participant may still mint a
+    // session invite token when one of the Human's owned Bots participates in
+    // the session.
+    let fx = Fixture::new().await;
+    fx.add_owned_bot("bot-a", "staff-owner").await;
+    fx.add_owned_bot("bot-b", "staff-9").await;
+    fx.store_group("grp-1", "bot-a").await;
+    let session_id = fx
+        .create_session_with_participants(
+            "grp-1",
+            "bot-a",
+            vec![
+                Participant::bot("bot-a", ParticipantRole::Driver),
+                Participant::bot("bot-b", ParticipantRole::Consultant),
+            ],
+        )
+        .await;
+
+    let cmd = CreateInviteTokenCommand {
+        caller_actor_id: None,
+        caller_staff_no: Some("staff-9".to_string()),
+        target_id: session_id.clone(),
+        ttl_seconds: None,
+    };
+    let result = fx
+        .service
+        .create_session_invite_token(cmd)
+        .await
+        .expect("owner of a participant bot may mint");
+    assert!(result.invite_token.len() > 0);
+    assert!(result.join_url.contains("/sessions/join/"));
+}
+
+#[tokio::test]
+async fn session_invite_token_rejects_human_without_participant_bot() {
+    // A Human caller whose owned Bots are NOT session participants is still
+    // forbidden: ownership alone (without session membership of the owned
+    // Bot) does not grant minting.
+    let fx = Fixture::new().await;
+    fx.add_owned_bot("bot-a", "staff-owner").await;
+    fx.add_owned_bot("bot-c", "staff-9").await;
+    fx.store_group("grp-1", "bot-a").await;
+    let session_id = fx
+        .create_session_with_participants(
+            "grp-1",
+            "bot-a",
+            vec![Participant::bot("bot-a", ParticipantRole::Driver)],
+        )
+        .await;
+
+    let cmd = CreateInviteTokenCommand {
+        caller_actor_id: None,
+        caller_staff_no: Some("staff-9".to_string()),
+        target_id: session_id.clone(),
+        ttl_seconds: None,
+    };
+    let error = fx
+        .service
+        .create_session_invite_token(cmd)
+        .await
+        .expect_err("human without a participant bot is forbidden");
 
     assert!(
         matches!(error, InviteUseCaseError::Forbidden(_)),


### PR DESCRIPTION
## Problem

Session invite-link creation (both `bcs_http` legacy route `create_session_invite_link` and the V1 OpenAPI route `create_session_invitation`) is gated on direct session membership. A Human caller whose own Bot participates in the session is rejected, even though they effectively have a member in the session.

## Solution

Extend the membership check in both code paths to also grant a Human caller when any of their owned Bots (`BotRegistryCoreService::list_bots_by_creator`, filtered to `ActorKind::Bot`) is a session participant:

- `bcs-group`: `InviteServiceImpl::ensure_session_member` becomes async and adds the owned-bot check for `caller_staff_no` callers.
- `bcs-app-invitation`: V1 `create_session_invitation` adds the same check for `Principal::Human`, mirroring the existing owned-bot pattern in `can_manage_group`.

Direct participants (any role, bot or human) keep their existing access; group-level roles still do not substitute for session membership.

## Validation

- New tests: human owner of a participant bot may mint (legacy + V1); human without any participant bot is still forbidden (legacy + V1).
- Existing `non_participant_forbidden` V1 test updated to use a caller owning no bots (its previous caller owned the participant bot, which is now allowed by design).
- `cargo test`: bcs-group (all suites), bcs-app-invitation (34 tests), bcs-api-http invitation_routes (10 tests), bcs-http — all pass.
- `cargo check --workspace --all-targets` clean.

## Compatibility and risk (optional)

Authorization is relaxed only: callers previously rejected (human owners of participant bots) now succeed. No token format or endpoint contract change. Rollback: revert the commit.