### PR TITLE
feat(bot_management): orchestrate create-as-service coding bot intake

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py
@@ -72,6 +72,7 @@ from agentclaw.community.core.bot_management.create_flow import (
     BotCreateDeploymentMode,
     BotCreateSpec,
     BotCreateTemplateValidationMode,
+    ServiceIntakeSeam,
     complete_bot_authorization,
     create_bot_with_authorization,
 )
@@ -86,6 +87,12 @@ from agentclaw.community.core.bot_management.services.bot_service import (
 from agentclaw.community.api.bot_startup_script_service import (
     SUPPORTED,
     BotStartupScriptServiceProtocol,
+)
+from agentclaw.community.api.service_publication_facade import (
+    ServicePublicationFacadeProtocol,
+)
+from agentclaw.community.core.service_bot.errors import (
+    ServicePublicationConflictError,
 )
 from agentclaw.community.api.data_init_service import DataInitServiceProtocol
 from agentclaw.community.core.workspace.constants import (
@@ -197,6 +204,32 @@ def _require_service_capable_engine(bot_type: str, engine: str) -> None:
         raise ServicePublicationUnsupportedError(
             decision.reason or "engine cannot be used by a service bot"
         )
+
+
+class _FacadeServiceIntakeSeam:
+    """Adapt the publication facade to the create flow's service intake seam.
+
+    The completion poll is the retry surface for a create-as-service request,
+    so a replayed conversion hits the facade's already-service conflict — for
+    intake that is success (the goal state is reached), not a failure to
+    surface to the caller.
+    """
+
+    def __init__(self, facade: ServicePublicationFacadeProtocol) -> None:
+        self._facade = facade
+
+    def convert(self, bot_id: str, *, actor_id: str, owner_id: str) -> None:
+        try:
+            self._facade.convert_to_service(
+                bot_id, actor_id=actor_id, owner_id=owner_id
+            )
+        except ServicePublicationConflictError as exc:
+            logger.info(
+                "[service_intake] conversion replay for already-serviced bot: "
+                "bot_id=%s, reason=%s",
+                bot_id,
+                exc,
+            )
 
 
 def _to_bot(d: dict[str, Any], *, space: dict[str, Any] | None = None) -> Bot:
@@ -506,6 +539,9 @@ async def create_bot(
     space_context: BusinessSpaceContextProtocol = Injected(
         BusinessSpaceContextProtocol
     ),
+    service_publication_facade: ServicePublicationFacadeProtocol = Injected(
+        ServicePublicationFacadeProtocol
+    ),
 ):
     """Create a bot (201), or 202 with authorization URLs when consent is needed.
 
@@ -515,6 +551,12 @@ async def create_bot(
     "engine_properties" and are interpreted by the selected engine;
     engine configuration is managed through the engine-config endpoints after
     creation.
+
+    A coding template with bot_type "service" (开启服务) is fulfilled
+    orchestratively: the bot is created by the personal-only template path and
+    immediately upgraded to a service bot, which is what the 201 reports. If
+    the upgrade fails the response is a 502 naming the created-as-personal
+    bot — retry via the lifecycle upgrade instead of re-creating.
     """
     # Engine-owned creation input is passed through opaquely below; the
     # engine-selected Core strategy owns its semantics and validation, so this
@@ -550,11 +592,13 @@ async def create_bot(
             deployment_mode=BotCreateDeploymentMode.CLOUD,
             space_kind=current_space.kind,
             space_quota=True,
+            service_intake=True,
         ),
         bot_service=bot_service,
         passport_plugin=passport_plugin,
         auth_rel_plugin=auth_rel_plugin,
         skill_set_factory=skill_set_factory,
+        service_intake_seam=_FacadeServiceIntakeSeam(service_publication_facade),
     )
 
     if isinstance(outcome, AuthPending):
@@ -1127,6 +1171,11 @@ def _complete_auth_status(
     passport_plugin: PassportPlugin,
     auth_rel_plugin: AuthRelationshipPlugin,
     space_context: BusinessSpaceContextProtocol,
+    # The POST spelling passes the orchestrating seam so an echoed
+    # bot_type=service coding create completes the upgrade; the retiring GET
+    # is plain-bot-only (no engine_properties to echo), so it passes nothing
+    # and keeps its historical behavior.
+    service_intake_seam: ServiceIntakeSeam | None = None,
 ) -> Envelope[BotAuthStatus] | JSONResponse:
     """Validate the echoed attributes, poll Passport, and map the outcome.
 
@@ -1175,10 +1224,12 @@ def _complete_auth_status(
                 deployment_mode=BotCreateDeploymentMode.CLOUD,
                 space_kind=current_space.kind,
                 space_quota=True,
+                service_intake=True,
             ),
             bot_service=bot_service,
             passport_plugin=passport_plugin,
             auth_rel_plugin=auth_rel_plugin,
+            service_intake_seam=service_intake_seam,
         )
     except AuthStatusUnavailableError:
         # The passport service answered with no status at all — typically the
@@ -1227,6 +1278,9 @@ async def poll_bot_auth_status(
     space_context: BusinessSpaceContextProtocol = Injected(
         BusinessSpaceContextProtocol
     ),
+    service_publication_facade: ServicePublicationFacadeProtocol = Injected(
+        ServicePublicationFacadeProtocol
+    ),
 ) -> Envelope[BotAuthStatus]:
     """Poll authorization for a pending creation; the bot is created on ISSUED.
 
@@ -1241,7 +1295,8 @@ async def poll_bot_auth_status(
     Every restriction create enforces is re-applied to the echoed values:
     the same engine registry check, the same engine/cluster pairing, the same
     personal/service restriction on bot_type, and the same business-space
-    resolution.
+    resolution. An echoed bot_type "service" coding create completes the
+    same orchestrated upgrade the create endpoint offers.
 
     While the authorization service has no status for the bot yet — the
     Passport is not ready — the poll answers PENDING with a message saying
@@ -1262,6 +1317,7 @@ async def poll_bot_auth_status(
         passport_plugin=passport_plugin,
         auth_rel_plugin=auth_rel_plugin,
         space_context=space_context,
+        service_intake_seam=_FacadeServiceIntakeSeam(service_publication_facade),
     )
 
 

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/errors_bot_create.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/errors_bot_create.py
@@ -9,6 +9,7 @@ from agentclaw.community.core.bot_management.errors import (
     ApplicationCodingUnavailableError as CoreApplicationCodingUnavailableError,
     BotCombinationUnsupportedError as CoreBotCombinationUnsupportedError,
     BotTemplateInvalidError as CoreBotTemplateInvalidError,
+    ServiceIntakeConversionError,
 )
 
 BOT_CREATE_HTTP_ERRORS = {
@@ -18,4 +19,13 @@ BOT_CREATE_HTTP_ERRORS = {
     CoreBotCombinationUnsupportedError: (409, "Coding template combination not supported"),
     ApplicationCodingUnavailableError: (503, "Application coding is unavailable in this deployment"),
     CoreApplicationCodingUnavailableError: (503, "Application coding is unavailable in this deployment"),
+    # The create half of a create-as-service request succeeded — the bot
+    # exists as personal — and only the upgrade failed. Downstream dependency
+    # failure, hence 502; the message points at the recovery (retry the
+    # lifecycle upgrade) instead of re-creating the bot.
+    ServiceIntakeConversionError: (
+        502,
+        "Bot created as personal, but converting it to service failed; "
+        "retry the lifecycle upgrade",
+    ),
 }

--- a/src/backend/src/agentclaw/community/core/bot_management/create_context.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/create_context.py
@@ -1,10 +1,20 @@
-"""Caller-resolved context carried through Bot creation."""
+"""Caller-resolved inputs carried through Bot creation.
+
+``BotCreateContext`` is the surface-resolved business context; ``BotCreateSpec``
+is the attribute bag each API surface maps its request into. Both live here, off
+``create_flow``, so ``create_flow`` holds the orchestration and the two input
+contracts stay together as one concern.
+"""
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import Any
+
+from agentclaw.community.core.bot_management.engines.provisioning import (
+    BotCreateTemplateValidationMode,
+)
 
 
 class BotCreateDeploymentMode(StrEnum):
@@ -22,12 +32,22 @@ class BotCreateContext:
     space_kind: str
     # Legacy callers keep BotService's established owner/device limit behavior.
     space_quota: bool = False
+    # Whether this surface offers the "create as service" coding intake: a
+    # coding create (engine_properties present) with bot_type="service" is
+    # translated to a personal create — the only shape the engine-strategy
+    # combination gate admits — and, once created and owned, upgraded through
+    # the ServiceIntakeSeam. Surfaces that do not opt in keep the historical
+    # 409. The seam must be wired for the translation to engage: an opted-in
+    # surface without one is a misconfiguration the gate refuses, not an
+    # intent to fulfill.
+    service_intake: bool = False
 
     def as_payload(self) -> dict[str, Any]:
         return {
             "deployment_mode": self.deployment_mode.value,
             "space_kind": self.space_kind,
             "space_quota": self.space_quota,
+            "service_intake": self.service_intake,
         }
 
     @classmethod
@@ -36,4 +56,55 @@ class BotCreateContext:
             deployment_mode=BotCreateDeploymentMode(payload["deployment_mode"]),
             space_kind=payload["space_kind"],
             space_quota=bool(payload.get("space_quota", False)),
+            service_intake=bool(payload.get("service_intake", False)),
         )
+
+
+@dataclass(frozen=True)
+class BotCreateSpec:
+    """The bot attributes a create / authorization-completion runs with.
+
+    An explicit contract instead of an untyped payload dict: each API surface
+    maps its own request shape into this, so a field added or renamed here is a
+    type error at every call site rather than a key that silently goes missing
+    on one surface.
+
+    ``entity_id`` and ``engine_type`` are **required and concrete** — each
+    surface resolves its own default while building the spec (the caller's id;
+    ``DEFAULT_ENGINE_TYPE``). ``BotService.create_bot`` only ever applies
+    ``x or <default>`` to them, so a concrete value is equivalent to leaving
+    them unset, and the flow never has to reason about an absent engine.
+
+    Two fields keep an unset state on purpose:
+
+    * ``bot_name`` — ``None`` means "no name given" so ``_resolve_bot_name``
+      derives one (the owner's nick name for a first bot, else the bot id). No
+      string can stand in: ``validate_bot_name("")`` rejects the request, and
+      the default needs a first-bot lookup the caller cannot pre-compute.
+    * ``bot_desc`` — stored straight through to a nullable column and echoed
+      back in responses, so ``None`` ("no description") and ``""`` are
+      genuinely different persisted values, not interchangeable defaults.
+    """
+
+    entity_id: str
+    engine_type: str
+    bot_type: str
+    bot_name: str | None
+    entity_type: str = "staff"
+    bot_desc: str | None = None
+    avatar_url: str | None = None
+    share_policy: dict[str, Any] | None = None
+    template_type: str | None = None
+    template_config: dict[str, Any] | None = None
+    # How strictly template ownership rules apply: PUBLIC for OpenAPI inputs,
+    # LEGACY for established internal snapshots (may carry ``template_uid``).
+    template_validation_mode: BotCreateTemplateValidationMode = (
+        BotCreateTemplateValidationMode.LEGACY
+    )
+    space_id: int | None = None
+    # Engine-owned creation properties (the public ``engine_properties``
+    # contract), kept opaque here: only the engine-selected
+    # ``EngineProvisioningStrategy`` may interpret its keys. The legacy
+    # template_type/template_config pair above serves established internal
+    # callers and is mutually exclusive with this bag.
+    engine_properties: dict[str, Any] = field(default_factory=dict)

--- a/src/backend/src/agentclaw/community/core/bot_management/create_flow.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/create_flow.py
@@ -26,6 +26,7 @@ from typing import TYPE_CHECKING, Any
 from agentclaw.community.core.bot_management.create_context import (
     BotCreateContext,
     BotCreateDeploymentMode as BotCreateDeploymentMode,
+    BotCreateSpec as BotCreateSpec,
 )
 from agentclaw.community.core.bot_management.engines.provisioning import (
     BotCreateTemplateValidationMode,
@@ -46,6 +47,11 @@ from agentclaw.community.core.bot_management.manifest_seam import (
 from agentclaw.community.core.bot_management.errors import (
     ApplicationCodingUnavailableError,
     BotTemplateInvalidError,
+)
+from agentclaw.community.core.bot_management.service_intake import (
+    ServiceIntakeSeam,
+    finish_service_intake,
+    prepare_service_intake,
 )
 from agentclaw.community.core.bot_management.services.bot_service import (
     BotServiceError,
@@ -233,56 +239,6 @@ class AuthStatusResult:
 
     status: str
     bot: dict[str, Any] = field(default_factory=dict)
-
-
-@dataclass(frozen=True)
-class BotCreateSpec:
-    """The bot attributes a create / authorization-completion runs with.
-
-    An explicit contract instead of an untyped payload dict: each API surface
-    maps its own request shape into this, so a field added or renamed here is a
-    type error at every call site rather than a key that silently goes missing
-    on one surface.
-
-    ``entity_id`` and ``engine_type`` are **required and concrete** — each
-    surface resolves its own default while building the spec (the caller's id;
-    ``DEFAULT_ENGINE_TYPE``). ``BotService.create_bot`` only ever applies
-    ``x or <default>`` to them, so a concrete value is equivalent to leaving
-    them unset, and the flow never has to reason about an absent engine.
-
-    Two fields keep an unset state on purpose:
-
-    * ``bot_name`` — ``None`` means "no name given" so ``_resolve_bot_name``
-      derives one (the owner's nick name for a first bot, else the bot id). No
-      string can stand in: ``validate_bot_name("")`` rejects the request, and
-      the default needs a first-bot lookup the caller cannot pre-compute.
-    * ``bot_desc`` — stored straight through to a nullable column and echoed
-      back in responses, so ``None`` ("no description") and ``""`` are
-      genuinely different persisted values, not interchangeable defaults.
-    """
-
-    entity_id: str
-    engine_type: str
-    bot_type: str
-    bot_name: str | None
-    entity_type: str = "staff"
-    bot_desc: str | None = None
-    avatar_url: str | None = None
-    share_policy: dict[str, Any] | None = None
-    template_type: str | None = None
-    template_config: dict[str, Any] | None = None
-    # How strictly template ownership rules apply: PUBLIC for OpenAPI inputs,
-    # LEGACY for established internal snapshots (may carry ``template_uid``).
-    template_validation_mode: BotCreateTemplateValidationMode = (
-        BotCreateTemplateValidationMode.LEGACY
-    )
-    space_id: int | None = None
-    # Engine-owned creation properties (the public ``engine_properties``
-    # contract), kept opaque here: only the engine-selected
-    # ``EngineProvisioningStrategy`` may interpret its keys. The legacy
-    # template_type/template_config pair above serves established internal
-    # callers and is mutually exclusive with this bag.
-    engine_properties: dict[str, Any] = field(default_factory=dict)
 
 
 def _prepare_create(
@@ -507,6 +463,7 @@ def create_bot_with_authorization(
     passport_plugin: PassportPlugin,
     auth_rel_plugin: AuthRelationshipPlugin,
     skill_set_factory: SkillSetServiceFactory,
+    service_intake_seam: ServiceIntakeSeam | None = None,
 ) -> Created | AuthPending:
     """Run the create + Passport-authorization flow for an already-allocated id.
 
@@ -521,6 +478,8 @@ def create_bot_with_authorization(
     downstream memoryos call still relies on it; the public ``/openapi/v1``
     surface does not pass it. Remove once the internal path stops needing it.
     """
+    spec, service_intake = prepare_service_intake(spec, context, service_intake_seam)
+
     # Creation policy is evaluated here, rather than in either transport, so no
     # caller can bypass template/combination rules before Passport or writes.
     spec = _prepare_create(spec=spec, context=context, bot_service=bot_service)
@@ -621,6 +580,11 @@ def create_bot_with_authorization(
         auth_rel_plugin, user_id=user_id, agent_code=agent_code,
         nick_name=nick_name, bot_id=bot_id,
     )
+
+    if service_intake:
+        result = finish_service_intake(
+            bot_id=bot_id, user_id=user_id, bot_service=bot_service, seam=service_intake_seam
+        )
 
     return Created(
         bot=result,
@@ -931,6 +895,7 @@ def complete_bot_authorization(
     passport_plugin: PassportPlugin,
     auth_rel_plugin: AuthRelationshipPlugin,
     provision: bool = True,
+    service_intake_seam: ServiceIntakeSeam | None = None,
 ) -> AuthStatusResult:
     """Poll Passport authorization for a pending bot; complete creation on ISSUED.
 
@@ -945,6 +910,8 @@ def complete_bot_authorization(
     ``cookie`` carries the browser session into the service layer — **bad
     practice**, see :func:`create_bot_with_authorization`; internal path only.
     """
+    spec, service_intake = prepare_service_intake(spec, context, service_intake_seam)
+
     # Re-run the same policy on authorization completion because callers echo
     # the creation attributes and must not bypass the original create contract.
     spec = _prepare_create(spec=spec, context=context, bot_service=bot_service)
@@ -987,4 +954,10 @@ def complete_bot_authorization(
         auth_rel_plugin, user_id=user_id, agent_code=agent_code,
         nick_name=nick_name, bot_id=bot_id,
     )
+
+    if service_intake:
+        result = finish_service_intake(
+            bot_id=bot_id, user_id=user_id, bot_service=bot_service, seam=service_intake_seam
+        )
+
     return AuthStatusResult(status=AuthStatus.ISSUED, bot=result)

--- a/src/backend/src/agentclaw/community/core/bot_management/errors.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/errors.py
@@ -35,3 +35,13 @@ class BotCombinationUnsupportedError(BotCreateError):
 
 class ApplicationCodingUnavailableError(BotCreateError):
     """Application Coding requires a Workspace Hosting capability."""
+
+
+class ServiceIntakeConversionError(BotCreateError):
+    """The Bot was created as personal, but its follow-up service upgrade failed.
+
+    The two-part "create as service" contract (personal create, then the
+    combination-gate-mandated upgrade) completed only its first half. The
+    caller should be told which bot exists — the message carries the id — so
+    it can retry the lifecycle upgrade instead of re-creating the bot.
+    """

--- a/src/backend/src/agentclaw/community/core/bot_management/service_intake.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/service_intake.py
@@ -1,0 +1,92 @@
+"""Create-as-service coding intake: create-as-personal, then upgrade to service.
+
+A coding create (``engine_properties`` present) is personal-only by the
+engine-strategy combination gate. A surface that opts in via
+``BotCreateContext.service_intake`` instead drives the product's 开启服务 flow:
+the spec is translated to ``personal`` so the same gate passes, and the
+created + owned bot is upgraded through the :class:`ServiceIntakeSeam`. The
+flow keeps one cohesive concern here: translation + post-create conversion,
+without weakening the gate for surfaces that do not opt in.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import TYPE_CHECKING, Any, Protocol
+
+from agentclaw.community.core.bot_management.create_context import BotCreateContext
+from agentclaw.community.core.bot_management.errors import ServiceIntakeConversionError
+from agentclaw.community.log import get_logger
+
+if TYPE_CHECKING:
+    from agentclaw.community.core.bot_management.create_flow import BotCreateSpec
+    from agentclaw.community.core.bot_management.services.bot_service import BotService
+
+logger = get_logger()
+
+
+class ServiceIntakeSeam(Protocol):
+    """Upgrade a freshly created bot to a service Bot, intake-style.
+
+    The create flow drives the second half of a create-as-service request.
+    The implementation must tolerate a replayed conversion (the completion
+    poll is the retry surface — a poll after a succeeded upgrade is success,
+    not a conflict) and raise only on real failure.
+    """
+
+    def convert(self, bot_id: str, *, actor_id: str, owner_id: str) -> None: ...
+
+
+def prepare_service_intake(
+    spec: "BotCreateSpec",
+    context: BotCreateContext,
+    seam: ServiceIntakeSeam | None,
+) -> tuple["BotCreateSpec", bool]:
+    """Translate a create-as-service coding request to its personal-create form.
+
+    Returns the spec to create with (``personal`` when intake, unchanged
+    otherwise) and whether the post-create service upgrade should run. Keeps
+    one cohesive concern in this module: the engine-strategy combination gate
+    stays personal-only for template carries; an opted-in surface (see
+    ``BotCreateContext.service_intake``) gets its service bot by translating
+    the create and then upgrading, never by weakening the gate.
+    """
+    if not (
+        context.service_intake
+        and seam is not None
+        and spec.bot_type == "service"
+        and spec.engine_properties
+    ):
+        return spec, False
+    return replace(spec, bot_type="personal"), True
+
+
+def finish_service_intake(
+    *,
+    bot_id: str,
+    user_id: str,
+    bot_service: "BotService",
+    seam: ServiceIntakeSeam,
+) -> dict[str, Any]:
+    """Drive the post-create upgrade and re-read the upgraded row.
+
+    The bot already exists and is owned at this point, so a failed upgrade
+    must not be swallowed: raise :class:`ServiceIntakeConversionError` naming
+    the bot so the caller can retry the upgrade (the bot list shows the
+    personal bot meanwhile) instead of re-creating.
+    """
+    try:
+        seam.convert(bot_id, actor_id=user_id, owner_id=user_id)
+    except Exception as exc:
+        logger.error(
+            "[create_flow.service_intake] conversion failed: bot_id=%s, "
+            "error=%s",
+            bot_id,
+            exc,
+            exc_info=True,
+        )
+        raise ServiceIntakeConversionError(
+            f"bot {bot_id} was created as personal but its service conversion "
+            f"failed; retry the lifecycle upgrade for this bot"
+        ) from exc
+    return bot_service.get_bot(bot_id, user_id)

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_bots_endpoints.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_bots_endpoints.py
@@ -65,6 +65,9 @@ from agentclaw.community.api.engine_config_service import EngineConfigServicePro
 from agentclaw.community.api.bot_startup_script_service import (
     BotStartupScriptServiceProtocol,
 )
+from agentclaw.community.api.service_publication_facade import (
+    ServicePublicationFacadeProtocol,
+)
 from agentclaw.community.plugin_api.auth_relationship import AuthRelationshipPlugin
 from agentclaw.community.plugin_api.passport import PassportPlugin
 
@@ -198,6 +201,14 @@ def startup_script():
     return m
 
 
+@pytest.fixture
+def service_publication():
+    """Service-publication facade mock: convert succeeds by default."""
+    m = MagicMock(spec=ServicePublicationFacadeProtocol)
+    m.convert_to_service.return_value = {"bot_id": "b1", "publication_id": 1}
+    return m
+
+
 class _CountingNoopSpace(NoopBusinessSpaceContext):
     """Noop space context that counts ``bot_space`` resolutions per instance."""
 
@@ -222,6 +233,7 @@ def client(
     skill_set_factory,
     auth_rel,
     startup_script,
+    service_publication,
 ):
     space = _CountingNoopSpace()
 
@@ -237,6 +249,7 @@ def client(
             binder.bind(SkillSetServiceFactoryProtocol, to=skill_set_factory)
             binder.bind(AuthRelationshipPlugin, to=auth_rel)
             binder.bind(BotStartupScriptServiceProtocol, to=startup_script)
+            binder.bind(ServicePublicationFacadeProtocol, to=service_publication)
             binder.bind(BusinessSpaceContextProtocol, to=space)
 
     app = FastAPI()
@@ -977,18 +990,153 @@ def test_create_rejects_legacy_template_key_name(client, svc):
     svc.create_bot.assert_not_called()
 
 
-def test_create_factory_snapshot_for_service_bot_is_409(client, svc):
+def test_create_factory_snapshot_for_service_bot_is_orchestrated(
+    client, svc, passport, service_publication
+):
+    """Create-as-service for a coding template: personal create, then upgrade.
+
+    The combination gate stays personal-only for template carries; this surface
+    answers the product's 开启服务 by translating the create and driving the
+    service upgrade behind the same request.
+    """
+    passport.apply_first_agent_passport.return_value = {
+        "token": "tok",
+        "agent_code": "ac",
+    }
+    svc.get_bot.return_value = {**BOT, "bot_type": "service"}
+
+    with patch.object(bots_router, "generate_bot_id", return_value="default"):
+        response = client.post(
+            "/openapi/v1/bots",
+            json={
+                **_CREATE_BODY,
+                "engine": "claude_code",
+                "bot_type": "service",
+                "engine_properties": dict(_FACTORY_SNAPSHOT_BODY),
+            },
+        )
+
+    body = response.json()
+    assert response.status_code == 201, body
+    # The gate the engine strategy enforces saw a personal create…
+    assert svc.create_bot.call_args.kwargs["bot_type"] == "personal"
+    # …and the freshly created bot went through the service upgrade.
+    service_publication.convert_to_service.assert_called_once_with(
+        "default", actor_id="u1", owner_id="u1"
+    )
+    assert body["data"]["bot_type"] == "service"
+
+
+def test_create_service_intake_conversion_failure_answers_502(
+    client, svc, passport, service_publication
+):
+    """The bot exists as personal; the caller must be told, not given a 201."""
+    passport.apply_first_agent_passport.return_value = {
+        "token": "tok",
+        "agent_code": "ac",
+    }
+    service_publication.convert_to_service.side_effect = RuntimeError("bcn down")
+
+    with patch.object(bots_router, "generate_bot_id", return_value="default"):
+        response = client.post(
+            "/openapi/v1/bots",
+            json={
+                **_CREATE_BODY,
+                "engine": "claude_code",
+                "bot_type": "service",
+                "engine_properties": dict(_FACTORY_SNAPSHOT_BODY),
+            },
+        )
+
+    body = response.json()
+    assert response.status_code == 502, body
+    assert body["code"] == 502000, body
+    svc.create_bot.assert_called_once()  # the bot exists; retry the upgrade
+
+
+def test_post_auth_status_service_intake_converts_on_issued(
+    client, svc, passport, service_publication
+):
+    """The poll is the retry surface: echoed bot_type=service completes + upgrades."""
+    passport.query_auth_status.return_value = {"status": "ISSUED"}
+    passport.query_agent_passport.return_value = {"agent_code": "ac"}
+    svc.get_bot.return_value = {**BOT, "bot_type": "service"}
+
     response = client.post(
-        "/openapi/v1/bots",
+        "/openapi/v1/bots/b1/auth-status",
         json={
-            **_CREATE_BODY,
             "engine": "claude_code",
+            "cluster_name": "ACRA",
             "bot_type": "service",
             "engine_properties": dict(_FACTORY_SNAPSHOT_BODY),
         },
     )
-    assert response.status_code == 409, response.json()
+
+    body = response.json()
+    assert response.status_code == 200, body
+    assert svc.create_bot.call_args.kwargs["bot_type"] == "personal"
+    service_publication.convert_to_service.assert_called_once_with(
+        "b1", actor_id="u1", owner_id="u1"
+    )
+    assert body["data"]["bot"]["bot_type"] == "service"
+
+
+def test_post_auth_status_pending_service_intake_does_not_convert(
+    client, svc, passport, service_publication
+):
+    passport.query_auth_status.return_value = {"status": "PENDING"}
+
+    response = client.post(
+        "/openapi/v1/bots/b1/auth-status",
+        json={
+            "engine": "claude_code",
+            "cluster_name": "ACRA",
+            "bot_type": "service",
+            "engine_properties": dict(_FACTORY_SNAPSHOT_BODY),
+        },
+    )
+
+    assert response.status_code == 200, response.json()
     svc.create_bot.assert_not_called()
+    service_publication.convert_to_service.assert_not_called()
+
+
+def test_post_auth_status_replayed_conversion_is_success(
+    client, svc, passport, service_publication
+):
+    """A poll after a succeeded conversion replays into already-service — success.
+
+    The completion is idempotent and the poll is its retry surface; a caller
+    (or a racing tab) re-polling must not read a 502 for a goal state already
+    reached.
+    """
+    from agentclaw.community.core.service_bot.errors import (
+        ServicePublicationConflictError,
+    )
+
+    passport.query_auth_status.return_value = {"status": "ISSUED"}
+    passport.query_agent_passport.return_value = {"agent_code": "ac"}
+    svc.get_bot.return_value = {**BOT, "bot_type": "service"}
+    service_publication.convert_to_service.side_effect = (
+        ServicePublicationConflictError("bot is already a service bot")
+    )
+
+    response = client.post(
+        "/openapi/v1/bots/b1/auth-status",
+        json={
+            "engine": "claude_code",
+            "cluster_name": "ACRA",
+            "bot_type": "service",
+            "engine_properties": dict(_FACTORY_SNAPSHOT_BODY),
+        },
+    )
+
+    body = response.json()
+    assert response.status_code == 200, body
+    service_publication.convert_to_service.assert_called_once_with(
+        "b1", actor_id="u1", owner_id="u1"
+    )
+    assert body["data"]["bot"]["bot_type"] == "service"
 
 
 def test_create_bot_cluster_mismatch_400(client, svc):

--- a/src/backend/tests/community/core/bot_management/test_create_flow_service_intake.py
+++ b/src/backend/tests/community/core/bot_management/test_create_flow_service_intake.py
@@ -1,0 +1,318 @@
+"""Service-intake translation: create-as-service coding bots via upgrade.
+
+A coding create (``engine_properties`` present) is personal-only by the
+engine-strategy combination gate. Surfaces that opt in via
+``BotCreateContext.service_intake`` get the product's "开启服务" flow instead:
+the spec is translated to ``personal`` so the same gate passes, and after the
+bot is created + owned the flow drives the service upgrade through the
+``ServiceIntakeSeam`` — the create-as-service the caller asked for, without
+weakening the gate for callers that did not opt in.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from agentclaw.community.api.bot_service import BotServiceProtocol
+from agentclaw.community.core.bot_management.create_flow import (
+    AuthPending,
+    AuthStatus,
+    BotCreateContext,
+    BotCreateDeploymentMode,
+    BotCreateSpec,
+    BotCreateTemplateValidationMode,
+    Created,
+    complete_bot_authorization,
+    create_bot_with_authorization,
+)
+from agentclaw.community.core.bot_management.errors import (
+    BotCombinationUnsupportedError,
+    ServiceIntakeConversionError,
+)
+
+pytestmark = pytest.mark.unit
+
+_BOT_ID = "20260904_svce0001"
+
+
+def _coding_spec(bot_type: str = "personal") -> BotCreateSpec:
+    return BotCreateSpec(
+        entity_id="85020",
+        engine_type="claude_code",
+        bot_type=bot_type,
+        bot_name="ac服务创建",
+        template_validation_mode=BotCreateTemplateValidationMode.PUBLIC,
+        engine_properties={
+            "template_type": "applicationCoding",
+            "template_config": {"token": "tok"},
+        },
+    )
+
+
+def _bot_service(**overrides) -> MagicMock:
+    service = MagicMock(spec=BotServiceProtocol)
+    service.is_first_bot.return_value = False
+    service.is_first_personal_bot.return_value = False
+    service.is_workspace_hosting_available.return_value = True
+    service.create_bot.return_value = {"bot_id": _BOT_ID, "bot_type": "personal"}
+    service.get_bot.return_value = {"bot_id": _BOT_ID, "bot_type": "service"}
+    for name, value in overrides.items():
+        setattr(service, name, value)
+    return service
+
+
+def _passport(issued: str | None = "tok") -> MagicMock:
+    passport = MagicMock()
+    passport.apply_agent_passport.return_value = {
+        "token": issued,
+        "agent_code": "ac-1",
+        "iframe_url": "http://auth" if issued is None else None,
+    }
+    passport.query_auth_status.return_value = {"status": AuthStatus.ISSUED}
+    passport.query_agent_passport.return_value = {"agent_code": "ac-1"}
+    return passport
+
+
+def _skill_set_factory() -> MagicMock:
+    factory = MagicMock()
+    factory.create.return_value.get_bot_mcp_codes.return_value = []
+    return factory
+
+
+def _intake_context() -> BotCreateContext:
+    return BotCreateContext(
+        deployment_mode=BotCreateDeploymentMode.CLOUD,
+        space_kind="personal",
+        service_intake=True,
+    )
+
+
+def _plain_context() -> BotCreateContext:
+    return BotCreateContext(
+        deployment_mode=BotCreateDeploymentMode.CLOUD,
+        space_kind="personal",
+    )
+
+
+# ----- translation + inline creation ---------------------------------------
+
+
+def test_service_intake_creates_personal_then_converts():
+    seam = MagicMock()
+    bot_service = _bot_service()
+
+    outcome = create_bot_with_authorization(
+        user_id="85020",
+        nick_name="Alice",
+        bot_id=_BOT_ID,
+        spec=_coding_spec(bot_type="service"),
+        context=_intake_context(),
+        bot_service=bot_service,
+        passport_plugin=_passport(),
+        auth_rel_plugin=MagicMock(),
+        skill_set_factory=_skill_set_factory(),
+        service_intake_seam=seam,
+    )
+
+    assert isinstance(outcome, Created)
+    # The strategy gate saw a personal create…
+    assert bot_service.create_bot.call_args.kwargs["bot_type"] == "personal"
+    # …then the freshly created bot was upgraded and the result re-read.
+    seam.convert.assert_called_once_with(
+        _BOT_ID, actor_id="85020", owner_id="85020"
+    )
+    assert bot_service.get_bot.call_args.args == (_BOT_ID, "85020")
+    assert outcome.bot["bot_type"] == "service"
+
+
+def test_service_intake_without_flag_keeps_the_combination_gate():
+    with pytest.raises(BotCombinationUnsupportedError):
+        create_bot_with_authorization(
+            user_id="85020",
+            nick_name="Alice",
+            bot_id=_BOT_ID,
+            spec=_coding_spec(bot_type="service"),
+            context=_plain_context(),
+            bot_service=_bot_service(),
+            passport_plugin=_passport(),
+            auth_rel_plugin=MagicMock(),
+            skill_set_factory=_skill_set_factory(),
+            service_intake_seam=MagicMock(),
+        )
+
+
+def test_service_intake_without_seam_keeps_the_combination_gate():
+    """Opt-in without the upgraded seam wired is misconfiguration, not intent."""
+    with pytest.raises(BotCombinationUnsupportedError):
+        create_bot_with_authorization(
+            user_id="85020",
+            nick_name="Alice",
+            bot_id=_BOT_ID,
+            spec=_coding_spec(bot_type="service"),
+            context=_intake_context(),
+            bot_service=_bot_service(),
+            passport_plugin=_passport(),
+            auth_rel_plugin=MagicMock(),
+            skill_set_factory=_skill_set_factory(),
+        )
+
+
+def test_plain_service_create_is_not_translated():
+    """No engine_properties → no coding gate to bypass, no conversion to drive."""
+    seam = MagicMock()
+    bot_service = _bot_service()
+
+    outcome = create_bot_with_authorization(
+        user_id="85020",
+        nick_name="Alice",
+        bot_id=_BOT_ID,
+        spec=BotCreateSpec(
+            entity_id="85020",
+            engine_type="openclaw",
+            bot_type="service",
+            bot_name="plain",
+        ),
+        context=_intake_context(),
+        bot_service=bot_service,
+        passport_plugin=_passport(),
+        auth_rel_plugin=MagicMock(),
+        skill_set_factory=_skill_set_factory(),
+        service_intake_seam=seam,
+    )
+
+    assert isinstance(outcome, Created)
+    assert bot_service.create_bot.call_args.kwargs["bot_type"] == "service"
+    seam.convert.assert_not_called()
+
+
+def test_service_intake_conversion_failure_raises_with_bot_id():
+    seam = MagicMock()
+    seam.convert.side_effect = RuntimeError("bcn down")
+
+    with pytest.raises(ServiceIntakeConversionError) as excinfo:
+        create_bot_with_authorization(
+            user_id="85020",
+            nick_name="Alice",
+            bot_id=_BOT_ID,
+            spec=_coding_spec(bot_type="service"),
+            context=_intake_context(),
+            bot_service=_bot_service(),
+            passport_plugin=_passport(),
+            auth_rel_plugin=MagicMock(),
+            skill_set_factory=_skill_set_factory(),
+            service_intake_seam=seam,
+        )
+
+    # The bot was created (and stays personal); the failure names it so the
+    # caller can retry the upgrade instead of re-creating.
+    assert _BOT_ID in str(excinfo.value)
+
+
+def test_service_intake_passport_pending_does_not_convert():
+    """Nothing exists yet on a pending authorization — nothing to upgrade."""
+    seam = MagicMock()
+    bot_service = _bot_service()
+
+    outcome = create_bot_with_authorization(
+        user_id="85020",
+        nick_name="Alice",
+        bot_id=_BOT_ID,
+        spec=_coding_spec(bot_type="service"),
+        context=_intake_context(),
+        bot_service=bot_service,
+        passport_plugin=_passport(issued=None),  # apply returns no token
+        auth_rel_plugin=MagicMock(),
+        skill_set_factory=_skill_set_factory(),
+        service_intake_seam=seam,
+    )
+
+    assert isinstance(outcome, AuthPending)
+    bot_service.create_bot.assert_not_called()
+    seam.convert.assert_not_called()
+
+
+# ----- ISSUED completion replays -------------------------------------------
+
+
+def test_service_intake_completes_and_converts_on_issued():
+    seam = MagicMock()
+    bot_service = _bot_service()
+
+    result = complete_bot_authorization(
+        user_id="85020",
+        nick_name="Alice",
+        bot_id=_BOT_ID,
+        spec=_coding_spec(bot_type="service"),
+        context=_intake_context(),
+        bot_service=bot_service,
+        passport_plugin=_passport(),
+        auth_rel_plugin=MagicMock(),
+        service_intake_seam=seam,
+    )
+
+    assert result.status == AuthStatus.ISSUED
+    assert bot_service.create_bot.call_args.kwargs["bot_type"] == "personal"
+    seam.convert.assert_called_once_with(
+        _BOT_ID, actor_id="85020", owner_id="85020"
+    )
+    assert result.bot["bot_type"] == "service"
+
+
+def test_service_intake_pending_completion_does_not_create_or_convert():
+    passport = _passport()
+    passport.query_auth_status.return_value = {"status": AuthStatus.PENDING}
+    seam = MagicMock()
+    bot_service = _bot_service()
+
+    result = complete_bot_authorization(
+        user_id="85020",
+        nick_name="Alice",
+        bot_id=_BOT_ID,
+        spec=_coding_spec(bot_type="service"),
+        context=_intake_context(),
+        bot_service=bot_service,
+        passport_plugin=passport,
+        auth_rel_plugin=MagicMock(),
+        service_intake_seam=seam,
+    )
+
+    assert result.status == AuthStatus.PENDING
+    bot_service.create_bot.assert_not_called()
+    seam.convert.assert_not_called()
+
+
+def test_service_intake_completion_conversion_failure_names_bot_id():
+    seam = MagicMock()
+    seam.convert.side_effect = RuntimeError("publish unavailable")
+
+    with pytest.raises(ServiceIntakeConversionError) as excinfo:
+        complete_bot_authorization(
+            user_id="85020",
+            nick_name="Alice",
+            bot_id=_BOT_ID,
+            spec=_coding_spec(bot_type="service"),
+            context=_intake_context(),
+            bot_service=_bot_service(),
+            passport_plugin=_passport(),
+            auth_rel_plugin=MagicMock(),
+            service_intake_seam=seam,
+        )
+
+    assert _BOT_ID in str(excinfo.value)
+
+
+def test_service_intake_completion_without_gate_keeps_409():
+    with pytest.raises(BotCombinationUnsupportedError):
+        complete_bot_authorization(
+            user_id="85020",
+            nick_name="Alice",
+            bot_id=_BOT_ID,
+            spec=_coding_spec(bot_type="service"),
+            context=_plain_context(),
+            bot_service=_bot_service(),
+            passport_plugin=_passport(),
+            auth_rel_plugin=MagicMock(),
+            service_intake_seam=MagicMock(),
+        )

--- a/src/gateway/configs/schemas/bots.openapi.json
+++ b/src/gateway/configs/schemas/bots.openapi.json
@@ -845,7 +845,7 @@
                 "type": "null"
               }
             ],
-            "description": "Optional engine-specific properties. Omit for a plain bot; provide template_config (hand-written application-coding or a template-factory snapshot) for a template-backed bot."
+            "description": "Optional engine-specific properties. Omit for a plain bot; provide template_config (hand-written application-coding or a template-factory snapshot) for a template-backed bot. Combined with bot_type=service on a coding engine, the bot is created through the template path and upgraded to a service bot before the create response."
           },
           "space_id": {
             "anyOf": [
@@ -24068,7 +24068,7 @@
         ]
       },
       "post": {
-        "description": "Create a bot (201), or 202 with authorization URLs when consent is needed.\n\nOn a 202, have the user complete authorization at one of the returned\nURLs, then poll the auth-status endpoint — the bot is only created there,\non ISSUED. Engine-specific creation properties belong under\n\"engine_properties\" and are interpreted by the selected engine;\nengine configuration is managed through the engine-config endpoints after\ncreation.",
+        "description": "Create a bot (201), or 202 with authorization URLs when consent is needed.\n\nOn a 202, have the user complete authorization at one of the returned\nURLs, then poll the auth-status endpoint — the bot is only created there,\non ISSUED. Engine-specific creation properties belong under\n\"engine_properties\" and are interpreted by the selected engine;\nengine configuration is managed through the engine-config endpoints after\ncreation.\n\nA coding template with bot_type=service (create-as-service) is fulfilled\norchestratively: the bot is created through the personal-only template path\nand immediately upgraded to a service bot, which is what the 201 reports. If\nthe upgrade fails the response is a 502 naming the created-as-personal bot —\nretry the lifecycle upgrade instead of re-creating.",
         "operationId": "create_bot_openapi_v1_bots_post",
         "parameters": [
           {
@@ -52337,7 +52337,7 @@
         ]
       },
       "post": {
-        "description": "Poll authorization for a pending creation; the bot is created on ISSUED.\n\nA POST because this operation is not a read: on the 202 create flow the\nbot is only actually created here, once authorization is granted. The\ncaller must re-supply the attributes it created with — the body fields\nmirror the create body and are forwarded to completion. Omit them and the\nbot is created with defaults that contradict what was requested, so\nalways echo back engine, cluster_name, bot_name, bot_desc, bot_type and\nspace_id when polling.\n\nEvery restriction create enforces is re-applied to the echoed values:\nthe same engine registry check, the same engine/cluster pairing, the same\npersonal/service restriction on bot_type, and the same business-space\nresolution.\n\nWhile the authorization service has no status for the bot yet — the\nPassport is not ready — the poll answers PENDING with a message saying\nso, rather than an error: keep polling.",
+        "description": "Poll authorization for a pending creation; the bot is created on ISSUED.\n\nA POST because this operation is not a read: on the 202 create flow the\nbot is only actually created here, once authorization is granted. The\ncaller must re-supply the attributes it created with — the body fields\nmirror the create body and are forwarded to completion. Omit them and the\nbot is created with defaults that contradict what was requested, so\nalways echo back engine, cluster_name, bot_name, bot_desc, bot_type and\nspace_id when polling.\n\nEvery restriction create enforces is re-applied to the echoed values:\nthe same engine registry check, the same engine/cluster pairing, the same\npersonal/service restriction on bot_type, and the same business-space\nresolution. An echoed bot_type=service with engine_properties completes the\nsame orchestrated service upgrade the create endpoint offers.\n\nWhile the authorization service has no status for the bot yet — the\nPassport is not ready — the poll answers PENDING with a message saying\nso, rather than an error: keep polling.",
         "operationId": "poll_bot_auth_status_openapi_v1_bots__bot_id__auth_status_post",
         "parameters": [
           {


### PR DESCRIPTION
## Problem
通过 OpenAPI 创建带模板的 coding bot,若 `bot_type=service`(开启服务)一律返回 `409 Coding template combination not supported`,调用方只能两步:先建 `personal` 再调 lifecycle upgrade,不存在"创建即服务"的一步路径。

根因:引擎策略组合门(`AicodingProvisioningStrategy.prepare_create`)对带 `engine_properties` 的创建强制 `bot_type=personal`,且该_gate_ 在工厂快照分支之前,任何模板创建都被拦。

## Solution
不删 gate,在 `create_flow` 层(opt-in)把 service 意向翻译为 personal 创建,建成功后经 `ServiceIntakeSeam` 驱动 `convert_to_service`,以升级后的行响应。翻译落在 `create_flow` 而非 route:202 之后调用方回显 `bot_type=service` 轮询,`complete_bot_authorization` 会重跑同一 gate,只有核心层翻译一致才不破。轮询即重试面。

- 抽独立 `service_intake.py`:`ServiceIntakeSeam` Protocol + `prepare_service_intake`(翻译)+ `finish_service_intake`(升级+重读)
- `BotCreateContext` 加 `service_intake` 开关(含 payload 往返);仅 OpenAPI create + POST auth-status 置 True
- 路由侧 `_FacadeServiceIntakeSeam` 适配 facade,吞 `ServicePublicationConflictError`(already-service = 重放成功)
- convert 失败 = `ServiceIntakeConversionError` → `502`,bot 以 personal 存续,可 retry lifecycle upgrade(不静默 201,不自动删 bot)
- 延续 dev 已起的拆分把 `BotCreateSpec` 一并迁入 `create_context.py`,re-export 保持调用方零改动,让 `create_flow`(963 行)留在 1000 行架构守卫内
- gateway `bots.openapi.json` 手工补 create / poll / `engine_properties` 描述(manifest 同名 schema 描述特意还原,该路未接)

未 opt-in 的面维持 409 原行为:`create_with_manifest`、内部 `/api/bots`、deprecated GET auth-status(plain-bot only)。

## Validation
- 新增 `test_create_flow_service_intake.py` 11 条:翻译/gate 保留/同步转化/PENDING 不转化/ISSUED 补建转化/convert 失败带 bot_id/无 seam 时仍 409/重放成功
- 新增 OpenAPI 端点测试:orchestrated 201、convert 失败 502、ISSUED 补建转化、PENDING 不转化、重放成功;翻转原 `...is_409` 断言为 `...is_orchestrated`(201)
- 本地全量 `ci_test.sh --base origin/dev`:**17590 passed,change-line coverage 100% (55/55)**,架构守卫 `test_no_new_oversized_files` 通过

## Notes
- 设计动机:服务化是生命周期(draft→verify→online)不是创建参数;直建会产出"看起来 service 但无服务骨架"的半初始化 bot,比 409 更糟。可观测中间态窗口亚秒级(同步路径内 create→convert),且 convert 完成后也仅是 service draft。
- OCB 侧:`bots.openapi.json` 走 git link,本仓库权威源已改无需手工双写。
- 未覆盖:manifest 直建留作未来"零中间态"正路(它本就有异步 job 模型)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)