### PR TITLE
fix(backend): align Discover with BCS catalog visibility

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bot_public/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bot_public/router.py
@@ -252,7 +252,7 @@ async def search_public_bots(
 )
 async def discover_public_bots(
     request: Request,
-    _principal: PrincipalDep,
+    principal: PrincipalDep,
     keyword: str = Query(min_length=1, description="Keyword used for discovery."),
     top_k: int = Query(default=10, ge=1, le=20, description="Maximum recommendations."),
     min_score: float = Query(
@@ -261,14 +261,39 @@ async def discover_public_bots(
     runtime_state: RuntimeState = Query(
         default="online", description="Runtime state filter."
     ),
+    viewer_actor_type: str | None = Query(
+        default=None, description="Explicit BCS viewer actor type: human or bot."
+    ),
+    viewer_actor_id: str | None = Query(
+        default=None, description="Explicit BCS viewer actor id; requires viewer_actor_type."
+    ),
     service: BotDiscoverServiceProtocol = Injected(BotDiscoverServiceProtocol),
 ) -> Envelope[Page[DiscoveredPublicBot]]:
+    try:
+        catalog_filters = _catalog_search_filters(
+            visibility=None,
+            user_visibility=None,
+            status="online" if runtime_state == "online" else None,
+            viewer_actor_type=viewer_actor_type,
+            viewer_actor_id=viewer_actor_id,
+            friendship=None,
+        )
+    except ValueError:
+        _log_failure("discover", request, "invalid_filters")
+        return error_response(422, "Invalid Catalog Search filters", request)
     try:
         result = service.search_by_keyword(
             keyword=keyword,
             top_k=top_k,
             min_score=min_score,
             filters={"runtime_state": [runtime_state]},
+            catalog_filters=catalog_filters,
+            caller=BotCatalogCaller(
+                tenant_id=principal.tenant,
+                user_id=principal.user_id or None,
+                app_id=principal.app_id,
+            ),
+            request_id=_request_id(request),
         )
     except Exception:  # noqa: BLE001 - the public error must remain fixed
         _log_failure("discover", request, "recommender_failure")

--- a/src/backend/src/agentclaw/community/core/bot_public/README.md
+++ b/src/backend/src/agentclaw/community/core/bot_public/README.md
@@ -12,7 +12,7 @@ provides:
   - "Bot-public SQLAlchemy models"
 consumes:
   - "BotManagement repo + service"
-  - "BotCatalogMetadata port (current BCS page, joined by (bot_id, entity_id))"
+  - "BotCatalogMetadata port (BCS search page or exact recommendation candidates, joined by (bot_id, entity_id))"
   - "AntProcess plugins (auth_relationship, bot_publish_approval, antprocess)"
   - "PassportPlugin"
   - "SkillCenter factories"

--- a/src/backend/src/agentclaw/community/core/bot_public/catalog_metadata.py
+++ b/src/backend/src/agentclaw/community/core/bot_public/catalog_metadata.py
@@ -73,6 +73,7 @@ class BotCatalogMetadataServiceProtocol(Protocol):
         search: str | None,
         page: int,
         page_size: int,
+        bot_uuids: Sequence[str] = (),
         filters: BotCatalogSearchFilters | None,
         caller: BotCatalogCaller,
         request_id: str,

--- a/src/backend/src/agentclaw/community/core/bot_public/services/bot_catalog_metadata_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_public/services/bot_catalog_metadata_service.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 
 import httpx
 
@@ -33,6 +33,7 @@ class BcsBotCatalogMetadataService:
         search: str | None,
         page: int,
         page_size: int,
+        bot_uuids: Sequence[str] = (),
         filters: BotCatalogSearchFilters | None = None,
         caller: BotCatalogCaller,
         request_id: str,
@@ -46,6 +47,8 @@ class BcsBotCatalogMetadataService:
         }
         if search and search.strip():
             params["q"] = search
+        if bot_uuids:
+            params["bot_uuids"] = ",".join(bot_uuids)
         if filters is not None:
             if filters.visibility:
                 params["visibility"] = ",".join(filters.visibility)

--- a/src/backend/src/agentclaw/community/core/bot_public/services/bot_discover_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_public/services/bot_discover_service.py
@@ -1,6 +1,6 @@
 """Bot Discover Service.
 
-封装对 BCSFuse recommend HTTP 接口的调用，并过滤非 public 的 bot。
+封装 BCSFuse 推荐，并通过 BCS Catalog 过滤当前 viewer 不可见的 Bot。
 """
 import json as _json
 from typing import Any, Optional, TYPE_CHECKING
@@ -10,6 +10,13 @@ import requests
 from agentclaw.community.core.repository.protocols.bot import BotRepository
 from agentclaw.community.log import get_logger
 from agentclaw.community.core.bot_public.bot_discover_service_protocol import BotDiscoverServiceProtocol
+from agentclaw.community.core.bot_public.catalog_metadata import (
+    BotCatalogCaller,
+    BotCatalogMetadata,
+    BotCatalogMetadataServiceProtocol,
+    BotCatalogSearchFilters,
+)
+from agentclaw.community.utils.avernet_tenant import get_current_avernet_tenant
 
 if TYPE_CHECKING:
     # Type-only: runtime ``from agentclaw.community.di import config`` would form a
@@ -25,7 +32,7 @@ logger = get_logger()
 class BotDiscoverService(BotDiscoverServiceProtocol):
     """Bot Discover 服务.
 
-    封装 BCSFuse recommend 接口的调用，并过滤非 public 的 bot。
+    封装 BCSFuse recommend 接口的调用，并使用 BCS Catalog 作为可见性权威源。
 
     """
 
@@ -33,9 +40,11 @@ class BotDiscoverService(BotDiscoverServiceProtocol):
         self,
         bot_repository: BotRepository,
         bcsfuse_config: "cfg.BcsFuseConfig",
+        catalog_metadata_service: BotCatalogMetadataServiceProtocol,
     ) -> None:
         self._bot_repository = bot_repository
         self._bcsfuse_config = bcsfuse_config
+        self._catalog_metadata_service = catalog_metadata_service
         self._bcsfuse_base_url = self._resolve_bcsfuse_base_url()
 
     def _resolve_bcsfuse_base_url(self) -> str:
@@ -60,12 +69,15 @@ class BotDiscoverService(BotDiscoverServiceProtocol):
         top_k: int = 10,
         min_score: float = 0.01,
         filters: Optional[dict[str, Any]] = None,
+        catalog_filters: BotCatalogSearchFilters | None = None,
+        caller: BotCatalogCaller | None = None,
+        request_id: str = "internal-discover",
     ) -> dict[str, Any]:
         """根据关键词搜索公开的 Bot.
 
         1. 调用 BCSFuse 的 recommend 接口获取推荐 bot 列表
-        2. 使用 BotRepository 过滤掉非 public 的 bot
-        3. 查询完整的 bot 信息（与 search 接口格式一致）
+        2. 使用 BCS Catalog Search 过滤当前 viewer 不可见的 bot
+        3. 从 BotRepository 查询完整展示信息（与 search 接口格式一致）
 
         Args:
             keyword: 搜索关键词
@@ -98,11 +110,36 @@ class BotDiscoverService(BotDiscoverServiceProtocol):
         recommendations = bcsfuse_results.get("recommendations", [])
         logger.info(f"[BotDiscover] BCSFuse 返回 {len(recommendations)} 个候选")
 
-        # 2. 获取 public bot 的完整信息
-        result = self._get_public_bots_with_details(recommendations, user_id)
+        # 2. Use the BCS catalog as the visibility authority, then join Backend details.
+        if caller is None:
+            caller = BotCatalogCaller(
+                tenant_id=get_current_avernet_tenant(),
+                user_id=user_id,
+                app_id=None,
+            )
+        if catalog_filters is None:
+            runtime_states = (filters or {}).get("runtime_state")
+            status = (
+                runtime_states[0]
+                if isinstance(runtime_states, list)
+                and len(runtime_states) == 1
+                and runtime_states[0] in {"online", "hidden"}
+                else None
+            )
+            catalog_filters = BotCatalogSearchFilters(
+                status=status,
+                viewer_actor_type="human" if user_id else None,
+                viewer_actor_id=user_id,
+            )
+        result = self._get_public_bots_with_details(
+            recommendations,
+            catalog_filters=catalog_filters,
+            caller=caller,
+            request_id=request_id,
+        )
 
         logger.info(
-            f"[BotDiscover] 查询完成: {result['total']}/{len(recommendations)} 个 public bot"
+            f"[BotDiscover] 查询完成: {result['total']}/{len(recommendations)} 个 catalog-visible bot"
         )
 
         result["context"] = {"recommend_response": bcsfuse_results}
@@ -169,13 +206,16 @@ class BotDiscoverService(BotDiscoverServiceProtocol):
     def _get_public_bots_with_details(
         self,
         recommendations: list[dict[str, Any]],
-        user_id: str,
+        *,
+        catalog_filters: BotCatalogSearchFilters,
+        caller: BotCatalogCaller,
+        request_id: str,
     ) -> dict[str, Any]:
         """获取 public bot 的完整信息.
 
         1. 解析 worker_id 获取 (bot_id, owner_id) 列表
-        2. 批量查询 public 状态
-        3. 获取完整的 bot 详情
+        2. 通过 BCS 批量查询 Catalog 可见性
+        3. 获取完整的 Backend bot 详情
         4. 组合返回结果
 
         Args:
@@ -203,10 +243,27 @@ class BotDiscoverService(BotDiscoverServiceProtocol):
         if not bot_entries:
             return {"total": 0, "items": []}
 
-        # 2. 批量查询所有 bot 的 public 状态和详情
-        public_bot_details = self._batch_get_public_bots(bot_entries, user_id)
+        # 2. Ask BCS which exact recommendations are visible to this viewer.
+        metadata_page = self._catalog_metadata_service.search_public_bot_metadata(
+            search=None,
+            page=1,
+            page_size=len(bot_entries),
+            bot_uuids=tuple(entry[0] for entry in bot_entries),
+            filters=catalog_filters,
+            caller=caller,
+            request_id=request_id,
+        )
+        metadata_by_address = {
+            (item.address.bot_id, item.address.entity_id): item
+            for item in metadata_page.items
+        }
 
-        # 3. 构建结果（每个 item 包含自己的 recommend 信息）
+        # 3. Join display details from Backend without consulting ac_bots.public.
+        public_bot_details = self._batch_get_public_bots(
+            bot_entries, metadata_by_address
+        )
+
+        # 4. 构建结果（每个 item 包含自己的 recommend 信息）
         items = []
 
         for bot_detail, rec in public_bot_details:
@@ -219,10 +276,10 @@ class BotDiscoverService(BotDiscoverServiceProtocol):
             }
             items.append(bot_detail)
 
-        # 4. 按 recommend.score 降序排序
+        # 5. 按 recommend.score 降序排序
         items.sort(key=lambda x: x.get("recommend", {}).get("score", 0.0), reverse=True)
 
-        # 5. Sanitize sensitive fields in ext
+        # 6. Sanitize sensitive fields in ext
         self._sanitize_ext_fields(items)
 
         return {
@@ -258,24 +315,26 @@ class BotDiscoverService(BotDiscoverServiceProtocol):
     def _batch_get_public_bots(
         self,
         bot_entries: list[tuple[str, str, str, dict[str, Any]]],
-        user_id: str,
+        metadata_by_address: dict[tuple[str, str], BotCatalogMetadata],
     ) -> list[tuple[dict[str, Any], dict[str, Any]]]:
-        """批量获取 public bot 的完整信息.
+        """批量获取已通过 BCS Catalog 过滤的 Bot 完整信息.
 
         使用单次 SQL 查询所有 bot，避免 N+1 问题。
 
         Args:
             bot_entries: [(worker_id, bot_id, owner_id, rec), ...]
-            user_id: 当前用户ID
+            metadata_by_address: 已通过 BCS Catalog Search 的候选元数据
 
         Returns:
-            [(bot_detail, rec), ...] 列表，只包含 public 的 bot
+            [(bot_detail, rec), ...] 列表，只包含 BCS Catalog 可见的 bot
         """
         try:
             # 构建 (bot_id, owner_id) 条件列表
             pairs: list[tuple[str, str]] = []
             bot_id_to_rec = {}  # (bot_id, owner_id) -> (worker_id, rec)
             for worker_id, bot_id, owner_id, rec in bot_entries:
+                if (bot_id, owner_id) not in metadata_by_address:
+                    continue
                 pairs.append((bot_id, owner_id))
                 bot_id_to_rec[(bot_id, owner_id)] = (worker_id, rec)
 
@@ -285,14 +344,25 @@ class BotDiscoverService(BotDiscoverServiceProtocol):
             # ORM 查询（经 do_orm_execute tenant guard 覆盖，自动按 tenant 隔离）。
             # 曾经是对 ac_bots 的 raw cursor SQL —— raw SQL 绕过了 BotModel 的
             # tenant guard（listener 只覆盖 ORM statement），故改走仓储的 ORM 方法。
-            bots = self._bot_repository.list_public_bots_by_owner_bot_pairs(pairs)
+            _, bots = self._bot_repository.list_bots_by_owner_bot_pairs(
+                pairs,
+                page=1,
+                page_size=len(pairs),
+            )
 
+            bots_by_address = {
+                (bot["bot_id"], bot["owner_id"]): bot for bot in bots
+            }
             result = []
-            for bot in bots:
-                key = (bot["bot_id"], bot["owner_id"])
+            for _, bot_id, owner_id, _ in bot_entries:
+                key = (bot_id, owner_id)
+                bot = bots_by_address.get(key)
+                if bot is None:
+                    continue
                 worker_id, rec = bot_id_to_rec.get(key, (None, None))
                 if not rec:
                     continue
+                metadata = metadata_by_address[key]
 
                 # 构建完整的 bot 详情（与 search 接口格式一致，to_dict() 已解析 JSON）
                 ext = bot.get("ext")
@@ -320,10 +390,25 @@ class BotDiscoverService(BotDiscoverServiceProtocol):
                     "ext": ext,
                     "public": bot["public"],
                     "owner_name": (ext or {}).get("owner_name") if ext else None,
+                    "bot_uuid": metadata.bot_uuid or worker_id,
                 }
+                for field_name in (
+                    "is_friend",
+                    "visibility",
+                    "is_online",
+                    "actor_kind",
+                    "friend_ext",
+                    "friend_check_in_strategy",
+                    "user_visibility",
+                ):
+                    value = getattr(metadata, field_name)
+                    if value is not None:
+                        bot_detail[field_name] = value
                 result.append((bot_detail, rec))
 
-            logger.debug(f"[BotDiscover] 批量查询完成: {len(result)}/{len(bot_entries)} 个 public")
+            logger.debug(
+                f"[BotDiscover] 批量查询完成: {len(result)}/{len(bot_entries)} 个 catalog-visible"
+            )
             return result
 
         except Exception as e:

--- a/src/backend/src/agentclaw/community/di/modules/bot_public_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/bot_public_module.py
@@ -88,6 +88,7 @@ class BotPublicModule(Module):
         self,
         bot_repository: BotRepository,
         bcsfuse_config: cfg.BcsFuseConfig,
+        catalog_metadata_service: BotCatalogMetadataServiceProtocol,
     ) -> BotDiscoverService:
         # Explicit provider (not ``binder.bind``): BotDiscoverService
         # types ``bcsfuse_config`` under TYPE_CHECKING to avoid a
@@ -98,6 +99,7 @@ class BotPublicModule(Module):
         return BotDiscoverService(
             bot_repository=bot_repository,
             bcsfuse_config=bcsfuse_config,
+            catalog_metadata_service=catalog_metadata_service,
         )
 
     @singleton

--- a/src/backend/tests/community/adapters/http/openapi_v1/bot_public/test_bot_public_router.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/bot_public/test_bot_public_router.py
@@ -449,11 +449,55 @@ def test_discover_uses_online_filter_by_default(
             "top_k": 10,
             "min_score": 0.1,
             "filters": {"runtime_state": ["online"]},
+            "catalog_filters": BotCatalogSearchFilters(status="online"),
+            "caller": BotCatalogCaller(
+                tenant_id="teamclaw", user_id="caller-1", app_id=None
+            ),
+            "request_id": "",
         }
     ]
     item = response.json()["data"]["items"][0]
     assert "friendship" not in item
     assert item["recommendation"]["score"] == 0.92
+
+
+def test_discover_forwards_verified_viewer_to_bcs_catalog(
+    client: TestClient, services: tuple[_PublicService, _DiscoverService]
+) -> None:
+    response = client.get(
+        _DISCOVER_PATH,
+        params={
+            "keyword": "automation",
+            "viewer_actor_type": "human",
+            "viewer_actor_id": "caller-1",
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    call = services[1].calls[0]
+    assert call["catalog_filters"] == BotCatalogSearchFilters(
+        status="online",
+        viewer_actor_type="human",
+        viewer_actor_id="caller-1",
+    )
+    assert call["caller"] == BotCatalogCaller(
+        tenant_id="teamclaw", user_id="caller-1", app_id=None
+    )
+    assert call["request_id"] == ""
+
+
+def test_discover_keeps_non_bcs_runtime_state_in_bcsfuse_only(
+    client: TestClient, services: tuple[_PublicService, _DiscoverService]
+) -> None:
+    response = client.get(
+        _DISCOVER_PATH,
+        params={"keyword": "automation", "runtime_state": "verify"},
+    )
+
+    assert response.status_code == 200, response.text
+    call = services[1].calls[0]
+    assert call["filters"] == {"runtime_state": ["verify"]}
+    assert call["catalog_filters"] == BotCatalogSearchFilters()
 
 
 def test_discover_preserves_allowlisted_legacy_json_values(

--- a/src/backend/tests/community/core/bot_public/test_bot_catalog_metadata_service.py
+++ b/src/backend/tests/community/core/bot_public/test_bot_catalog_metadata_service.py
@@ -243,6 +243,37 @@ def test_bcs_catalog_search_forwards_only_supplied_frontend_filters() -> None:
     assert "headers" not in call.kwargs
 
 
+def test_bcs_catalog_search_forwards_exact_bot_uuid_candidates() -> None:
+    """Discover candidates must be checked by the same BCS catalog search path."""
+    service, http = _make_service()
+    http.set_response("get", _response(200, {"total": 0, "items": []}))
+
+    result = service.search_public_bot_metadata(
+        search=None,
+        page=1,
+        page_size=2,
+        bot_uuids=("bot-1:owner-1", "bot-2:owner-2"),
+        filters=BotCatalogSearchFilters(
+            status="online",
+            viewer_actor_type="human",
+            viewer_actor_id="owner-1",
+        ),
+        caller=_caller(),
+        request_id="trace-discover",
+    )
+
+    assert result == BotCatalogMetadataPage(total=0, items=[])
+    assert http.calls_to("get")[0].kwargs["params"] == {
+        "offset": 0,
+        "limit": 2,
+        "tc_bot": True,
+        "bot_uuids": "bot-1:owner-1,bot-2:owner-2",
+        "status": "online",
+        "viewer_actor_type": "human",
+        "viewer_actor_id": "owner-1",
+    }
+
+
 @pytest.mark.parametrize(
     "item",
     [

--- a/src/backend/tests/community/core/bot_public/test_bot_discover_service.py
+++ b/src/backend/tests/community/core/bot_public/test_bot_discover_service.py
@@ -1,0 +1,142 @@
+"""BCSFuse ranking joined with the authoritative BCS Bot catalog."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from agentclaw.community.core.bot_public.catalog_metadata import (
+    BotCatalogAddress,
+    BotCatalogCaller,
+    BotCatalogMetadata,
+    BotCatalogMetadataPage,
+    BotCatalogSearchFilters,
+)
+from agentclaw.community.core.bot_public.services.bot_discover_service import (
+    BotDiscoverService,
+)
+
+
+def _backend_bot(*, public: str = "0") -> dict[str, Any]:
+    return {
+        "id": 1,
+        "bot_id": "catalog-bot",
+        "bot_type": "service",
+        "bot_name": "Catalog Bot",
+        "bot_desc": "BCS-visible bot",
+        "entity_id": "owner-1",
+        "entity_type": "user",
+        "creator_id": "owner-1",
+        "owner_id": "owner-1",
+        "engine_types": ["openclaw"],
+        "status": "ACTIVE",
+        "binding_id": None,
+        "gmt_create": 1,
+        "gmt_modified": 2,
+        "modifier_id": "owner-1",
+        "share_policy": None,
+        "is_delete": 0,
+        "active_engine": "openclaw",
+        "device_id": "secret-device",
+        "env": "pre",
+        "ext": {"owner_name": "Owner"},
+        "public": public,
+    }
+
+
+@dataclass
+class _Repo:
+    calls: list[tuple[list[tuple[str, str]], int, int]] = field(default_factory=list)
+
+    def list_bots_by_owner_bot_pairs(
+        self,
+        pairs: list[tuple[str, str]],
+        page: int = 1,
+        page_size: int = 20,
+    ) -> tuple[int, list[dict[str, Any]]]:
+        self.calls.append((pairs, page, page_size))
+        return 1, [_backend_bot(public="0")]
+
+    def list_public_bots_by_owner_bot_pairs(self, _pairs):
+        raise AssertionError("Discover must not use the legacy ac_bots.public filter")
+
+
+@dataclass
+class _Metadata:
+    calls: list[dict[str, Any]] = field(default_factory=list)
+
+    def search_public_bot_metadata(self, **kwargs: Any) -> BotCatalogMetadataPage:
+        self.calls.append(kwargs)
+        return BotCatalogMetadataPage(
+            total=1,
+            items=[
+                BotCatalogMetadata(
+                    address=BotCatalogAddress("catalog-bot", "owner-1"),
+                    kind="bot",
+                    bot_uuid="catalog-bot:owner-1",
+                    visibility="private",
+                    user_visibility="public",
+                    actor_kind="bot",
+                    is_online=True,
+                )
+            ],
+        )
+
+
+def test_discover_uses_bcs_visibility_and_not_legacy_backend_public(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A human-visible BCS Bot remains discoverable when ac_bots.public is stale."""
+    repo = _Repo()
+    metadata = _Metadata()
+    service = BotDiscoverService(
+        bot_repository=repo,
+        bcsfuse_config=SimpleNamespace(
+            base_url="http://bcsfuse.test", base_url_pre=None
+        ),
+        catalog_metadata_service=metadata,
+    )
+    recommendations = [
+        {"worker_id": "catalog-bot:owner-1", "score": 0.9, "reasons": ["match"]},
+        {"worker_id": "default:owner-1", "score": 0.8, "reasons": ["stale"]},
+    ]
+    monkeypatch.setattr(
+        service,
+        "_call_bcsfuse_recommend",
+        lambda **_kwargs: {"recommendations": recommendations},
+    )
+    caller = BotCatalogCaller("teamclaw", "owner-1", None)
+    filters = BotCatalogSearchFilters(
+        status="online", viewer_actor_type="human", viewer_actor_id="owner-1"
+    )
+
+    result = service.search_by_keyword(
+        keyword="研发",
+        top_k=20,
+        min_score=0.1,
+        filters={"runtime_state": ["online"]},
+        catalog_filters=filters,
+        caller=caller,
+        request_id="trace-discover",
+    )
+
+    assert result["total"] == 1
+    assert result["items"][0]["bot_uuid"] == "catalog-bot:owner-1"
+    assert result["items"][0]["visibility"] == "private"
+    assert result["items"][0]["user_visibility"] == "public"
+    assert result["items"][0]["recommend"]["score"] == 0.9
+    assert repo.calls == [([("catalog-bot", "owner-1")], 1, 1)]
+    assert metadata.calls == [
+        {
+            "search": None,
+            "page": 1,
+            "page_size": 2,
+            "bot_uuids": ("catalog-bot:owner-1", "default:owner-1"),
+            "filters": filters,
+            "caller": caller,
+            "request_id": "trace-discover",
+        }
+    ]

--- a/src/backend/tests/community/repository/bot/test_bot_tenant_raw_sql_and_threads.py
+++ b/src/backend/tests/community/repository/bot/test_bot_tenant_raw_sql_and_threads.py
@@ -20,6 +20,10 @@ from agentclaw.community.core.bot_collaborator.models import BotCollaboratorMode
 from agentclaw.community.core.bot_public.services.bot_discover_service import (
     BotDiscoverService,
 )
+from agentclaw.community.core.bot_public.catalog_metadata import (
+    BotCatalogAddress,
+    BotCatalogMetadata,
+)
 from agentclaw.community.core.service_bot.repository.models import BotPublishModel
 from agentclaw.community.di.config import BcsFuseConfig
 from agentclaw.community.plugin_api.models import BotModel
@@ -140,7 +144,11 @@ def test_list_live_bots_by_owner_bot_pairs_keeps_non_public_and_scopes_live_rows
 # ── Comment 1: the real caller (_batch_get_public_bots) end-to-end ──
 
 def _discover_service(repo):
-    return BotDiscoverService(bot_repository=repo, bcsfuse_config=BcsFuseConfig())
+    return BotDiscoverService(
+        bot_repository=repo,
+        bcsfuse_config=BcsFuseConfig(),
+        catalog_metadata_service=object(),
+    )
 
 
 def test_batch_get_public_bots_returns_detail_and_is_tenant_scoped(repo):
@@ -158,10 +166,17 @@ def test_batch_get_public_bots_returns_detail_and_is_tenant_scoped(repo):
     svc = _discover_service(repo)
     rec = {"score": 0.9}
     entries = [("own-a:worker", "bot-a", "own-a", rec)]
+    metadata = {
+        ("bot-a", "own-a"): BotCatalogMetadata(
+            address=BotCatalogAddress("bot-a", "own-a"),
+            kind="bot",
+            bot_uuid="bot-a:own-a",
+        )
+    }
 
     # Under tenant-a: the detail comes back, ext parsed, rec threaded through.
     with avernet_tenant_scope("tenant-a"):
-        result = svc._batch_get_public_bots(entries, user_id="own-a")
+        result = svc._batch_get_public_bots(entries, metadata)
     assert len(result) == 1
     bot_detail, got_rec = result[0]
     assert bot_detail["bot_id"] == "bot-a"
@@ -174,12 +189,12 @@ def test_batch_get_public_bots_returns_detail_and_is_tenant_scoped(repo):
     # Under tenant-b: the ORM guard hides tenant-a's bot — the real leak the
     # raw SQL allowed is now closed at the service entry point.
     with avernet_tenant_scope("tenant-b"):
-        assert svc._batch_get_public_bots(entries, user_id="own-a") == []
+        assert svc._batch_get_public_bots(entries, metadata) == []
 
 
 def test_batch_get_public_bots_empty_entries(repo):
     svc = _discover_service(repo)
-    assert svc._batch_get_public_bots([], user_id="u") == []
+    assert svc._batch_get_public_bots([], {}) == []
 
 
 # ── Comment 2: a repo read inside a bound thread keeps the tenant ───

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/bots.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/bots.rs
@@ -483,6 +483,7 @@ pub async fn search_bots(
         "user_visibility",
         &["public", "protected", "private"],
     )?;
+    let bot_uuids = parse_bot_uuid_filter(q.bot_uuids.as_deref())?;
     let status = match q.status.as_deref() {
         Some("online") => Some(ActorStatus::Online),
         Some("hidden") => Some(ActorStatus::Hidden),
@@ -586,6 +587,7 @@ pub async fn search_bots(
         .services
         .bot_query
         .search_bots(SearchBotsCommand {
+            bot_uuids,
             q: q.q.clone(),
             visibility: effective_visibility,
             user_visibility: effective_user_visibility,
@@ -630,6 +632,28 @@ pub async fn search_bots(
         "offset": offset,
         "limit": limit,
     })))
+}
+
+fn parse_bot_uuid_filter(raw: Option<&str>) -> Result<Option<Vec<String>>, HttpAdapterError> {
+    let Some(raw) = raw else { return Ok(None) };
+    let mut values = Vec::new();
+    for part in raw.split(',') {
+        let value = part.trim();
+        if value.is_empty() {
+            return Err(HttpAdapterError::BadRequest(
+                "bot_uuids must contain non-empty comma-separated values".to_string(),
+            ));
+        }
+        if !values.iter().any(|existing| existing == value) {
+            values.push(value.to_string());
+        }
+    }
+    if values.len() > 100 {
+        return Err(HttpAdapterError::BadRequest(
+            "bot_uuids must contain at most 100 values".to_string(),
+        ));
+    }
+    Ok(Some(values))
 }
 
 fn parse_csv_filter(
@@ -925,4 +949,3 @@ async fn dispatch_visibility_sync_after_update(
 fn invalid_visibility_message() -> &'static str {
     "visibility must be 'public', 'protected', or 'private'"
 }
-

--- a/src/bcs/crates/adapters/http/bcs-http/tests/bots_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/bots_contract.rs
@@ -1553,6 +1553,55 @@ async fn search_bots_route_forwards_exact_bot_uuid_filter() {
     );
 }
 
+#[tokio::test]
+async fn search_bots_route_rejects_empty_exact_bot_uuid_filter_entry() {
+    let query = Arc::new(RecordingBotQueryService {
+        search_result: Ok(BotSearchResult { items: vec![], total: 0 }),
+        ..Default::default()
+    });
+    let services = Services::builder().bot_query(query.clone()).build_for_test();
+    let app = build_router(HttpAppState::new(services));
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/bots/search?bot_uuids=bot-alpha,")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert!(query.search_commands.lock().await.is_empty());
+}
+
+#[tokio::test]
+async fn search_bots_route_rejects_more_than_one_hundred_exact_bot_uuids() {
+    let query = Arc::new(RecordingBotQueryService {
+        search_result: Ok(BotSearchResult { items: vec![], total: 0 }),
+        ..Default::default()
+    });
+    let services = Services::builder().bot_query(query.clone()).build_for_test();
+    let app = build_router(HttpAppState::new(services));
+    let bot_uuids = (0..101)
+        .map(|index| format!("bot-{index}"))
+        .collect::<Vec<_>>()
+        .join(",");
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/bots/search?bot_uuids={bot_uuids}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert!(query.search_commands.lock().await.is_empty());
+}
 
 #[tokio::test]
 async fn search_bots_route_accepts_multi_visibility_and_returns_friend_policy_fields() {

--- a/src/bcs/crates/adapters/http/bcs-http/tests/bots_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/bots_contract.rs
@@ -1522,6 +1522,37 @@ async fn search_bots_route_forwards_tc_bot_filter_param() {
     assert_eq!(commands[0].tc_bot, Some(true));
 }
 
+#[tokio::test]
+async fn search_bots_route_forwards_exact_bot_uuid_filter() {
+    let query = Arc::new(RecordingBotQueryService {
+        search_result: Ok(BotSearchResult { items: vec![], total: 0 }),
+        ..Default::default()
+    });
+    let services = Services::builder().bot_query(query.clone()).build_for_test();
+    let app = build_router(HttpAppState::new(services));
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/bots/search?bot_uuids=bot-alpha%3Aowner-1,bot-beta%3Aowner-2")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let commands = query.search_commands.lock().await;
+    assert_eq!(commands.len(), 1);
+    assert_eq!(
+        commands[0].bot_uuids.as_ref().unwrap(),
+        &vec![
+            "bot-alpha:owner-1".to_string(),
+            "bot-beta:owner-2".to_string(),
+        ]
+    );
+}
+
 
 #[tokio::test]
 async fn search_bots_route_accepts_multi_visibility_and_returns_friend_policy_fields() {

--- a/src/bcs/crates/contracts/bcs-protocol/src/http/bots.rs
+++ b/src/bcs/crates/contracts/bcs-protocol/src/http/bots.rs
@@ -8,6 +8,9 @@ use crate::{BindingChannels, Skill, deserialize_skills};
 /// Query parameters for `GET /bots/search`.
 #[derive(Debug, Clone, Deserialize)]
 pub struct BotSearchQuery {
+    /// Exact Bot UUID filter: comma-separated values, up to 100 entries.
+    #[serde(default)]
+    pub bot_uuids: Option<String>,
     /// Name/summary fuzzy search (contains, case-insensitive).
     #[serde(default)]
     pub q: Option<String>,
@@ -325,4 +328,3 @@ mod tests {
         assert!(serialized.get("agent_token").is_none());
     }
 }
-

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/bot_query.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/bot_query.rs
@@ -110,6 +110,7 @@ pub struct BotQueryByIdsResult {
 /// restricts to non-TC bots; `None` applies no such filter.
 #[derive(Debug, Clone)]
 pub struct SearchBotsCommand {
+    pub bot_uuids: Option<Vec<String>>,
     pub q: Option<String>,
     pub visibility: Option<Vec<String>>,
     pub user_visibility: Option<Vec<String>>,
@@ -125,6 +126,7 @@ pub struct SearchBotsCommand {
 impl Default for SearchBotsCommand {
     fn default() -> Self {
         Self {
+            bot_uuids: None,
             q: None,
             visibility: None,
             user_visibility: None,

--- a/src/bcs/crates/service-api/bcs-service-api/src/types/bot_control_plane.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/types/bot_control_plane.rs
@@ -66,6 +66,7 @@ pub struct BotSearchCandidateQuery {
     pub env: String,
     pub visibility: BotCandidateVisibility,
     pub friend_ids: HashSet<String>,
+    pub bot_uuids: Option<Vec<String>>,
     pub name: Option<String>,
     pub q: Option<String>,
     pub visibility_filter: Option<Vec<String>>,

--- a/src/bcs/crates/services/bcs-bot-store/src/lib.rs
+++ b/src/bcs/crates/services/bcs-bot-store/src/lib.rs
@@ -3171,6 +3171,19 @@ impl BotControlPlaneRepoPort for PersistentBotRepo {
                     .filter(|value| !value.is_empty())
             })
             .map(str::to_lowercase);
+        let bot_uuid_filter = match query.bot_uuids.as_ref() {
+            Some(values) if values.is_empty() => return Ok((Vec::new(), 0)),
+            Some(values) => {
+                let mut values = values
+                    .iter()
+                    .map(|value| value.trim().to_string())
+                    .collect::<Vec<_>>();
+                values.sort_unstable();
+                values.dedup();
+                Some(values)
+            }
+            None => None,
+        };
         let visibility_filter = match query.visibility_filter.as_ref() {
             Some(values) if values.is_empty() => return Ok((Vec::new(), 0)),
             Some(values) => Some(
@@ -3229,6 +3242,13 @@ impl BotControlPlaneRepoPort for PersistentBotRepo {
             .collect::<Vec<_>>();
         params.push(Value::from(query.env.as_str()));
         params.push(Value::from(query.acting_bot_id.as_str()));
+        if let Some(values) = bot_uuid_filter.as_ref() {
+            predicates.push(format!(
+                "b.bot_uuid IN ({})",
+                vec!["?"; values.len()].join(", ")
+            ));
+            params.extend(values.iter().map(|value| Value::from(value.as_str())));
+        }
         if let Some(search_text) = search_text.as_ref() {
             predicates.push(
                 "(INSTR(LOWER(COALESCE(b.name, '')), ?) > 0 OR INSTR(LOWER(COALESCE(b.bot_info, '')), ?) > 0 OR INSTR(LOWER(b.bot_uuid), ?) > 0)"

--- a/src/bcs/crates/services/bcs-bot-store/src/memory.rs
+++ b/src/bcs/crates/services/bcs-bot-store/src/memory.rs
@@ -2037,6 +2037,11 @@ impl BotControlPlaneRepoPort for MemoryBotRepo {
                     .filter(|value| !value.is_empty())
             })
             .map(str::to_lowercase);
+        let bot_uuid_filter = match query.bot_uuids.as_ref() {
+            Some(values) if values.is_empty() => return Ok((Vec::new(), 0)),
+            Some(values) => Some(values.iter().map(String::as_str).collect::<HashSet<_>>()),
+            None => None,
+        };
         let visibility_filter = match query.visibility_filter.as_ref() {
             Some(values) if values.is_empty() => return Ok((Vec::new(), 0)),
             Some(values) => Some(
@@ -2063,6 +2068,12 @@ impl BotControlPlaneRepoPort for MemoryBotRepo {
                 continue;
             };
             if bot.bot_id == query.acting_bot_id || bot.kind != bcs_service_api::ActorKind::Bot {
+                continue;
+            }
+            if bot_uuid_filter
+                .as_ref()
+                .is_some_and(|values| !values.contains(bot.bot_id.as_str()))
+            {
                 continue;
             }
             if search_text.as_ref().is_some_and(|needle| {

--- a/src/bcs/crates/services/bcs-bot-store/tests/conformance_bot_control_plane_repo.rs
+++ b/src/bcs/crates/services/bcs-bot-store/tests/conformance_bot_control_plane_repo.rs
@@ -1501,6 +1501,7 @@ async fn memory_control_plane_search_covers_search_text_friendship_and_tc_filter
             env: env.clone(),
             visibility: BotCandidateVisibility::Discovery,
             friend_ids: HashSet::from(["friend-memory".to_string()]),
+            bot_uuids: None,
             name: Some(" needle ".to_string()),
             q: None,
             visibility_filter: None,
@@ -1516,12 +1517,38 @@ async fn memory_control_plane_search_covers_search_text_friendship_and_tc_filter
     assert_eq!(match_name.1, 1);
     assert_eq!(match_name.0[0].bot.bot_id, "search-match-memory");
 
+    let (exact_bots, total) = repo
+        .search_control_plane_candidates(BotSearchCandidateQuery {
+            acting_bot_id: "acting-memory-search".to_string(),
+            env: env.clone(),
+            visibility: BotCandidateVisibility::Discovery,
+            friend_ids: HashSet::new(),
+            bot_uuids: Some(vec![
+                "search-match-memory".to_string(),
+                "missing-memory".to_string(),
+            ]),
+            name: None,
+            q: None,
+            visibility_filter: None,
+            user_visibility: None,
+            status: None,
+            friendship: None,
+            tc_bot: None,
+            offset: 0,
+            limit: 20,
+        })
+        .await
+        .expect("exact bot uuid filter");
+    assert_eq!(total, 1);
+    assert_eq!(exact_bots[0].bot.bot_id, "search-match-memory");
+
     let (empty_visibility, total) = repo
         .search_control_plane_candidates(BotSearchCandidateQuery {
             acting_bot_id: "acting-memory-search".to_string(),
             env: env.clone(),
             visibility: BotCandidateVisibility::Discovery,
             friend_ids: HashSet::new(),
+            bot_uuids: None,
             name: None,
             q: None,
             visibility_filter: Some(vec![]),
@@ -1543,6 +1570,7 @@ async fn memory_control_plane_search_covers_search_text_friendship_and_tc_filter
             env: env.clone(),
             visibility: BotCandidateVisibility::Discovery,
             friend_ids: HashSet::new(),
+            bot_uuids: None,
             name: None,
             q: None,
             visibility_filter: None,
@@ -1564,6 +1592,7 @@ async fn memory_control_plane_search_covers_search_text_friendship_and_tc_filter
             env: env.clone(),
             visibility: BotCandidateVisibility::Discovery,
             friend_ids: HashSet::new(),
+            bot_uuids: None,
             name: None,
             q: None,
             visibility_filter: None,
@@ -1585,6 +1614,7 @@ async fn memory_control_plane_search_covers_search_text_friendship_and_tc_filter
             env: env.clone(),
             visibility: BotCandidateVisibility::Discovery,
             friend_ids: HashSet::from(["friend-memory".to_string()]),
+            bot_uuids: None,
             name: None,
             q: None,
             visibility_filter: None,
@@ -1607,6 +1637,7 @@ async fn memory_control_plane_search_covers_search_text_friendship_and_tc_filter
             env: env.clone(),
             visibility: BotCandidateVisibility::Discovery,
             friend_ids: HashSet::from(["friend-memory".to_string()]),
+            bot_uuids: None,
             name: None,
             q: None,
             visibility_filter: None,
@@ -1628,6 +1659,7 @@ async fn memory_control_plane_search_covers_search_text_friendship_and_tc_filter
             env: env.clone(),
             visibility: BotCandidateVisibility::Discovery,
             friend_ids: HashSet::new(),
+            bot_uuids: None,
             name: None,
             q: None,
             visibility_filter: None,
@@ -1649,6 +1681,7 @@ async fn memory_control_plane_search_covers_search_text_friendship_and_tc_filter
             env: env,
             visibility: BotCandidateVisibility::Discovery,
             friend_ids: HashSet::new(),
+            bot_uuids: None,
             name: None,
             q: None,
             visibility_filter: None,
@@ -1741,6 +1774,7 @@ async fn persistent_control_plane_search_covers_search_text_friendship_and_tc_fi
             env: "dev".to_string(),
             visibility: BotCandidateVisibility::Discovery,
             friend_ids: HashSet::from(["friend-persistent".to_string()]),
+            bot_uuids: None,
             name: Some(" needle ".to_string()),
             q: None,
             visibility_filter: None,
@@ -1756,12 +1790,38 @@ async fn persistent_control_plane_search_covers_search_text_friendship_and_tc_fi
     assert_eq!(match_name.1, 1);
     assert_eq!(match_name.0[0].bot.bot_id, "search-match-persistent");
 
+    let (exact_bots, total) = repo
+        .search_control_plane_candidates(BotSearchCandidateQuery {
+            acting_bot_id: "acting-persistent-search".to_string(),
+            env: "dev".to_string(),
+            visibility: BotCandidateVisibility::Discovery,
+            friend_ids: HashSet::new(),
+            bot_uuids: Some(vec![
+                "search-match-persistent".to_string(),
+                "missing-persistent".to_string(),
+            ]),
+            name: None,
+            q: None,
+            visibility_filter: None,
+            user_visibility: None,
+            status: None,
+            friendship: None,
+            tc_bot: None,
+            offset: 0,
+            limit: 20,
+        })
+        .await
+        .expect("exact bot uuid filter");
+    assert_eq!(total, 1);
+    assert_eq!(exact_bots[0].bot.bot_id, "search-match-persistent");
+
     let (empty_visibility, total) = repo
         .search_control_plane_candidates(BotSearchCandidateQuery {
             acting_bot_id: "acting-persistent-search".to_string(),
             env: "dev".to_string(),
             visibility: BotCandidateVisibility::Discovery,
             friend_ids: HashSet::new(),
+            bot_uuids: None,
             name: None,
             q: None,
             visibility_filter: Some(vec![]),
@@ -1783,6 +1843,7 @@ async fn persistent_control_plane_search_covers_search_text_friendship_and_tc_fi
             env: "dev".to_string(),
             visibility: BotCandidateVisibility::Discovery,
             friend_ids: HashSet::new(),
+            bot_uuids: None,
             name: None,
             q: None,
             visibility_filter: None,
@@ -1804,6 +1865,7 @@ async fn persistent_control_plane_search_covers_search_text_friendship_and_tc_fi
             env: "dev".to_string(),
             visibility: BotCandidateVisibility::Discovery,
             friend_ids: HashSet::new(),
+            bot_uuids: None,
             name: None,
             q: None,
             visibility_filter: None,
@@ -1825,6 +1887,7 @@ async fn persistent_control_plane_search_covers_search_text_friendship_and_tc_fi
             env: "dev".to_string(),
             visibility: BotCandidateVisibility::Discovery,
             friend_ids: HashSet::from(["friend-persistent".to_string()]),
+            bot_uuids: None,
             name: None,
             q: None,
             visibility_filter: None,
@@ -1847,6 +1910,7 @@ async fn persistent_control_plane_search_covers_search_text_friendship_and_tc_fi
             env: "dev".to_string(),
             visibility: BotCandidateVisibility::Discovery,
             friend_ids: HashSet::from(["friend-persistent".to_string()]),
+            bot_uuids: None,
             name: None,
             q: None,
             visibility_filter: None,
@@ -1868,6 +1932,7 @@ async fn persistent_control_plane_search_covers_search_text_friendship_and_tc_fi
             env: "dev".to_string(),
             visibility: BotCandidateVisibility::Discovery,
             friend_ids: HashSet::new(),
+            bot_uuids: None,
             name: None,
             q: None,
             visibility_filter: None,
@@ -1889,6 +1954,7 @@ async fn persistent_control_plane_search_covers_search_text_friendship_and_tc_fi
             env: "dev".to_string(),
             visibility: BotCandidateVisibility::Discovery,
             friend_ids: HashSet::new(),
+            bot_uuids: None,
             name: None,
             q: None,
             visibility_filter: None,

--- a/src/bcs/crates/services/bcs-bot/src/application/bot.rs
+++ b/src/bcs/crates/services/bcs-bot/src/application/bot.rs
@@ -421,6 +421,7 @@ impl Bot {
             env: bcs_config::resolve_env_str(),
             visibility: bcs_service_api::BotCandidateVisibility::Discovery,
             friend_ids,
+            bot_uuids: command.bot_uuids.clone(),
             name: command.q.clone(),
             q: command.q.clone(),
             visibility_filter: command.visibility.clone(),

--- a/src/bcs/crates/services/bcs-bot/tests/bot_search_contract.rs
+++ b/src/bcs/crates/services/bcs-bot/tests/bot_search_contract.rs
@@ -285,6 +285,31 @@ async fn search_bots_visibility_filter_accepts_multiple_values() {
 }
 
 #[tokio::test]
+async fn search_bots_applies_exact_bot_uuid_candidates() {
+    let (bot, core, _data_dir) = build_bot().await;
+    core.register("candidate-bot".to_string(), capabilities("Candidate", "public"))
+        .await
+        .expect("register candidate bot");
+    core.register("other-bot".to_string(), capabilities("Other", "public"))
+        .await
+        .expect("register other bot");
+
+    let result = bot
+        .search_bots(SearchBotsCommand {
+            bot_uuids: Some(vec![
+                "candidate-bot".to_string(),
+                "missing-bot".to_string(),
+            ]),
+            ..Default::default()
+        })
+        .await
+        .expect("search exact candidates");
+
+    assert_eq!(result.total, 1);
+    assert_eq!(result.items[0].bot_uuid, "candidate-bot");
+}
+
+#[tokio::test]
 async fn search_bots_excludes_soft_deleted_persistent_rows_even_if_memory_has_bot() {
     let cache = Arc::new(InMemoryCachePlugin::new());
     let db = sqlite_db().await;
@@ -445,4 +470,3 @@ async fn search_bots_rejects_friendship_filter_without_viewer_actor() {
         )) if message == "friendship filter requires viewer_actor_id"
     ));
 }
-

--- a/src/bcs/docs/superpowers/specs/2026-08-20-bot-search-endpoint-design.md
+++ b/src/bcs/docs/superpowers/specs/2026-08-20-bot-search-endpoint-design.md
@@ -35,6 +35,7 @@ GET /bots/search
 
 | 参数 | 类型 | 默认 | 说明 |
 |---|---|---|---|
+| `bot_uuids` | string | — | 精确 Bot UUID 集合，逗号分隔，最多 100 个；与其他可见性、状态及 viewer 条件共同生效 |
 | `q` | string | — | 名称/简介模糊搜索（contains，大小写不敏感） |
 | `visibility` | string | — | Bot 可见性过滤，支持单值或多值 OR：`public` / `protected` / `private`，推荐逗号分隔如 `visibility=public,protected`；非法值 → 400 |
 | `user_visibility` | string | — | 用户侧可见/可加好友策略过滤，支持单值或多值 OR：`public` / `protected` / `private`，推荐逗号分隔如 `user_visibility=public,protected`；非法值 → 400 |
@@ -196,6 +197,9 @@ GET /bots/search?visibility=protected&viewer_actor_type=bot&viewer_actor_id=bot-
 
 # 仅返回 TeamClaw backend 过来的 bot
 GET /bots/search?tc_bot=true
+
+# 在推荐候选中复用相同的 Catalog 可见性规则
+GET /bots/search?bot_uuids=bot-a:owner-1,bot-b:owner-2&viewer_actor_type=human&viewer_actor_id=owner-1
 
 # 无认证 → 仅返回 public bot
 GET /bots/search?q=助手


### PR DESCRIPTION
## Problem

The Bot catalog Search and Discover APIs used different visibility sources.

Search uses `bcs_bots` as the catalog authority, while Discover filtered BCSFuse recommendations using the legacy `ac_bots.public = '1'` field. As a result, all BCSFuse candidates could be removed even when they were visible through Search. Stale BCSFuse worker IDs could also fail the exact Backend join.

## Solution

- Added an optional exact `bot_uuids` filter to BCS `GET /bots/search`.
- Applied the filter in both persistent and in-memory BCS repositories while preserving the existing visibility, viewer, friendship, status, and `tc_bot` rules.
- Updated Backend Discover to:
  - use BCSFuse only for semantic ranking;
  - validate candidates through BCS Catalog Search;
  - use BCS visibility metadata as the authority;
  - query `ac_bots` only for display details without filtering on `ac_bots.public`;
  - forward `viewer_actor_type` and `viewer_actor_id`;
  - preserve existing `draft` and `verify` runtime-state behavior.
- Added regression and contract coverage for the new flow.

## Validation

- Backend catalog, repository, router, and architecture tests: 203 passed.
- BCS HTTP, application, and repository contract tests: 58 passed.
- Ruff checks passed for all changed Python files.
- `git diff --check` passed.
- The repository pre-push lint gate passed.

## Compatibility and risk

The new BCS query parameter is optional, so existing Search callers are unaffected.

Deploy BCS before Backend. An older BCS version ignores the new filter, which can cause Discover candidates to be omitted until both services are upgraded. BCSFuse does not require deployment changes.