### PR TITLE
fix(bcs): count cancelled HTTP requests in metrics

### DIFF
--- a/src/bcs/crates/bootstrap/bcs/src/metrics.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/metrics.rs
@@ -468,6 +468,15 @@ impl MetricsRuntime {
     ) {
         record_http_request(&self.env, route, method, status, duration);
     }
+
+    pub fn record_http_request_cancelled(
+        &self,
+        route: &str,
+        method: &str,
+        duration: Duration,
+    ) {
+        record_http_request_cancelled(&self.env, route, method, duration);
+    }
 }
 
 #[cfg(feature = "prometheus-metrics")]
@@ -1250,29 +1259,74 @@ fn record_http_request(
     #[cfg(feature = "prometheus-metrics")]
     {
         let status_class = http_status_class(status);
-        metrics::counter!(
-            "bcs_http_requests_total",
-            "env" => env.to_string(),
-            "route" => route.to_string(),
-            "method" => method.to_string(),
-            "status_class" => status_class,
-            "result" => http_result_label(status),
-        )
-        .increment(1);
-        metrics::histogram!(
-            "bcs_http_request_duration_seconds",
-            "env" => env.to_string(),
-            "route" => route.to_string(),
-            "method" => method.to_string(),
-            "status_class" => status_class,
-        )
-        .record(duration.as_secs_f64());
+        record_http_request_outcome(
+            env,
+            route,
+            method,
+            status_class,
+            http_result_label(status),
+            duration,
+        );
     }
 
     #[cfg(not(feature = "prometheus-metrics"))]
     {
         let _ = (env, route, method, status, duration);
     }
+}
+
+fn record_http_request_cancelled(
+    env: &str,
+    route: &str,
+    method: &str,
+    duration: Duration,
+) {
+    #[cfg(feature = "prometheus-metrics")]
+    {
+        // A cancelled request has no application response status. Classify
+        // the proxy-499 equivalent as a failed 4xx terminal outcome.
+        record_http_request_outcome(env, route, method, "4xx", "error", duration);
+        metrics::counter!(
+            "bcs_http_request_cancellations_total",
+            "env" => env.to_string(),
+            "route" => route.to_string(),
+            "method" => method.to_string(),
+        )
+        .increment(1);
+    }
+
+    #[cfg(not(feature = "prometheus-metrics"))]
+    {
+        let _ = (env, route, method, duration);
+    }
+}
+
+#[cfg(feature = "prometheus-metrics")]
+fn record_http_request_outcome(
+    env: &str,
+    route: &str,
+    method: &str,
+    status_class: &'static str,
+    result: &'static str,
+    duration: Duration,
+) {
+    metrics::counter!(
+        "bcs_http_requests_total",
+        "env" => env.to_string(),
+        "route" => route.to_string(),
+        "method" => method.to_string(),
+        "status_class" => status_class,
+        "result" => result,
+    )
+    .increment(1);
+    metrics::histogram!(
+        "bcs_http_request_duration_seconds",
+        "env" => env.to_string(),
+        "route" => route.to_string(),
+        "method" => method.to_string(),
+        "status_class" => status_class,
+    )
+    .record(duration.as_secs_f64());
 }
 
 #[cfg(feature = "prometheus-metrics")]

--- a/src/bcs/crates/bootstrap/bcs/src/server.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/server.rs
@@ -926,6 +926,55 @@ async fn metrics_handler(State(state): State<Arc<BcsServerState>>) -> Response {
         .into_response()
 }
 
+struct HttpRequestMetricsGuard {
+    metrics: Arc<crate::metrics::MetricsRuntime>,
+    route: String,
+    method: String,
+    start: Instant,
+    completed: bool,
+}
+
+impl HttpRequestMetricsGuard {
+    fn new(
+        metrics: Arc<crate::metrics::MetricsRuntime>,
+        route: String,
+        method: String,
+    ) -> Self {
+        Self {
+            metrics,
+            route,
+            method,
+            start: Instant::now(),
+            completed: false,
+        }
+    }
+
+    fn complete(mut self, status: StatusCode) {
+        self.completed = true;
+        self.metrics.record_http_request(
+            &self.route,
+            &self.method,
+            status,
+            self.start.elapsed(),
+        );
+    }
+}
+
+impl Drop for HttpRequestMetricsGuard {
+    fn drop(&mut self) {
+        if !self.completed {
+            // Axum drops the request future when the upstream connection is
+            // abandoned. This is the application-side equivalent of a proxy
+            // reporting 499; there is no HTTP response status to inspect.
+            self.metrics.record_http_request_cancelled(
+                &self.route,
+                &self.method,
+                self.start.elapsed(),
+            );
+        }
+    }
+}
+
 async fn http_metrics_middleware(
     State(state): State<Arc<BcsServerState>>,
     req: Request<Body>,
@@ -944,10 +993,10 @@ async fn http_metrics_middleware(
         .get::<MatchedPath>()
         .map(|matched| matched.as_str().to_string())
         .unwrap_or_else(|| "unmatched".to_string());
-    let start = Instant::now();
+    let guard = HttpRequestMetricsGuard::new(metrics, route, method);
     let response = next.run(req).await;
     let status = response.status();
-    metrics.record_http_request(&route, &method, status, start.elapsed());
+    guard.complete(status);
     response
 }
 
@@ -4922,10 +4971,6 @@ let collaboration_templates = build_collaboration_template_service_with_storage(
         );
 
         Ok(router
-            .layer(middleware::from_fn_with_state(
-                Arc::clone(&self.state),
-                http_metrics_middleware,
-            ))
             .layer(middleware::from_fn(debug_middleware))
             .layer(CatchPanicLayer::custom(
                 |_: Box<dyn std::any::Any + Send>| {
@@ -4939,6 +4984,12 @@ let collaboration_templates = build_collaboration_template_service_with_storage(
                         .body(axum::body::Body::from(body.to_string()))
                         .unwrap()
                 },
+            ))
+            // Keep metrics outside panic handling so handler panics are
+            // recorded as the generated 500 response, not as cancellations.
+            .layer(middleware::from_fn_with_state(
+                Arc::clone(&self.state),
+                http_metrics_middleware,
             ))
             .layer(
                 TraceLayer::new_for_http()
@@ -5359,6 +5410,37 @@ mod tests {
     use tokio::net::TcpListener;
     use tokio::time::{Duration, timeout};
     use tower::ServiceExt;
+
+    #[cfg(feature = "prometheus-metrics")]
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn dropped_http_metrics_guard_records_cancelled_request() {
+        let mut config = BcsConfig::default();
+        config.metrics.enabled = true;
+        let metrics = crate::metrics::MetricsRuntime::install(&config)
+            .expect("install metrics")
+            .expect("metrics enabled");
+        let route = "/metrics-test/{request_id}";
+
+        {
+            let _guard = HttpRequestMetricsGuard::new(
+                metrics.clone(),
+                route.to_string(),
+                "POST".to_string(),
+            );
+        }
+
+        let body = metrics.render();
+        let env = metrics.env.as_ref();
+        assert!(body.contains(&format!(
+            "bcs_http_requests_total{{env=\"{env}\",route=\"{route}\",method=\"POST\",status_class=\"4xx\",result=\"error\"}}"
+        )));
+        assert!(body.contains(&format!(
+            "bcs_http_request_cancellations_total{{env=\"{env}\",route=\"{route}\",method=\"POST\"}}"
+        )));
+
+        metrics.shutdown().await;
+    }
 
     #[derive(Default)]
     struct RecordingSessionChannelOutbound {

--- a/src/bcs/observability/grafana/README.md
+++ b/src/bcs/observability/grafana/README.md
@@ -8,3 +8,9 @@ This directory keeps the maintained BCS Grafana dashboards:
 - `bcs-sla-dashboard.json`: portable SLA dashboard with HTTP, message-flow, delivery, and BCS-attributed direct-chat success rates.
 
 The dashboards use a Grafana datasource variable named `datasource`. When importing, choose a Prometheus-compatible datasource.
+
+HTTP API panels exclude `route="/health"` so probe traffic does not inflate
+request volume or success-rate calculations. The raw
+`bcs_http_requests_total` metric still includes health checks for independent
+probe diagnostics. HTTP SLA panels return no value when there is no API
+traffic instead of defaulting to 100%.

--- a/src/bcs/observability/grafana/bcs-monitoring-dashboard.json
+++ b/src/bcs/observability/grafana/bcs-monitoring-dashboard.json
@@ -159,7 +159,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "sum(rate(bcs_http_requests_total{env=\"$env\"}[1m])) or vector(0)",
+          "expr": "sum(rate(bcs_http_requests_total{env=\"$env\",route!=\"/health\"}[1m])) or vector(0)",
           "instant": false,
           "legendFormat": "http qps",
           "range": true,
@@ -226,7 +226,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "100 * (sum(rate(bcs_http_requests_total{env=\"$env\",result=\"error\"}[1m])) or vector(0)) / clamp_min((sum(rate(bcs_http_requests_total{env=\"$env\"}[1m])) or vector(0)), 0.001)",
+          "expr": "100 * (sum(rate(bcs_http_requests_total{env=\"$env\",route!=\"/health\",result=\"error\"}[1m])) or vector(0)) / clamp_min((sum(rate(bcs_http_requests_total{env=\"$env\",route!=\"/health\"}[1m])) or vector(0)), 0.001)",
           "instant": false,
           "legendFormat": "http error rate",
           "range": true,
@@ -841,7 +841,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "sum(rate(bcs_http_requests_total{env=\"$env\",route!~\"/chat/runs/[{]run_id[}]|/sessions/[{]sid[}]/chat|/bot/events|/bots/[{]id[}]/chat-async|/ws|/ws/bot\"}[1m])) or vector(0)",
+          "expr": "sum(rate(bcs_http_requests_total{env=\"$env\",route!=\"/health\",route!~\"/chat/runs/[{]run_id[}]|/sessions/[{]sid[}]/chat|/bot/events|/bots/[{]id[}]/chat-async|/ws|/ws/bot\"}[1m])) or vector(0)",
           "instant": false,
           "legendFormat": "ordinary qps",
           "range": true,
@@ -1006,7 +1006,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "sum(increase(bcs_http_requests_total{env=\"$env\",result=\"error\"}[1h])) or vector(0)",
+          "expr": "sum(increase(bcs_http_requests_total{env=\"$env\",route!=\"/health\",result=\"error\"}[1h])) or vector(0)",
           "instant": true,
           "legendFormat": "errors in 1h",
           "range": false,
@@ -1072,7 +1072,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "topk(20, sum by(route, method, status_class) (increase(bcs_http_requests_total{env=\"$env\",result=\"error\"}[1h])))",
+          "expr": "topk(20, sum by(route, method, status_class) (increase(bcs_http_requests_total{env=\"$env\",route!=\"/health\",result=\"error\"}[1h])))",
           "instant": true,
           "legendFormat": "{{route}} {{method}} / {{status_class}}",
           "range": false,
@@ -1170,7 +1170,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "100 * (sum(rate(bcs_http_requests_total{env=\"$env\",result=\"error\"}[1m])) or vector(0)) / clamp_min((sum(rate(bcs_http_requests_total{env=\"$env\"}[1m])) or vector(0)), 0.001)",
+          "expr": "100 * (sum(rate(bcs_http_requests_total{env=\"$env\",route!=\"/health\",result=\"error\"}[1m])) or vector(0)) / clamp_min((sum(rate(bcs_http_requests_total{env=\"$env\",route!=\"/health\"}[1m])) or vector(0)), 0.001)",
           "instant": false,
           "legendFormat": "error %",
           "range": true,
@@ -1395,7 +1395,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "sum by(route, method) (rate(bcs_http_requests_total{env=\"$env\"}[1m]))",
+          "expr": "sum by(route, method) (rate(bcs_http_requests_total{env=\"$env\",route!=\"/health\"}[1m]))",
           "instant": false,
           "legendFormat": "{{route}} {{method}}",
           "range": true,
@@ -1571,7 +1571,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "sum by(status_class, result) (rate(bcs_http_requests_total{env=\"$env\"}[1m]))",
+          "expr": "sum by(status_class, result) (rate(bcs_http_requests_total{env=\"$env\",route!=\"/health\"}[1m]))",
           "instant": false,
           "legendFormat": "{{status_class}} / {{result}}",
           "range": true,
@@ -1637,7 +1637,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "topk(10, sum by(route, method) (rate(bcs_http_requests_total{env=\"$env\"}[1m])))",
+          "expr": "topk(10, sum by(route, method) (rate(bcs_http_requests_total{env=\"$env\",route!=\"/health\"}[1m])))",
           "instant": false,
           "legendFormat": "{{route}} {{method}}",
           "range": true,

--- a/src/bcs/observability/grafana/bcs-sla-dashboard.json
+++ b/src/bcs/observability/grafana/bcs-sla-dashboard.json
@@ -1827,7 +1827,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "topk(20, sum by(route, method, status_class) (increase(bcs_http_requests_total{env=\"$env\",route!=\"/health\",result=\"error\"}[1h])))",
+          "expr": "topk(20, sum by(route, method, status_class) (increase(bcs_http_requests_total{env=\"$env\",route!=\"/health\",status_class=\"5xx\",result=\"error\"}[1h])))",
           "instant": true,
           "legendFormat": "{{route}} {{method}}",
           "range": false,

--- a/src/bcs/observability/grafana/bcs-sla-dashboard.json
+++ b/src/bcs/observability/grafana/bcs-sla-dashboard.json
@@ -101,7 +101,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "((100 * ((sum(increase(bcs_http_requests_total{env=\"$env\",result=\"success\"}[1h]))) or vector(0)) / ((sum(increase(bcs_http_requests_total{env=\"$env\"}[1h]))) or vector(0))) unless (((sum(increase(bcs_http_requests_total{env=\"$env\"}[1h]))) or vector(0)) == 0)) or vector(100)",
+          "expr": "(100 * ((sum(increase(bcs_http_requests_total{env=\"$env\",route!=\"/health\",result=\"success\"}[1h]))) or vector(0)) / ((sum(increase(bcs_http_requests_total{env=\"$env\",route!=\"/health\"}[1h]))) or vector(0))) unless (((sum(increase(bcs_http_requests_total{env=\"$env\",route!=\"/health\"}[1h]))) or vector(0)) == 0)",
           "instant": false,
           "legendFormat": "value",
           "range": true,
@@ -173,7 +173,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "((100 * ((sum(increase(bcs_http_requests_total{env=\"$env\",result=\"success\"}[1d]))) or vector(0)) / ((sum(increase(bcs_http_requests_total{env=\"$env\"}[1d]))) or vector(0))) unless (((sum(increase(bcs_http_requests_total{env=\"$env\"}[1d]))) or vector(0)) == 0)) or vector(100)",
+          "expr": "(100 * ((sum(increase(bcs_http_requests_total{env=\"$env\",route!=\"/health\",result=\"success\"}[1d]))) or vector(0)) / ((sum(increase(bcs_http_requests_total{env=\"$env\",route!=\"/health\"}[1d]))) or vector(0))) unless (((sum(increase(bcs_http_requests_total{env=\"$env\",route!=\"/health\"}[1d]))) or vector(0)) == 0)",
           "instant": false,
           "legendFormat": "value",
           "range": true,
@@ -245,7 +245,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "((100 * ((sum(increase(bcs_http_requests_total{env=\"$env\",result=\"success\"}[7d]))) or vector(0)) / ((sum(increase(bcs_http_requests_total{env=\"$env\"}[7d]))) or vector(0))) unless (((sum(increase(bcs_http_requests_total{env=\"$env\"}[7d]))) or vector(0)) == 0)) or vector(100)",
+          "expr": "(100 * ((sum(increase(bcs_http_requests_total{env=\"$env\",route!=\"/health\",result=\"success\"}[7d]))) or vector(0)) / ((sum(increase(bcs_http_requests_total{env=\"$env\",route!=\"/health\"}[7d]))) or vector(0))) unless (((sum(increase(bcs_http_requests_total{env=\"$env\",route!=\"/health\"}[7d]))) or vector(0)) == 0)",
           "instant": false,
           "legendFormat": "value",
           "range": true,
@@ -1467,7 +1467,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "((100 * ((sum(rate(bcs_http_requests_total{env=\"$env\",result=\"success\"}[15m]))) or vector(0)) / ((sum(rate(bcs_http_requests_total{env=\"$env\"}[15m]))) or vector(0))) unless (((sum(rate(bcs_http_requests_total{env=\"$env\"}[15m]))) or vector(0)) == 0)) or vector(100)",
+          "expr": "(100 * ((sum(rate(bcs_http_requests_total{env=\"$env\",route!=\"/health\",result=\"success\"}[15m]))) or vector(0)) / ((sum(rate(bcs_http_requests_total{env=\"$env\",route!=\"/health\"}[15m]))) or vector(0))) unless (((sum(rate(bcs_http_requests_total{env=\"$env\",route!=\"/health\"}[15m]))) or vector(0)) == 0)",
           "instant": false,
           "legendFormat": "HTTP API",
           "range": true,
@@ -1827,7 +1827,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "topk(20, sum by(route, method, status_class) (increase(bcs_http_requests_total{env=\"$env\",result=\"error\"}[1h])))",
+          "expr": "topk(20, sum by(route, method, status_class) (increase(bcs_http_requests_total{env=\"$env\",route!=\"/health\",result=\"error\"}[1h])))",
           "instant": true,
           "legendFormat": "{{route}} {{method}}",
           "range": false,

--- a/src/bcs/observability/grafana/bcs-troubleshooting-dashboard.json
+++ b/src/bcs/observability/grafana/bcs-troubleshooting-dashboard.json
@@ -167,7 +167,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "100 * (sum(rate(bcs_http_requests_total{env=\"$env\",result=\"error\"}[5m])) or vector(0)) / clamp_min((sum(rate(bcs_http_requests_total{env=\"$env\"}[5m])) or vector(0)), 0.001)",
+          "expr": "100 * (sum(rate(bcs_http_requests_total{env=\"$env\",route!=\"/health\",result=\"error\"}[5m])) or vector(0)) / clamp_min((sum(rate(bcs_http_requests_total{env=\"$env\",route!=\"/health\"}[5m])) or vector(0)), 0.001)",
           "instant": false,
           "legendFormat": "http error %",
           "range": true,
@@ -1165,7 +1165,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "sum(increase(bcs_http_requests_total{env=\"$env\",result=\"error\"}[5m])) or vector(0)",
+          "expr": "sum(increase(bcs_http_requests_total{env=\"$env\",route!=\"/health\",result=\"error\"}[5m])) or vector(0)",
           "instant": true,
           "legendFormat": "errors in 5m",
           "range": false,
@@ -1231,7 +1231,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "topk(20, sum by(route, method, status_class) (increase(bcs_http_requests_total{env=\"$env\",result=\"error\"}[5m])))",
+          "expr": "topk(20, sum by(route, method, status_class) (increase(bcs_http_requests_total{env=\"$env\",route!=\"/health\",result=\"error\"}[5m])))",
           "instant": true,
           "legendFormat": "{{route}} {{method}} / {{status_class}}",
           "range": false,
@@ -1329,7 +1329,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "sum by(route, method) (rate(bcs_http_requests_total{env=\"$env\"}[5m]))",
+          "expr": "sum by(route, method) (rate(bcs_http_requests_total{env=\"$env\",route!=\"/health\"}[5m]))",
           "instant": false,
           "legendFormat": "{{route}} {{method}}",
           "range": true,
@@ -1427,7 +1427,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "100 * (sum by(route, method) (rate(bcs_http_requests_total{env=\"$env\",result=\"error\"}[5m])) or (0 * sum by(route, method) (rate(bcs_http_requests_total{env=\"$env\"}[5m])))) / clamp_min(sum by(route, method) (rate(bcs_http_requests_total{env=\"$env\"}[5m])), 0.001)",
+          "expr": "100 * (sum by(route, method) (rate(bcs_http_requests_total{env=\"$env\",route!=\"/health\",result=\"error\"}[5m])) or (0 * sum by(route, method) (rate(bcs_http_requests_total{env=\"$env\",route!=\"/health\"}[5m])))) / clamp_min(sum by(route, method) (rate(bcs_http_requests_total{env=\"$env\",route!=\"/health\"}[5m])), 0.001)",
           "instant": false,
           "legendFormat": "{{route}} {{method}}",
           "range": true,
@@ -1493,7 +1493,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "topk(20, sum by(route, method, status_class) (rate(bcs_http_requests_total{env=\"$env\",result=\"error\"}[5m])))",
+          "expr": "topk(20, sum by(route, method, status_class) (rate(bcs_http_requests_total{env=\"$env\",route!=\"/health\",result=\"error\"}[5m])))",
           "instant": false,
           "legendFormat": "{{route}} {{method}} / {{status_class}}",
           "range": true,
@@ -1559,7 +1559,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "topk(20, sum by(route, method) (rate(bcs_http_requests_total{env=\"$env\"}[5m])))",
+          "expr": "topk(20, sum by(route, method) (rate(bcs_http_requests_total{env=\"$env\",route!=\"/health\"}[5m])))",
           "instant": false,
           "legendFormat": "{{route}} {{method}}",
           "range": true,


### PR DESCRIPTION
## Problem

BCS only recorded `bcs_http_requests_total` after an HTTP handler returned a
response. When database operations were slow and the client or upstream proxy
closed the connection, the request future was dropped before the metrics code
ran.

As a result, proxy-499-equivalent requests were missing from the total request
count. Health checks became the main recorded traffic, causing the HTTP success
rate to remain at 100%.

The maintained Grafana dashboards also included `/health` traffic in HTTP API
traffic and SLA calculations, and the HTTP SLA panels defaulted to 100% when
there was no API traffic.

## Solution

- Add an HTTP request lifecycle guard that records exactly one terminal metric.
- Record dropped request futures as:
  - `status_class="4xx"`
  - `result="error"`
  - the matched route template and HTTP method
- Add `bcs_http_request_cancellations_total` for dedicated cancellation
  diagnostics.
- Keep metrics middleware outside panic handling so generated 500 responses are
  recorded as server errors instead of cancellations.
- Keep `/health` in the raw `bcs_http_requests_total` metric for probe
  diagnostics.
- Exclude `/health` from HTTP API panels in the monitoring, SLA, and
  troubleshooting dashboards.
- Remove the HTTP SLA fallback that displayed 100% when there was no API
  traffic.

## Validation

- `cargo test -p bcs dropped_http_metrics_guard_records_cancelled_request --features prometheus-metrics`
  - Passed: 1 test.
- `cargo test -p bcs --test metrics_http --features prometheus-metrics`
  - Passed: 2 tests.
- `cargo check -p bcs --no-default-features`
  - Passed.
- Validated all modified Grafana dashboards with `jq empty`.
- Confirmed general HTTP dashboard queries exclude `/health`.
- Confirmed HTTP SLA queries no longer use `or vector(100)`.
- `git diff --check`
  - Passed.

The complete `cargo test --workspace` suite was not run because this change is
limited to the BCS bootstrap metrics middleware and Grafana dashboard JSON; the
closest metrics tests and both feature configurations were validated.

## Compatibility and risk

There is no HTTP API, schema, or configuration contract change.

`bcs_http_requests_total` keeps its existing label schema but now includes an
additional terminal outcome for cancelled requests. A new additive Prometheus
counter, `bcs_http_request_cancellations_total`, is exposed.

The cancellation classification represents an application-side dropped request
future, equivalent to the common proxy 499 case; BCS does not receive an actual
HTTP 499 response status from the proxy.

Rollback is a revert of commit `8521f8a07`.