### PR TITLE
fix(gateway): republish the bots OpenAPI artifact and unbreak its regeneration

### DIFF
--- a/src/gateway/configs/schemas/bots.openapi.json
+++ b/src/gateway/configs/schemas/bots.openapi.json
@@ -19531,6 +19531,18 @@
         "additionalProperties": false,
         "description": "Create-a-session request body.",
         "properties": {
+          "cwd": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional absolute working directory for the session on the bot's device. Left unset, the bot's engine picks its own default. The device holds this to its own configured workspace roots and refuses anything outside them, so a path the bot is not allowed to run in fails the request rather than being silently relocated. A bot whose engine does not model a working directory ignores this and reports `cwd` empty on the created session.",
+            "title": "Cwd"
+          },
           "model": {
             "anyOf": [
               {

--- a/src/gateway/scripts/dump_and_publish.sh
+++ b/src/gateway/scripts/dump_and_publish.sh
@@ -73,11 +73,13 @@ _upstream_dir() {
 
 _upstream_env() {
     case "$1" in
-        # The community overlay requires a deployment-supplied DATABASE_URL (it is
-        # the Aliyun/OceanBase profile, so its url placeholder has no default).
-        # Dumping the schema only imports the app; no connection is opened, so a
-        # placeholder DSN is enough to get past config resolution.
-        backend) echo "DEPLOY_PROFILE=community DATABASE_URL=mysql+pymysql://dump:dump@127.0.0.1:3306/agentclaw" ;;
+        # The community overlay carries four placeholders with no default —
+        # DATABASE_URL (it is the Aliyun/OceanBase profile) and the three BCS_*
+        # values. Config resolution is strict and raises on any one of them being
+        # unset, so all four must be present or the dump dies before it imports
+        # the app. Dumping the schema only imports the app; no connection is
+        # opened and no BCS call is made, so placeholders are enough.
+        backend) echo "DEPLOY_PROFILE=community DATABASE_URL=mysql+pymysql://dump:dump@127.0.0.1:3306/agentclaw BCS_URL=http://127.0.0.1:0 BCS_ADMIN_TOKEN=dump BCS_PROVIDER_ID=dump" ;;
         baas)    echo "SECBAAS_RUN_MODE=bare" ;;
         bcn)     echo "" ;;
         bcn-internal) echo "" ;;
@@ -136,9 +138,16 @@ main() {
     fi
 
     # ── backend ────────────────────────────────────────────────────────────────
-    # bots domain — the harness operations sit under /openapi/v1/bots/{bot_id}/harness
-    # and are part of this dump; there is no separate harness artifact.
-    _dump_upstream backend --path-prefix /openapi/v1/bots
+    # The whole public /openapi/v1 surface, not just /openapi/v1/bots: the backend
+    # publishes ONE artifact and the gateway hands the same file to several
+    # domains, each of which filters it to its own prefix at serve time (see
+    # `upstreams.domains.org` in configs/application.yaml). Narrowing the dump to
+    # /openapi/v1/bots would strip the org and collaboration paths the other
+    # domains serve from this file, and the compat gate rightly refuses that as a
+    # breaking change. The harness operations sit under
+    # /openapi/v1/bots/{bot_id}/harness and are part of this dump; there is no
+    # separate harness artifact.
+    _dump_upstream backend
     if ! $DRY_RUN; then
         _gate_and_publish \
             backend \


### PR DESCRIPTION
## Problem

[#1848](https://github.com/inclusionAI/Avernet/pull/1848) added an optional `cwd` to the public `SessionCreate` body, and deliberately left `src/gateway/configs/schemas/bots.openapi.json` untouched on the grounds that "release CI regenerates it from `scripts/dump_openapi.py`".

It does not. Nothing in `.github/` runs `src/gateway/scripts/dump_and_publish.sh`, and — more to the point — **the script could not have produced this artifact anyway**. So the gateway still serves a create-session body carrying only `title` and `model`, and an integrator reading the gateway's published doc has no way to discover the field the backend now accepts.

The artifact is descriptive, not enforcing (it feeds `build_served_openapi`; the forwarder does not validate bodies against it), so nothing was *rejected* — the field was simply undiscoverable.

## Solution

### 1. Republish the artifact through the documented pipeline

`dump_openapi.py` → `gate_and_publish_openapi.py`, exactly as `configs/schemas/README.md` requires ("Do not edit these files by hand — regenerate them"). The compat gate passes on its own judgement — `compatible` — since a new optional request property is additive.

The resulting diff is **exactly the twelve lines of `cwd`** on `SessionCreate` and nothing else: no incidental drift had accumulated, which also confirms the regenerated surface is otherwise in sync with the backend.

### 2. Fix the two bugs in `dump_and_publish.sh` that made regeneration impossible

These are why the artifact drifted, and why it would have drifted again on the next change:

- **`--path-prefix /openapi/v1/bots` was too narrow.** The backend publishes *one* artifact and the gateway hands the same file to several domains, each filtering it to its own prefix at serve time — `configs/application.yaml` says so outright on the `org` domain: *"Backend publishes one public artifact; domain generation filters it to /openapi/v1/org before serving it through this route."* Narrowing the dump dropped 8 paths (the `/openapi/v1/org/**` and `/openapi/v1/collaboration/**` surfaces) and 37 component schemas. The gate correctly refused that as **45 breaking changes** — I ran it to confirm, and it exits on `Refusing to publish`. Anyone who last tried to regenerate would have hit that wall and stopped, which is the most likely explanation for the drift. The dump now takes the whole public `/openapi/v1` surface, which is what the published artifact has always carried.
- **Three required env placeholders were missing.** The community overlay resolves `${BCS_URL}`, `${BCS_ADMIN_TOKEN}` and `${BCS_PROVIDER_ID}` with no defaults, and `_expand_env_placeholders` is strict, so the dump died with a `KeyError` before it even imported the app. Added next to the `DATABASE_URL` placeholder that was already there, with the comment updated to say all four are needed and why placeholders are safe (the dump only imports the app — no connection is opened and no BCS call is made).

I did not touch `configs/schemas/README.md`, though its surface list omits the `/openapi/v1/collaboration/**` paths the artifact actually carries. That inaccuracy predates this change and is worth a separate look.

## Validation

- **Compat gate:** `gate_and_publish_openapi.py configs/schemas/bots.openapi.json <candidate>` → `published … (compatible)`.
- **Pipeline end-to-end:** `bash scripts/dump_and_publish.sh --dry-run --skip baas --skip bcn --skip bcn-internal` now completes; before the fix it died on `KeyError: BCS_URL`.
- **The committed file is byte-identical to the script's output** (`diff -q` clean) — the artifact is genuinely a build output of the fixed pipeline, not a hand-assembled one.
- **Gateway suite:** `pytest tests` → **1160 passed, 17 skipped, 10 failed**. All 10 failures are in `tests/e2e/**` and are **pre-existing**: I re-ran the full suite on a stashed clean tree and got the identical 10, each failing with `httpx.ConnectError: All connection attempts failed` — they need a live server. `tests/unit/core/forwarding` (the 168 tests that read this artifact, including `test_served_openapi.py`) passes in full.
- **Field reaches the served surface:** `SessionCreate.properties` is now `['cwd', 'model', 'title']`, and `POST /openapi/v1/bots/{bot_id}/sessions` references it via `$ref`, so component pruning keeps it in the bots domain document.

One deviation worth flagging: the sandbox could not reach `mirrors.aliyun.com` (egress policy returns 403), so the venvs were built against `pypi.org` via `UV_DEFAULT_INDEX`. That rewrote both `uv.lock` files as a side effect; **I reverted both**, and this PR touches only the two intended files. The dependency set is otherwise the locked one.

## Compatibility and risk

Additive and optional. The artifact gains one optional request property; the gateway's own backward-compat gate classifies the change as compatible, and no existing caller's request shape changes. The artifact is consumed only to build the served OpenAPI document, so there is no runtime behaviour change on the forwarding path.

The `dump_and_publish.sh` change alters what a **release operator** gets when they run the script: the backend dump is no longer silently narrowed to a subset that the gate would reject. Any existing automation pinning the narrow prefix was already non-functional.

Rollback is the revert of this single commit; no schema, storage, or config migration is involved.

## Related issues

Completes the artifact half of [#1848](https://github.com/inclusionAI/Avernet/pull/1848).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011PVGMpFMAquTivDNY1CAig

---
_Generated by [Claude Code](https://claude.ai/code/session_011PVGMpFMAquTivDNY1CAig)_