### PR TITLE
feat(sessions): filter OpenClaw sessions by caller

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/sessions/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/sessions/router.py
@@ -100,7 +100,6 @@ SessionIdPath = Annotated[
     ),
 ]
 
-
 #: One extra item is requested beyond the page, purely to learn whether more
 #: exist. Neither engine route reports a total, and ``Page.total`` is required —
 #: so for this group the total is derived from the window rather than invented,
@@ -213,6 +212,8 @@ async def list_sessions(
         bot_id=bot_id, user_id=user_id, owner_id=owner_id, stage=stage,
     )
     params: dict[str, Any] = _window(page)
+    if owner_id == user_id:
+        params.update(user_id=user_id, source="all_but_others")
     if agent_id:
         params["agent_id"] = agent_id
     # Both filters are applied upstream, *before* the engine paginates — so

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/sessions/schemas_helpers.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/sessions/schemas_helpers.py
@@ -111,9 +111,10 @@ def _window(page_params: Any) -> dict[str, int]:
     capped the reported total at the prefix length.
 
     This is the **session list**'s window, and it is the straightforward one: the
-    engine paginates a fully-materialised list
-    (``plugins/openclaw/_session.py``: ``raw_sessions[offset : offset+limit]``),
-    so ``offset``/``limit`` mean what they say. Message history does not — see
+    engine materialises enough of the provider's list, applies its filters,
+    and then slices it (``plugins/openclaw/_session.py``:
+    ``raw_sessions[offset : offset+limit]``), so ``offset``/``limit`` mean what
+    they say. Message history does not — see
     :func:`_history_window`.
     """
     return {

--- a/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_sessions.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_sessions.py
@@ -65,6 +65,12 @@ def test_list_sessions(client, relay):
     assert data["total"] == 1
     assert data["items"][0]["session_id"] == SESSION_ID
     assert relay.paths == ["/api/sessions"]
+    assert relay.calls[0]["params"] == {
+        "offset": 0,
+        "limit": 21,
+        "user_id": OWNER,
+        "source": "all_but_others",
+    }
 
 
 def test_list_sessions_hides_openclaw_internal_title_suffix(client, relay):
@@ -90,10 +96,34 @@ def test_list_filters_are_forwarded_to_the_engine(client, relay, filter_name):
     assert relay.calls[0]["params"][filter_name] == "v"
 
 
-def test_list_omits_filters_the_caller_did_not_send(client, relay):
+def test_list_omits_optional_client_filters_the_caller_did_not_send(client, relay):
     relay.results = [EngineResult(data=[ENGINE_SESSION])]
     ok(client.get(_base()))
-    assert set(relay.calls[0]["params"]) == {"offset", "limit"}
+    assert set(relay.calls[0]["params"]) == {
+        "offset", "limit", "user_id", "source",
+    }
+
+
+def test_list_with_explicit_current_owner_adds_the_owner_source_filter(client, relay):
+    relay.results = [EngineResult(data=[ENGINE_SESSION])]
+
+    ok(client.get(_base(), params={"owner_id": OWNER}))
+
+    assert relay.calls[0]["params"]["user_id"] == OWNER
+    assert relay.calls[0]["params"]["source"] == "all_but_others"
+
+
+def test_list_for_collaborators_does_not_add_the_owner_source_filter(
+    make_client, relay
+):
+    relay.set_bot_type("service")
+    relay.add_operator("u2")
+    collaborator = make_client(router, caller="u2")
+    relay.results = [EngineResult(data=[ENGINE_SESSION])]
+
+    ok(collaborator.get(_base(), params={"owner_id": OWNER}))
+
+    assert relay.calls[0]["params"] == {"offset": 0, "limit": 21}
 
 
 def test_list_does_not_publish_engine_only_fields(client, relay):
@@ -361,7 +391,12 @@ def test_a_late_page_is_fetched_from_the_engine_not_sliced_locally(client, relay
     """
     relay.results = [EngineResult(data=_sessions(3))]
     data = ok(client.get(_base(), params={"page": 400, "page_size": 3}))
-    assert relay.calls[0]["params"] == {"offset": 1197, "limit": 4}
+    assert relay.calls[0]["params"] == {
+        "offset": 1197,
+        "limit": 4,
+        "user_id": OWNER,
+        "source": "all_but_others",
+    }
     assert [i["session_id"] for i in data["items"]] == ["s0", "s1", "s2"]
 
 
@@ -610,7 +645,12 @@ def test_the_session_window_stays_page_sized(client, relay):
     is a page size and must not grow with the offset."""
     relay.results = [EngineResult(data=[ENGINE_SESSION])]
     ok(client.get(_base(), params={"page": 3, "page_size": 50}))
-    assert relay.calls[0]["params"] == {"offset": 100, "limit": 51}
+    assert relay.calls[0]["params"] == {
+        "offset": 100,
+        "limit": 51,
+        "user_id": OWNER,
+        "source": "all_but_others",
+    }
 
 
 # ── the operator gate ────────────────────────────────────────────────────────

--- a/src/engine/src/engine/community/api/session/router.py
+++ b/src/engine/src/engine/community/api/session/router.py
@@ -116,6 +116,7 @@ async def list_sessions(
     user_id: Optional[str] = None,
     agent_id: Optional[str] = None,
     session_key: str | None = None,
+    source: str | None = None,
     limit: int = 20,
     offset: int = 0,
     engine: Optional[str] = None,
@@ -128,6 +129,7 @@ async def list_sessions(
             user_id=user_id,
             agent_id=agent_id,
             session_key=session_key,
+            source=source,
             limit=limit,
             offset=offset,
         ))

--- a/src/engine/src/engine/community/api/tests/test_session_router.py
+++ b/src/engine/src/engine/community/api/tests/test_session_router.py
@@ -96,12 +96,16 @@ class TestListSessions:
         assert body["data"][0]["id"] == "sess-1"
 
     def test_query_params_forwarded(self, client, mock_session_api):
-        resp = client.get("/api/sessions?user_id=u1&agent_id=a1&limit=5&offset=10")
+        resp = client.get(
+            "/api/sessions?user_id=u1&agent_id=a1&source=all_but_others"
+            "&limit=5&offset=10"
+        )
         assert resp.status_code == 200
         call_args = mock_session_api.list.call_args[0][0]
         assert call_args.user_id == "u1"
         assert call_args.agent_id == "a1"
         assert call_args.session_key is None
+        assert call_args.source == "all_but_others"
         assert call_args.limit == 5
         assert call_args.offset == 10
 
@@ -110,6 +114,12 @@ class TestListSessions:
         assert resp.status_code == 200
         call_args = mock_session_api.list.call_args[0][0]
         assert call_args.session_key == "session:target"
+
+    def test_unknown_source_is_forwarded_without_http_validation(self, client, mock_session_api):
+        resp = client.get("/api/sessions?source=unsupported")
+
+        assert resp.status_code == 200
+        assert mock_session_api.list.call_args[0][0].source == "unsupported"
 
     def test_service_error_returns_500(self, client, mock_session_api):
         mock_session_api.list.side_effect = RuntimeError("db error")

--- a/src/engine/src/engine/community/core/adapters/openclaw/session.py
+++ b/src/engine/src/engine/community/core/adapters/openclaw/session.py
@@ -282,7 +282,7 @@ class OpenClawSessionAdapter(SessionService):
 
         The port handles the complete legacy ordering: sessions.list RPC →
         internal BCS and bcs:group filters (keeping namespaced bcs_grp DM/bcs-cli) →
-        agent_id/session_key filters → paginate → chat.history (page only) →
+        source/agent_id/session_key filters → paginate → chat.history (page only) →
         Bot 初始化配置 filter → model normalisation.
         The adapter receives the already-filtered, already-paginated page and
         only builds DTOs.
@@ -296,6 +296,8 @@ class OpenClawSessionAdapter(SessionService):
             limit=request.limit,
             agent_id=request.agent_id,
             session_key=request.session_key,
+            user_id=request.user_id,
+            source=request.source,
         )
 
         sessions: list[Session] = []

--- a/src/engine/src/engine/community/core/adapters/openclaw/tests/test_session.py
+++ b/src/engine/src/engine/community/core/adapters/openclaw/tests/test_session.py
@@ -149,6 +149,8 @@ class _FakeSessionPort:
         limit: int = 50,
         agent_id: str | None = None,
         session_key: str | None = None,
+        user_id: str | None = None,
+        source: str | None = None,
     ) -> list[dict]:
         self.sessions_list_calls.append(
             {
@@ -157,6 +159,8 @@ class _FakeSessionPort:
                 "limit": limit,
                 "agent_id": agent_id,
                 "session_key": session_key,
+                "user_id": user_id,
+                "source": source,
             }
         )
         # Mirror the real port: request filtering happens before pagination.
@@ -281,6 +285,19 @@ async def test_list_forwards_session_key_to_port():
     await adapter.list(SessionListRequest(session_key="session:target"))
 
     assert port.sessions_list_calls[0]["session_key"] == "session:target"
+
+
+@pytest.mark.asyncio
+async def test_list_forwards_source_context_to_port():
+    port = _FakeSessionPort()
+    adapter = OpenClawSessionAdapter(port)
+
+    await adapter.list(
+        SessionListRequest(user_id="u1", source="all_but_others")
+    )
+
+    assert port.sessions_list_calls[0]["user_id"] == "u1"
+    assert port.sessions_list_calls[0]["source"] == "all_but_others"
 
 
 @pytest.mark.asyncio

--- a/src/engine/src/engine/community/core/session/models.py
+++ b/src/engine/src/engine/community/core/session/models.py
@@ -54,6 +54,7 @@ class SessionListRequest(BaseModel):
     user_id: str | None = None
     agent_id: str | None = None
     session_key: str | None = None
+    source: str | None = None
     status: Literal["active", "archived", "all"] = "active"
     limit: int = 20
     offset: int = 0

--- a/src/engine/src/engine/community/local/openclaw/plugin_impl.py
+++ b/src/engine/src/engine/community/local/openclaw/plugin_impl.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from engine.community.kernel.frames import EventFrame, ResponseFrame
 from engine.community.plugin_api.openclaw.plugin import OpenClawPlugin
+from engine.community.shared.utils import filter_openclaw_sessions_by_source
 
 
 @dataclass
@@ -156,8 +157,15 @@ class LocalOpenClawPluginImpl(OpenClawPlugin):
         limit: int = 50,
         agent_id: str | None = None,
         session_key: str | None = None,
+        user_id: str | None = None,
+        source: str | None = None,
     ) -> list[dict]:
         items = list(self._sessions.values())
+        items = filter_openclaw_sessions_by_source(
+            items,
+            source=source,
+            user_id=user_id,
+        )
         requested_session_key = session_key if session_key and session_key.strip() else None
         if requested_session_key is not None:
             # Keep local mode aligned with production: filter before pagination.

--- a/src/engine/src/engine/community/plugin_api/openclaw/session.py
+++ b/src/engine/src/engine/community/plugin_api/openclaw/session.py
@@ -27,24 +27,29 @@ class OpenClawSessionPort(Protocol):
         limit: int = 50,
         agent_id: str | None = None,
         session_key: str | None = None,
+        user_id: str | None = None,
+        source: str | None = None,
     ) -> list[dict]:
         """Orchestrate `sessions.list` + bcs filter + paginate + chat.history + init filter.
 
         Exact ordering (matches legacy `engines/openclaw/session.py:list`):
-          1. `sessions.list` RPC → raw sessions
+          1. Fetch a sufficient newest-session prefix via `sessions.list(limit)`
           2. Filter internal `agent:main:bcs_grp_` sessions and `bcs:group`
              sessions (keep namespaced `bcs_grp_*_dm_*` and bcs-cli)
-          3. Filter by `agent_id` if provided (request-param-driven but primitive)
-          4. Filter by exact non-blank `session_key` if provided
-          5. Paginate: slice `[offset : offset+limit]`
-          6. Fetch `chat.history` ONLY for the paginated page sessions
-          7. Filter out single-message "Bot 初始化配置" sessions from the page
-          8. Normalise model strings via `providers.available` (cached)
-          9. Return the final page dicts (with `_messages` and `_message_count` populated)
+          3. Apply the optional caller-relative `source` filter
+          4. Filter by `agent_id` if provided (request-param-driven but primitive)
+          5. Filter by exact non-blank `session_key` if provided
+          6. Paginate: slice `[offset : offset+limit]`
+          7. Fetch `chat.history` ONLY for the paginated page sessions
+          8. Filter out single-message "Bot 初始化配置" sessions from the page
+          9. Normalise model strings via `providers.available` (cached)
+          10. Return the final page dicts (with `_messages` and `_message_count` populated)
 
         Pagination is performed BEFORE the per-session `chat.history` RPCs so
         that history is fetched only for the visible page — matching legacy
-        behaviour exactly.  A page may return fewer than `limit` items when
+        behaviour exactly. The gateway prefix is expanded when local filters
+        would otherwise leave the requested page incomplete. A page may return
+        fewer than `limit` items when
         "Bot 初始化配置" sessions fall within it.
 
         Returns `[]` on gateway error.

--- a/src/engine/src/engine/community/plugins/openclaw/_session.py
+++ b/src/engine/src/engine/community/plugins/openclaw/_session.py
@@ -11,6 +11,8 @@ from typing import Any
 
 from engine.community.openclaw.client.gateway_client import OpenClawGatewayClient
 from engine.community.shared.utils import (
+    OPENCLAW_SOURCE_ALL_BUT_OTHERS,
+    filter_openclaw_sessions_by_source,
     managed_session_keys_equal,
     normalize_managed_session_lookup_key,
 )
@@ -133,26 +135,34 @@ class _SessionPortMixin:
         limit: int = 50,
         agent_id: str | None = None,
         session_key: str | None = None,
+        user_id: str | None = None,
+        source: str | None = None,
     ) -> list[dict[str, Any]]:
         """Orchestrate session listing with the exact legacy ordering.
 
         Exact sequence (mirrors `engines/openclaw/session.py:list`):
-          1. `sessions.list` RPC → raw sessions
+          1. Fetch a sufficient newest-session prefix via `sessions.list(limit)`
           2. Filter internal BCS sessions and `bcs:group` sessions, keeping
              namespaced `bcs_grp_*_dm_*` and bcs-cli
-          3. Filter by `agent_id` if provided
-          4. Filter by exact non-blank `session_key` if provided
-          5. Paginate: slice `[offset : offset+limit]` — BEFORE history fetch
-          6. Fetch `chat.history` ONLY for the paginated page sessions
-          7. Filter "Bot 初始化配置" single-message sessions from the page
-          8. Normalise model strings (cached provider map)
-          9. Return the final page dicts with `_messages`/`_message_count` set
+          3. Apply the optional caller-relative `source` filter
+          4. Filter by `agent_id` if provided
+          5. Filter by exact non-blank `session_key` if provided
+          6. Paginate: slice `[offset : offset+limit]` — BEFORE history fetch
+          7. Fetch `chat.history` ONLY for the paginated page sessions
+          8. Filter "Bot 初始化配置" single-message sessions from the page
+          9. Normalise model strings (cached provider map)
+          10. Return the final page dicts with `_messages`/`_message_count` set
 
         Returns `[]` for gateway business errors. Transport failures propagate
         so callers never mistake an unavailable gateway for an empty session
         collection. A page may return fewer than `limit` items when "Bot 初始化配置"
         sessions fall within it (exact legacy behaviour).
         """
+        if source is not None and (
+            source != OPENCLAW_SOURCE_ALL_BUT_OTHERS or not user_id
+        ):
+            return []
+
         client = await self._pooled_client(token)
         requested_session_key = (
             session_key if session_key and session_key.strip() else None
@@ -163,64 +173,118 @@ class _SessionPortMixin:
             else None
         )
 
-        # Push the lookup into the gateway before its default result cap is
-        # applied. Keep the exact local filter because gateway search is fuzzy.
-        list_params = (
-            {"search": lookup_session_key}
-            if lookup_session_key is not None
-            else {}
-        )
+        # OpenClaw 2026.5.12 has `limit` but no `offset`, and defaults to the
+        # newest 100 rows. Grow that prefix only when local filters leave too
+        # few rows to serve the requested window.
+        window_end = max(offset + limit, 1)
+        required_rows = 1 if requested_session_key is not None else window_end
+        gateway_limit = window_end
+        previous_raw_count = -1
+        raw_sessions: list[dict[str, Any]] = []
 
-        # Step 1: sessions.list RPC
-        try:
-            response = await client.send_request("sessions.list", list_params)
-        except (ConnectionError, TimeoutError):
-            # An empty list is a valid answer, so it must not mask an upstream outage.
-            raise
-        except Exception as e:
-            log.exception("[sessions_list] unexpected error: %s", e)
-            return []
+        while True:
+            list_params: dict[str, Any] = {"limit": gateway_limit}
+            if lookup_session_key is not None:
+                # Gateway search is fuzzy, so the exact local filter remains.
+                list_params["search"] = lookup_session_key
 
-        if not response.ok:
-            error_msg = response.error.message if response.error else "Unknown error"
-            log.error("[sessions_list] sessions.list failed: %s", error_msg)
-            return []
+            try:
+                response = await client.send_request("sessions.list", list_params)
+            except (ConnectionError, TimeoutError):
+                # An empty list is a valid answer, so it must not mask an upstream outage.
+                raise
+            except Exception as e:
+                log.exception("[sessions_list] unexpected error: %s", e)
+                return []
 
-        payload = response.payload or []
-        if isinstance(payload, dict):
-            raw_sessions: list[dict[str, Any]] = payload.get("sessions", [])
-        elif isinstance(payload, list):
-            raw_sessions = payload
-        else:
-            log.warning("[sessions_list] unexpected payload type: %s", type(payload).__name__)
-            return []
+            if not response.ok:
+                error_msg = response.error.message if response.error else "Unknown error"
+                log.error("[sessions_list] sessions.list failed: %s", error_msg)
+                return []
 
-        raw_sessions = [s for s in raw_sessions if isinstance(s, dict)]
+            payload = response.payload or []
+            total_count: int | None = None
+            if isinstance(payload, dict):
+                rows = payload.get("sessions", [])
+                if not isinstance(rows, list):
+                    log.warning(
+                        "[sessions_list] sessions field has unexpected type: %s",
+                        type(rows).__name__,
+                    )
+                    return []
+                reported_total = payload.get("totalCount")
+                if (
+                    isinstance(reported_total, int)
+                    and not isinstance(reported_total, bool)
+                    and reported_total >= 0
+                ):
+                    total_count = reported_total
+                has_more = payload.get("hasMore") is True
+                if total_count is not None:
+                    has_more = has_more or len(rows) < total_count
+            elif isinstance(payload, list):
+                rows = payload
+                has_more = False
+            else:
+                log.warning(
+                    "[sessions_list] unexpected payload type: %s",
+                    type(payload).__name__,
+                )
+                return []
 
-        # Step 2: Hide BCS group chats while keeping user-visible DM sessions.
-        raw_sessions = [s for s in raw_sessions if _should_keep_session(s)]
+            raw_count = len(rows)
+            raw_sessions = [s for s in rows if isinstance(s, dict)]
 
-        # Step 3: Filter by agent_id if provided (primitive, not DTO-driven).
-        if agent_id is not None:
-            raw_sessions = [s for s in raw_sessions if s.get("agentId") == agent_id]
+            # Step 2: Hide BCS group chats while keeping user-visible DM sessions.
+            raw_sessions = [s for s in raw_sessions if _should_keep_session(s)]
 
-        if requested_session_key is not None:
-            # Filter before pagination so a copied key can be found beyond the current page.
-            raw_sessions = [
-                s
-                for s in raw_sessions
-                if isinstance(s.get("key"), str)
-                and managed_session_keys_equal(s["key"], requested_session_key)
-            ]
+            # Step 3: Apply the optional caller-relative visibility filter.
+            raw_sessions = filter_openclaw_sessions_by_source(
+                raw_sessions,
+                source=source,
+                user_id=user_id,
+            )
 
-        # Step 5: Paginate BEFORE history fetch (legacy ordering).
+            # Step 4: Filter by agent_id if provided (primitive, not DTO-driven).
+            if agent_id is not None:
+                raw_sessions = [
+                    s for s in raw_sessions if s.get("agentId") == agent_id
+                ]
+
+            if requested_session_key is not None:
+                # Filter before pagination so a copied key can be found beyond the current page.
+                raw_sessions = [
+                    s
+                    for s in raw_sessions
+                    if isinstance(s.get("key"), str)
+                    and managed_session_keys_equal(s["key"], requested_session_key)
+                ]
+
+            if len(raw_sessions) >= required_rows or not has_more:
+                break
+            if raw_count <= previous_raw_count:
+                log.warning(
+                    "[sessions_list] gateway prefix did not grow at limit=%d",
+                    gateway_limit,
+                )
+                break
+
+            previous_raw_count = raw_count
+            next_limit = gateway_limit * 2
+            if total_count is not None:
+                next_limit = min(next_limit, total_count)
+            if next_limit <= gateway_limit:
+                break
+            gateway_limit = next_limit
+
+        # Step 6: Paginate BEFORE history fetch (legacy ordering).
         page = raw_sessions[offset: offset + limit]
 
         # Build/retrieve the cached provider map (FIX 2 — at most one RPC ever).
         provider_map = await self._get_provider_map(client)
 
-        # Step 6: Fetch chat.history ONLY for the page sessions.
-        # Step 7: Filter "Bot 初始化配置" single-message init sessions from page.
+        # Step 7: Fetch chat.history ONLY for the page sessions.
+        # Step 8: Filter "Bot 初始化配置" single-message init sessions from page.
         enriched: list[dict[str, Any]] = []
         for s in page:
             key = s.get("key", "")

--- a/src/engine/src/engine/community/plugins/openclaw/tests/test_session_port.py
+++ b/src/engine/src/engine/community/plugins/openclaw/tests/test_session_port.py
@@ -114,8 +114,19 @@ def _err(message: str = "gateway error") -> ResponseFrame:
 class TestSessionsList:
     """Orchestration tests for sessions_list (port-level raw dict asserts)."""
 
-    def _sessions_payload(self, sessions: list[dict]) -> ResponseFrame:
-        return _ok({"sessions": sessions})
+    def _sessions_payload(
+        self,
+        sessions: list[dict],
+        *,
+        total_count: int | None = None,
+        has_more: bool | None = None,
+    ) -> ResponseFrame:
+        payload: dict[str, Any] = {"sessions": sessions}
+        if total_count is not None:
+            payload["totalCount"] = total_count
+        if has_more is not None:
+            payload["hasMore"] = has_more
+        return _ok(payload)
 
     def _history_payload(self, messages: list[dict]) -> ResponseFrame:
         return _ok({"messages": messages})
@@ -280,6 +291,156 @@ class TestSessionsList:
         assert history_calls[0][1]["sessionKey"] == "s2"
         assert history_calls[1][1]["sessionKey"] == "s3"
 
+    async def test_source_filter_is_applied_before_pagination_and_history(self):
+        sessions = [
+            {"key": "session:other-1:user:u2", "label": "Other 1"},
+            {"key": "session:own-1:user:u1", "label": "Own 1"},
+            {
+                "key": "agent:main:session:other-2:user:u2",
+                "label": "Other 2",
+            },
+            {"key": "agent:main:dingtalk:direct:u2", "label": "DingTalk"},
+            {
+                "key": "agent:main:session:own-2:user:U1",
+                "label": "Own 2",
+            },
+        ]
+        impl, client = _make_impl({
+            "sessions.list": [
+                self._sessions_payload(
+                    sessions[:3], total_count=5, has_more=True
+                ),
+                self._sessions_payload(
+                    sessions, total_count=5, has_more=False
+                ),
+            ],
+            "chat.history": self._history_payload([]),
+            "providers.available": self._providers_payload(),
+        })
+
+        result = await impl.sessions_list(
+            token="tok",
+            source="all_but_others",
+            user_id="u1",
+            offset=1,
+            limit=2,
+        )
+
+        assert [session["key"] for session in result] == [
+            "agent:main:dingtalk:direct:u2",
+            "agent:main:session:own-2:user:U1",
+        ]
+        history_calls = [call for call in client.calls if call[0] == "chat.history"]
+        assert [call[1]["sessionKey"] for call in history_calls] == [
+            "agent:main:dingtalk:direct:u2",
+            "agent:main:session:own-2:user:U1",
+        ]
+        list_calls = [call for call in client.calls if call[0] == "sessions.list"]
+        assert [call[1]["limit"] for call in list_calls] == [3, 5]
+
+    async def test_source_filter_stops_when_the_requested_window_is_full(self):
+        sessions = [
+            {"key": "session:own-1:user:u1", "label": "Own 1"},
+            {"key": "agent:main:dingtalk:direct:u2", "label": "DingTalk"},
+            {"key": "agent:main:session:own-2:user:u1", "label": "Own 2"},
+        ]
+        impl, client = _make_impl({
+            "sessions.list": self._sessions_payload(
+                sessions, total_count=100, has_more=True
+            ),
+            "chat.history": self._history_payload([]),
+            "providers.available": self._providers_payload(),
+        })
+
+        result = await impl.sessions_list(
+            token="tok",
+            source="all_but_others",
+            user_id="u1",
+            offset=1,
+            limit=2,
+        )
+
+        assert [session["key"] for session in result] == [
+            "agent:main:dingtalk:direct:u2",
+            "agent:main:session:own-2:user:u1",
+        ]
+        list_calls = [call for call in client.calls if call[0] == "sessions.list"]
+        assert [call[1]["limit"] for call in list_calls] == [3]
+
+    async def test_source_filter_expands_the_gateway_prefix_progressively(self):
+        first_page = [
+            {"key": "session:other:user:u2", "label": "Other"},
+            {"key": "session:own-1:user:u1", "label": "Own 1"},
+            {"key": "session:own-2:user:u1", "label": "Own 2"},
+        ]
+        expanded_page = [
+            *first_page,
+            {"key": "session:own-3:user:u1", "label": "Own 3"},
+            {"key": "session:own-4:user:u1", "label": "Own 4"},
+            {"key": "session:own-5:user:u1", "label": "Own 5"},
+        ]
+        impl, client = _make_impl({
+            "sessions.list": [
+                self._sessions_payload(
+                    first_page, total_count=10_000, has_more=True
+                ),
+                self._sessions_payload(
+                    expanded_page, total_count=10_000, has_more=True
+                ),
+            ],
+            "chat.history": self._history_payload([]),
+            "providers.available": self._providers_payload(),
+        })
+
+        result = await impl.sessions_list(
+            token="tok",
+            source="all_but_others",
+            user_id="u1",
+            limit=3,
+        )
+
+        assert [session["key"] for session in result] == [
+            "session:own-1:user:u1",
+            "session:own-2:user:u1",
+            "session:own-3:user:u1",
+        ]
+        list_calls = [call for call in client.calls if call[0] == "sessions.list"]
+        assert [call[1]["limit"] for call in list_calls] == [3, 6]
+
+    @pytest.mark.parametrize("source", ["mine", "others", "", "unsupported"])
+    async def test_unsupported_source_returns_no_sessions(self, source: str):
+        impl, client = _make_impl({
+            "sessions.list": self._sessions_payload([
+                {"key": "session:own:user:u1", "label": "Own"},
+            ]),
+            "providers.available": self._providers_payload(),
+        })
+
+        result = await impl.sessions_list(
+            token="tok",
+            source=source,
+            user_id="u1",
+        )
+
+        assert result == []
+        assert client.calls == []
+
+    async def test_all_but_others_without_user_returns_no_sessions(self):
+        impl, client = _make_impl({
+            "sessions.list": self._sessions_payload([
+                {"key": "agent:main:main", "label": "Main"},
+            ]),
+            "providers.available": self._providers_payload(),
+        })
+
+        result = await impl.sessions_list(
+            token="tok",
+            source="all_but_others",
+        )
+
+        assert result == []
+        assert client.calls == []
+
     async def test_session_key_filter_applied_before_pagination(self):
         sessions = [
             {"key": f"s{i}", "label": f"Session {i}", "model": None}
@@ -297,7 +458,11 @@ class TestSessionsList:
 
         assert [session["key"] for session in result] == ["s20"]
         sessions_list_calls = [call for call in client.calls if call[0] == "sessions.list"]
-        assert sessions_list_calls == [("sessions.list", {"search": "s20"}, None)]
+        assert sessions_list_calls == [(
+            "sessions.list",
+            {"limit": 1, "search": "s20"},
+            None,
+        )]
         history_calls = [call for call in client.calls if call[0] == "chat.history"]
         assert [call[1]["sessionKey"] for call in history_calls] == ["s20"]
 
@@ -315,7 +480,11 @@ class TestSessionsList:
 
         assert [session["key"] for session in result] == ["target"]
         sessions_list_calls = [call for call in client.calls if call[0] == "sessions.list"]
-        assert sessions_list_calls == [("sessions.list", {"search": "target"}, None)]
+        assert sessions_list_calls == [(
+            "sessions.list",
+            {"limit": 50, "search": "target"},
+            None,
+        )]
 
     async def test_session_key_filter_accepts_cloud_create_relative_key(self):
         canonical = "agent:main:session:abc-123:user:clouduser"
@@ -336,7 +505,7 @@ class TestSessionsList:
         sessions_list_calls = [call for call in client.calls if call[0] == "sessions.list"]
         assert sessions_list_calls == [(
             "sessions.list",
-            {"search": "session:abc-123:user:clouduser"},
+            {"limit": 50, "search": "session:abc-123:user:clouduser"},
             None,
         )]
 
@@ -370,7 +539,7 @@ class TestSessionsList:
 
         assert [session["key"] for session in result] == ["s1"]
         sessions_list_calls = [call for call in client.calls if call[0] == "sessions.list"]
-        assert sessions_list_calls == [("sessions.list", {}, None)]
+        assert sessions_list_calls == [("sessions.list", {"limit": 2}, None)]
 
     async def test_model_normalization_present(self):
         """_normalized_model is set for each returned session dict."""
@@ -478,8 +647,7 @@ class TestSessionsList:
         assert len(result) == 1
         assert result[0]["key"] == "s1"
 
-    async def test_sessions_list_sends_correct_rpc(self):
-        """sessions.list is called with an empty params dict {}."""
+    async def test_sessions_list_sends_requested_window_as_gateway_limit(self):
         impl, client = _make_impl({
             "sessions.list": _ok([]),
             "providers.available": self._providers_payload(),
@@ -487,7 +655,7 @@ class TestSessionsList:
         await impl.sessions_list(token="tok")
         sl_calls = [c for c in client.calls if c[0] == "sessions.list"]
         assert len(sl_calls) == 1
-        assert sl_calls[0][1] == {}
+        assert sl_calls[0][1] == {"limit": 50}
 
 
 # ── session_create ────────────────────────────────────────────────────────────

--- a/src/engine/src/engine/community/shared/tests/test_utils.py
+++ b/src/engine/src/engine/community/shared/tests/test_utils.py
@@ -6,6 +6,7 @@ import pytest
 from engine.community.shared.utils import (
     decode_session_key,
     encode_session_key,
+    filter_openclaw_sessions_by_source,
     managed_session_keys_equal,
     normalize_managed_session_lookup_key,
 )
@@ -39,6 +40,59 @@ def test_managed_session_keys_match_relative_and_agent_scoped_forms():
     )
     assert not managed_session_keys_equal("Opaque-ID", "opaque-id")
     assert not managed_session_keys_equal("prefix:target", "target")
+
+
+def test_openclaw_all_but_others_filters_only_managed_user_sessions():
+    sessions = [
+        {"key": "session:own:user:CloudUser"},
+        {"key": "agent:main:session:own-2:user:clouduser"},
+        {"key": "session:other:user:another-user"},
+        {"key": "agent:main:session:other-2:user:another-user"},
+        {"key": "agent:other:session:other-agent:user:another-user"},
+        {"key": "agent:main:dingtalk:direct:another-user"},
+        {"key": "agent:main:cron:daily"},
+        {"key": "agent:main:main"},
+    ]
+
+    visible = filter_openclaw_sessions_by_source(
+        sessions,
+        source="all_but_others",
+        user_id="clouduser",
+    )
+
+    assert [session["key"] for session in visible] == [
+        "session:own:user:CloudUser",
+        "agent:main:session:own-2:user:clouduser",
+        "agent:other:session:other-agent:user:another-user",
+        "agent:main:dingtalk:direct:another-user",
+        "agent:main:cron:daily",
+        "agent:main:main",
+    ]
+
+
+def test_openclaw_source_omission_preserves_the_unfiltered_list():
+    sessions = [{"key": "session:other:user:another-user"}]
+
+    assert filter_openclaw_sessions_by_source(
+        sessions, source=None, user_id=None
+    ) is sessions
+
+
+@pytest.mark.parametrize("source", ["mine", "others", "", "unsupported"])
+def test_openclaw_unsupported_source_values_return_no_sessions(source):
+    sessions = [{"key": "session:own:user:u1"}, {"key": "agent:main:main"}]
+
+    assert filter_openclaw_sessions_by_source(
+        sessions, source=source, user_id="u1"
+    ) == []
+
+
+def test_openclaw_all_but_others_without_a_user_returns_no_sessions():
+    assert filter_openclaw_sessions_by_source(
+        [{"key": "agent:main:main"}],
+        source="all_but_others",
+        user_id=None,
+    ) == []
 
 
 class TestEncodeSessionKey:

--- a/src/engine/src/engine/community/shared/utils.py
+++ b/src/engine/src/engine/community/shared/utils.py
@@ -3,11 +3,45 @@
 """
 import base64
 import re
+from typing import Any
 
 _MANAGED_SESSION_KEY = re.compile(
     r"^(?:agent:([^:]+):)?(session:[^:]+:user:[^:]+)$",
     re.IGNORECASE,
 )
+_OPENCLAW_USER_SESSION_KEY = re.compile(
+    r"^(?:agent:main:)?session:[^:]+:user:([^:]+)$"
+)
+
+OPENCLAW_SOURCE_ALL_BUT_OTHERS = "all_but_others"
+
+
+def filter_openclaw_sessions_by_source(
+    sessions: list[dict[str, Any]],
+    *,
+    source: str | None,
+    user_id: str | None,
+) -> list[dict[str, Any]]:
+    """Apply OpenClaw's optional caller-relative session visibility filter."""
+    if source is None:
+        return sessions
+    if source != OPENCLAW_SOURCE_ALL_BUT_OTHERS or not user_id:
+        # COSEC: Unknown explicit filters fail closed instead of exposing an
+        # unfiltered session list under a restriction the caller expected.
+        return []
+
+    caller_id = user_id.casefold()
+    visible: list[dict[str, Any]] = []
+    for session in sessions:
+        key = session.get("key")
+        match = (
+            _OPENCLAW_USER_SESSION_KEY.fullmatch(key)
+            if isinstance(key, str)
+            else None
+        )
+        if match is None or match.group(1).casefold() == caller_id:
+            visible.append(session)
+    return visible
 
 
 def normalize_managed_session_lookup_key(session_key: str) -> str:

--- a/src/engine/src/engine/community/tests/contracts/test_openclaw_local_plugin.py
+++ b/src/engine/src/engine/community/tests/contracts/test_openclaw_local_plugin.py
@@ -90,10 +90,26 @@ async def test_local_openclaw_plugin_stateful_ports_and_error_branches():
     # Session/chat history lifecycle.
     await plugin.session_create("s1", label="one", model="m1")
     await plugin.session_create("s2", label="two", model="m2")
+    await plugin.session_create("session:own:user:u1", label="own")
+    await plugin.session_create("session:other:user:u2", label="other")
+    await plugin.session_create("agent:main:dingtalk:direct:u2", label="dingtalk")
     assert [s["key"] for s in await plugin.sessions_list(offset=1, limit=1)] == ["s2"]
     assert [s["key"] for s in await plugin.sessions_list(session_key="s2", limit=1)] == ["s2"]
     assert await plugin.sessions_list(session_key="missing") == []
     assert [s["key"] for s in await plugin.sessions_list(session_key="   ", limit=1)] == ["s1"]
+    assert [
+        s["key"]
+        for s in await plugin.sessions_list(
+            source="all_but_others",
+            user_id="u1",
+        )
+    ] == [
+        "s1",
+        "s2",
+        "session:own:user:u1",
+        "agent:main:dingtalk:direct:u2",
+    ]
+    assert await plugin.sessions_list(source="others", user_id="u1") == []
     await plugin.session_patch_then_get("s1", label="patched")
     assert (await plugin.sessions_list())[0]["label"] == "patched"
     await plugin.session_patch_then_get("new", model="m3")


### PR DESCRIPTION
## Summary
- derive `source=all_but_others` for owner-facing OpenAPI session listings without exposing `source` publicly
- forward the optional source context through the Engine Adapter while unsupported engines preserve their existing behavior
- filter only the agreed OpenClaw managed-user session-key forms before pagination, preserving DingTalk and other channel sessions
- adapt limit-only OpenClaw pagination by progressively expanding the fetched prefix when local filters leave a page incomplete

## Compatibility
- requests without `source` keep the existing OpenClaw listing behavior
- collaborator listings do not receive the owner-relative filter
- invalid explicit OpenClaw source values fail closed with an empty list

## Tests
- `DEPLOY_PROFILE=test uv run pytest tests/community/adapters/http/openapi_v1/engine_runtime/test_sessions.py -q` (97 passed)
- `PYTHONPATH=... python -m pytest src/engine/community -q` (2458 passed)
- `git diff --check`