### PR TITLE
fix(backend): register legacy Claude Code bots without template type

### DIFF
--- a/src/backend/specs/claude-code-empty-template-bcn-register/001-spec-output.md
+++ b/src/backend/specs/claude-code-empty-template-bcn-register/001-spec-output.md
@@ -1,0 +1,108 @@
+---
+agent: tc-review
+status: approved
+created: 2026-09-04
+task: claude-code-empty-template-bcn-register
+source: user-approved-bounded-design
+---
+
+# Claude Code Empty Template BCN Registration Compatibility
+
+## 1. Requirement
+
+`BotService._should_register_bcn_provider()` currently registers legacy
+`claude_code` bots only when `template_type == "normalCC"` (or when the
+personal-coding condition applies). Historical `claude_code` bot rows may have
+`template_type` stored as `NULL` or an empty string. These two missing-value
+forms must be treated as equivalent to `normalCC` for BCN Provider registration.
+
+## 2. Existing flow and boundaries
+
+### Existing flow
+
+- `create_bot`, `start_bot`, and BaaS restart paths call the centralized
+  `_should_register_bcn_provider()` predicate.
+- A template-factory snapshot with explicitly declared capabilities is the
+  authoritative source and returns before legacy fallback evaluation.
+- Legacy fallback currently recognizes `claude_code + normalCC`, coding-personal
+  templates, `teclaw`, and `openclaw` service bots.
+
+### Allowed changes
+
+- `src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py`
+  - Update only the legacy `claude_code` standard-template predicate.
+  - Update nearby documentation to describe `None`/empty compatibility.
+  - Add a stable non-sensitive diagnostic log when the compatibility fallback
+    for a missing `template_type` is used.
+- BCN-focused tests under
+  `src/backend/tests/community/core/bot_management/services/`.
+- Task reports under
+  `src/backend/specs/claude-code-empty-template-bcn-register/`.
+
+### Forbidden changes
+
+- Do not change declared template-factory capability precedence.
+- Do not make `applicationCoding` or other non-empty template types eligible.
+- Do not change BCN registration RPC payloads, DRM behavior, exception
+  semantics, repository schemas, routers, device allocation, or unrelated code.
+- Do not log tokens, credentials, headers, user content, or serialized objects.
+
+## 3. Coding Spec
+
+1. Add a failing regression test proving `active_engine="claude_code"` with
+   `template_type=None` is eligible.
+2. Add a failing regression test proving the empty string is eligible.
+3. Preserve `normalCC` eligibility and `applicationCoding` ineligibility.
+4. Verify at least the `create_bot` entry path invokes BCN registration for a
+   missing template type when the DRM gate is enabled.
+5. Implement the minimum centralized predicate change. Whitespace-only values
+   are not considered empty and remain ineligible.
+6. Emit one stable diagnostic event for the compatibility branch, containing
+   only engine/template classification fields and no bot/user/token data.
+
+## 4. Review Spec
+
+- Confirm the capabilities-first return is unchanged.
+- Confirm only `None`, `""`, and `"normalCC"` are accepted by the standard
+  `claude_code` legacy branch.
+- Confirm personal-coding, `teclaw`, and `openclaw` service behavior is unchanged.
+- Confirm logging contains no sensitive values and is not added to unrelated
+  paths.
+- Confirm no unused imports/variables and `git diff --check` passes.
+
+## 5. QA / Regression Spec
+
+Run from `src/backend`:
+
+```bash
+uv run pytest -q \
+  tests/community/core/bot_management/services/test_bot_service_create_bcn_register.py \
+  tests/community/core/bot_management/services/test_bot_service_stop_start.py \
+  tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py \
+  -k 'bcn or BCN'
+uv run ruff check \
+  src/agentclaw/community/core/bot_management/services/bot_service.py \
+  tests/community/core/bot_management/services/test_bot_service_create_bcn_register.py
+git diff --check
+```
+
+Acceptance criteria:
+
+- All selected tests pass.
+- New tests fail against the pre-change production predicate and pass after the
+  implementation.
+- `None` and `""` are equivalent to `normalCC` only in the specified legacy
+  fallback.
+- `applicationCoding` remains rejected.
+
+## 6. Ship / PR Spec
+
+- Source repository: `inclusionAI/Avernet` on GitHub.
+- Base branch: latest remote `dev`.
+- Topic branch: `fix/claude-code-empty-template-bcn-register`.
+- Rebase the topic commit(s) onto the latest GitHub `dev` immediately before
+  push.
+- Push with `--no-verify` because this is a feature/fix topic branch.
+- Create an English PR with non-empty Problem, Solution, and Validation sections.
+- Observe reviews and GitHub checks. Fix deterministic code/test/lint failures;
+  report infrastructure or permission failures as pending/blocked.

--- a/src/backend/specs/claude-code-empty-template-bcn-register/002-code-report.md
+++ b/src/backend/specs/claude-code-empty-template-bcn-register/002-code-report.md
@@ -1,0 +1,94 @@
+---
+agent: tc-code
+status: completed
+created: 2026-09-04
+iteration: 1
+source: controller-tdd-after-subagent-timeout
+---
+
+# Coding Report: Claude Code Empty Template BCN Registration
+
+## Worktree
+
+- Path: `/Users/helloworld/Desktop/codes/teamclaw_worktrees/Avernet_worktrees/fix-claude-code-empty-template-bcn-register`
+- Branch: `fix/claude-code-empty-template-bcn-register`
+- GitHub base at creation: `dev@6ecb42630227da0a2030a051659312ac88dea86c`
+
+## Existing chain and boundary
+
+- Existing lifecycle callers (`create_bot`, `start_bot`, and BaaS restart) remain
+  wired to the centralized `_should_register_bcn_provider()` predicate.
+- Declared template-factory capabilities still return before the legacy fallback.
+- No BCN RPC payload, DRM, repository, schema, router, device-allocation, or
+  exception behavior changed.
+
+## Changed files
+
+1. `src/agentclaw/community/core/bot_management/services/bot_service.py`
+   - Added `is_claude_code_standard` accepting only `None`, `""`, and
+     `"normalCC"` for `active_engine="claude_code"`.
+   - Preserved all other eligibility branches.
+   - Added a non-sensitive compatibility diagnostic event.
+2. `tests/community/core/bot_management/services/test_bot_service_create_bcn_register.py`
+   - Replaced the obsolete missing-template rejection assertion with parameterized
+     `None` and empty-string registration coverage.
+   - Asserted the diagnostic event and normalized template-state field.
+3. `tests/community/core/bot_management/services/test_bot_service_stop_start.py`
+   - Updated the obsolete `start_bot` missing-template assertion to require BCN
+     registration.
+
+## TDD evidence
+
+### RED
+
+Command:
+
+```bash
+uv run pytest -q \
+  tests/community/core/bot_management/services/test_bot_service_create_bcn_register.py \
+  -k 'missing_template_type'
+```
+
+Result before production change: `2 failed, 18 deselected`. Both `None` and `""`
+failed because `register_provider_bot` was called zero times.
+
+### GREEN
+
+Same command after the minimum production change: `2 passed, 18 deselected`.
+
+## Regression and quality checks
+
+```bash
+uv run pytest -q \
+  tests/community/core/bot_management/services/test_bot_service_create_bcn_register.py \
+  tests/community/core/bot_management/services/test_bot_service_stop_start.py \
+  tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py \
+  tests/community/core/bot_management/services/test_bot_service_misc.py \
+  -k 'bcn or BCN or should_register_bcn_provider'
+```
+
+Result: `50 passed, 158 deselected`.
+
+```bash
+uv run ruff check --ignore F401 \
+  src/agentclaw/community/core/bot_management/services/bot_service.py \
+  tests/community/core/bot_management/services/test_bot_service_create_bcn_register.py \
+  tests/community/core/bot_management/services/test_bot_service_stop_start.py
+```
+
+Result: PASS. An unmodified GitHub `dev` copy of `bot_service.py` independently
+reproduces one existing `F401` at line 57 for `McpSyncProtocol`; this task does
+not remove unrelated baseline code.
+
+`git diff --check`: PASS.
+
+## Diagnostic logging
+
+- Event: `legacy_claude_code_missing_template_type`
+- Logger context: `bot_service._should_register_bcn_provider`
+- Fields:
+  - `active_engine=claude_code`
+  - `template_type_state=none|empty`
+  - `fallback_template_type=normalCC`
+- Sensitive fields: none. No bot ID, user ID, token, headers, credentials,
+  request payload, or raw template object is recorded.

--- a/src/backend/specs/claude-code-empty-template-bcn-register/003-review-report.md
+++ b/src/backend/specs/claude-code-empty-template-bcn-register/003-review-report.md
@@ -1,0 +1,76 @@
+---
+agent: tc-code-reviewer
+status: completed
+created: 2026-09-04T00:00:00+08:00
+iteration: 1
+---
+
+# 代码评审报告
+
+## 评审范围
+
+- Worktree: `/Users/helloworld/Desktop/codes/teamclaw_worktrees/Avernet_worktrees/fix-claude-code-empty-template-bcn-register`
+- 分支: `fix/claude-code-empty-template-bcn-register`
+- Base: `github/dev@6ecb42630227da0a2030a051659312ac88dea86c`
+- 当前 HEAD: `6ecb42630227da0a2030a051659312ac88dea86c`（本次实现均为未提交改动）
+- 改动文件数: 3 个代码/测试文件；另有任务报告文件
+- 审查对象:
+  - `src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py`
+  - `src/backend/tests/community/core/bot_management/services/test_bot_service_create_bcn_register.py`
+  - `src/backend/tests/community/core/bot_management/services/test_bot_service_stop_start.py`
+
+## 逐条评审意见
+
+### 固定检查维度
+
+| 维度 | 结论 | 说明 |
+|------|------|------|
+| 正确性 | PASS | 改动只在 legacy fallback 中增加 `is_claude_code_standard`，条件为 `active_engine == "claude_code"` 且 `template_type in (None, "", "normalCC")`。因此 `applicationCoding`、其他非空值及仅含空白的值均不匹配。`personalCoding`、`teclaw`、`openclaw` 原分支保持原表达式和顺序。create 测试参数化覆盖 `None`/`""` 并断言真实注册参数；start 测试覆盖缺失模板时的真实注册调用。 |
+| 安全性 | PASS | 新日志仅包含固定事件名、固定 engine、归一化状态 `none/empty` 和固定 fallback 类型；不记录 bot/user/token/header/credential、请求正文或序列化对象。未改变鉴权、RPC payload、异常处理或数据访问边界。 |
+| 性能 | PASS | 新增常量规模 membership 判断和仅在 legacy `claude_code` 缺失模板时产生的一次 INFO 事件；无循环、查询或额外外部调用。 |
+| 代码风格 | PASS | 改动集中于指定 predicate、相邻说明和 BCN 定向测试，无顺手重构或无关格式化。`git diff --check 6ecb426...` 实测通过。 |
+| 测试覆盖 | PASS | 独立执行 Review Spec 指定的三个测试文件并筛选 `bcn or BCN`：`46 passed, 92 deselected, 0 failed`。新增 create 用例覆盖 `None`、空字符串和日志状态；start 用例覆盖缺失模板的注册调用；同一套既有回归继续覆盖 normalCC、applicationCoding、personalCoding、teclaw、openclaw 及 capabilities 行为。局部行为测试通过不替代正式 ACI。 |
+| ACI 覆盖率门禁 | PENDING | 当前实现未提交，HEAD 与 base 相同，无法用 `base..head` 对未提交变更形成正式 ACI change-line 证据；也尚无远端 PR/job。不得将本地测试结果写作 ACI PASS。 |
+| 静态检查 | PASS | 未过滤 `ruff` 仅报告 `bot_service.py:57` 的既有 `McpSyncProtocol` F401；该行存在于给定 dev 基线且不在本次 diff。对改动文件执行 `ruff check --ignore F401` 通过，未发现本次新增的未使用 import/变量或格式问题。 |
+| 外部系统边界日志（如适用） | PASS | 本次未修改 BCN RPC、入参、响应或异常路径，只扩大既有集中 predicate 的一个兼容分类。新增诊断日志为低敏感、稳定字段，并且只位于 legacy `claude_code` 缺失模板分支，不扩散到无关路径。 |
+
+### ACI 覆盖率证据
+
+- Base / Head: `6ecb42630227da0a2030a051659312ac88dea86c` / `WORKTREE UNCOMMITTED`（Git HEAD 仍为 base）
+- 本地定向用例: `46/46 (100%)`, skipped=`0`, failed=`0`; threshold = `100%`
+- 总行覆盖率: `PENDING`（本轮未生成可供正式 ACI 使用的 coverage XML）；threshold `>= 70%`
+- 变更行覆盖率: `PENDING`（未提交变更没有可供 `base..head` 门禁计算的 head）；threshold `>= 90%`
+- 未覆盖变更行: `PENDING`，需在提交形成明确 head 后由 regression/ACI job 计算
+- 远端 ACI job: `PENDING`（PR 尚未创建）
+
+### Review Spec 检查项
+
+| 编号 | 检查项 | 结论 | 说明 |
+|------|--------|------|------|
+| R-01 | capabilities-first return 不变 | PASS | `is_template_factory_config(...) && has_declared_capabilities(...)` 的 early return 仍位于 legacy 判断之前，相关两行未改；新增日志和 predicate 均在 early return 之后，声明 capabilities 的模板不会落入本次兼容分支。 |
+| R-02 | `claude_code` 仅接受 `None`、`""`、`"normalCC"` | PASS | `bot_service.py:3425-3428` 使用精确三值 membership；没有 strip、truthiness 或宽松类型转换，因此 `applicationCoding`、任意其他非空值和 whitespace-only 值不匹配。 |
+| R-03 | personal-coding、teclaw、openclaw service 行为不变 | PASS | `is_coding_personal` 原条件未改；最终 return 中 `teclaw` 和 `openclaw` 条件未改。定向回归套件全部通过。 |
+| R-04 | create 路径正确 | PASS | 新参数化测试以 DRM gate enabled 调用 `create_bot`，对 `None`/`""` 分别断言 `register_provider_bot` 恰好一次及完整稳定业务参数，并断言兼容事件和归一化状态。 |
+| R-05 | start 路径正确 | PASS | 更新后的 start 测试构造 `active_engine="claude_code"`、缺失 template type，启用 DRM 后断言 `register_provider_bot` 恰好一次及正确 bot/owner/name/summary。 |
+| R-06 | applicationCoding/其他非空不匹配 | PASS | 既有 create/start/applicationCoding 回归仍在并通过；生产条件为精确白名单，其他非空值不可能进入 standard branch。 |
+| R-07 | 日志低敏感、稳定、低噪声 | PASS | 事件只在 `claude_code` 且 `template_type` 为 `None`/`""` 时发出；字段集合固定，不包含动态身份、token、header、用户内容或原始对象。normalCC 和所有其他路径不记录该事件。 |
+| R-08 | 无越界改动 | PASS | diff 仅包含允许的一个生产文件、两个 BCN 生命周期测试文件和任务报告；未修改 RPC payload、DRM、异常语义、repository/schema/router/device allocation 等禁止范围。 |
+| R-09 | 静态与 whitespace 检查 | PASS | `git diff --check` 通过；ruff 的唯一未过滤错误是明确的 dev 基线 `McpSyncProtocol` F401，本次 diff 未新增静态告警。 |
+
+### 具体问题列表
+
+无阻塞问题。
+
+## 整体结论
+
+**结论: PASS**
+
+本次未提交实现符合 001 Review Spec：capabilities 优先级保持不变，legacy `claude_code` 标准模板只扩展到 `None` 和空字符串，非空非 `normalCC` 类型不匹配，create/start 行为测试通过，日志低敏感且范围收敛，未发现越界改动或本次新增静态问题。
+
+### 必须修复项
+
+无。
+
+### 改进建议（非阻塞）
+
+1. 提交形成明确 head 后，继续由 `tc-engine-regression` / 远端 ACI 生成并核验 `casePassRate`、`lineCoverage`、`changeLineCoverage` 三项正式门禁证据；当前 ACI 状态仍为 `PENDING`。

--- a/src/backend/specs/claude-code-empty-template-bcn-register/003b-regression-report.md
+++ b/src/backend/specs/claude-code-empty-template-bcn-register/003b-regression-report.md
@@ -1,0 +1,67 @@
+---
+agent: tc-engine-regression
+status: completed
+created: 2026-09-04
+execution: controller-fallback-after-regression-agent-timeout
+---
+
+# Local Regression Report
+
+## Scope
+
+- Worktree: `/Users/helloworld/Desktop/codes/teamclaw_worktrees/Avernet_worktrees/fix-claude-code-empty-template-bcn-register`
+- Base: `github/dev@6ecb42630227da0a2030a051659312ac88dea86c`
+- Changed behavior: legacy `claude_code` BCN eligibility for missing
+  `template_type` values (`None` and `""`).
+
+## Test results
+
+### Focused BCN behavior
+
+```bash
+uv run pytest -q \
+  tests/community/core/bot_management/services/test_bot_service_create_bcn_register.py \
+  tests/community/core/bot_management/services/test_bot_service_stop_start.py \
+  tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py \
+  tests/community/core/bot_management/services/test_bot_service_misc.py \
+  -k 'bcn or BCN or should_register_bcn_provider'
+```
+
+Result: `50 passed, 158 deselected, 0 failed`.
+
+### Complete affected test files
+
+```bash
+uv run pytest -q \
+  tests/community/core/bot_management/services/test_bot_service_create_bcn_register.py \
+  tests/community/core/bot_management/services/test_bot_service_stop_start.py \
+  tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py \
+  tests/community/core/bot_management/services/test_bot_service_misc.py
+```
+
+Result: `208 passed, 0 failed`; 17 existing Pydantic deprecation warnings.
+
+## Static checks
+
+- `git diff --check`: PASS.
+- Ruff on changed files with the unrelated baseline `F401` excluded: PASS.
+- Running Ruff on the exact unmodified `github/dev` `bot_service.py` reproduces
+  `McpSyncProtocol` unused at line 57. This is a pre-existing base issue and no
+  new import or unused variable was introduced by this change.
+
+## Behavior matrix
+
+| active_engine | template_type | expected | evidence |
+|---|---|---:|---|
+| claude_code | normalCC | register | existing create/start tests pass |
+| claude_code | None | register | new create test and updated start test pass |
+| claude_code | empty string | register | new parameterized create test passes |
+| claude_code | applicationCoding | do not register | existing create/start tests pass |
+| claude_code/aicoding | personalCoding | register | existing tests pass |
+| declared capabilities | capability result | authoritative | early-return implementation unchanged and existing tests pass |
+
+## Conclusion
+
+**PASS** — the relevant behavior and complete affected test files pass. Formal
+remote ACI/CI and coverage gates remain pending until the branch is pushed and a
+PR exists.

--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -3422,12 +3422,23 @@ class BotService(BotServiceProtocol):
             active_engine in ("claude_code", "aicoding")
             and template_type == "personalCoding"
         )
+        is_claude_code_standard = (
+            active_engine == "claude_code"
+            and template_type in (None, "", "normalCC")
+        )
+        if is_claude_code_standard and template_type != "normalCC":
+            template_type_state = "none" if template_type is None else "empty"
+            logger.info(
+                "[bot_service._should_register_bcn_provider] "
+                "event=legacy_claude_code_missing_template_type "
+                "active_engine=claude_code "
+                f"template_type_state={template_type_state} "
+                "fallback_template_type=normalCC"
+            )
+
         return (
             is_coding_personal
-            or (
-                active_engine == "claude_code"
-                and template_type == "normalCC"
-            )
+            or is_claude_code_standard
             or active_engine == "teclaw"
             or (active_engine == "openclaw" and bot_type in ("service", "personal"))
         )
@@ -3454,7 +3465,7 @@ class BotService(BotServiceProtocol):
         """Bot 创建/启动时把自己注册到 BCN 为 Provider (下行链路).
 
         当前在以下场景调用 (由 create / start 判定):
-          - active_engine == "claude_code" 且 template_type == "normalCC"
+          - active_engine == "claude_code" 且 template_type 为 "normalCC"、None 或空字符串
           - active_engine == "claude_code" 且 template_type == "personalCoding"
           - active_engine == "aicoding" 且 template_type == "personalCoding"
           - active_engine == "teclaw"

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_create_bcn_register.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_create_bcn_register.py
@@ -1,7 +1,7 @@
 """Unit tests for BCN provider registration during create_bot.
 
 create_bot 在 Bot 落库后、设备分配前，应按与 start_bot 相同的条件注册 BCN Provider:
-- active_engine == "claude_code" 且 template_type == "normalCC"
+- active_engine == "claude_code" 且 template_type 为 "normalCC"、None 或空字符串
 - active_engine == "claude_code" 且 template_type == "personalCoding"
 - active_engine == "aicoding" 且 template_type == "personalCoding"
 - active_engine == "teclaw" (所有 bot_type)
@@ -305,22 +305,45 @@ class TestCreateBotBcnRegister:
             template_type="applicationCoding",
         ) is False
 
-    def test_claude_code_missing_template_type_does_not_trigger_bcn_register(self):
-        """claude_code + 缺失 template_type 创建时不应触发 BCN 注册。"""
+    @pytest.mark.parametrize(
+        ("template_type", "template_type_state"),
+        [(None, "none"), ("", "empty")],
+        ids=["none", "empty"],
+    )
+    def test_claude_code_missing_template_type_triggers_bcn_register(
+        self,
+        template_type: str | None,
+        template_type_state: str,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        """claude_code + 缺失 template_type 与 normalCC 等价。"""
+        caplog.set_level("INFO")
         svc = _make_service()
         _attach_device_service(svc)
+        svc._bcn_service.register_provider_bot.return_value = {
+            "bot_uuid": "u1",
+            "bot_runtime_token": "tok",
+        }
 
         with patch.object(BotService, "_is_claude_code_bcn_register_enabled", return_value=True):
             svc.create_bot(
                 user_id="u1",
                 nick_name="nick",
                 bot_name="cc-no-template",
-                bot_id="cc-none-1",
+                bot_id="cc-missing-template-1",
                 engine_type="claude_code",
                 bot_type="personal",
+                template_type=template_type,
             )
 
-        svc._bcn_service.register_provider_bot.assert_not_called()
+        svc._bcn_service.register_provider_bot.assert_called_once_with(
+            teamclaw_bot_uuid="cc-missing-template-1",
+            owner_workno="u1",
+            name="cc-no-template",
+            summary="",
+        )
+        assert "event=legacy_claude_code_missing_template_type" in caplog.text
+        assert f"template_type_state={template_type_state}" in caplog.text
 
     def test_teclaw_personal_triggers_bcn_register(self):
         """teclaw 引擎 personal bot 创建时应触发 BCN 注册（与 claude_code 一致）。"""

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_stop_start.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_stop_start.py
@@ -381,9 +381,13 @@ class TestStartBotBcnRegister:
             ext_update={"bcn_registered": True},
         )
 
-    def test_claude_code_missing_template_type_does_not_trigger_bcn_register(self):
+    def test_claude_code_missing_template_type_triggers_bcn_register(self):
         svc = _make_service()
         svc._bcn_service = MagicMock()
+        svc._bcn_service.register_provider_bot.return_value = {
+            "bot_uuid": "u1",
+            "bot_runtime_token": "tok",
+        }
         bot = _make_bot()
         bot["active_engine"] = "claude_code"
         svc._repository.get_by_id_and_owner.side_effect = [bot, bot]
@@ -392,7 +396,12 @@ class TestStartBotBcnRegister:
              patch.object(BotService, "_is_claude_code_bcn_register_enabled", return_value=True):
             svc.start_bot(bot_id="bot001", user_id="user001")
 
-        svc._bcn_service.register_provider_bot.assert_not_called()
+        svc._bcn_service.register_provider_bot.assert_called_once_with(
+            teamclaw_bot_uuid="bot001",
+            owner_workno="user001",
+            name="TestBot",
+            summary="",
+        )
 
     def test_non_claude_code_does_not_trigger_bcn_register(self):
         svc = _make_service()


### PR DESCRIPTION
## Problem

Legacy Claude Code bot records can have `template_type` stored as `NULL` or an empty string. The BCN provider eligibility fallback currently recognizes only `template_type="normalCC"`, so those otherwise equivalent legacy bots skip BCN provider registration during create or start lifecycle flows.

## Solution

- Treat `template_type=None` and `template_type=""` as equivalent to `normalCC` when `active_engine="claude_code"` in the legacy fallback.
- Preserve declared template-factory capabilities as the authoritative early-return path.
- Preserve the behavior of `personalCoding`, `applicationCoding`, `teclaw`, and `openclaw` bot types.
- Emit a low-sensitivity diagnostic event when the missing-template compatibility fallback is used.
- Update create and start lifecycle regression tests for the compatible legacy values.

## Validation

- `uv run pytest -q tests/community/core/bot_management/services/test_bot_service_create_bcn_register.py tests/community/core/bot_management/services/test_bot_service_stop_start.py tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py tests/community/core/bot_management/services/test_bot_service_misc.py` — 208 passed.
- `uv run ruff check --ignore F401 src/agentclaw/community/core/bot_management/services/bot_service.py tests/community/core/bot_management/services/test_bot_service_create_bcn_register.py tests/community/core/bot_management/services/test_bot_service_stop_start.py` — passed. The ignored `F401` is independently reproducible on the unmodified `dev` version of `bot_service.py` and is outside this change.
- `git diff --check github/dev...HEAD` — passed.
- Independent code review — PASS.

## Compatibility and risk

The change is limited to the legacy fallback and accepts only `None`, the empty string, and `normalCC`. Whitespace-only and other non-empty template types remain ineligible. No schema, RPC payload, authentication, DRM, or external-call behavior changes.

## Spec

- `src/backend/specs/claude-code-empty-template-bcn-register/001-spec-output.md`
- `src/backend/specs/claude-code-empty-template-bcn-register/002-code-report.md`
- `src/backend/specs/claude-code-empty-template-bcn-register/003-review-report.md`
- `src/backend/specs/claude-code-empty-template-bcn-register/003b-regression-report.md`
