### PR TITLE
refactor(backend): bind and inject the creation seam as its Protocol

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/create_with_manifest.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/create_with_manifest.py
@@ -19,7 +19,7 @@ what polls AgentPass), starts no work, and writes nothing, so polling faster
 never changes an outcome and a caller that stops polling loses nothing.
 
 **Nothing here decides what a manifest means.** Validation, storage and apply are
-W1's and W4's, reached through ``BotCreationManifestSeam``; creation itself is
+W1's and W4's, reached through ``ManifestCreationSeam``; creation itself is
 ``create_flow``'s, and ``bot_service.create_bot`` is untouched. This module
 composes them and shapes the answer.
 """
@@ -66,7 +66,6 @@ from agentclaw.community.core.bot_config_manifest.create_job import (
 from agentclaw.community.core.bot_config_manifest.creation import (
     CREATE_ON_CONTAINER_TRIGGER,
     CREATE_PRE_CONTAINER_TRIGGER,
-    BotCreationManifestSeam,
 )
 from agentclaw.community.core.bot_inventory.protocols import (
     BusinessSpaceContextProtocol,
@@ -77,6 +76,9 @@ from agentclaw.community.core.bot_management.create_flow import (
     BotCreateSpec,
     BotCreateTemplateValidationMode,
     submit_bot_creation_with_manifest,
+)
+from agentclaw.community.core.bot_management.manifest_seam import (
+    ManifestCreationSeam,
 )
 from agentclaw.community.core.bot_management.services.bot_service import (
     BotNotFoundError,
@@ -150,7 +152,7 @@ async def create_bot_with_manifest(
     space_context: BusinessSpaceContextProtocol = Injected(
         BusinessSpaceContextProtocol
     ),
-    manifest_seam: BotCreationManifestSeam = Injected(BotCreationManifestSeam),
+    manifest_seam: ManifestCreationSeam = Injected(ManifestCreationSeam),
 ) -> Envelope[BotCreateWithManifestAccepted]:
     """Create a bot and its configuration in one request. Always `202`.
 
@@ -252,7 +254,7 @@ async def get_bot_create_with_manifest_status(
     apply_service: BotConfigManifestApplyServiceProtocol = Injected(
         BotConfigManifestApplyServiceProtocol
     ),
-    manifest_seam: BotCreationManifestSeam = Injected(BotCreationManifestSeam),
+    manifest_seam: ManifestCreationSeam = Injected(ManifestCreationSeam),
 ) -> Envelope[BotCreateWithManifestStatus]:
     """Where a creation stands. Takes a `bot_id` and nothing else.
 

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/README.md
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/README.md
@@ -584,7 +584,7 @@ provides:
   - ApplyTaskLifecycle
   - APPLY_TASK_TYPE
   - build_apply_task_payload
-  - BotCreationManifestSeam
+  - BotCreationManifestSeam (the ManifestCreationSeam implementation; only DI names it)
   - CREATE_PRE_CONTAINER_TRIGGER
   - CREATE_ON_CONTAINER_TRIGGER
   - preflight_creation_manifest
@@ -701,7 +701,7 @@ internal_dependencies:
   - agentclaw.community.plugin_api.object_storage  # the bot-data object store the managed-files store writes a teclaw bot's manifest-delivered files into (W8), and the cli_tools store keeps a bot's tool bytes in (W9)
   - agentclaw.community.core.bot_startup_script
   - agentclaw.community.core.bot_management.engines.registry  # the pure runtime-engine routing policy the resources materialiser addresses workspaces through, the router's own rule (W6)
-  - agentclaw.community.core.bot_management.manifest_seam  # the Protocol creation states its four operations as; the creation seam declares it rather than matching it by shape, so the contract is checked in one place
+  - agentclaw.community.core.bot_management.manifest_seam  # the Protocol the creation seam is declared as, bound as, and injected as everywhere; declaring it rather than matching it by shape is what checks the contract in one place
   - agentclaw.community.core.bot_management.token_vault
   - agentclaw.community.core.bot_management.utils  # resolve_agent_code — the creation job asks whether completion's *second* write (the owner relationship) actually landed, since the bot record alone cannot tell it
   - agentclaw.community.core.mcp.mcp_auth_service_protocol  # the permission check DirectActivationService also consults

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/README.md
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/README.md
@@ -701,6 +701,7 @@ internal_dependencies:
   - agentclaw.community.plugin_api.object_storage  # the bot-data object store the managed-files store writes a teclaw bot's manifest-delivered files into (W8), and the cli_tools store keeps a bot's tool bytes in (W9)
   - agentclaw.community.core.bot_startup_script
   - agentclaw.community.core.bot_management.engines.registry  # the pure runtime-engine routing policy the resources materialiser addresses workspaces through, the router's own rule (W6)
+  - agentclaw.community.core.bot_management.manifest_seam  # the Protocol creation states its four operations as; the creation seam declares it rather than matching it by shape, so the contract is checked in one place
   - agentclaw.community.core.bot_management.token_vault
   - agentclaw.community.core.bot_management.utils  # resolve_agent_code — the creation job asks whether completion's *second* write (the owner relationship) actually landed, since the bot record alone cannot tell it
   - agentclaw.community.core.mcp.mcp_auth_service_protocol  # the permission check DirectActivationService also consults

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/create_job.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/create_job.py
@@ -42,7 +42,9 @@ from agentclaw.community.core.bot_config_manifest.bot_config_manifest_apply_serv
 from agentclaw.community.core.bot_config_manifest.creation import (
     CREATE_ON_CONTAINER_TRIGGER,
     CREATE_PRE_CONTAINER_TRIGGER,
-    BotCreationManifestSeam,
+)
+from agentclaw.community.core.bot_management.manifest_seam import (
+    ManifestCreationSeam,
 )
 from agentclaw.community.core.repository.protocols.bot import BotRepository
 from agentclaw.community.plugin_api.passport import PassportPlugin
@@ -295,7 +297,7 @@ class BotCreateWithManifestHandler:
     def __init__(
         self,
         *,
-        manifest_seam_provider: Callable[[], BotCreationManifestSeam],
+        manifest_seam_provider: Callable[[], ManifestCreationSeam],
         apply_service_provider: Callable[[], BotConfigManifestApplyServiceProtocol],
         bot_repository_provider: Callable[[], BotRepository],
         passport_plugin_provider: Callable[[], PassportPlugin],
@@ -304,7 +306,10 @@ class BotCreateWithManifestHandler:
         # ``core/bot_management`` or the graph it pulls in, and this package is
         # what that graph reaches into. Naming their types here would close the
         # cycle at import time, which is why they arrive as callables the DI
-        # module resolves. ``complete_authorization`` is
+        # module resolves. ``ManifestCreationSeam`` above is from that same
+        # package and imported outright, which is not an exception: it is a
+        # Protocol module that imports nothing but ``typing`` and one value
+        # type, so it pulls none of the graph behind it. ``complete_authorization`` is
         # ``create_flow.complete_bot_authorization``, ``bot_service_provider``
         # yields ``BotService``, and ``auth_relationship_provider`` yields the
         # relationship writer the owner-repair step consults.

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/creation.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/creation.py
@@ -171,12 +171,12 @@ class BotCreationManifestSeam(ManifestCreationSeam):
     """Everything bot creation asks of the manifest layer, in one place.
 
     The base class is ``core/bot_management``'s :class:`ManifestCreationSeam`,
-    the Protocol naming the four operations submission calls — **declared** here
-    rather than merely satisfied by shape. Structural conformance was checked
-    nowhere: a signature drifting from the contract surfaced, if at all, as a
-    type error at the one call site that passes this class where the Protocol is
-    asked for, and neither a reader nor an IDE could get from the contract to its
-    single real implementation. Inheriting costs nothing at runtime — every
+    the Protocol naming these six operations — **declared** here rather than
+    merely satisfied by shape. Structural conformance was checked nowhere: a
+    signature drifting from the contract surfaced, if at all, as a type error at
+    whichever call site happened to pass this class where the Protocol was
+    asked for, and neither a reader nor an IDE could get from the contract to
+    its single real implementation. Inheriting costs nothing at runtime — every
     method the Protocol names is overridden below — and makes both hold; the
     signatures themselves are pinned by ``test_creation_seam``, since no type
     checker runs on this tree.
@@ -188,10 +188,15 @@ class BotCreationManifestSeam(ManifestCreationSeam):
     The dependency direction is unchanged: this package already imports
     ``core/bot_management`` (the engine registry, the token vault), and it is the
     *reverse* that would close a cycle, which is why the contract lives over
-    there. What this class adds beyond it — ``apply_pre_container``,
-    ``find_job``, and ``discard``'s ``owner_id`` — stays off the Protocol on
-    purpose: those belong to the creation job and the poll, which hold this class
-    directly and need no stand-in for it.
+    there.
+
+    **This class is named in two places and no more**: here, and the DI provider
+    that constructs it. Everything that *uses* the seam — submission, the two
+    routes, the creation job — holds the Protocol, which is also what the
+    container binds. That is why the Protocol names ``apply_pre_container`` and
+    ``find_job`` too: they have exactly one caller each, but those callers are
+    injected like every other, and a binding that handed out the class would
+    make them depend on how the seam is built.
 
     Deliberately small and free of creation policy: creation decides *when* to
     call these, this decides what each one means. Everything underneath is W1's

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/creation.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/creation.py
@@ -50,6 +50,9 @@ from agentclaw.community.core.bot_config_manifest.schema import (
     ManifestValidationError,
     Violation,
 )
+from agentclaw.community.core.bot_management.manifest_seam import (
+    ManifestCreationSeam,
+)
 from agentclaw.community.core.task_queue.types import TaskRecord
 from agentclaw.community.log import get_logger
 from agentclaw.community.utils.avernet_tenant import get_current_avernet_tenant
@@ -164,8 +167,31 @@ def _location_for(construct: ApplyConstruct) -> str:
     return f"manifest.{construct.value}"
 
 
-class BotCreationManifestSeam:
+class BotCreationManifestSeam(ManifestCreationSeam):
     """Everything bot creation asks of the manifest layer, in one place.
+
+    The base class is ``core/bot_management``'s :class:`ManifestCreationSeam`,
+    the Protocol naming the four operations submission calls — **declared** here
+    rather than merely satisfied by shape. Structural conformance was checked
+    nowhere: a signature drifting from the contract surfaced, if at all, as a
+    type error at the one call site that passes this class where the Protocol is
+    asked for, and neither a reader nor an IDE could get from the contract to its
+    single real implementation. Inheriting costs nothing at runtime — every
+    method the Protocol names is overridden below — and makes both hold; the
+    signatures themselves are pinned by ``test_creation_seam``, since no type
+    checker runs on this tree.
+
+    It does bring one hazard, which the same test pins: a Protocol method's body
+    is ``...``, so an operation dropped from this class would be *inherited* and
+    quietly answer ``None`` where it used to raise ``AttributeError``.
+
+    The dependency direction is unchanged: this package already imports
+    ``core/bot_management`` (the engine registry, the token vault), and it is the
+    *reverse* that would close a cycle, which is why the contract lives over
+    there. What this class adds beyond it — ``apply_pre_container``,
+    ``find_job``, and ``discard``'s ``owner_id`` — stays off the Protocol on
+    purpose: those belong to the creation job and the poll, which hold this class
+    directly and need no stand-in for it.
 
     Deliberately small and free of creation policy: creation decides *when* to
     call these, this decides what each one means. Everything underneath is W1's

--- a/src/backend/src/agentclaw/community/core/bot_management/manifest_seam.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/manifest_seam.py
@@ -1,22 +1,27 @@
-"""What bot creation needs from the manifest layer, stated without importing it.
+"""The manifest layer's creation seam, stated without importing it.
 
 Its own module rather than a declaration inside ``create_flow``: that file is
-already at the size the architecture cap allows, and a contract is a different
-kind of thing from the flow that calls it. It is also what the implementation
-imports to declare itself — see the class docstring — so keeping it free of
-everything but ``typing`` is what lets that import stay one-directional.
+already at the size the architecture cap allows, a contract is a different kind
+of thing from the flow that calls it, and ``create_flow`` is only one of the
+three callers. It is also what the implementation imports to declare itself and
+what the DI container binds, so it stays free of everything but ``typing`` and
+one value type — that is what lets the import stay one-directional and the
+module stay cheap to import.
 
-The reason it is a ``Protocol`` at all is the import cycle — again, see the
-class docstring.
+The reason it is a ``Protocol`` at all is the import cycle — see the class
+docstring.
 """
 
 from __future__ import annotations
 
-from typing import Any, Protocol
+from typing import Any, Protocol, runtime_checkable
+
+from agentclaw.community.core.task_queue.types import TaskRecord
 
 
+@runtime_checkable
 class ManifestCreationSeam(Protocol):
-    """What creation needs from the manifest package, named without importing it.
+    """Everything bot creation asks of the manifest package, named without it.
 
     A ``Protocol`` rather than the concrete ``BotCreationManifestSeam``:
     ``core/bot_management`` must not import ``core/bot_config_manifest`` — that
@@ -25,21 +30,40 @@ class ManifestCreationSeam(Protocol):
     double satisfies it by shape, with no base class and no import, which is the
     second reason.
 
+    **This is the type the container binds and every consumer holds.** The
+    concrete class is constructed in one place, the DI provider that wires its
+    collaborators; everywhere else — ``submit_bot_creation_with_manifest``, the
+    two ``with-manifest`` routes, the creation job's handler — names this. A
+    consumer that held the class instead would be depending on how the seam is
+    built rather than on what it promises, and would drag the whole manifest
+    package into modules that need six method signatures.
+
+    ``@runtime_checkable`` follows from that binding and nothing else:
+    python-injector ``isinstance``-checks an instance against the key it is
+    bound to, so rebinding this key to a stand-in — which the endpoint suite
+    does — raises on a plain ``Protocol``. It buys no guarantee worth having on
+    its own, since the check is attribute presence and never a signature; that
+    is what the implementation's declaration and ``test_creation_seam`` are for.
+
     **The one real implementation says so out loud.**
     ``BotCreationManifestSeam`` inherits this explicitly. That import runs
     manifest → management, the direction that is allowed and that the manifest
     package already takes; only the reverse closes the cycle. It buys what
     conformance-by-shape alone never did: the contract is checked against *this*
-    file rather than against whichever call site happens to pass the seam here,
-    and a reader or an IDE can walk between the contract and its implementation
+    file rather than against whichever call site happens to pass the seam, and a
+    reader or an IDE can walk between the contract and its implementation
     instead of guessing which class fits. The checking is a type checker's in an
     editor and ``test_creation_seam``'s in CI — the suite pins both the
-    inheritance and the four signatures, because no type checker runs on this
-    tree.
+    inheritance and the signatures, because no type checker runs on this tree.
 
-    Only the four operations submission calls are here. The pre-container apply
-    and the job's own steps belong to the creation job, which holds the seam
-    directly and needs no stand-in for it.
+    **Why all six and not only submission's four.** ``preflight``, ``persist``,
+    ``start_job`` and ``discard`` are what submission calls; ``apply_pre_container``
+    is the creation job's and ``find_job`` the poll's. They are one contract
+    because they are served by one object with one lifetime, handed out under
+    one binding: naming only submission's would leave the job and the route
+    holding the concrete class, which is the coupling this exists to remove.
+    ``create_flow`` calling four of six is the ordinary shape of a caller that
+    does not need everything, not a reason to split the seam in two.
     """
 
     def preflight(
@@ -61,6 +85,20 @@ class ManifestCreationSeam(Protocol):
         """Store the document and return the ``entity_id`` it was keyed by."""
         ...
 
+    def apply_pre_container(
+        self,
+        *,
+        entity_id: str,
+        bot_id: str,
+        owner_id: str,
+        actor_id: str,
+        engine_type: str | None,
+        bot_type: str | None,
+        bot: dict[str, Any] | None = None,
+    ) -> str | None:
+        """Run the pre-container phase. Never raises; ``None`` if it never started."""
+        ...
+
     def start_job(
         self,
         *,
@@ -75,7 +113,13 @@ class ManifestCreationSeam(Protocol):
         """Hand the creation to its durable job."""
         ...
 
-    def discard(self, *, entity_id: str, bot_id: str) -> bool:
+    def find_job(self, *, entity_id: str, bot_id: str) -> TaskRecord | None:
+        """This creation's task row, or ``None`` if none was submitted."""
+        ...
+
+    def discard(
+        self, *, entity_id: str, bot_id: str, owner_id: str | None = None
+    ) -> bool:
         """Undo what submission wrote. Never raises; reports whether it landed."""
         ...
 

--- a/src/backend/src/agentclaw/community/core/bot_management/manifest_seam.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/manifest_seam.py
@@ -2,8 +2,12 @@
 
 Its own module rather than a declaration inside ``create_flow``: that file is
 already at the size the architecture cap allows, and a contract is a different
-kind of thing from the flow that calls it. The reason it is a ``Protocol`` at
-all is the import cycle — see the class docstring.
+kind of thing from the flow that calls it. It is also what the implementation
+imports to declare itself — see the class docstring — so keeping it free of
+everything but ``typing`` is what lets that import stay one-directional.
+
+The reason it is a ``Protocol`` at all is the import cycle — again, see the
+class docstring.
 """
 
 from __future__ import annotations
@@ -17,9 +21,21 @@ class ManifestCreationSeam(Protocol):
     A ``Protocol`` rather than the concrete ``BotCreationManifestSeam``:
     ``core/bot_management`` must not import ``core/bot_config_manifest`` — that
     closes a cycle, since the manifest package reaches back into the creation
-    graph — and structural typing states the contract with no import at all. The
-    real seam satisfies it by shape; a test double satisfies it by shape too,
-    which is the second reason.
+    graph — and a Protocol states the contract with no import at all. A test
+    double satisfies it by shape, with no base class and no import, which is the
+    second reason.
+
+    **The one real implementation says so out loud.**
+    ``BotCreationManifestSeam`` inherits this explicitly. That import runs
+    manifest → management, the direction that is allowed and that the manifest
+    package already takes; only the reverse closes the cycle. It buys what
+    conformance-by-shape alone never did: the contract is checked against *this*
+    file rather than against whichever call site happens to pass the seam here,
+    and a reader or an IDE can walk between the contract and its implementation
+    instead of guessing which class fits. The checking is a type checker's in an
+    editor and ``test_creation_seam``'s in CI — the suite pins both the
+    inheritance and the four signatures, because no type checker runs on this
+    tree.
 
     Only the four operations submission calls are here. The pre-container apply
     and the job's own steps belong to the creation job, which holds the seam

--- a/src/backend/src/agentclaw/community/di/modules/bot_management_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/bot_management_module.py
@@ -114,6 +114,7 @@ from agentclaw.community.core.bot_config_manifest.apply.resource_port import (
 from agentclaw.community.core.bot_config_manifest.fetch.git_source import (
     GitSourceClient,
 )
+from agentclaw.community.core.bot_management.manifest_seam import ManifestCreationSeam
 from agentclaw.community.core.skill_center.capability_state_contract import (
     BotCapabilityStateReaderProtocol,
 )
@@ -792,13 +793,13 @@ class BotManagementModule(Module):
         script_service_provider: Callable[[], BotStartupScriptServiceProtocol],
         task_queue_provider: Callable[[], TaskQueueService],
         create_with_manifest_config: cfg.BotCreateWithManifestConfig,
-    ) -> BotCreationManifestSeam:
+    ) -> ManifestCreationSeam:
         """The operations bot creation asks of the manifest layer.
 
-        The job's two operations are bound here rather than imported by the seam:
-        ``create_job`` imports ``creation`` for the phase triggers, so the
-        dependency has to run one way. The queue stays behind the same lazy
-        provider the apply service uses.
+        Bound under the **Protocol** every consumer holds; the one place naming
+        the implementation, since it is the one that builds it. The job's two
+        operations are wired here rather than imported by the seam (``create_job``
+        imports ``creation`` for the triggers), behind the same lazy queue provider.
         """
         return BotCreationManifestSeam(
             manifest_service=manifest_service,
@@ -843,7 +844,7 @@ class BotManagementModule(Module):
             )
 
         return BotCreateWithManifestHandler(
-            manifest_seam_provider=lambda: injector.get(BotCreationManifestSeam),
+            manifest_seam_provider=lambda: injector.get(ManifestCreationSeam),
             apply_service_provider=lambda: injector.get(
                 BotConfigManifestApplyService
             ),

--- a/src/backend/tests/community/core/bot_config_manifest/creation/test_creation_seam.py
+++ b/src/backend/tests/community/core/bot_config_manifest/creation/test_creation_seam.py
@@ -1,12 +1,19 @@
 """The four operations bot creation asks of the manifest layer."""
 from __future__ import annotations
 
+import inspect
+
+import pytest
+
 from agentclaw.community.core.bot_config_manifest.create_job import (
     DEFAULT_CREATE_DEADLINE_SECONDS,
 )
 from agentclaw.community.core.bot_config_manifest.creation import (
     CREATE_PRE_CONTAINER_TRIGGER,
     BotCreationManifestSeam,
+)
+from agentclaw.community.core.bot_management.manifest_seam import (
+    ManifestCreationSeam,
 )
 
 
@@ -188,3 +195,58 @@ def test_persist_keys_by_the_spec_entity_id_and_nothing_else():
     )
     assert entity_id == "u_owner"
     assert manifests.puts[0]["entity_id"] == "u_owner"
+
+
+# ── the contract itself (``ManifestCreationSeam``) ─────────────────────────
+
+
+def test_the_seam_declares_the_creation_protocol_rather_than_matching_it():
+    """The contract is a base class, not a resemblance.
+
+    ``core/bot_management`` states what submission needs as a ``Protocol`` and
+    must not import this package to say it — that closes a cycle. The dependency
+    runs the other way, so this class can and does inherit it, which is what lets
+    a reader (and an IDE) get from ``submit_bot_creation_with_manifest``'s
+    parameter to the one class that answers it. Matching by shape looked
+    identical to a type checker and led nowhere for a human.
+    """
+    assert ManifestCreationSeam in BotCreationManifestSeam.__mro__
+
+
+@pytest.mark.parametrize(
+    "operation", ["preflight", "persist", "start_job", "discard"]
+)
+def test_every_declared_operation_keeps_the_contract_signature(operation):
+    """Signature drift is caught here, because no type checker runs in CI.
+
+    Inheriting the Protocol is what makes a checker verify these; the suite is
+    what verifies them on this tree. Each contract parameter must survive by
+    name — silently renaming one would leave every caller passing an argument
+    the implementation no longer takes. Extra parameters are allowed only with a
+    default (``discard``'s ``owner_id``, which the creation job passes and
+    submission does not), since a required one the Protocol does not name could
+    never be supplied through it.
+
+    The first assertion is the hazard the base class brings with it: a Protocol
+    method's body is ``...``, so an operation dropped from the seam would be
+    *inherited* and answer ``None`` — a submission that silently persisted
+    nothing — where before the base class it raised ``AttributeError``.
+    """
+    assert operation in vars(BotCreationManifestSeam), (
+        f"{operation} is inherited from the Protocol rather than implemented; "
+        "its body is `...`, so it would answer None instead of raising"
+    )
+
+    declared = inspect.signature(getattr(ManifestCreationSeam, operation))
+    implemented = inspect.signature(getattr(BotCreationManifestSeam, operation))
+
+    missing = set(declared.parameters) - set(implemented.parameters)
+    assert not missing, f"{operation} no longer accepts {sorted(missing)}"
+
+    for name, parameter in implemented.parameters.items():
+        if name in declared.parameters:
+            continue
+        assert parameter.default is not inspect.Parameter.empty, (
+            f"{operation} requires {name!r}, which no caller holding the "
+            "Protocol can pass"
+        )

--- a/src/backend/tests/community/core/bot_config_manifest/creation/test_creation_seam.py
+++ b/src/backend/tests/community/core/bot_config_manifest/creation/test_creation_seam.py
@@ -1,4 +1,10 @@
-"""The four operations bot creation asks of the manifest layer."""
+"""The operations bot creation asks of the manifest layer, and the contract.
+
+Most of this file is behavioural: what each operation does, and what it must not
+do. The section at the bottom pins the seam against ``ManifestCreationSeam`` — the
+Protocol it declares, the container binds, and every consumer holds — because no
+type checker runs on this tree to do it.
+"""
 from __future__ import annotations
 
 import inspect

--- a/src/backend/tests/community/core/bot_config_manifest/creation/test_creation_seam.py
+++ b/src/backend/tests/community/core/bot_config_manifest/creation/test_creation_seam.py
@@ -199,6 +199,16 @@ def test_persist_keys_by_the_spec_entity_id_and_nothing_else():
 
 # ── the contract itself (``ManifestCreationSeam``) ─────────────────────────
 
+#: The operations the Protocol declares, read off the Protocol rather than
+#: retyped: a contract that grows is covered by the signature test below
+#: without anyone remembering to extend a list here. Dunders are dropped
+#: because ``Protocol`` puts one of its own (``__init__``) on every subclass.
+_CONTRACT_OPERATIONS = sorted(
+    name
+    for name, member in vars(ManifestCreationSeam).items()
+    if inspect.isfunction(member) and not name.startswith("_")
+)
+
 
 def test_the_seam_declares_the_creation_protocol_rather_than_matching_it():
     """The contract is a base class, not a resemblance.
@@ -213,9 +223,26 @@ def test_the_seam_declares_the_creation_protocol_rather_than_matching_it():
     assert ManifestCreationSeam in BotCreationManifestSeam.__mro__
 
 
-@pytest.mark.parametrize(
-    "operation", ["preflight", "persist", "start_job", "discard"]
-)
+def test_the_contract_names_the_whole_seam():
+    """Every operation a consumer reaches through the container is on it.
+
+    The container binds ``ManifestCreationSeam``, so an operation missing from
+    it is an operation nobody can call: submission's four, the creation job's
+    ``apply_pre_container`` and the poll's ``find_job``. Pinned as an exact set
+    rather than left to the parametrization below, which would silently shrink
+    along with the contract and go on passing.
+    """
+    assert _CONTRACT_OPERATIONS == [
+        "apply_pre_container",
+        "discard",
+        "find_job",
+        "persist",
+        "preflight",
+        "start_job",
+    ]
+
+
+@pytest.mark.parametrize("operation", _CONTRACT_OPERATIONS)
 def test_every_declared_operation_keeps_the_contract_signature(operation):
     """Signature drift is caught here, because no type checker runs in CI.
 
@@ -223,9 +250,9 @@ def test_every_declared_operation_keeps_the_contract_signature(operation):
     what verifies them on this tree. Each contract parameter must survive by
     name — silently renaming one would leave every caller passing an argument
     the implementation no longer takes. Extra parameters are allowed only with a
-    default (``discard``'s ``owner_id``, which the creation job passes and
-    submission does not), since a required one the Protocol does not name could
-    never be supplied through it.
+    default, since a required one the Protocol does not name could never be
+    supplied by a caller holding the Protocol — which, now that the container
+    binds it, is every caller.
 
     The first assertion is the hazard the base class brings with it: a Protocol
     method's body is ``...``, so an operation dropped from the seam would be

--- a/src/backend/tests/community/di/test_bot_management_module_wiring.py
+++ b/src/backend/tests/community/di/test_bot_management_module_wiring.py
@@ -83,3 +83,63 @@ def test_create_bot_for_others_service_is_composed_from_control_plane_dependenci
     ]
     assert "device_service" not in arg_names
     assert "baas_service" not in arg_names
+
+
+def test_the_manifest_creation_seam_is_bound_under_its_protocol() -> None:
+    """The container hands out ``ManifestCreationSeam``, never the class.
+
+    Submission, both ``with-manifest`` routes and the creation job's handler all
+    ask for the Protocol; this provider is the only place that names the
+    implementation, because it is the only place that knows how to build one.
+    Asserted on the provider's **return annotation**, which is what
+    python-injector uses as the binding key — annotate it with the class again
+    and every one of those consumers is asking for a key nobody binds.
+    """
+    module_path = Path(bot_management_module.__file__)
+    tree = ast.parse(module_path.read_text(encoding="utf-8"))
+    providers = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "bot_creation_manifest_seam"
+    ]
+    assert providers, "BotManagementModule should define the seam provider"
+    provider = providers[0]
+
+    assert isinstance(provider.returns, ast.Name)
+    assert provider.returns.id == "ManifestCreationSeam", (
+        "the seam is bound under the Protocol; binding the class instead leaves "
+        "every consumer asking for an unbound key"
+    )
+
+    constructed = [
+        node
+        for node in ast.walk(provider)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "BotCreationManifestSeam"
+    ]
+    assert constructed, "the provider still builds the one real implementation"
+
+
+def test_nothing_in_the_composition_root_resolves_the_seam_by_its_class() -> None:
+    """One binding, so one seam — and one creation job queue behind it.
+
+    ``injector.get(BotCreationManifestSeam)`` would not fail loudly: the class is
+    not bound, so python-injector would *construct a second one*, unwired and
+    with none of the collaborators above. The handler would then enqueue through
+    a seam the routes never touch.
+    """
+    source = Path(bot_management_module.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    resolved = {
+        node.args[0].id
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "get"
+        and node.args
+        and isinstance(node.args[0], ast.Name)
+    }
+    assert "BotCreationManifestSeam" not in resolved
+    assert "ManifestCreationSeam" in resolved

--- a/src/backend/tests/community/endpoints/test_openapi_create_with_manifest.py
+++ b/src/backend/tests/community/endpoints/test_openapi_create_with_manifest.py
@@ -405,6 +405,9 @@ from agentclaw.community.core.bot_config_manifest.create_job import (
 from agentclaw.community.core.bot_config_manifest.creation import (
     BotCreationManifestSeam,
 )
+from agentclaw.community.core.bot_management.manifest_seam import (
+    ManifestCreationSeam,
+)
 from agentclaw.community.core.repository.protocols.bot import (
     BotConfigManifestRepositoryProtocol,
 )
@@ -720,7 +723,11 @@ def test_an_abandoned_creation_expires_rather_than_reading_as_declined(
         self._authorization_window_seconds = 1
         return BotCreationManifestSeam.start_job(self, **kwargs)
 
-    bind_overrides(world, BotCreationManifestSeam, {"start_job": _one_second_window})
+    # Keyed by the Protocol, because that is what the container binds — the
+    # concrete class is not a binding at all, and asking for it would build a
+    # second, unwired seam. ``bind_overrides`` subclasses whatever the binding
+    # actually serves, so the stand-in still carries the real implementation.
+    bind_overrides(world, ManifestCreationSeam, {"start_job": _one_second_window})
 
     bot_id = _submit(client).json()["data"]["bot_id"]
     time.sleep(1.2)


### PR DESCRIPTION
## Problem

`submit_bot_creation_with_manifest` takes a `ManifestCreationSeam`, and every caller handed it a `BotCreationManifestSeam`. The two were related only by shape, and the wiring named the class everywhere:

```python
manifest_seam: BotCreationManifestSeam = Injected(BotCreationManifestSeam)   # the route
...
submit_bot_creation_with_manifest(..., manifest_seam=manifest_seam)          # param is ManifestCreationSeam
```

Two problems, one under the other:

1. **Nothing connected the contract to its one implementation.** A reader (or an IDE) standing on the Protocol could not get to the class that answers it, and a signature drifting from the contract surfaced — if at all — as a type error at whichever call site happened to pass the seam, never against the contract itself.
2. **The container bound the class, so every consumer depended on it.** Declaring a contract while binding past it left the routes and the creation job's handler coupled to how the seam is built rather than to what it promises.

## Solution

Two commits.

**1. Make the relationship nominal.** `BotCreationManifestSeam` now inherits `ManifestCreationSeam` — declared, not merely satisfied by shape.

**2. Make the Protocol the type the container binds and every consumer holds.** The DI provider returns `ManifestCreationSeam`; `injector.get`, both `with-manifest` routes' `Injected(...)`, and the job handler's `Callable[[], ...]` all name it. The implementation is now named in exactly two places: its own definition, and the provider that constructs it.

That second step required the Protocol to name the **whole** seam, not only submission's four operations. `apply_pre_container` (the creation job's) and `find_job` (the poll's) have one caller each, but those callers are injected like any other — a contract without them would leave them holding the class, which is the coupling being removed. `discard` gains the optional `owner_id` the job passes. `create_flow` calling four of six is the ordinary shape of a caller that does not need everything, not a reason to split the seam in two.

`@runtime_checkable` follows from the binding and nothing else: python-injector `isinstance`-checks an instance against the key it is bound to, so rebinding this key to a stand-in — which the endpoint suite does — raises on a plain `Protocol`. It buys no guarantee on its own, since the check is attribute presence and never a signature.

**The dependency direction is unchanged.** The import runs manifest → management, which `core/bot_config_manifest` already takes (the engine registry, the token vault). Only the reverse closes a cycle, which is why the contract lives in `core/bot_management`, and why `manifest_seam.py` imports nothing but `typing` and one value type (`TaskRecord`, for `find_job`'s return).

**It stays a `Protocol`.** That was never only about the cycle: the test doubles in `test_create_flow_with_manifest` satisfy it by shape, with no base class and no import, and still do.

### Guards

No type checker runs on this tree, so the invariants are pinned by tests:

- **The provider's return annotation is the Protocol.** It *is* python-injector's binding key, so annotating the class again leaves every consumer asking for a key nobody binds.
- **Nothing in the composition root resolves the seam by its class.** This is the one failure that would not be loud: the class is unbound, so injector would *construct a second, unwired seam*, and the job handler would enqueue through one the routes never touch.
- **The contract names all six operations**, pinned as an exact set — the signature test derives its parametrization from the Protocol, so without this a dropped operation would shrink the parametrization and go on passing.
- **Each operation is implemented on the class itself, with the contract's parameters.** The base class brings one hazard: a Protocol method's body is `...`, so an operation dropped from the seam would be *inherited* and quietly answer `None` where it previously raised `AttributeError`.

Docstrings on both sides say why the Protocol exists, why the implementation declares it, and why the container binds it; `bot_config_manifest/README.md` declares the import in its context boundary (Rule 22 — the arch test enforces the whitelist).

## Validation

Run with `.venv` built from `uv.lock`'s pinned versions, from `src/backend`:

- `pytest tests/community/{core/bot_config_manifest,core/bot_management,endpoints,di,architecture}` — **3973 passed**. (The run showed 3 setup errors from `fixture 'caplog' not found`; that was a `-p no:logging` flag on my own invocation disabling the plugin that provides it, and those 3 pass with it enabled.)
- Mutation checks of the new guards, each reverted after:
  - Re-annotating the provider with the class fails `test_the_manifest_creation_seam_is_bound_under_its_protocol` **and all seven endpoint tests** (`TypeError` at request time).
  - Dropping `apply_pre_container` from the Protocol fails `test_the_contract_names_the_whole_seam`.
  - Renaming `persist` on the seam fails `test_every_declared_operation_keeps_the_contract_signature[persist]` with the "inherited from the Protocol … would answer None instead of raising" message.
- The `@runtime_checkable` requirement was found by the suite rather than predicted: without it, the endpoint test that rebinds the seam fails with `TypeError: Instance and class checks can only be used with @runtime_checkable protocols`.
- Runtime check that the base class does not disturb construction: MRO is `BotCreationManifestSeam → ManifestCreationSeam → Protocol → Generic → object`, `_is_protocol` is `False`, and the seam instantiates through its own `__init__` unchanged.

Not run: the full `tests/community` suite and the frontend/e2e gates. `uv sync --frozen` could not fetch the lock's aliyun mirror from this environment, so the venv was built by installing `uv.lock`'s exact pins from pypi.org; `uv.lock` and `pyproject.toml` are unmodified.

## Compatibility and risk

No contract, schema, config or migration impact, and no runtime behaviour change: the same single instance is constructed by the same provider and serves the same callers — only the name it is bound and injected under changes. Rollback is reverting the two commits.

One thing for a reviewer to know: `di/modules/bot_management_module.py` was two lines under the R9 1000-line cap, so the new import is a single line and the explanation was absorbed into the existing provider docstring rather than added as a paragraph. It lands at 999 — no headroom left for the next change to that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YZRzbXc54v7X54cZS3TzXZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZRzbXc54v7X54cZS3TzXZ)_