### PR TITLE
feat(backend): allow callers to restart existing instances

### DIFF
--- a/src/backend/specs/caller-instance-self-restart/001-spec-output.md
+++ b/src/backend/specs/caller-instance-self-restart/001-spec-output.md
@@ -2,7 +2,7 @@
 agent: tc-review
 status: approved-design
 created: 2026-09-04
-baseline: origin/dev@6ecb42630227da0a2030a051659312ac88dea86c
+baseline: github/REL20260904@3c3aeaf109638ea5e1d917a31dd0fd38d971e5ac
 repository: inclusionAI/Avernet
 ---
 
@@ -230,8 +230,8 @@ Reviewer 必须检查：
 
 本次源码位于 Avernet 子模块，采用双仓交付：
 
-1. 在独立 Avernet worktree 分支 `feat/caller-instance-self-restart` 完成源码和测试。
-2. 源码必须推送到 GitHub `inclusionAI/Avernet` 并创建 Avernet PR；不得向 `mirrors/Avernet` 推送源码。
+1. 在独立 Avernet worktree 分支 `rebase/caller-instance-self-restart-on-REL20260904` 完成源码和测试。
+2. 源码必须推送到 GitHub `inclusionAI/Avernet` 并以 `REL20260904` 为 base 创建 Avernet PR；不得向 `mirrors/Avernet` 推送源码。
 3. Avernet PR/CI 通过且提交已同步到 `.gitmodules` 配置的镜像后，才在 OCB 独立 worktree 更新 `ocb-public` git gitlink。
 4. OCB PR 只包含 gitlink 和确有必要的 Corp 回归，不复制 Avernet 源文件。
 5. 部署/预发 QA 必须在用户审核代码后进行；本轮编码完成不自动触发真实 `force_upgrade=true`。

--- a/src/backend/specs/caller-instance-self-restart/001-spec-output.md
+++ b/src/backend/specs/caller-instance-self-restart/001-spec-output.md
@@ -1,0 +1,261 @@
+---
+agent: tc-review
+status: approved-design
+created: 2026-09-04
+baseline: origin/dev@6ecb42630227da0a2030a051659312ac88dea86c
+repository: inclusionAI/Avernet
+---
+
+# Caller 实例本人重启权限升级 Spec
+
+## 1. 需求背景
+
+现有 `POST /api/v1/expert-chats/caller-connection` 是会创建、复用或升级 Caller 独立容器的写接口。当前只允许 `super_admin` 调用，管理员可通过 `bot_id + owner_id + user_id` 为任意 Caller 管理实例。
+
+本次在不破坏管理员旧逻辑的前提下，允许普通登录用户管理**自己已经存在的 Caller 容器**：只有当 `ac_expert_chat_instance` 在当前环境中精确匹配请求的 `bot_id + owner_id + user_id`，且记录已有有效 `ext.bot_uuid` 时，普通用户才可获取连接或通过 `force_upgrade=true` 重启/升级该指定容器。
+
+普通用户不得通过此接口首次创建 Caller 实例；公开 Bot、协作者关系或普通聊天权限不构成本接口的授权依据。
+
+## 2. 现有链路与边界
+
+### 2.1 既有链路
+
+1. Router `get_caller_connection_for_other` 从 `get_current_user()` 获取可信 `user.staffId`。
+2. Router 当前要求 `user.staffId in super_admin()`。
+3. Router 调用 `ExpertChatInstanceService.get_caller_connection()`。
+4. Service 按 `(bot_id, owner_id, user_id, env)` 查建 `ac_expert_chat_instance`。
+5. Service 解析服务 Bot 的成功发布单，按实例状态复用、创建或升级 BaaS 容器，并返回连接。
+
+### 2.2 允许新增点
+
+- 在 `ExpertChatInstanceServiceProtocol` 与 `ExpertChatInstanceService` 中新增 actor-aware 的接口入口，承载管理员兼容和普通用户既有实例匹配规则。
+- Router 改为调用 actor-aware 入口，只负责传递认证身份和 HTTP 参数、映射业务异常。
+- 增补 Endpoint、Service 和 Acceptance 测试。
+- 为本次修改的 HTTP 入站边界补齐最小、结构化、可关联且不包含连接凭据的请求、成功和拒绝/失败日志。
+
+### 2.3 禁止触碰点
+
+- 不修改 `get_caller_connection()` 现有创建、复用、升级和进度状态机。
+- 不修改 `_create_container()`、`_upgrade_container()`、BaaS、Relay、WebSocket、Cron 或通用 HTTP Client。
+- 不修改 `ac_expert_chat_instance` 表结构、唯一键和 Repository 查询语义。
+- 不把 public/collaborator/互动列表权限引入本管理型接口。
+- 不新增 GET 路由；保留 POST，避免浏览器预取或代理重试意外触发生命周期操作。
+- 不修改 Caller binding 现有归属语义。
+
+## 3. 编码 Spec
+
+### 3.1 权限决策表
+
+| 操作者 | 条件 | 结果 |
+|---|---|---|
+| 匿名/空身份 | `operator_id` 为空或 `anonymous` | 拒绝，`error_code=400` |
+| 超级管理员 | `operator_id in super_admin()` | 保留旧逻辑；允许目标实例不存在并首次创建，也允许为任意 `user_id` 复用/升级 |
+| 普通用户本人 | `operator_id == requested_user_id`，且当前 env 下精确存在实例，且 `ext.bot_uuid` 为非空字符串 | 允许复用连接；`force_upgrade=true` 时允许升级/重启该实例 |
+| 普通用户跨用户 | `operator_id != requested_user_id` | 拒绝，`error_code=403` |
+| 普通用户无匹配实例 | 精确查询返回 `None` | 拒绝，`error_code=403`；不得首次创建 |
+| 普通用户实例无容器 | 记录存在但 `ext.bot_uuid` 缺失、为空或非字符串 | 拒绝，`error_code=403`；不得首次创建 |
+
+授权拒绝必须发生在 `_resolve_build_artifact()`、`release_async()`、`upgrade_async()`、`get_publish_progress()` 和 `get_ws_info_by_bot_uuid()` 之前。
+
+### 3.2 关键方法抽象
+
+#### `ExpertChatInstanceServiceProtocol.get_authorized_caller_connection`
+
+建议签名：
+
+```python
+async def get_authorized_caller_connection(
+    self,
+    *,
+    operator_id: str,
+    user_id: str,
+    bot_id: str,
+    owner_id: str,
+    is_super_admin: bool,
+    force_upgrade: bool = False,
+) -> Dict[str, Any]:
+    ...
+```
+
+职责：
+
+- 以认证上下文中的 `operator_id` 作 actor，并接收 Router 从可信认证配置解析出的 `is_super_admin` 角色事实。
+- `is_super_admin=True` 时直接委托现有 `get_caller_connection()`，保持旧行为。
+- 普通用户先校验 `operator_id == user_id`。
+- 普通用户通过现有 `ExpertChatInstanceRepository.get_instance(user_id, bot_id, owner_id)` 在当前 env 精确匹配实例。
+- 普通用户校验实例 `ext.bot_uuid` 为非空字符串后，才委托现有 `get_caller_connection()`。
+- 权限失败抛出 `ChatPermissionError`，由 Router 映射为 `error_code=403`。
+
+不承担：
+
+- 不实现 BaaS 生命周期。
+- 不检查 public/collaborator 聊天权限。
+- 不修改实例状态或字段。
+- 不解析 HTTP Request、Cookie 或 Header。
+
+#### `get_caller_connection_for_other` Router
+
+职责：
+
+- 保留空身份/anonymous 的现有 400 行为。
+- 使用既有 `super_admin()` 将认证身份解析为 `is_super_admin`，并调用 actor-aware Service 入口。
+- 将 `ChatPermissionError` 映射为 `ApiResponse(success=False, error_code=403)`。
+- 记录入站请求、成功、权限拒绝和意外失败的结构化事件。
+
+不承担：
+
+- 不直接查询 Repository。
+- 不实现管理员/实例归属规则。
+- 不修改 query 中的 `user_id` 后再透传；由 Service 使用 actor 明确判断。
+
+### 3.3 关键领域模型
+
+#### `CallerInstanceAccessRequest`（概念命令，不新增持久化 DTO）
+
+表达一次 Caller 实例访问/重启请求。为保持最小改动，使用方法参数承载，不新增 class。
+
+| 字段 | 类型 | 必填 | 来源/所有者 | 业务含义与约束 |
+|---|---|---:|---|---|
+| `operator_id` | `str` | 是 | `get_current_user().staffId` | 可信操作者身份；普通用户不得由 query 覆盖 |
+| `is_super_admin` | `bool` | 是 | Router 根据既有 `super_admin()` 解析 | 仅表达认证角色事实；Service 仍负责全部领域授权不变量 |
+| `user_id` | `str` | 是 | query | 目标 Caller；普通用户必须与 `operator_id` 相等 |
+| `bot_id` | `str` | 是 | query | 服务 Bot 标识；参与实例精确键匹配 |
+| `owner_id` | `str` | 是 | query | 服务 Bot Owner；参与实例精确键匹配，不等同于 Caller |
+| `force_upgrade` | `bool` | 否 | query，默认 `False` | `True` 时跳过版本快路径；仍必须先通过权限检查 |
+
+#### `ac_expert_chat_instance`
+
+本次不变更模型，只把其既有记录作为普通用户管理权限的服务端证明。
+
+| 字段 | 约束 | 本次用途 |
+|---|---|---|
+| `bot_id` | 唯一键成员 | 必须与请求精确匹配 |
+| `owner_id` | 唯一键成员 | 必须与请求精确匹配 |
+| `user_id` | 唯一键成员 | 必须等于请求 `user_id`，普通用户同时必须等于 `operator_id` |
+| `env` | 唯一键成员，由 Repository 使用当前环境 | 防止跨环境实例命中 |
+| `status` | `init/success/failed` | 不作为授权依据；失败或 init 的既有容器仍可按原生命周期处理 |
+| `ext.bot_uuid` | 普通用户路径要求非空字符串 | 证明已有指定 Caller 容器；缺失时禁止普通用户首次创建 |
+
+关键不变量：
+
+1. 普通用户的授权必须同时满足“可信身份等于目标 Caller”和“当前环境精确实例存在且已有 bot_uuid”。
+2. 管理员旧路径不得因新增普通用户规则而要求实例预先存在。
+3. 权限拒绝不得产生 BaaS、发布进度、连接获取或持久化副作用。
+
+### 3.4 业务异常与 HTTP 映射
+
+- `ChatPermissionError`：普通用户跨用户、无实例或无有效 bot_uuid；HTTP envelope `error_code=403`。
+- 现有其他异常保持 catch-all 行为和返回契约，不在本次扩张修改。
+- 错误消息不返回实例是否属于其他用户的详细信息，避免暴露非公开实例状态。
+
+### 3.5 外部边界结构化日志
+
+本次修改的是入站 HTTP 边界，不新增出站调用。日志使用项目现有 logger，不记录 `connection`、token、Cookie、Header 或完整 `instance.ext`。
+
+稳定事件：
+
+| 事件名 | 时机 | 非敏感字段 |
+|---|---|---|
+| `expert_chat.caller_connection.request` | 认证完成、调用 Service 前 | `direction=inbound`、`operation=caller_connection`、`method=POST`、`route`、`operator_id`、`bot_id`、`owner_id`、`user_id`、`force_upgrade` |
+| `expert_chat.caller_connection.success` | Service 成功返回 | 上述关联字段、`authorized_as=admin/self`、`need_poll`、`duration_ms` |
+| `expert_chat.caller_connection.denied` | 匿名或权限失败 | 关联字段、`reason=missing_operator/cross_user/instance_not_found/instance_missing_bot_uuid`、`duration_ms` |
+| `expert_chat.caller_connection.failed` | 意外异常 | 关联字段、`exception_type`、`duration_ms`；异常栈沿用项目设施，但不得附请求凭据 |
+
+脱敏要求：
+
+- 禁止记录 `connection.token`、`IAM_TOKEN`、Authorization、Cookie、secret、key、credential、session 内容。
+- 不使用 `str(request)`、headers dump 或原始响应序列化。
+- 测试断言请求、成功、拒绝事件存在，并断言注入的敏感哨兵值不出现在日志文本。
+
+### 3.6 TDD 实现顺序
+
+1. RED：普通用户本人有精确实例且 bot_uuid 有效时应成功；当前代码因非管理员返回 403。
+2. RED：普通用户无实例时应 403，且 lifecycle 方法零调用。
+3. RED：普通用户跨 user_id 时应 403，即使目标实例存在。
+4. RED：普通用户实例缺少/无效 bot_uuid 时应 403。
+5. RED：超级管理员在实例不存在时仍可成功进入旧创建逻辑。
+6. RED：权限拒绝发生在 BaaS 调用前。
+7. RED：入站 request/success/denied 日志存在且敏感哨兵不落日志。
+8. GREEN：实现最小 actor-aware Service 入口和 Router 映射。
+9. REFACTOR：只消除本次新增重复，保持行为不变。
+
+## 4. Review Spec
+
+Reviewer 必须检查：
+
+- [ ] 仅修改 actor-aware Service API、实现、Router、对应测试和 Spec/报告。
+- [ ] Router 不直接访问 Repository，不承载领域权限判断。
+- [ ] 普通用户必须同时满足 `operator_id == user_id`、实例精确存在、`ext.bot_uuid` 有效。
+- [ ] 普通用户不能首次创建实例。
+- [ ] 管理员可在实例不存在时继续走原逻辑。
+- [ ] 所有拒绝路径均在任何 BaaS/发布/连接副作用之前返回。
+- [ ] 不引入 public/collaborator 权限。
+- [ ] 不新增 GET，不修改数据库 schema 和 lifecycle 状态机。
+- [ ] 日志事件覆盖 request/success/denied/failed，不包含 token、Cookie、Header、connection 或完整 ext。
+- [ ] 测试具有行为断言，非纯 mock 存在性检查；TDD RED 证据写入编码报告。
+- [ ] Python 无未使用 import/变量、无无关格式化 diff。
+- [ ] Avernet 源码改动不提交到 `mirrors/Avernet`，后续源码 PR 走 GitHub `inclusionAI/Avernet`。
+
+本地门禁：
+
+- 相关 Endpoint + Service tests 100% 通过。
+- 相关 Acceptance tests 在可用的 Singlebox 环境中通过；若环境不可用，必须明确记录未运行原因。
+- 远端 ACI：casePassRate 100%、lineCoverage >=70%、changeLineCoverage >=90%；PR 前为 PENDING，不得虚报 PASS。
+
+## 5. QA Spec
+
+### 5.1 本地/自动化用例
+
+1. 管理员、owner、caller 三者不同：仍可创建/复用/升级。
+2. 普通用户 `operator=user_id`，精确实例存在且有 bot_uuid：可返回连接。
+3. 同上且 `force_upgrade=true`：进入既有升级流程。
+4. 普通用户实例不存在：403，不新增实例，不调用 BaaS。
+5. 普通用户实例存在但无 bot_uuid：403，不调用 BaaS。
+6. 普通用户 `operator != user_id`：403，即使目标记录存在。
+7. 相同 user_id 但 bot_id 或 owner_id 不匹配：403。
+8. 匿名：维持 400。
+9. 拒绝日志包含非敏感业务键和 reason；不出现 token/Cookie/secret 哨兵。
+10. 管理员旧用例和 force_upgrade 用例不回归。
+
+### 5.2 预发验证
+
+- 使用 POST，不通过浏览器地址栏 GET 调用。
+- 首先对普通用户已有实例执行 `force_upgrade=false` 只读式连接复用验证。
+- 经用户确认具体 Bot 后，再执行 `force_upgrade=true` 的真实重启验证。
+- 核对同一 `(bot_id, owner_id, user_id, env)` 的实例 `bot_uuid` 与发布进度，禁止输出连接 token。
+- 验证普通用户跨 user_id 和无实例均返回 403，且后端日志无 BaaS 出站事件。
+- 验证超级管理员代其他 Caller 的旧路径仍成功。
+
+## 6. Ship Spec
+
+本次源码位于 Avernet 子模块，采用双仓交付：
+
+1. 在独立 Avernet worktree 分支 `feat/caller-instance-self-restart` 完成源码和测试。
+2. 源码必须推送到 GitHub `inclusionAI/Avernet` 并创建 Avernet PR；不得向 `mirrors/Avernet` 推送源码。
+3. Avernet PR/CI 通过且提交已同步到 `.gitmodules` 配置的镜像后，才在 OCB 独立 worktree 更新 `ocb-public` git gitlink。
+4. OCB PR 只包含 gitlink 和确有必要的 Corp 回归，不复制 Avernet 源文件。
+5. 部署/预发 QA 必须在用户审核代码后进行；本轮编码完成不自动触发真实 `force_upgrade=true`。
+6. 回滚：Avernet 回退该权限提交；OCB gitlink 回退到升级前 SHA。无数据库迁移。
+
+# 权限控制类安全约束设计与风险识别
+
+>/*数字支付需求安全分析要求*/
+
+## 权限控制类安全约束设计
+
+涉及到非公开数据 Caller 容器、Caller 实例记录和连接信息，仅限超级管理员操作任意目标 Caller；普通用户仅可操作 `ac_expert_chat_instance` 中 `bot_id`、`owner_id`、`user_id` 与请求精确匹配、`user_id` 为当前登录用户且 `ext.bot_uuid` 有效的既有 Caller 容器。
+
+**注意** 1、在进行权限安全校验时使用到的用户身份信息（包括用户类型和用户Id）和业务中需要消费当前用户身份信息时，必须从安全的上下文中获取的（用户登录态或其他用户不可控身份组件）2、代码编写中确保所有校验逻辑代码都已完全实现，如果保留todo则该函数示例返回应该默认校验不通过
+
+## 技术安全风险识别
+
+- **技术安全风险描述**：仅校验实例存在但不校验登录身份与 `user_id` 相等，会允许重启他人的 Caller 容器。**安全设计要求**：普通用户必须使用认证上下文身份与实例 `user_id` 双重匹配。
+- **技术安全风险描述**：普通用户命中无 `bot_uuid` 的占位记录后进入原流程，会产生首次创建副作用。**安全设计要求**：普通用户路径必须要求有效 `ext.bot_uuid`，否则先于生命周期调用拒绝。
+- **技术安全风险描述**：仅在 Router 做权限校验，其他入口可直接调用生命周期方法绕过。**安全设计要求**：为 HTTP 用例提供 Service actor-aware 入口并集中落实权限不变量。
+
+## 7. Iteration 2 架构修订
+
+- `ExpertChatInstanceServiceProtocol` 的唯一权威定义位于 `core/expert_chat/expert_chat_instance_service_protocol.py`；`api/expert_chat_instance_service.py` 仅直接 re-export 同一 Protocol 对象。
+- HTTP Router 采用既有 `super_admin()` 解析认证角色，并以显式 `is_super_admin` 参数传入 core Service；core Service 不依赖 `core.access`，但继续集中执行管理员兼容、`operator_id == user_id`、精确既有实例和有效 `bot_uuid` 四项授权规则。
+- Protocol/Concrete pair 纳入 `tests/community/architecture/test_service_api_conformance.py`，同时锁定 API re-export 与 owning core Protocol 的对象同一性和方法签名。
+- `tests/community/endpoints/` 只保留真实 world/DI 用例；使用 mock/patch 的 Router 日志及敏感哨兵测试位于 `tests/community/api/expert_chat/test_router.py`。

--- a/src/backend/specs/caller-instance-self-restart/002-code-report.md
+++ b/src/backend/specs/caller-instance-self-restart/002-code-report.md
@@ -9,8 +9,8 @@ iteration: 2
 
 ## Worktree 信息
 - 路径: /Users/helloworld/Desktop/codes/teamclaw_worktrees/Avernet_worktrees/caller-instance-self-restart
-- 分支: feat/caller-instance-self-restart
-- 基线: origin/dev@6ecb42630227da0a2030a051659312ac88dea86c
+- 分支: rebase/caller-instance-self-restart-on-REL20260904
+- 最终 PR 基线: github/REL20260904@3c3aeaf109638ea5e1d917a31dd0fd38d971e5ac
 - 复用既有 worktree，未创建新 worktree；保留并更新 `001-spec-output.md` 的 iteration 2 架构约束。
 
 ## Iteration 2 修复摘要
@@ -131,3 +131,12 @@ uv run pytest \
 - 003 必修：API/core Protocol 双权威 → owning core Protocol 单一声明，API 恢复直接 re-export，并加入 conformance gate。
 - 003b 回归：core 未声明 `core.access` 依赖 → Router 解析角色后显式传 `is_super_admin`，core import 删除。
 - 003b 回归：Endpoint 禁止 mock/patch → 日志测试迁移到 API Router 测试目录，Endpoint 只保留真实 world/DI 用例。
+
+
+## REL20260904 Rebase 与最终本地门禁
+
+- 原功能提交 `e23e3ab58` 仅作为 topic，使用 `git rebase --onto github/REL20260904 6ecb42630227da0a2030a051659312ac88dea86c` 重放。
+- Rebase 后功能提交：`abb5fa5608e10d3e648005d938f3eef35bb3ce2a`。
+- `github/REL20260904..HEAD` 仅包含本任务 1 个功能提交，没有夹带 `dev` 的其他提交。
+- REL 基线 Backend CI：case pass `100.00% (17127/17127)`；line coverage `88.55%`；change-line coverage `100.00% (44/44)`；`backend CI gate passed`。
+- Coverage pytest：`17068 passed, 59 skipped, 0 failed`。Acceptance/live Singlebox 场景未启动，不作为本地通过证据。ouchers

--- a/src/backend/specs/caller-instance-self-restart/002-code-report.md
+++ b/src/backend/specs/caller-instance-self-restart/002-code-report.md
@@ -1,0 +1,133 @@
+---
+agent: tc-code
+status: completed
+created: 2026-09-04T16:43:24+08:00
+iteration: 2
+---
+
+# 编码报告
+
+## Worktree 信息
+- 路径: /Users/helloworld/Desktop/codes/teamclaw_worktrees/Avernet_worktrees/caller-instance-self-restart
+- 分支: feat/caller-instance-self-restart
+- 基线: origin/dev@6ecb42630227da0a2030a051659312ac88dea86c
+- 复用既有 worktree，未创建新 worktree；保留并更新 `001-spec-output.md` 的 iteration 2 架构约束。
+
+## Iteration 2 修复摘要
+
+1. **恢复单一 Service API 权威**
+   - `get_authorized_caller_connection()` 已声明在 owning core Protocol。
+   - `api/expert_chat_instance_service.py` 已恢复为基线直接 re-export，同一 Protocol 对象同时供 Concrete、DI 和 Router 使用。
+   - Protocol/Concrete pair 已加入 conformance registry，并增加公开 API 与 core Protocol 对象同一性断言。
+2. **移除未声明 core 内部依赖**
+   - core Service 不再 import `core.access`。
+   - Router 从可信认证身份和既有 `super_admin()` 解析 `is_super_admin`，显式传给 Service。
+   - Service 继续集中执行管理员兼容、本人匹配、精确实例存在和有效 `bot_uuid` 领域规则。
+3. **恢复 Endpoint 测试分层**
+   - Endpoint 文件移除全部 `unittest.mock`、`AsyncMock`、`patch` 和 direct-router 测试，仅保留真实 world/DI 用例。
+   - request/success/denied/failed 日志和敏感哨兵测试迁至 `tests/community/api/expert_chat/test_router.py`。
+4. 未修改 BaaS、schema、Repository 查询语义或既有 lifecycle 状态机。
+
+## 改动文件列表
+| 文件路径 | 改动类型 | 说明 |
+|----------|----------|------|
+| src/backend/src/agentclaw/community/core/expert_chat/expert_chat_instance_service_protocol.py | 修改 | 在 owning core Protocol 声明 actor-aware 方法及显式管理员角色参数 |
+| src/backend/src/agentclaw/community/core/expert_chat/services/expert_chat_instance_service.py | 修改 | 使用显式 `is_super_admin`，移除 `core.access` import并保留领域授权规则 |
+| src/backend/src/agentclaw/community/adapters/http/expert_chat/router.py | 修改 | 从认证配置解析管理员角色并传入 Service；保留安全结构化日志 |
+| src/backend/tests/community/architecture/test_service_api_conformance.py | 修改 | 注册 Protocol/Concrete pair并锁定 API/core 同一对象与签名 |
+| src/backend/tests/community/api/expert_chat/test_router.py | 修改 | 承载允许 mock 的 Router 日志、角色传递和敏感值测试 |
+| src/backend/tests/community/endpoints/test_expert_chat_caller_connection.py | 修改 | 仅保留真实 world/DI Endpoint 用例 |
+| src/backend/tests/community/core/expert_chat/services/test_expert_chat_instance_service.py | 修改 | 使用显式 `is_super_admin` 验证管理员、自有实例与拒绝路径 |
+| src/backend/specs/caller-instance-self-restart/001-spec-output.md | 修改 | 补充 iteration 2 架构与参数约束 |
+| src/backend/specs/caller-instance-self-restart/002-code-report.md | 修改 | iteration 2 编码报告 |
+
+## TDD / 回归 RED 证据
+
+### RED 1：API/core Protocol 双权威
+
+```bash
+uv run pytest \
+  tests/community/architecture/test_service_api_conformance.py::test_expert_chat_instance_api_reexports_owning_core_protocol \
+  -q
+```
+
+结果：`1 failed`。公开 API 派生 Protocol 与 owning core Protocol 不是同一对象，断言按预期失败。
+
+### RED 2：两个 Backend 全量回归门禁
+
+```bash
+uv run pytest \
+  tests/community/framework/test_no_mock_in_endpoint_tests.py::test_no_mock_or_patch_in_endpoint_tests \
+  tests/community/architecture/test_module_boundaries.py::test_declared_deps_cover_actual_imports \
+  -q
+```
+
+结果：`2 failed`：
+- Endpoint 文件发现 `unittest.mock`、`AsyncMock` 和 `patch`。
+- `core.expert_chat` 发现未声明的 `core.access` import。
+
+## GREEN 验证
+
+### 两个原失败门禁
+
+同一命令复跑结果：`2 passed`。
+
+### 相关功能回归
+
+```bash
+uv run pytest \
+  tests/community/core/expert_chat \
+  tests/community/endpoints/test_expert_chat_caller_connection.py \
+  tests/community/endpoints/test_expert_chat_multi_session.py \
+  tests/community/api/expert_chat/test_router.py \
+  tests/community/acceptance/expert_chat/test_caller_connection_api.py \
+  -q -rs
+```
+
+结果：`244 passed, 14 skipped, 18 warnings in 1.12s`。
+- 14 个 Acceptance 均因未设置 `RUN_ACCEPTANCE=1`、未启动 live Singlebox 而跳过。
+- warnings 为既有 Pydantic/Starlette deprecation warnings。
+
+### 架构契约与 HTTP adapter suite
+
+```bash
+uv run pytest \
+  tests/community/architecture/test_service_api_conformance.py \
+  tests/community/architecture/test_api_layer_is_protocols_only.py \
+  tests/community/architecture/test_http_adapter_layer_is_http_only.py \
+  -q
+```
+
+结果：`148 passed, 17 warnings in 1.94s`。新增 Protocol pair 和 API/core 同一性门禁均通过。
+
+## 代码质量检查
+- `ruff check --ignore F841`（全部本次改动 Python 文件）：PASS。
+- `ruff check --select F401,F811,F821`：PASS，无新增未使用 import、重复 import 或未定义名称。
+- `pycodestyle --select=E203,E265`：PASS。
+- `git diff --check`：PASS。
+- Service 测试文件既有 16 个基线 `F841` 未作无关清理；本次无新增 Ruff finding。
+
+## Git Diff 摘要
+
+```text
+ .../community/adapters/http/expert_chat/router.py  | 129 +++++++++++++------
+ .../expert_chat_instance_service_protocol.py       |  13 ++
+ .../services/expert_chat_instance_service.py       |  47 +++++++
+ .../tests/community/api/expert_chat/test_router.py | 141 ++++++++++++++++++++-
+ .../architecture/test_service_api_conformance.py   |  16 +++
+ .../services/test_expert_chat_instance_service.py  | 105 +++++++++++++++
+ .../test_expert_chat_caller_connection.py          |  69 ++++++++++
+ 7 files changed, 479 insertions(+), 41 deletions(-)
+```
+
+## 外部系统边界日志
+- 事件保持为 `expert_chat.caller_connection.request/success/denied/failed`。
+- Router API 测试验证 `operator_id`、`is_super_admin`、请求参数和 `force_upgrade` 正确适配。
+- 成功日志只记录 `authorized_as`、`need_poll`、`duration_ms` 等非敏感字段。
+- 拒绝日志记录稳定 reason；失败日志只记录 `exception_type`。
+- `SENSITIVE_CONNECTION`、`SENSITIVE_TOKEN`、`SENSITIVE_SECRET`、`SENSITIVE_CREDENTIAL` 以及 Authorization/Cookie 均不落日志。
+
+## 回退修复记录
+- 003 必修：API/core Protocol 双权威 → owning core Protocol 单一声明，API 恢复直接 re-export，并加入 conformance gate。
+- 003b 回归：core 未声明 `core.access` 依赖 → Router 解析角色后显式传 `is_super_admin`，core import 删除。
+- 003b 回归：Endpoint 禁止 mock/patch → 日志测试迁移到 API Router 测试目录，Endpoint 只保留真实 world/DI 用例。

--- a/src/backend/specs/caller-instance-self-restart/003-review-report.md
+++ b/src/backend/specs/caller-instance-self-restart/003-review-report.md
@@ -1,0 +1,39 @@
+---
+agent: tc-code-reviewer
+status: completed
+created: 2026-09-04T17:12:00+08:00
+iteration: 2
+base: github/REL20260904@3c3aeaf109638ea5e1d917a31dd0fd38d971e5ac
+head: abb5fa5608e10d3e648005d938f3eef35bb3ce2a
+---
+
+# Code Review 报告：Caller 实例本人重启权限
+
+## 结论
+
+**PASS（本地代码审查）**。远端 GitHub PR/CI 在 PR 创建前仍为 PENDING。
+
+## 审查结果
+
+- 管理员旧逻辑保留：`is_super_admin=True` 时直接委托原 `get_caller_connection()`，不要求实例预先存在。
+- 普通用户必须满足 `operator_id == user_id`、当前环境精确实例存在、`ext.bot_uuid` 为有效非空字符串。
+- 跨用户、无实例、无有效 `bot_uuid` 均在生命周期、发布、BaaS 和连接调用前拒绝。
+- 普通用户不能通过该接口首次创建 Caller 实例。
+- Router 不访问 Repository；角色事实由可信认证身份和既有 `super_admin()` 得出，领域准入由 Service 集中执行。
+- 未引入 public/collaborator 权限；路由继续使用 POST；未修改 schema、Repository 或 BaaS lifecycle。
+- Service API 由 owning core Protocol 单一定义，API 层直接 re-export；Protocol/Concrete conformance 已纳入架构门禁。
+- Endpoint 目录不使用 mock/patch；Router 日志测试位于允许隔离依赖的 API 测试层。
+- request/success/denied/failed 日志不记录 connection、完整 ext、异常消息、Authorization、Cookie、token、secret 或 credential。
+
+## 验证证据
+
+- 相关功能与架构测试：`403 passed, 0 failed`。
+- REL 基线 Backend CI：`casePassRate 100.00% (17127/17127)`。
+- 总行覆盖率：`88.55%`，门槛 `>=75%`。
+- 变更行覆盖率：`100.00% (44/44)`，门槛 `>=80%`。
+- `git diff --check`：PASS。
+- Acceptance/live Singlebox：未启动，不能作为真实 BaaS 容器验证。
+
+## 范围检查
+
+`github/REL20260904..HEAD` 仅包含本任务 1 个功能提交。未发现无关重构、格式化噪声或对 BaaS/Relay/WebSocket/Cron 的越界修改。

--- a/src/backend/specs/caller-instance-self-restart/003b-regression-report.md
+++ b/src/backend/specs/caller-instance-self-restart/003b-regression-report.md
@@ -1,0 +1,52 @@
+---
+agent: tc-engine-regression
+status: completed
+created: 2026-09-04T17:12:00+08:00
+iteration: 2
+base: github/REL20260904@3c3aeaf109638ea5e1d917a31dd0fd38d971e5ac
+head: abb5fa5608e10d3e648005d938f3eef35bb3ce2a
+---
+
+# Backend 本地回归报告：Caller 实例本人重启权限
+
+## 结论
+
+**PASS（REL20260904 本地回归与覆盖率门禁）**。
+
+## 最终命令
+
+```bash
+cd src/backend
+BACKEND_CI_SKIP_INSTALL=1 BACKEND_CI_PYTEST_WORKERS=auto \
+  uv run bash scripts/ci_test.sh \
+  --base 3c3aeaf109638ea5e1d917a31dd0fd38d971e5ac \
+  --head abb5fa5608e10d3e648005d938f3eef35bb3ce2a
+```
+
+## 结果
+
+| 门禁 | 结果 | 证据 |
+|---|---:|---|
+| Backend coverage pytest | PASS | 17068 passed，59 skipped，0 failed |
+| casePassRate | PASS | 100.00%（17127/17127），要求 >=100% |
+| lineCoverage | PASS | 88.55%，要求 >=75% |
+| changeLineCoverage | PASS | 100.00%（44/44），要求 >=80% |
+| Backend CI | PASS | `backend CI gate passed` |
+| 相关功能/架构测试 | PASS | 403 passed，0 failed |
+| Endpoint no-mock 门禁 | PASS | 已包含在架构测试与全量 CI |
+| Module boundary | PASS | 已包含在架构测试与全量 CI |
+| Protocol conformance | PASS | 已包含在架构测试与全量 CI |
+| git diff whitespace | PASS | `git diff --check` exit 0 |
+| Acceptance/live Singlebox | NOT RUN | 未启动 Backend/BaaS live stack；不伪报通过 |
+
+## 行为覆盖
+
+- 管理员可以继续为任意 Caller 创建、复用或升级实例。
+- 普通用户仅能管理自己已有且含有效 `bot_uuid` 的精确实例。
+- 普通用户无实例、无 `bot_uuid` 或跨用户时，不发生 lifecycle/BaaS 副作用。
+- `force_upgrade` 只有在上述授权通过后才进入既有升级流程。
+- 四类入站日志已验证，敏感哨兵未落日志。
+
+## 远端状态
+
+GitHub PR 尚未创建时，远端 CI/ACI 为 PENDING。本报告只证明本地 REL 基线门禁通过。

--- a/src/backend/specs/caller-instance-self-restart/009-pr-report.md
+++ b/src/backend/specs/caller-instance-self-restart/009-pr-report.md
@@ -1,0 +1,42 @@
+# PR 收敛报告：caller-instance-self-restart
+
+## 范围
+- Worktree / repo: `/Users/helloworld/Desktop/codes/teamclaw_worktrees/Avernet_worktrees/caller-instance-self-restart` / `inclusionAI/Avernet`
+- Head / base: `rebase/caller-instance-self-restart-on-REL20260904` / `REL20260904`
+- Base SHA: `3c3aeaf109638ea5e1d917a31dd0fd38d971e5ac`
+- Current head SHA: `abb5fa5608e10d3e648005d938f3eef35bb3ce2a`
+- PR: NOT_CREATED
+- PR title: `feat(backend): allow callers to restart existing instances`
+- PR description sections: Problem / Solution / Validation / Compatibility and risk / Spec
+- 人工意见模式: auto
+
+## PR 判定
+| 结果 | 证据 | 说明 |
+|---|---|---|
+| Rebase PASS | `github/REL20260904..HEAD` 仅 1 个提交 | REL 在下，本任务 topic 在上 |
+| Local CI PASS | case 100%，line 88.55%，change line 100% | 使用 Python 3.12 `uv run` 完整执行 |
+
+## 自动意见
+| 轮次 | 来源 | 链接 | 决定 | 理由 | 修改/提交 | 验证 |
+|---|---|---|---|---|---|---|
+| 0 | 尚未创建 PR | - | PENDING | 等待 PR 创建 | - | - |
+
+## ACI/CI
+| Job/指标 | 状态 | 证据 | 根因 | 修复/提交 | 验证 |
+|---|---|---|---|---|---|
+| 本地 casePassRate | PASS | 17127/17127 | - | abb5fa560 | 100% |
+| 本地 lineCoverage | PASS | 88.55% | - | abb5fa560 | >=75% |
+| 本地 changeLineCoverage | PASS | 44/44 | - | abb5fa560 | 100% |
+| 远端 GitHub checks | PENDING | PR 未创建 | - | - | - |
+
+## 人工意见
+| 轮次 | 作者 | 链接 | 决定 | 理由 | 修改/提交 | 验证 |
+|---|---|---|---|---|---|---|
+| 0 | 尚无 | - | CLEAR | PR 未创建 | - | - |
+
+## 当前结论
+- PR: NOT_CREATED
+- 自动意见: PENDING
+- ACI/CI: PENDING（本地门禁 PASS）
+- 人工意见: CLEAR
+- 下一步: 提交报告、推送 GitHub head、创建以 `REL20260904` 为 base 的 PR。

--- a/src/backend/src/agentclaw/community/adapters/http/expert_chat/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/expert_chat/router.py
@@ -19,6 +19,7 @@ ExpertChat Router — HTTP接口入口
   OK:  import core.expert_chat.errors          (业务异常)
   BAD: import plugins.*                   (never import impl directly)
 """
+import time
 import traceback
 
 from fastapi import APIRouter, Depends, Query, Request
@@ -478,51 +479,99 @@ async def get_caller_connection_for_other(
     user_id: str = Query(..., description="调用者(Caller)用户ID"),
     force_upgrade: bool = Query(False, description="强制升级，跳过版本检查"),
     user: AuthenticatedUser = Depends(get_current_user),
-    instance_service: ExpertChatInstanceServiceProtocol = Injected(ExpertChatInstanceServiceProtocol)
+    instance_service: ExpertChatInstanceServiceProtocol = Injected(
+        ExpertChatInstanceServiceProtocol
+    ),
 ):
-    """
-    获取 caller 独立容器连接信息(管理员接口)
+    """Get or restart an authorized caller's existing container instance."""
+    started_at = time.perf_counter()
+    operator_id = user.staffId
+    log_args = (operator_id, bot_id, owner_id, user_id, force_upgrade)
+    logger.info(
+        "event=expert_chat.caller_connection.request direction=inbound "
+        "operation=caller_connection method=POST "
+        "route=/api/v1/expert-chats/caller-connection operator_id=%s "
+        "bot_id=%s owner_id=%s user_id=%s force_upgrade=%s",
+        *log_args,
+    )
 
-    为每个 caller (user_id) 创建/复用独立的 BaaS 容器实例。
-    仅限超级管理员调用，用于为其他用户（caller）管理独立容器实例。
-
-    参数通过 query string 传递:
-        - bot_id: Bot ID
-        - owner_id: Bot 所有者ID
-        - user_id: 调用者用户ID
-        - force_upgrade: 是否强制升级（跳过版本检查快速路径）
-
-    返回:
-        - instance: 实例记录
-        - connection: WebSocket 连接信息 (当 need_poll=False 时)
-        - need_poll: 是否需要轮询等待容器就绪
-    """
-    try:
-        operator_id = user.staffId
-
-        # 操作者身份校验
-        if not operator_id or operator_id == "anonymous":
-            return ApiResponse(success=False, message="无法获取操作者信息", error_code=400, data=None)
-
-        # 权限校验：只有 SUPER_ADMIN 中的用户才能操作
-        if operator_id not in super_admin():
-            logger.warning(f"[get_caller_connection_for_other] Permission denied: operator={operator_id}")
-            return ApiResponse(success=False, message="无权限执行此操作", error_code=403, data=None)
-
-        logger.info(
-            f"[get_caller_connection_for_other] Creating/retrieving caller instance: "
-            f"bot_id={bot_id}, owner_id={owner_id}, user_id={user_id}, operator={operator_id}"
+    if not operator_id or operator_id == "anonymous":
+        duration_ms = (time.perf_counter() - started_at) * 1000
+        logger.warning(
+            "event=expert_chat.caller_connection.denied direction=inbound "
+            "operation=caller_connection method=POST "
+            "route=/api/v1/expert-chats/caller-connection operator_id=%s "
+            "bot_id=%s owner_id=%s user_id=%s force_upgrade=%s "
+            "reason=missing_operator duration_ms=%.1f",
+            *log_args,
+            duration_ms,
+        )
+        return ApiResponse(
+            success=False,
+            message="无法获取操作者信息",
+            error_code=400,
+            data=None,
         )
 
-        result = await instance_service.get_caller_connection(
+    try:
+        is_super_admin = operator_id in super_admin()
+        result = await instance_service.get_authorized_caller_connection(
+            operator_id=operator_id,
             user_id=user_id,
             bot_id=bot_id,
             owner_id=owner_id,
+            is_super_admin=is_super_admin,
             force_upgrade=force_upgrade,
         )
-        return ApiResponse(success=True, message="获取成功", error_code=0, data=result)
-
-    except Exception as e:
-        logger.error(f"[expert_chats.get_caller_connection_for_other] Unexpected error: {type(e).__name__}: {e}")
-        logger.error(f"[expert_chats.get_caller_connection_for_other] Traceback: {traceback.format_exc()}")
-        return ApiResponse(success=False, message="获取 Caller 连接失败，请稍后重试", error_code=5999)
+        duration_ms = (time.perf_counter() - started_at) * 1000
+        authorized_as = "admin" if is_super_admin else "self"
+        logger.info(
+            "event=expert_chat.caller_connection.success direction=inbound "
+            "operation=caller_connection method=POST "
+            "route=/api/v1/expert-chats/caller-connection operator_id=%s "
+            "bot_id=%s owner_id=%s user_id=%s force_upgrade=%s "
+            "authorized_as=%s need_poll=%s duration_ms=%.1f",
+            *log_args,
+            authorized_as,
+            result.get("need_poll"),
+            duration_ms,
+        )
+        return ApiResponse(
+            success=True, message="获取成功", error_code=0, data=result
+        )
+    except ChatPermissionError as error:
+        duration_ms = (time.perf_counter() - started_at) * 1000
+        reason = getattr(error, "reason", "permission_denied")
+        logger.warning(
+            "event=expert_chat.caller_connection.denied direction=inbound "
+            "operation=caller_connection method=POST "
+            "route=/api/v1/expert-chats/caller-connection operator_id=%s "
+            "bot_id=%s owner_id=%s user_id=%s force_upgrade=%s "
+            "reason=%s duration_ms=%.1f",
+            *log_args,
+            reason,
+            duration_ms,
+        )
+        return ApiResponse(
+            success=False,
+            message="无权限执行此操作",
+            error_code=403,
+            data=None,
+        )
+    except Exception as error:
+        duration_ms = (time.perf_counter() - started_at) * 1000
+        logger.error(
+            "event=expert_chat.caller_connection.failed direction=inbound "
+            "operation=caller_connection method=POST "
+            "route=/api/v1/expert-chats/caller-connection operator_id=%s "
+            "bot_id=%s owner_id=%s user_id=%s force_upgrade=%s "
+            "exception_type=%s duration_ms=%.1f",
+            *log_args,
+            type(error).__name__,
+            duration_ms,
+        )
+        return ApiResponse(
+            success=False,
+            message="获取 Caller 连接失败，请稍后重试",
+            error_code=5999,
+        )

--- a/src/backend/src/agentclaw/community/core/expert_chat/expert_chat_instance_service_protocol.py
+++ b/src/backend/src/agentclaw/community/core/expert_chat/expert_chat_instance_service_protocol.py
@@ -15,6 +15,19 @@ class ExpertChatInstanceServiceProtocol(Protocol):
     caller.
     """
 
+    async def get_authorized_caller_connection(
+        self,
+        *,
+        operator_id: str,
+        user_id: str,
+        bot_id: str,
+        owner_id: str,
+        is_super_admin: bool,
+        force_upgrade: bool = False,
+    ) -> Dict[str, Any]:
+        """Authorize an actor before entering caller lifecycle operations."""
+        ...
+
     async def get_caller_connection(
         self,
         user_id: str,

--- a/src/backend/src/agentclaw/community/core/expert_chat/services/expert_chat_instance_service.py
+++ b/src/backend/src/agentclaw/community/core/expert_chat/services/expert_chat_instance_service.py
@@ -45,6 +45,7 @@ from agentclaw.community.core.devices.models import DeviceBindingStatus
 from agentclaw.community.core.repository.protocols.devices import DeviceBindingRepository
 from agentclaw.community.core.expert_chat.errors import (
     BotNotPublishedError,
+    ChatPermissionError,
     ConnectionError,
 )
 from agentclaw.community.core.repository.protocols.chat import ExpertChatInstanceRepository
@@ -128,6 +129,52 @@ class ExpertChatInstanceService(ExpertChatInstanceServiceProtocol):
     # ------------------------------------------------------------------
     # Public entry
     # ------------------------------------------------------------------
+    async def get_authorized_caller_connection(
+        self,
+        *,
+        operator_id: str,
+        user_id: str,
+        bot_id: str,
+        owner_id: str,
+        is_super_admin: bool,
+        force_upgrade: bool = False,
+    ) -> Dict[str, Any]:
+        """Authorize an actor before entering the existing lifecycle flow."""
+        if is_super_admin:
+            return await self.get_caller_connection(
+                user_id=user_id,
+                bot_id=bot_id,
+                owner_id=owner_id,
+                force_upgrade=force_upgrade,
+            )
+
+        # COSEC: caller lifecycle access requires trusted actor identity plus
+        # an exact existing instance with a reusable container identifier.
+        if operator_id != user_id:
+            raise self._caller_permission_error("cross_user")
+
+        instance = self._instance_repo.get_instance(user_id, bot_id, owner_id)
+        if instance is None:
+            raise self._caller_permission_error("instance_not_found")
+
+        ext = instance.get("ext")
+        bot_uuid = ext.get("bot_uuid") if isinstance(ext, dict) else None
+        if not isinstance(bot_uuid, str) or not bot_uuid.strip():
+            raise self._caller_permission_error("instance_missing_bot_uuid")
+
+        return await self.get_caller_connection(
+            user_id=user_id,
+            bot_id=bot_id,
+            owner_id=owner_id,
+            force_upgrade=force_upgrade,
+        )
+
+    @staticmethod
+    def _caller_permission_error(reason: str) -> ChatPermissionError:
+        error = ChatPermissionError("无权限执行此操作")
+        error.reason = reason
+        return error
+
     async def get_caller_connection(
         self,
         user_id: str,

--- a/src/backend/tests/community/api/expert_chat/test_router.py
+++ b/src/backend/tests/community/api/expert_chat/test_router.py
@@ -1,6 +1,8 @@
 """Tests for ExpertChat API router."""
+import logging
+
 import pytest
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from fastapi_injector import attach_injector
@@ -16,6 +18,9 @@ from agentclaw.community.core.expert_chat.errors import (
 )
 from agentclaw.community.core.expert_chat.services.expert_chat_service import (
     ExpertChatService,
+)
+from agentclaw.community.core.expert_chat.services.expert_chat_instance_service import (
+    ExpertChatInstanceService,
 )
 
 
@@ -117,6 +122,140 @@ def client_with_mock(mock_expert_chat_service):
 
     client = TestClient(app)
     yield client, mock_expert_chat_service
+
+
+@pytest.fixture
+def caller_connection_client():
+    """Create a focused caller-connection client with a mockable Service API."""
+    from agentclaw.community.adapters.http.expert_chat import router as expert_chat_router
+    from agentclaw.community.adapters.http.auth.dependencies import get_current_user
+    from agentclaw.community.api.expert_chat_instance_service import (
+        ExpertChatInstanceServiceProtocol,
+    )
+    from agentclaw.community.plugin_api.auth import AuthenticatedIdentity
+
+    app = FastAPI()
+    app.include_router(expert_chat_router)
+
+    instance_service = MagicMock(spec=ExpertChatInstanceService)
+    instance_service.get_authorized_caller_connection = AsyncMock()
+
+    class _TestModule(Module):
+        def configure(self, binder):
+            binder.bind(
+                ExpertChatInstanceServiceProtocol, to=instance_service
+            )
+
+    attach_injector(app, Injector([_TestModule()]))
+
+    mock_user = MagicMock(spec=AuthenticatedIdentity)
+    mock_user.staffId = "caller_user"
+    mock_user.operatorName = "Caller User"
+    mock_user.nickName = "Caller User"
+    mock_user.tenantId = "test_tenant"
+    app.dependency_overrides[get_current_user] = lambda: mock_user
+
+    with TestClient(app) as client:
+        yield client, instance_service, mock_user
+
+
+class TestCallerConnection:
+    """Router adaptation and safe boundary logging for caller instances."""
+
+    @staticmethod
+    def _post(client):
+        return client.post(
+            "/api/v1/expert-chats/caller-connection",
+            params={
+                "bot_id": "caller_bot",
+                "owner_id": "caller_owner",
+                "user_id": "caller_user",
+                "force_upgrade": "true",
+            },
+        )
+
+    def test_passes_actor_role_and_logs_safe_success(
+        self, caller_connection_client, caplog
+    ):
+        client, instance_service, _ = caller_connection_client
+        instance_service.get_authorized_caller_connection.return_value = {
+            "instance": {"ext": {"connection": "SENSITIVE_CONNECTION"}},
+            "connection": {"token": "SENSITIVE_TOKEN"},
+            "need_poll": False,
+        }
+
+        with caplog.at_level(logging.INFO), patch(
+            "agentclaw.community.adapters.http.expert_chat.router.super_admin",
+            return_value=frozenset(),
+        ):
+            response = self._post(client)
+
+        assert response.status_code == 200
+        assert response.json()["success"] is True
+        instance_service.get_authorized_caller_connection.assert_awaited_once_with(
+            operator_id="caller_user",
+            user_id="caller_user",
+            bot_id="caller_bot",
+            owner_id="caller_owner",
+            is_super_admin=False,
+            force_upgrade=True,
+        )
+        logs = caplog.text
+        assert "event=expert_chat.caller_connection.request" in logs
+        assert "event=expert_chat.caller_connection.success" in logs
+        assert "authorized_as=self" in logs
+        assert "need_poll=False" in logs
+        assert "SENSITIVE_CONNECTION" not in logs
+        assert "SENSITIVE_TOKEN" not in logs
+        assert "Authorization" not in logs
+        assert "Cookie" not in logs
+
+    @pytest.mark.parametrize(
+        ("operator_id", "reason", "expected_code"),
+        [
+            ("anonymous", "missing_operator", 400),
+            ("caller_user", "instance_not_found", 403),
+        ],
+    )
+    def test_logs_safe_denial(
+        self, caller_connection_client, caplog, operator_id, reason, expected_code
+    ):
+        client, instance_service, mock_user = caller_connection_client
+        mock_user.staffId = operator_id
+        error = ChatPermissionError("SENSITIVE_SECRET")
+        error.reason = reason
+        instance_service.get_authorized_caller_connection.side_effect = error
+
+        with caplog.at_level(logging.INFO):
+            response = self._post(client)
+
+        assert response.status_code == 200
+        assert response.json()["error_code"] == expected_code
+        assert "event=expert_chat.caller_connection.request" in caplog.text
+        assert "event=expert_chat.caller_connection.denied" in caplog.text
+        assert f"reason={reason}" in caplog.text
+        assert "SENSITIVE_SECRET" not in caplog.text
+        if expected_code == 400:
+            instance_service.get_authorized_caller_connection.assert_not_awaited()
+        else:
+            instance_service.get_authorized_caller_connection.assert_awaited_once()
+
+    def test_logs_exception_type_without_secret(
+        self, caller_connection_client, caplog
+    ):
+        client, instance_service, _ = caller_connection_client
+        instance_service.get_authorized_caller_connection.side_effect = RuntimeError(
+            "SENSITIVE_CREDENTIAL"
+        )
+
+        with caplog.at_level(logging.INFO):
+            response = self._post(client)
+
+        assert response.status_code == 200
+        assert response.json()["error_code"] == 5999
+        assert "event=expert_chat.caller_connection.failed" in caplog.text
+        assert "exception_type=RuntimeError" in caplog.text
+        assert "SENSITIVE_CREDENTIAL" not in caplog.text
 
 
 class TestAddChatBot:

--- a/src/backend/tests/community/architecture/test_service_api_conformance.py
+++ b/src/backend/tests/community/architecture/test_service_api_conformance.py
@@ -82,6 +82,15 @@ from agentclaw.community.api.engine_runtime_service import EngineRuntimeRelayPro
 from agentclaw.community.api.health_diagnosis_service import (
     HealthDiagnosisServiceProtocol,
 )
+from agentclaw.community.api.expert_chat_instance_service import (
+    ExpertChatInstanceServiceProtocol,
+)
+from agentclaw.community.core.expert_chat.expert_chat_instance_service_protocol import (
+    ExpertChatInstanceServiceProtocol as CoreExpertChatInstanceServiceProtocol,
+)
+from agentclaw.community.core.expert_chat.services.expert_chat_instance_service import (
+    ExpertChatInstanceService,
+)
 from agentclaw.community.api.local_bot_workflow_service import (
     LocalBotWorkflowServiceProtocol,
 )
@@ -269,6 +278,7 @@ from agentclaw.community.core.spaces.services import (
 
 # (Protocol, ConcreteService) pairs whose Protocol declares real signatures.
 _PAIRS = [
+    (ExpertChatInstanceServiceProtocol, ExpertChatInstanceService),
     (BotAppGrantServiceProtocol, BotAppGrantService),
     (CollaboratorServiceProtocol, CollaboratorService),
     (BotInventoryServiceProtocol, BotInventoryService),
@@ -378,6 +388,12 @@ def test_protocol_signatures_match_the_implementation(protocol, concrete) -> Non
         f"{concrete.__name__} drifted from {protocol.__name__}:\n  "
         + "\n  ".join(mismatches)
     )
+
+
+@pytest.mark.unit
+def test_expert_chat_instance_api_reexports_owning_core_protocol() -> None:
+    """The adapter and concrete service must share one Protocol authority."""
+    assert ExpertChatInstanceServiceProtocol is CoreExpertChatInstanceServiceProtocol
 
 
 @pytest.mark.unit

--- a/src/backend/tests/community/core/expert_chat/services/test_expert_chat_instance_service.py
+++ b/src/backend/tests/community/core/expert_chat/services/test_expert_chat_instance_service.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass
 
 from agentclaw.community.core.expert_chat.errors import (
     BotNotPublishedError,
+    ChatPermissionError,
     ConnectionError,
 )
 from agentclaw.community.core.expert_chat.services.expert_chat_instance_service import (
@@ -1877,3 +1878,107 @@ class TestCallerIdentityExchange:
         call_kwargs = caller_identity.exchange_caller_identity.call_args[1]
         # binding_id=0 should be passed as is (the method signature accepts Optional[int])
         assert call_kwargs["binding_id"] == 0
+
+
+class TestGetAuthorizedCallerConnection:
+    """Actor-aware authorization before the existing lifecycle entry."""
+
+    @pytest.mark.asyncio
+    async def test_admin_preserves_existing_creation_path(self):
+        svc, instance_repo, baas, *_ = _make_service()
+        expected = {"connection": None, "need_poll": True}
+        svc.get_caller_connection = AsyncMock(return_value=expected)
+
+        result = await svc.get_authorized_caller_connection(
+            operator_id="admin",
+            user_id=USER_ID,
+            bot_id=BOT_ID,
+            owner_id=OWNER_ID,
+            is_super_admin=True,
+        )
+
+        assert result == expected
+        instance_repo.get_instance.assert_not_called()
+        svc.get_caller_connection.assert_awaited_once_with(
+            user_id=USER_ID,
+            bot_id=BOT_ID,
+            owner_id=OWNER_ID,
+            force_upgrade=False,
+        )
+        baas.get_publish_progress.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_self_with_existing_bot_uuid_delegates_force_upgrade(self):
+        svc, instance_repo, _, *_ = _make_service()
+        instance_repo.get_instance.return_value = {
+            "status": "success",
+            "ext": {"bot_uuid": BOT_UUID},
+        }
+        expected = {"connection": None, "need_poll": True}
+        svc.get_caller_connection = AsyncMock(return_value=expected)
+
+        result = await svc.get_authorized_caller_connection(
+            operator_id=USER_ID,
+            user_id=USER_ID,
+            bot_id=BOT_ID,
+            owner_id=OWNER_ID,
+            is_super_admin=False,
+            force_upgrade=True,
+        )
+
+        assert result == expected
+        instance_repo.get_instance.assert_called_once_with(
+            USER_ID, BOT_ID, OWNER_ID
+        )
+        svc.get_caller_connection.assert_awaited_once_with(
+            user_id=USER_ID,
+            bot_id=BOT_ID,
+            owner_id=OWNER_ID,
+            force_upgrade=True,
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("operator_id", "instance", "reason"),
+        [
+            ("other-user", {"ext": {"bot_uuid": BOT_UUID}}, "cross_user"),
+            (USER_ID, None, "instance_not_found"),
+            (USER_ID, {"ext": {}}, "instance_missing_bot_uuid"),
+            (USER_ID, {"ext": {"bot_uuid": "  "}}, "instance_missing_bot_uuid"),
+            (USER_ID, {"ext": {"bot_uuid": 123}}, "instance_missing_bot_uuid"),
+            (USER_ID, {"ext": "invalid-ext"}, "instance_missing_bot_uuid"),
+        ],
+    )
+    async def test_denied_before_lifecycle_calls(
+        self, operator_id, instance, reason
+    ):
+        svc, instance_repo, baas, _, bot_repo, _, bot_build_service, *_ = (
+            _make_service()
+        )
+        instance_repo.get_instance.return_value = instance
+        svc.get_caller_connection = AsyncMock()
+
+        with pytest.raises(ChatPermissionError) as exc_info:
+            await svc.get_authorized_caller_connection(
+                operator_id=operator_id,
+                user_id=USER_ID,
+                bot_id=BOT_ID,
+                owner_id=OWNER_ID,
+                is_super_admin=False,
+            )
+
+        assert getattr(exc_info.value, "reason") == reason
+        svc.get_caller_connection.assert_not_awaited()
+        instance_repo.upsert_instance.assert_not_called()
+        instance_repo.update_instance.assert_not_called()
+        bot_repo.get_by_id_and_owner.assert_not_called()
+        bot_build_service.release_async.assert_not_called()
+        bot_build_service.upgrade_async.assert_not_called()
+        baas.get_publish_progress.assert_not_called()
+        baas.get_ws_info_by_bot_uuid.assert_not_called()
+        if reason == "cross_user":
+            instance_repo.get_instance.assert_not_called()
+        else:
+            instance_repo.get_instance.assert_called_once_with(
+                USER_ID, BOT_ID, OWNER_ID
+            )

--- a/src/backend/tests/community/endpoints/test_expert_chat_caller_connection.py
+++ b/src/backend/tests/community/endpoints/test_expert_chat_caller_connection.py
@@ -7,6 +7,9 @@ LocalHttpClient.set_override mechanism for HTTP interactions.
 from typing import Annotated
 
 from agentclaw.community.core.repository.protocols.bot import BotRepository
+from agentclaw.community.core.repository.protocols.chat import (
+    ExpertChatInstanceRepository,
+)
 from agentclaw.community.core.repository.protocols.devices import DeviceBindingRepository
 from agentclaw.community.core.repository.protocols.publishing import BotPublishRepositoryProtocol
 from agentclaw.community.core.service_bot.repository.models import PublishStatus
@@ -181,6 +184,19 @@ def _seed_happy(world) -> None:
     _install_baas(world)
 
 
+def _seed_existing_caller_instance(world) -> None:
+    """Seed an existing caller container eligible for self-management."""
+    _seed_happy(world)
+    make_staff_user(world, user_id=_USER_ID)
+    world.get(ExpertChatInstanceRepository).upsert_instance(
+        user_id=_USER_ID,
+        bot_id=_BOT_ID,
+        owner_id=_OWNER_ID,
+        status="success",
+        ext={"bot_uuid": _BOT_UUID, "version": 1},
+    )
+
+
 # ---------------------------------------------------------------------------
 # Happy path: super admin successfully gets caller connection
 # ---------------------------------------------------------------------------
@@ -208,6 +224,59 @@ def _seed_happy(world) -> None:
 )
 def test_caller_connection_happy():
     """Super admin can get caller connection for another user."""
+
+
+# ---------------------------------------------------------------------------
+# Happy path: caller can manage their own existing container
+# ---------------------------------------------------------------------------
+
+@endpoint_test(
+    method="POST",
+    path="/api/v1/expert-chats/caller-connection",
+    scenario="caller_gets_existing_own_connection",
+    input=CaseInput(
+        query_params={
+            "bot_id": _BOT_ID,
+            "owner_id": _OWNER_ID,
+            "user_id": _USER_ID,
+        },
+        headers={"x-user-id": _USER_ID},
+    ),
+    seed=_seed_existing_caller_instance,
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={
+            "success": True,
+            "error_code": 0,
+        },
+    ),
+)
+def test_caller_connection_self_existing_instance():
+    """A caller can obtain their own exact existing container connection."""
+
+
+@endpoint_test(
+    method="POST",
+    path="/api/v1/expert-chats/caller-connection",
+    scenario="caller_without_instance_forbidden",
+    input=CaseInput(
+        query_params={
+            "bot_id": _BOT_ID,
+            "owner_id": _OWNER_ID,
+            "user_id": _USER_ID,
+        },
+        headers={"x-user-id": _USER_ID},
+    ),
+    expect=ExpectError(
+        status=200,
+        json_contains={
+            "success": False,
+            "error_code": 403,
+        },
+    ),
+)
+def test_caller_connection_self_without_instance():
+    """A caller cannot create their first container through this endpoint."""
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`POST /api/v1/expert-chats/caller-connection` only allowed super administrators to create, reuse, or upgrade per-caller container instances. A regular caller could not restart an already-provisioned container that belongs to their own exact `ac_expert_chat_instance` record.

The endpoint returns private runtime connection data, so self-service access must not allow first-time provisioning creation, cross-user operations, or access based only on public/collaborator chat permissions.

## Solution

- Preserve the existing super-administrator path, including delegated first-time creation, reuse, and forced upgrade.
- Add an actor-aware service entry point for regular users.
- Require the authenticated operator to equal the requested caller `user_id`.
- Require an exact current-environment `ac_expert_chat_instance` match for `bot_id + owner_id + user_id` with a non-empty string `ext.bot_uuid`.
- Reject cross-user, missing-instance, and missing-container cases before any lifecycle, publish, BaaS, or connection call.
- Keep the route as POST and do not introduce public/collaborator authorization.
- Keep the Service API contract single-sourced in the owning core Protocol and add Protocol/Concrete conformance coverage.
- Add structured request, success, denial, and failure logs without logging connection credentials, cookies, headers, tokens, or full instance extensions.

## Validation

Validated against `REL20260904` at `3c3aeaf109638ea5e1d917a31dd0fd38d971e5ac`:

```text
Backend CI gate: PASS
casePassRate: 100.00% (17127/17127)
lineCoverage: 88.55% (required >= 75%)
changeLineCoverage: 100.00% (44/44, required >= 80%)
coverage pytest: 17068 passed, 59 skipped, 0 failed
focused feature and architecture tests: 403 passed, 0 failed
git diff --check: PASS
```

The skipped tests require a live Singlebox/Backend/BaaS environment. No live container restart was performed as part of local validation.

## Compatibility and risk

- The existing administrator behavior and POST request contract remain unchanged.
- There is no database migration or schema change.
- Regular users cannot create a first caller instance through this endpoint.
- Rollback is limited to reverting the two commits in this PR.

## Spec

- `src/backend/specs/caller-instance-self-restart/001-spec-output.md`
- `src/backend/specs/caller-instance-self-restart/002-code-report.md`
- `src/backend/specs/caller-instance-self-restart/003-review-report.md`
- `src/backend/specs/caller-instance-self-restart/003b-regression-report.md`


## Remote PR status

- GitHub checks: all required checks passed, including Backend unit tests and Singlebox coverage.
- Review decision: approved.
- Automated review comments: none.
- Inline and issue comments requiring changes: none.
