### PR TITLE
ci(singlebox-coverage): stop paying npm's retired audit endpoint and cache the BCN plugin

### DIFF
--- a/.github/workflows/singlebox-coverage.yml
+++ b/.github/workflows/singlebox-coverage.yml
@@ -193,6 +193,29 @@ jobs:
             ${{ runner.os }}-cargo-e2e-
             ${{ runner.os }}-cargo-
 
+      - name: Cache built BCN plugin
+        if: steps.changes.outputs.skip != 'true'
+        uses: actions/cache@v4
+        with:
+          # `setup_bcn_plugin` (scripts/modules/bcs.sh) rebuilds the plugin from
+          # source on every run: three unlocked npm tree operations in a fresh
+          # temp dir. package-lock.json is gitignored for this package, so npm
+          # re-resolves all 2051 packages from the registry each time — the one
+          # npm step in this job with no lockfile to fall back on. That cost 29s
+          # when the registry was fast and 11m when it was not (run 33837445531).
+          # Restoring dist/ + node_modules makes the script's own
+          # "BCN plugin already built, skipping" branch fire instead.
+          #
+          # No restore-keys: a near-miss would restore a dist/ built from a
+          # different package.json and the skip branch would accept it, so the
+          # key must match exactly or the plugin is rebuilt. node_modules is the
+          # prod-only tree the build reduces to before copying back: `ws` alone,
+          # 232 KB, so this entry stays small against the repo cache budget.
+          path: |
+            src/bcs/crates/plugins/openclaw-channel-bcn/dist
+            src/bcs/crates/plugins/openclaw-channel-bcn/node_modules
+          key: ${{ runner.os }}-bcn-plugin-${{ hashFiles('src/bcs/crates/plugins/openclaw-channel-bcn/package.json', 'src/bcs/crates/plugins/openclaw-channel-bcn/.npmrc') }}
+
       - name: Validate shell scripts
         if: steps.changes.outputs.skip != 'true'
         run: |

--- a/scripts/modules/bcs.sh
+++ b/scripts/modules/bcs.sh
@@ -324,12 +324,21 @@ install_bcs_panel_asset_deps() {
     log_info "Installing BCS panel asset dependencies..."
     cd "${BCS_PANEL_ASSET_DIR}"
 
+    # --no-audit/--no-fund: npm's legacy audit endpoint is being retired
+    # ("This endpoint is being retired. Use the bulk advisory endpoint
+    # instead"), and the call now stalls for ~7m before npm gives up and
+    # prints neither "audited N packages" nor a vulnerability count. The
+    # stall is a fixed cost per invocation, not proportional to the tree:
+    # these 33 packages took 421s with audit on and 3s with it off, for an
+    # identical node_modules. Auditing here was never a gate either — it
+    # printed advisories into a CI log nobody reads. Same flags as the
+    # claude_relays.sh gateway build.
     if [ -f package-lock.json ]; then
-        if ! HUSKY=0 npm ci --registry="${NPM_REGISTRY_URL}"; then
+        if ! HUSKY=0 npm ci --registry="${NPM_REGISTRY_URL}" --no-audit --no-fund; then
             log_error "Failed to install BCS panel asset dependencies"
             return 1
         fi
-    elif ! HUSKY=0 npm install --registry="${NPM_REGISTRY_URL}"; then
+    elif ! HUSKY=0 npm install --registry="${NPM_REGISTRY_URL}" --no-audit --no-fund; then
         log_error "Failed to install BCS panel asset dependencies"
         return 1
     fi

--- a/scripts/modules/bcs.sh
+++ b/scripts/modules/bcs.sh
@@ -538,11 +538,24 @@ setup_bcn_plugin() {
                 return 1
             fi
 
+            # The dev tree this build needs is 2051 packages / 348 MB / 56k
+            # files (.npmrc pins install-strategy=nested, so nothing dedupes).
+            # Only `ws` ships, so the tree has to be reduced before it is copied
+            # back — but `npm prune --omit=dev` reduces it by reconciling that
+            # whole tree, which takes ~7m (measured: 423s, and the same
+            # "up to date in 7m" line appears in CI run 33837445531). Deleting
+            # node_modules and reinstalling prod-only lands the same shipped
+            # tree in 4s — `ws` and nothing else, where prune also left a few
+            # empty scope dirs behind — because it resolves one package
+            # instead of 2051.
+            # --no-audit/--no-fund drop two registry round-trips whose output
+            # nobody reads out of a throwaway build dir.
             if (
                 cd "${work}" &&
-                    npm install --registry="${NPM_REGISTRY_URL}" &&
+                    npm install --registry="${NPM_REGISTRY_URL}" --no-audit --no-fund &&
                     npm run build &&
-                    npm prune --omit=dev
+                    rm -rf "${work}/node_modules" &&
+                    npm install --omit=dev --registry="${NPM_REGISTRY_URL}" --no-audit --no-fund
             ); then
                 rm -rf "${plugin_src}/dist" "${plugin_src}/node_modules"
                 if ! cp -R "${work}/dist" "${work}/node_modules" "${plugin_src}/"; then

--- a/scripts/modules/frontend.sh
+++ b/scripts/modules/frontend.sh
@@ -84,15 +84,19 @@ install_frontend_deps() {
     # 用 --registry 仅影响下载来源,npm ci 不会回写 lockfile。
     # 前端 dev server 依赖 cross-env 和 @umijs/max 等 devDependencies，显式包含 dev
     # 依赖，避免 NODE_ENV=production 或 npm omit 配置导致启动命令缺失。
+    # --no-audit/--no-fund: npm's legacy audit endpoint is being retired and
+    # the call now stalls for ~7m before giving up, a fixed cost per
+    # invocation regardless of tree size (see install_bcs_panel_asset_deps in
+    # bcs.sh for the measurement). Neither flag changes what is installed.
     if [ -f package-lock.json ]; then
-        if ! HUSKY=0 npm ci --include=dev --registry="${NPM_REGISTRY_URL}"; then
+        if ! HUSKY=0 npm ci --include=dev --registry="${NPM_REGISTRY_URL}" --no-audit --no-fund; then
             log_error "Failed to install frontend dependencies (npm ci)."
             log_error "若刚改过 package.json,请先本地 'npm install' 更新 package-lock.json 再提交。"
             return 1
         fi
     else
         log_warn "No package-lock.json; falling back to 'npm install' (will generate a lockfile)."
-        if ! HUSKY=0 npm install --include=dev --registry="${NPM_REGISTRY_URL}"; then
+        if ! HUSKY=0 npm install --include=dev --registry="${NPM_REGISTRY_URL}" --no-audit --no-fund; then
             log_error "Failed to install frontend dependencies"
             return 1
         fi

--- a/scripts/test_bcn_plugin_source.sh
+++ b/scripts/test_bcn_plugin_source.sh
@@ -546,4 +546,96 @@ test_stack_config_allows_plugin_path_refresh
 test_dynamic_config_refreshes_plugin_path
 test_dynamic_config_copies_thinking_default
 
+# Lays out a fake PROJECT_ROOT holding just the plugin source, plus an npm stub
+# that records every invocation and fakes the artifacts the real one leaves
+# behind. Echoes "<fake_root>|<calls_file>|<ext_dir>".
+_bcn_source_fixture() {
+  local tmp="$1"
+  local src="${tmp}/root/src/bcs/crates/plugins/openclaw-channel-bcn"
+  local bindir="${tmp}/bin" calls="${tmp}/npm-calls" ext="${tmp}/ext"
+  mkdir -p "$src" "$bindir" "$ext"
+  printf '{"name":"stub","version":"0.0.0"}\n' > "${src}/package.json"
+  cat > "${bindir}/npm" <<STUB
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "${calls}"
+[ "\$1 \$2" = "run build" ] && mkdir -p dist/esm && : > dist/esm/index.js
+[ "\$1" = "install" ] && mkdir -p node_modules
+exit 0
+STUB
+  chmod +x "${bindir}/npm"
+  printf '%s|%s|%s\n' "${tmp}/root" "$calls" "$ext"
+}
+
+_run_setup_bcn_source() {
+  local root="$1" bindir="$2" ext="$3" home="$4"
+  PROJECT_ROOT="$root" BCS_DIR="${root}/src/bcs" \
+  PATH="${bindir}:$PATH" OPENCLAW_EXTENSIONS_ROOT="$ext" HOME="$home" \
+  BCN_PLUGIN_SOURCE=source bash -c '
+    . "'"${SCRIPT_DIR}"'/utils.sh"
+    . "'"${SCRIPT_DIR}"'/modules/bcs.sh"
+    setup_bcn_plugin
+  ' >/dev/null 2>&1
+}
+
+# The source build reduces a 2051-package dev tree to the one package that
+# ships. `npm prune --omit=dev` did that by reconciling the whole tree (~7m
+# measured); reinstalling prod-only reaches the same state in seconds. Pin the
+# sequence so the slow form cannot come back unnoticed.
+test_source_build_reinstalls_prod_deps_instead_of_pruning() {
+  local tmp; tmp="$(mktemp -d)"
+  local fixture root calls ext
+  fixture="$(_bcn_source_fixture "$tmp")"
+  root="${fixture%%|*}"; calls="$(printf '%s' "$fixture" | cut -d'|' -f2)"
+  ext="${fixture##*|}"
+
+  _run_setup_bcn_source "$root" "${tmp}/bin" "$ext" "$tmp"
+
+  local first second third
+  first="$(sed -n 1p "$calls")"
+  second="$(sed -n 2p "$calls")"
+  third="$(sed -n 3p "$calls")"
+
+  assert_contains "$first" "install"
+  assert_contains "$first" "--no-audit"
+  assert_contains "$first" "--no-fund"
+  assert_eq "$second" "run build" "build runs against the dev tree"
+  assert_contains "$third" "install"
+  assert_contains "$third" "--omit=dev"
+
+  if grep -q -- "prune" "$calls"; then
+    fail "source build should not call npm prune: $(cat "$calls")"
+  fi
+  # The dev tree must be gone before the prod install, or the reinstall would
+  # leave all 2051 packages in place and the reduction would be a no-op.
+  if [ -d "${root}/src/bcs/crates/plugins/openclaw-channel-bcn/node_modules/eslint" ]; then
+    fail "dev dependencies survived into the copied-back tree"
+  fi
+  rm -rf "$tmp"
+}
+
+# The singlebox-coverage workflow caches dist/ + node_modules and relies on this
+# branch to turn a cache hit into a skipped build. If the skip stops firing the
+# cache silently buys nothing, so assert npm is never reached.
+test_source_build_skips_when_already_built() {
+  local tmp; tmp="$(mktemp -d)"
+  local fixture root calls ext src
+  fixture="$(_bcn_source_fixture "$tmp")"
+  root="${fixture%%|*}"; calls="$(printf '%s' "$fixture" | cut -d'|' -f2)"
+  ext="${fixture##*|}"
+  src="${root}/src/bcs/crates/plugins/openclaw-channel-bcn"
+
+  mkdir -p "${src}/dist/esm" "${src}/node_modules"
+  : > "${src}/dist/esm/index.js"
+
+  _run_setup_bcn_source "$root" "${tmp}/bin" "$ext" "$tmp"
+
+  if [ -s "$calls" ]; then
+    fail "prebuilt plugin should skip npm entirely, got: $(cat "$calls")"
+  fi
+  rm -rf "$tmp"
+}
+
+test_source_build_reinstalls_prod_deps_instead_of_pruning
+test_source_build_skips_when_already_built
+
 if [ "$FAILS" -eq 0 ]; then echo "ALL PASS"; else echo "${FAILS} FAILURE(S)"; exit 1; fi

--- a/scripts/test_singlebox_service_guards.sh
+++ b/scripts/test_singlebox_service_guards.sh
@@ -202,6 +202,24 @@ test_frontend_install_includes_dev_dependencies() (
   esac
 )
 
+# npm's legacy audit endpoint is being retired and the call now stalls ~7m
+# before giving up — a fixed cost per invocation, not proportional to the tree
+# (33 packages: 421s with audit, 3s without, identical node_modules). Every
+# install in the singlebox path must opt out, so a new call site cannot
+# silently reintroduce the stall. Global installs (-g) do not audit.
+test_npm_installs_opt_out_of_the_audit_call() {
+    local offenders
+    offenders="$(
+        grep -nE '(^|[^[:alnum:]_./-])npm[[:space:]]+(ci|install)([[:space:]]|$)' \
+            "${ROOT}"/scripts/modules/*.sh \
+        | grep -vE 'log_(info|warn|error)' \
+        | grep -vE '^[^:]*:[0-9]+:[[:space:]]*#' \
+        | grep -vE 'npm[[:space:]]+install[[:space:]]+-g' \
+        | grep -v -- '--no-audit' || true
+    )"
+    [ -z "$offenders" ] || fail "npm install/ci without --no-audit: ${offenders}"
+}
+
 test_service_modules_use_ownership_aware_stop_helpers() {
   local offenders
   offenders="$(
@@ -616,6 +634,7 @@ test_backend_default_readiness_window_covers_cold_start
 test_frontend_start_prepares_dependencies_before_launch
 test_frontend_deps_require_dev_commands
 test_frontend_install_includes_dev_dependencies
+test_npm_installs_opt_out_of_the_audit_call
 test_service_modules_use_ownership_aware_stop_helpers
 test_service_starts_fail_when_ports_remain_occupied
 test_baas_stop_does_not_delegate_to_app_stop


### PR DESCRIPTION
## Problem

"Singlebox Coverage" went from ~13m to 19–32m across **every** PR in the repo, at a single moment between 2026-09-03 13:42 UTC and 2026-09-04 04:14 UTC. Every run on 09-03 was 12.6–15.2m; every run after the cliff was 18.9–31.6m.

The controlled comparison is one branch, unchanged, run either side of it — [33753393854](https://github.com/inclusionAI/Avernet/actions/runs/33753393854) (09-03, 12m02s) vs [33837445531](https://github.com/inclusionAI/Avernet/actions/runs/33837445531) (09-04, 22m32s). Setup steps are identical (~50s either way); cargo, pytest, the BCS e2e and the coverage gates are flat to within seconds. The entire delta is npm.

Nothing in the repo changed between those runs: same plugin version `1.0.23`, same `.npmrc`, same 2051 resolved packages, same npm cache key, same runner image, region and Node version.

### Root cause: npm's legacy audit endpoint is being retired

```
npm notice This endpoint is being retired. Use the bulk advisory endpoint
instead. See: https://api-docs.npmjs.com/#tag/Audit
```

The audit call now stalls for ~7m and npm gives up, printing neither `audited N packages` nor a vulnerability count — which is exactly why the slow logs show a bare `up to date in 7m`. **It is a fixed cost per invocation, not proportional to the tree.** Runs pay it once per audit-enabled npm call, so the spread across PRs tracks how many such calls a run makes and its cache state.

The decisive evidence is this PR's own first run ([33861748256](https://github.com/inclusionAI/Avernet/actions/runs/33861748256)), where the BCN plugin build — already carrying `--no-audit` from commit 2 — sat between the two installs that still audited:

| Step | Packages | Audit | Time |
| --- | --- | --- | --- |
| BCS panel `npm ci` | 33 | on | **7m00s** |
| BCN plugin `npm install` | 2051 | off | **27s** |
| frontend `npm ci` | 2153 | on | **7m05s** |

Package count is uncorrelated with time; the audit flag is perfectly correlated. Reproduced locally on the BCS panel package, same command as CI: **421s with audit, 3s without**, identical package sets and identical 99M `node_modules`.

> An earlier revision of this description attributed the regression to general npm registry latency, with the lockfile-less BCN build as the main exposure. That was wrong about the mechanism — lockfile-backed `npm ci` audits too, which is why the frontend went 45s → 7m. The audit endpoint is the actual cause.

## Solution

Three commits, each independently revertable.

**1. Opt every npm install out of the audit call** (`--no-audit --no-fund`) — the BCS panel asset and the frontend, both branches each, matching what `claude_relays.sh` already does for the gateway build. Neither flag changes what is installed. Auditing here was never a gate: it printed advisories into a CI log with nothing reading them or failing on them. A guard test asserts every `npm install`/`npm ci` under `scripts/modules` opts out, so a new call site cannot silently reintroduce the stall (global installs excluded — `npm install -g` does not audit). **~14m.**

**2. Replace `npm prune --omit=dev` with a prod-only reinstall.** The dev tree is 348 MB / 56083 files (`.npmrc` pins `install-strategy=nested`, so nothing dedupes). Prune reduces it by reconciling that whole tree — 423s measured, and it audits. Deleting `node_modules` and reinstalling `--omit=dev` lands the same shipped tree (`ws` and nothing else) in 4s. Dropping the prune outright was rejected: it is load-bearing, taking 348 MB down to 232 K, and without it all 348 MB is copied back into the source tree and into the cache below. **~7m on a cold build.**

**3. Cache `dist/` + `node_modules`**, keyed on the plugin's `package.json` and `.npmrc`. `setup_bcn_plugin` already short-circuits with `BCN plugin already built, skipping` when both exist, so a hit skips the build outright. No `restore-keys`: a near-miss would restore a `dist/` built from a different `package.json` and the skip branch would accept it. The cached tree is `ws` alone, 232 KB, so the entry stays small against a cache budget that is already evicting ([run 33842045450](https://github.com/inclusionAI/Avernet/actions/runs/33842045450) lost both the npm and cargo caches and took 30m16s). **~30s per run once warm.**

## Validation

- **Local A/B, BCS panel package**, same command as CI: `npm ci` 421s → `npm ci --no-audit --no-fund` 3s; `diff` over resolved package sets empty, both 99M.
- **Local A/B, BCN plugin**: `npm prune --omit=dev` 423s (printing the same `up to date in 7m` as CI) → `rm -rf node_modules && npm install --omit=dev` 4s. Same shipped tree.
- **End-to-end `setup_bcn_plugin` against the real plugin**: rc=0 in 55s; `dist/esm/index.js` and `dist/commonjs/index.js` both produced; `node_modules` 228K / 27 files containing only `ws`; symlink correct.
- **CI**: run [33861748256](https://github.com/inclusionAI/Avernet/actions/runs/33861748256) green on commits 2–3, with the BCN phase down from 11m03s to 35s on a cold cache and the cache entry saved.
- **Tests** → `scripts/test_bcn_plugin_source.sh` ALL PASS and `scripts/test_singlebox_service_guards.sh` PASS, with three new cases where the source-build path previously had none: the BCN command sequence (that `npm prune` is gone), the `already built, skipping` branch the cache depends on, and the repo-wide `--no-audit` guard. Negative controls: each fails when its change is reverted.
- `test_singlebox_bcs_prereqs`, `test_singlebox_default_mode`, `test_singlebox_toolchain`, `test_singlebox_bcs_runtime_config`, `test_singlebox_rule_bots` → PASS. The workflow's own "Validate shell scripts" commands → OK.
- **Pre-existing failures, unchanged here and reproduced on a clean tree with identical messages**: `test_singlebox_model_config` (this sandbox's `stat` output format), `test_singlebox_demo_bot` (bcs/bcsfuse start-order mismatch on dev), and `test_singlebox_coverage_gate` (needs `src/backend/.venv`). None is touched by this PR.

## Compatibility and risk

No gate, threshold, report path, or coverage content changes — `SINGLEBOX_COVERAGE_BCS_LINE_MIN=40` / `METHOD_MIN=36` and `verify_singlebox_coverage_artifacts.py` are untouched — and no change to any resolved dependency tree.

Local `singlebox.sh` runs stop printing the post-install advisory summary; `npm audit` on demand is unaffected. If the team wants dependency review enforced, it belongs in a dedicated check that can actually fail a build, not as a side effect of service setup.

A stale cache entry cannot outlive a `package.json` or `.npmrc` edit because both are part of the key. Rollback is reverting any subset of the three commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kv9sczD8rpocHsm9YE4PuH