### PR TITLE
fix(service-bot): persist default image policy before publish

### DIFF
--- a/src/backend/src/agentclaw/community/core/service_bot/services/bot_publish_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/bot_publish_service.py
@@ -25,6 +25,7 @@ from agentclaw.community.core.service_bot.services.publish_exceptions import (
 )
 from agentclaw.community.core.service_bot.services.publish_rollback_mixin import PublishRollbackMixin
 from agentclaw.community.core.service_bot.services.arca_image_pin import (
+    apply_default_image_to_ext,
     apply_image_pin_to_ext,
     clear_image_policy_from_ext,
     copy_image_policy_to_ext,
@@ -1312,6 +1313,27 @@ class BotPublishService(PublishDraftRestoreMixin, PublishRollbackMixin):
             f"[offline_publish] Publish status updated to released: publish_id={publish_id}"
         )
 
+    def _resolve_upgrade_image_policy_ext(
+        self,
+        bot: Dict[str, Any],
+    ) -> Dict[str, Any] | None:
+        """Resolve the current image policy before personal-to-service conversion.
+
+        Conversion creates a draft immediately, while the service-Bot restart
+        is asynchronous. Persisting the policy together with ``bot_type``
+        prevents ``create_publish`` from observing a service Bot without its
+        policy and incorrectly snapshotting a Pin image.
+
+        Template routing is intentionally not handled here; that is a separate
+        follow-up change.
+        """
+        current_ext = bot.get("ext")
+        if resolve_current_arca_image(
+            self._common_config_service, env=self._env
+        ) is None:
+            return current_ext
+        return apply_default_image_to_ext(current_ext)
+
     def upgrade_bot_to_service(
         self,
         bot_id: str,
@@ -1341,13 +1363,23 @@ class BotPublishService(PublishDraftRestoreMixin, PublishRollbackMixin):
                 f"aicoding type bot cannot be upgraded to service: bot_id={bot_id}"
             )
 
+        # Resolve the policy before side effects. Restart is asynchronous,
+        # whereas create_publish() runs immediately after the Bot update.
+        is_teclaw = self._bot_service.is_teclaw_bot(active_engine)
+        service_ext = (
+            bot.get("ext") if is_teclaw else self._resolve_upgrade_image_policy_ext(bot)
+        )
+
         # 5. 调用 BCN switch_bot 接口切换绑定
         switch_result = self._bcn_service.switch_bot(teamclaw_bot_uuid=bot_id, owner_workno=owner_id, name=bot.get("bot_name") or bot_id, summary=bot.get("bot_desc") or "")
         logger.info(f"[upgrade_bot_to_service] BCN switch_bot succeeded: bot_id={bot_id}, owner_id={owner_id}, websocket_kicked={switch_result.get('websocket_kicked')}, idempotent_replay={switch_result.get('idempotent_replay')}")
 
         # 6. 更新 bot_type 为 "service"
+        update_fields = {"bot_type": "service"}
+        if service_ext != bot.get("ext"):
+            update_fields["ext"] = service_ext
         updated_bot = self._bot_repo.update_by_owner(
-            bot_id, owner_id, {"bot_type": "service"}
+            bot_id, owner_id, update_fields
         )
         if not updated_bot:
             raise BotNotFoundError(f"Failed to update bot: bot_id={bot_id}")
@@ -1358,7 +1390,7 @@ class BotPublishService(PublishDraftRestoreMixin, PublishRollbackMixin):
         #    （producer/composer 不读 bot_type，出站规则也不区分），个人/服务是同一个容器，
         #    因此 teclaw 不需要重启；一旦重启会 destroy 容器 + 重新分配失败，把 bot 打成
         #    无 binding 的坏状态，并丢掉个人阶段的容器内文件（Dima 2026070100117117968）。
-        if self._bot_service.is_teclaw_bot(active_engine):
+        if is_teclaw:
             logger.info(
                 f"[upgrade_bot_to_service] teclaw bot, skip restart (container is "
                 f"bot_type-agnostic, restart would strand it): bot_id={bot_id}"

--- a/src/backend/tests/community/core/service_bot/services/test_bot_publish_service.py
+++ b/src/backend/tests/community/core/service_bot/services/test_bot_publish_service.py
@@ -1098,6 +1098,50 @@ class TestUpgradeBotToService:
             nick_name="Test User",
         )
 
+    def test_upgrade_bot_to_service_persists_default_before_creating_publish(self):
+        """默认镜像策略必须在异步 restart 前写入 Bot，避免新发布单误 Pin。"""
+        publish_repo = Mock()
+        publish_repo.get_by_publish_bot_id.return_value = None
+        publish_repo.get_by_publish_bot_id_and_version.return_value = None
+        publish_repo.insert.return_value = _create_mock_record(
+            record_id=10, status=PublishStatus.DRAFT, ext={"sbot_use_default_image": True}
+        )
+        bot_repo = Mock()
+        bot = {
+            "id": 100, "bot_id": "bot_001", "bot_name": "Test Bot",
+            "bot_type": "personal", "active_engine": "openclaw",
+            "owner_id": "user_001", "owner_name": "Test User",
+            "ext": {"stale": True},
+        }
+        bot_repo.get_by_id_and_owner.return_value = bot
+        bot_repo.update_by_owner.return_value = {
+            **bot, "bot_type": "service",
+            "ext": {"stale": True, "sbot_use_default_image": True},
+        }
+        bot_repo.get_by_id_and_owner.side_effect = [bot, bot_repo.update_by_owner.return_value]
+        bot_service = Mock()
+        bot_service.is_teclaw_bot.return_value = False
+        common_config = Mock()
+        common_config.get_value.return_value = {"image": "arca:v2"}
+        service = _make_service(
+            publish_repo, bot_repo=bot_repo, bot_service=bot_service,
+            common_config_service=common_config,
+        )
+
+        result = service.upgrade_bot_to_service("bot_001", "user_001")
+
+        assert result["publish_record"].id == 10
+        bot_repo.update_by_owner.assert_called_once_with(
+            "bot_001", "user_001",
+            {"bot_type": "service", "ext": {
+                "stale": True, "sbot_use_default_image": True,
+            }},
+        )
+        assert publish_repo.insert.call_args.args[0]["ext"] == {
+            "sbot_use_default_image": True,
+        }
+        bot_service.restart_bot.assert_called_once()
+
     def test_upgrade_bot_to_service_with_existing_publish(self):
         """已有发布记录时，只更新 bot_type，不创建新发布记录，返回已有发布记录，但会异步重启 Bot。"""
         # Arrange


### PR DESCRIPTION
## Problem
个人 Bot 转服务 Bot 时，`restart_bot()` 是异步执行的，而 `create_publish()` 会紧接着创建发布单。

原流程先将 `bot_type` 更新为 `service`，但默认镜像策略尚未同步持久化到 `ac_bots.ext`。在竞态窗口内，`create_publish()` 可能将 Bot 误判为 Legacy ARCA Bot，进而在发布单中错误写入 `sbot_pin_image` 和 `sbot_docker_image`。

## Solution
- 在个人 Bot 转服务 Bot 时，先根据当前环境的默认 ARCA 镜像配置解析镜像策略。
- 将 `bot_type=service` 与 `sbot_use_default_image=true` 一起更新到 `ac_bots`。
- 保持现有 TeClaw 行为：不修改镜像策略、不触发 restart。
- 复用现有 `resolve_current_arca_image()` 和 `apply_default_image_to_ext()`
- `create_publish()` 随后重新读取已更新的 Bot，使用正确的镜像策略生成发布单。

## Validation
- `DEPLOY_PROFILE=test .venv/bin/pytest tests/community/core/service_bot/services/test_bot_publish_service.py tests/community/core/service_bot/services/test_arca_image_pin.py -q`
- Result: `154 passed`
- `git diff --check` passed
- 新增回归测试覆盖：默认镜像策略在异步 restart 前已持久化，并被后续 `create_publish()` 正确读取。

## Compatibility and risk
- 仅影响个人 Bot 转服务 Bot 且当前环境启用了有效默认 ARCA 镜像配置的场景。
- 无有效默认镜像配置时保持原有 `ext`。
- TeClaw 场景保持原有升级和重启行为。
- 现有 `ext` 中的其他业务字段会被保留，不会被默认镜像策略覆盖。
- 历史 Bot 和历史发布单不做主动迁移。
