### PR TITLE
fix(bcs): sync friend permissions and honor bot friend policies

### DIFF
--- a/src/bcs/crates/adapters/http/bcs-http/src/oauth/mod.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/oauth/mod.rs
@@ -204,6 +204,7 @@ impl AuthService for OAuthRouteState {
             src: request.provider.clone(),
             iat: now,
             exp: now + self.config.idle_timeout_secs(),
+            name: user_info.name.clone(),
         };
         let jwt = self.jwt_service.sign(&claims).map_err(|e| {
             warn!(error = %e, "JWT signing failed");
@@ -262,8 +263,8 @@ impl AuthService for OAuthRouteState {
             .verify_no_exp(&jwt)
             .map_err(|_| ApplicationError::Unauthenticated)?;
 
-        match self.user_port.get_identity_by_token(&bcs_jwt::token_hash(&jwt)).await {
-            Ok(Some(info)) if info.user_id == claims.sub => {}
+        let info = match self.user_port.get_identity_by_token(&bcs_jwt::token_hash(&jwt)).await {
+            Ok(Some(info)) if info.user_id == claims.sub => info,
             Ok(_) => return Err(ApplicationError::Unauthenticated),
             Err(e) => {
                 warn!(error = %e, "refresh: identity lookup failed");
@@ -281,6 +282,7 @@ impl AuthService for OAuthRouteState {
             src: claims.src.clone(),
             iat,
             exp: iat + self.config.idle_timeout_secs(),
+            name: info.user_name.or(info.external_user_name),
         };
         let new_jwt = self.jwt_service.sign(&new_claims).map_err(|e| {
             warn!(error = %e, "refresh: JWT signing failed");
@@ -454,6 +456,7 @@ pub async fn callback_handler(
         src: provider_name.clone(),
         iat: now,
         exp: now + state.config.idle_timeout_secs(),
+        name: user_info.name.clone(),
     };
     let jwt = match state.jwt_service.sign(&claims) {
         Ok(j) => j,
@@ -563,8 +566,8 @@ pub async fn refresh_handler(
     };
 
     // Confirm the presented JWT is the current bound session before renewing.
-    match state.user_port.get_identity_by_token(&bcs_jwt::token_hash(&jwt)).await {
-        Ok(Some(info)) if info.user_id == claims.sub => {}
+    let info = match state.user_port.get_identity_by_token(&bcs_jwt::token_hash(&jwt)).await {
+        Ok(Some(info)) if info.user_id == claims.sub => info,
         Ok(_) => return (StatusCode::UNAUTHORIZED, "not authenticated").into_response(),
         Err(e) => {
             warn!(error = %e, "refresh: identity lookup failed");
@@ -581,6 +584,7 @@ pub async fn refresh_handler(
         src: claims.src.clone(),
         iat: now,
         exp: now + state.config.idle_timeout_secs(),
+        name: info.user_name.or(info.external_user_name),
     };
     let new_jwt = match state.jwt_service.sign(&new_claims) {
         Ok(j) => j,
@@ -718,7 +722,10 @@ mod tests {
     use super::*;
     use async_trait::async_trait;
     use axum::body::to_bytes;
-    use bcs_auth_api::{AuthError, AuthPlugin, AuthPluginChain, AuthPrincipal, AuthSource};
+    use bcs_auth_api::{
+        AuthError, AuthPlugin, AuthPluginChain, AuthPrincipal, AuthSource, UserIdentityInfo,
+        UserIdentityPort,
+    };
     use bcs_test_support::{MockOAuthProvider, NoopAuthPlugin, NoopUserIdentityPort};
 
     /// A chain plugin that always yields a principal with the given `user_id`
@@ -821,6 +828,22 @@ mod tests {
         assert!(result.set_cookie.starts_with("bcs_session="));
         assert!(result.set_cookie.contains("HttpOnly"));
         assert!(result.set_cookie.contains("SameSite=Lax"));
+
+        // The issued `bcs_session` JWT must carry the user's display name so an
+        // external JWT-only verifier (e.g. a gateway) can populate user_name.
+        let jwt = result
+            .set_cookie
+            .strip_prefix("bcs_session=")
+            .and_then(|rest| rest.split(';').next())
+            .expect("bcs_session cookie value");
+        let claims = JwtService::new("test-secret-key-at-least-32-bytes!!")
+            .verify_no_exp(jwt)
+            .expect("verify issued login jwt");
+        assert_eq!(
+            claims.name.as_deref(),
+            Some("Mock User"),
+            "login JWT must carry the provider's display name"
+        );
     }
 
 
@@ -927,5 +950,162 @@ mod tests {
         let (status, body) = run_current_user(chain_with(Some("u-123".to_string()))).await;
         assert_eq!(status, StatusCode::OK, "real user_id => 200, got {body}");
         assert_eq!(body["user_id"], "u-123");
+    }
+
+    /// In-memory `UserIdentityPort` for refresh tests: binds one session token
+    /// hash to a single user and serves its display name, so `refresh_session`
+    /// (which reads `get_identity_by_token` and re-signs) can be exercised
+    /// without `NoopUserIdentityPort` short-circuiting to `None`.
+    struct BoundTokenIdentityPort {
+        user_id: String,
+        name: Option<String>,
+        bound: tokio::sync::Mutex<Option<String>>,
+    }
+
+    impl BoundTokenIdentityPort {
+        fn new(user_id: &str, name: Option<&str>) -> Self {
+            Self {
+                user_id: user_id.to_string(),
+                name: name.map(str::to_string),
+                bound: tokio::sync::Mutex::new(None),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl UserIdentityPort for BoundTokenIdentityPort {
+        async fn ensure_identity(
+            &self,
+            _auth_source: &str,
+            _external_user_id: &str,
+            _external_user_name: Option<&str>,
+            _avatar: Option<&str>,
+            _env: &str,
+        ) -> Result<String, AuthError> {
+            Ok(self.user_id.clone())
+        }
+
+        async fn lookup_by_user_id(
+            &self,
+            _user_id: &str,
+            _auth_source: &str,
+        ) -> Result<Option<String>, AuthError> {
+            Ok(Some(self.user_id.clone()))
+        }
+
+        async fn get_identity_by_token(
+            &self,
+            token_hash: &str,
+        ) -> Result<Option<UserIdentityInfo>, AuthError> {
+            let bound = self.bound.lock().await;
+            if bound.as_deref() == Some(token_hash) {
+                Ok(Some(UserIdentityInfo {
+                    user_id: self.user_id.clone(),
+                    auth_source: "google".to_string(),
+                    user_name: self.name.clone(),
+                    external_user_name: self.name.clone(),
+                    avatar: None,
+                }))
+            } else {
+                Ok(None)
+            }
+        }
+
+        async fn get_identity_by_user_id(
+            &self,
+            _user_id: &str,
+        ) -> Result<Option<UserIdentityInfo>, AuthError> {
+            Ok(Some(UserIdentityInfo {
+                user_id: self.user_id.clone(),
+                auth_source: "google".to_string(),
+                user_name: self.name.clone(),
+                external_user_name: self.name.clone(),
+                avatar: None,
+            }))
+        }
+
+        async fn update_token(
+            &self,
+            _user_id: &str,
+            token_hash: &str,
+            _expire_at: u64,
+        ) -> Result<(), AuthError> {
+            *self.bound.lock().await = if token_hash.is_empty() {
+                None
+            } else {
+                Some(token_hash.to_string())
+            };
+            Ok(())
+        }
+    }
+
+    /// `refresh_session` must re-sign the JWT carrying the identity row's CURRENT
+    /// display name (so an edited `user_name` re-syncs into the gateway-parsed
+    /// cookie on sliding renewal), regardless of the presented JWT's own `name`.
+    #[tokio::test]
+    async fn refresh_session_emits_current_name_in_jwt() {
+        let jwt_secret = "test-secret-key-at-least-32-bytes!!";
+        let port = Arc::new(BoundTokenIdentityPort::new("u1", Some("The Name")));
+        let state = OAuthRouteState::new(
+            jwt_secret,
+            port.clone(),
+            HashMap::new(),
+            OAuthConfig {
+                jwt_secret: jwt_secret.to_string(),
+                idle_timeout_minutes: 30,
+                base_url: "https://bcs.example.com".to_string(),
+                cookie_secure: false,
+                env: "test".to_string(),
+                success_redirect_path: "/".to_string(),
+            },
+            None,
+        );
+
+        // Issue and bind a login-style JWT; its `name` is irrelevant — refresh
+        // re-derives the name from the identity row via `get_identity_by_token`.
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let svc = JwtService::new(jwt_secret);
+        let login_jwt = svc
+            .sign(&Claims {
+                sub: "u1".to_string(),
+                src: "google".to_string(),
+                iat: now,
+                exp: now + 60,
+                name: None,
+            })
+            .expect("sign login jwt");
+        port.update_token("u1", &bcs_jwt::token_hash(&login_jwt), now + 60)
+            .await
+            .expect("bind login token");
+
+        let result = state
+            .refresh_session(RefreshSession {
+                headers: RequestAuthHeaders {
+                    authorization: None,
+                    cookie: Some(format!("bcs_session={login_jwt}")),
+                    forwarded_headers: Vec::new(),
+                },
+            })
+            .await
+            .expect("refresh");
+        assert!(result.set_cookie.starts_with("bcs_session="));
+
+        let new_jwt = result
+            .set_cookie
+            .strip_prefix("bcs_session=")
+            .and_then(|rest| rest.split(';').next())
+            .expect("new bcs_session value");
+        let claims = JwtService::new(jwt_secret)
+            .verify_no_exp(new_jwt)
+            .expect("verify renewed jwt");
+        assert_eq!(claims.sub, "u1");
+        assert_eq!(
+            claims.name.as_deref(),
+            Some("The Name"),
+            "refresh must re-sign the JWT with the identity row's current name"
+        );
     }
 }

--- a/src/bcs/crates/bootstrap/bcs/src/server.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/server.rs
@@ -4126,16 +4126,18 @@ let collaboration_templates = build_standalone_collaboration_template_service(&c
             bot_registry.clone(),
         );
 
-        // Create SQLite-backed friend services.
-        let (legacy_friend_core, friend_request_svc): (
-            Arc<dyn bcs_service_api::FriendCoreService>,
-            Arc<dyn bcs_service_api::FriendRequestCoreService>,
+        // Create DB-backed legacy friend repositories. The FriendCore service is
+        // built after edge-permission wiring so legacy friendship mutations can
+        // dual-write both coexistence paths.
+        let (friend_repo, friend_request_repo): (
+            Arc<dyn bcs_service_api::FriendRepoPort>,
+            Arc<dyn bcs_service_api::FriendRequestRepoPort>,
         ) = {
             info!(
                 db_plugin = %db_kind,
-                "Initializing DB-backed friend storage with relation dual-write"
+                "Initializing DB-backed friend storage with relation and edge-permission dual-write"
             );
-            let friend_repo = match db_kind {
+            let friend_repo: Arc<dyn bcs_service_api::FriendRepoPort> = match db_kind {
                 DbPluginKind::LocalSqlite => Arc::new(DbFriendStore::sqlite(db_plugin.clone())),
                 DbPluginKind::Mysql => Arc::new(DbFriendStore::mysql(db_plugin.clone())),
                 DbPluginKind::External(provider) => {
@@ -4145,9 +4147,7 @@ let collaboration_templates = build_standalone_collaboration_template_service(&c
                     )
                 }
             };
-            let friend_store: Arc<dyn bcs_service_api::FriendCoreService> =
-                Arc::new(FriendCore::with_repo(friend_repo).with_relation(relation_svc.clone()));
-            let friend_request_repo = match db_kind {
+            let friend_request_repo: Arc<dyn bcs_service_api::FriendRequestRepoPort> = match db_kind {
                 DbPluginKind::LocalSqlite => {
                     Arc::new(DbFriendRequestStore::sqlite(db_plugin.clone()))
                 }
@@ -4159,14 +4159,8 @@ let collaboration_templates = build_standalone_collaboration_template_service(&c
                     )
                 }
             };
-            let friend_request_store: Arc<dyn bcs_service_api::FriendRequestCoreService> =
-                Arc::new(FriendRequestCore::with_repo(
-                    friend_request_repo,
-                    friend_store.clone(),
-                    bot_registry.clone(),
-                ));
 
-            (friend_store, friend_request_store)
+            (friend_repo, friend_request_repo)
         };
 
         // Edge-permission stores + services (T16): real DB-backed impls back
@@ -4242,11 +4236,6 @@ let collaboration_templates = build_standalone_collaboration_template_service(&c
             (edge_grant_repo, profile_repo, request_repo, bot_config_repo)
         };
         let edge_permission_env = crate::env::resolve_env();
-        // friend_svc = legacy FriendCore (reads bcs_friendships/old tables).
-        // Gates (group/proposal/a2a) use this until edge_grants data is migrated.
-        // See docs/superpowers/plans/2026-08-19-v2-friends-parallel-interface.md.
-        let friend_svc: Arc<dyn bcs_service_api::FriendCoreService> =
-            legacy_friend_core.clone();
         let friend_connect_notification: Arc<dyn bcs_service_api::FriendConnectNotificationPort> =
             match config.friend_work_order_base_url.as_deref() {
                 Some(base_url) => Arc::new(
@@ -4255,15 +4244,33 @@ let collaboration_templates = build_standalone_collaboration_template_service(&c
                 ),
                 None => Arc::new(bcs_service_api::NoopFriendConnectNotificationPort),
             };
+        let connect_service_impl = Arc::new(bcs_edge_permission::DbConnectService::new(
+            edge_grant_store.clone(),
+            profile_store.clone(),
+            request_store.clone(),
+            bot_config_store.clone(),
+            user_directory.clone(),
+            friend_connect_notification,
+            edge_permission_env,
+        ));
         let connect_service: Arc<dyn bcs_service_api::application::ConnectService> =
-            Arc::new(bcs_edge_permission::DbConnectService::new(
-                edge_grant_store.clone(),
-                profile_store.clone(),
-                request_store.clone(),
-                bot_config_store.clone(),
-                user_directory.clone(),
-                friend_connect_notification,
-                edge_permission_env,
+            connect_service_impl.clone();
+        let edge_permission_friend_sync: Arc<dyn bcs_service_api::EdgePermissionFriendSyncService> =
+            connect_service_impl.clone();
+        // friend_svc = legacy FriendCore (reads bcs_friendships/old tables) plus
+        // coexistence dual-write into edge_grants while the old and new friend
+        // APIs run in parallel.
+        // See docs/superpowers/plans/2026-08-19-v2-friends-parallel-interface.md.
+        let friend_svc: Arc<dyn bcs_service_api::FriendCoreService> = Arc::new(
+            FriendCore::with_repo(friend_repo)
+                .with_relation(relation_svc.clone())
+                .with_edge_permission_sync(edge_permission_friend_sync),
+        );
+        let friend_request_svc: Arc<dyn bcs_service_api::FriendRequestCoreService> =
+            Arc::new(FriendRequestCore::with_repo(
+                friend_request_repo,
+                friend_svc.clone(),
+                bot_registry.clone(),
             ));
         let admission_service: Arc<dyn bcs_service_api::application::AdmissionService> =
             Arc::new(bcs_edge_permission::DbAdmissionService::new(

--- a/src/bcs/crates/bootstrap/bcs/tests/integration_auth_user.rs
+++ b/src/bcs/crates/bootstrap/bcs/tests/integration_auth_user.rs
@@ -258,6 +258,7 @@ async fn auth_user_returns_oauth_name_and_avatar_from_cookie() {
         src: "google".to_string(),
         iat: now,
         exp: now + 1800,
+        name: None,
     };
     let jwt = jwt_svc.sign(&claims).expect("sign jwt");
     user_port
@@ -326,6 +327,7 @@ async fn auth_user_rejects_unbound_cookie_without_mock_identity() {
         src: "google".to_string(),
         iat: now,
         exp: now + 1800,
+        name: None,
     };
     let jwt = jwt_svc.sign(&claims).expect("sign jwt");
 

--- a/src/bcs/crates/bootstrap/bcs/tests/integration_oauth_routes.rs
+++ b/src/bcs/crates/bootstrap/bcs/tests/integration_oauth_routes.rs
@@ -97,6 +97,7 @@ async fn seed_bound_oauth_cookie(
         src: "google".to_string(),
         iat: now,
         exp: now + 1800,
+        name: None,
     };
     let jwt = jwt_svc.sign(&claims).expect("sign jwt");
     user_port

--- a/src/bcs/crates/plugins/bcs-auth-google/tests/google_oauth_flow.rs
+++ b/src/bcs/crates/plugins/bcs-auth-google/tests/google_oauth_flow.rs
@@ -103,6 +103,7 @@ async fn full_oauth_session_flow() {
         src: "google".to_string(),
         iat: now,
         exp: now + 1800,
+        name: None,
     };
     let jwt = jwt_svc.sign(&claims).unwrap();
     // Callback persists the JWT fingerprint so the hot path can bind to it.
@@ -172,6 +173,7 @@ async fn expired_jwt_returns_none() {
         src: "google".to_string(),
         iat: 50,
         exp: 100,
+        name: None,
     };
     let jwt = jwt_svc.sign(&claims).unwrap();
 
@@ -211,6 +213,7 @@ async fn verify_oauth_session_hot_path_does_not_refresh() {
         src: "google".to_string(),
         iat: now - 1500,
         exp: now + 300,
+        name: None,
     };
     let jwt = jwt_svc.sign(&claims).unwrap();
     // Bind the session (as the callback would) so the hash check passes.
@@ -253,6 +256,7 @@ async fn verify_oauth_session_rejects_unbound_jwt() {
         src: "google".to_string(),
         iat: now,
         exp: now + 1800,
+        name: None,
     };
     let jwt = jwt_svc.sign(&claims).unwrap();
     // Note: no update_token — this JWT was never bound as the current session.

--- a/src/bcs/crates/service-api/bcs-service-api/src/core/actor.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/core/actor.rs
@@ -104,3 +104,16 @@ pub trait RelationCoreService: Send + Sync {
         env: &str,
     ) -> ServiceResult<Vec<String>>;
 }
+
+/// Synchronizes legacy friendship mutations into the edge-permission friend
+/// edge model while both friendship links coexist.
+#[async_trait]
+pub trait EdgePermissionFriendSyncService: Send + Sync {
+    /// Mirror an established legacy friendship into approved edge-permission
+    /// friend edges. Implementations must be idempotent.
+    async fn sync_add_friendship(&self, a: &str, b: &str) -> ServiceResult<()>;
+
+    /// Mirror removal of one legacy friendship into edge-permission friend-edge
+    /// revocation. Implementations must preserve unrelated non-friend grants.
+    async fn sync_remove_friendship(&self, a: &str, b: &str) -> ServiceResult<()>;
+}

--- a/src/bcs/crates/service-api/bcs-service-api/src/lib.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/lib.rs
@@ -260,7 +260,7 @@ pub use core::{
     ContextBotSummary, HiddenMentionInfo, ContextBotSummary as BotContextSummary, ContextConflict, ContextConflictPosition,
     ContextFusionRequest, ContextFusionResponse, ContextParticipantPerspective, DefaultDelivery,
     DeliveryType, DmActorSpec, DynamicStatusResponse, EnsureHumanResult, EnsureOwnerEdgesResult,
-    FriendCoreService, FriendRequest, FriendRequestCoreService, FriendRequestDirection,
+    EdgePermissionFriendSyncService, FriendCoreService, FriendRequest, FriendRequestCoreService, FriendRequestDirection,
     FriendRequestStatus, Friendship, FusionCoreService, Group, GroupChatProposal, GroupCoreService, GroupKind,
     GroupMessage, GroupMessageType, GroupMutableFieldsPatch, GroupStatus, GroupStrategy, MessageRole,
     Participant, ParticipantKind, ParticipantMode, ParticipantRole, ProposalCoreService,

--- a/src/bcs/crates/services/bcs-edge-permission-store/src/lib.rs
+++ b/src/bcs/crates/services/bcs-edge-permission-store/src/lib.rs
@@ -995,7 +995,7 @@ impl DbBotActorConfigStore {
     /// SELECT the decision columns for `(bot_uuid, env)`. Excludes soft-deleted
     /// rows, mirroring the bot store read (`COALESCE(is_deleted, 0) = 0`).
     const SELECT_BOT_CONFIG_SQL: &'static str =
-        "SELECT bot_uuid, env, name, visibility, user_visibility, bot_info, status, created_by \
+        "SELECT bot_uuid, env, name, visibility, user_visibility, friend_check_in_strategy, friend_ext, bot_info, status, created_by \
          FROM bcs_bots \
          WHERE bot_uuid = ? AND env = ? AND COALESCE(is_deleted, 0) = 0 LIMIT 1";
 }
@@ -1153,23 +1153,27 @@ fn row_to_edge_grant(row: &DbRow) -> ServiceResult<EdgeGrant> {
 /// `created_by` is `NULL` for legacy bots. `user_visibility` is read from its
 /// own `bcs_bots.user_visibility` column — the same column the internal-
 /// attributes PATCH writes — so friend-gating sees the value the operator
-/// actually set (rather than a `bot_info` default that no write path populates).
-/// `bot_info` still carries `friend_check_in_strategy` / `friend_ext`.
+/// actually set.
+/// `friend_check_in_strategy` is read from its dedicated column so the
+/// friend-connect policy does not depend on `bot_info` JSON projection order.
+/// `friend_ext` is read from the dedicated `bcs_bots.friend_ext` column, with
+/// a legacy `bot_info.friend_ext` fallback for older rows.
 fn row_to_bot_actor_config(row: &DbRow) -> ServiceResult<BotActorConfig> {
     let bot_info = optional_string(row, "bot_info")?
         .and_then(|value| serde_json::from_str::<serde_json::Value>(&value).ok())
         .unwrap_or_default();
     let user_visibility = optional_string(row, "user_visibility")?
         .unwrap_or_else(|| "protected".to_string());
-    let friend_check_in_strategy = bot_info
-        .get("friend_check_in_strategy")
-        .and_then(|value| value.as_str())
-        .unwrap_or("APPROVAL")
-        .to_string();
-    let friend_ext = bot_info
-        .get("friend_ext")
-        .and_then(|value| value.as_object())
-        .cloned()
+    let friend_check_in_strategy = optional_string(row, "friend_check_in_strategy")?
+        .unwrap_or_else(|| "APPROVAL".to_string());
+    let friend_ext = optional_string(row, "friend_ext")?
+        .and_then(|value| serde_json::from_str::<serde_json::Value>(&value).ok())
+        .and_then(|value| value.as_object().cloned())
+        .or_else(|| {
+            bot_info
+                .get("friend_ext")
+                .and_then(|value| value.as_object().cloned())
+        })
         .unwrap_or_default();
     Ok(BotActorConfig {
         bot_id: required_string(row, "bot_uuid")?,
@@ -1837,7 +1841,9 @@ mod tests {
                 name TEXT NOT NULL DEFAULT '', \
                 visibility TEXT NOT NULL DEFAULT 'public', \
                 user_visibility TEXT NOT NULL DEFAULT 'protected', \
+                friend_check_in_strategy TEXT NOT NULL DEFAULT 'APPROVAL', \
                 bot_info TEXT DEFAULT NULL, \
+                friend_ext TEXT DEFAULT NULL, \
                 status TEXT NOT NULL DEFAULT 'online', \
                 created_by TEXT, \
                 is_deleted INTEGER NOT NULL DEFAULT 0, \
@@ -1884,6 +1890,7 @@ mod tests {
         created_by: Option<&str>,
         friend_ext: serde_json::Map<String, serde_json::Value>,
     ) {
+        let friend_ext_json = serde_json::to_string(&friend_ext).expect("friend_ext json");
         let bot_info = serde_json::json!({
             "friend_check_in_strategy": friend_check_in_strategy,
             "friend_ext": friend_ext,
@@ -1893,15 +1900,17 @@ mod tests {
                 "seed_bot",
                 DbStatement::with_params(
                     "INSERT INTO bcs_bots \
-                     (bot_uuid, env, name, visibility, user_visibility, bot_info, status, created_by) \
-                     VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                     (bot_uuid, env, name, visibility, user_visibility, friend_check_in_strategy, bot_info, friend_ext, status, created_by) \
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                     vec![
                         DbValue::from(bot_uuid),
                         DbValue::from(env),
                         DbValue::from(bot_uuid),
                         DbValue::from(visibility),
                         DbValue::from(user_visibility),
+                        DbValue::from(friend_check_in_strategy),
                         DbValue::from(serde_json::to_string(&bot_info).expect("bot_info json")),
+                        DbValue::from(friend_ext_json),
                         DbValue::from(status),
                         match created_by {
                             Some(v) => DbValue::from(v),
@@ -1943,6 +1952,40 @@ mod tests {
         assert_eq!(cfg.status, "online");
         assert_eq!(cfg.created_by.as_deref(), Some("85020"));
     }
+    #[tokio::test]
+    async fn bot_actor_config_reads_friend_strategy_from_column() {
+        let store = bot_config_store().await;
+        store
+            .execute(
+                "seed_bot_column_strategy",
+                DbStatement::with_params(
+                    "INSERT INTO bcs_bots \
+                     (bot_uuid, env, name, visibility, user_visibility, friend_check_in_strategy, bot_info, friend_ext, status, created_by) \
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    vec![
+                        DbValue::from("column-strategy-bot"),
+                        DbValue::from("dev"),
+                        DbValue::from("column-strategy-bot"),
+                        DbValue::from("protected"),
+                        DbValue::from("public"),
+                        DbValue::from("OPEN"),
+                        DbValue::from(r#"{"friend_ext": {"scope": "bot_info"}}"#),
+                        DbValue::from(r#"{"scope": "column"}"#),
+                        DbValue::from("online"),
+                        DbValue::Null,
+                    ],
+                ),
+            )
+            .await
+            .expect("seed bot with column strategy");
+
+        let cfg = store
+            .get("column-strategy-bot", "dev")
+            .await
+            .expect("bot exists");
+        assert_eq!(cfg.friend_check_in_strategy, "OPEN");
+        assert_eq!(cfg.friend_ext["scope"], "column");
+    }
 
     #[tokio::test]
     async fn bot_actor_config_missing_returns_none_and_legacy_owner() {
@@ -1953,7 +1996,8 @@ mod tests {
         seed_bot(&store, "bot_b", "prod", "protected", "private", "DEPT_FREE", "hidden", None).await;
         assert!(store.get("bot_b", "dev").await.is_none());
         // Same env row reads back; user_visibility comes from its column,
-        // friend_* still come from bot_info.
+        // friend_check_in_strategy comes from its dedicated column, and
+        // friend_ext now comes from its dedicated column with bot_info fallback.
         let cfg = store.get("bot_b", "prod").await.expect("bot exists in prod");
         assert_eq!(cfg.user_visibility, "private");
         assert_eq!(cfg.friend_check_in_strategy, "DEPT_FREE");

--- a/src/bcs/crates/services/bcs-edge-permission/src/lib.rs
+++ b/src/bcs/crates/services/bcs-edge-permission/src/lib.rs
@@ -138,6 +138,21 @@ fn is_lock_wait_timeout(err: &ServiceError) -> bool {
     message.contains("1205") || message.to_ascii_lowercase().contains("lock wait timeout")
 }
 
+fn normalize_friend_sync_pair<'a>(
+    a: &'a str,
+    b: &'a str,
+) -> ServiceResult<Option<(&'a str, &'a str, ActorKind, ActorKind)>> {
+    if a == b {
+        return Err(ServiceError::CannotAddSelf);
+    }
+    match (actor_kind_of(a), actor_kind_of(b)) {
+        (ActorKind::Human, ActorKind::Bot) => Ok(Some((a, b, ActorKind::Human, ActorKind::Bot))),
+        (ActorKind::Bot, ActorKind::Human) => Ok(Some((b, a, ActorKind::Human, ActorKind::Bot))),
+        (ActorKind::Bot, ActorKind::Bot) => Ok(Some((a, b, ActorKind::Bot, ActorKind::Bot))),
+        (ActorKind::Human, ActorKind::Human) => Ok(None),
+    }
+}
+
 fn normalize_policy_value(value: &str) -> String {
     value.trim().to_ascii_lowercase()
 }
@@ -150,11 +165,12 @@ fn is_private_visibility(value: &str) -> bool {
     matches!(normalize_policy_value(value).as_str(), "private")
 }
 
-fn bot_friend_ext_no_check_scope_friend_deps(
+fn bot_friend_ext_scope_friend_deps(
     friend_ext: &serde_json::Map<String, serde_json::Value>,
+    key: &str,
 ) -> HashSet<String> {
     friend_ext
-        .get("no_check_scope_friend_deps")
+        .get(key)
         .and_then(|value| value.as_array())
         .map(|items| {
             items
@@ -166,6 +182,24 @@ fn bot_friend_ext_no_check_scope_friend_deps(
                 .collect()
         })
         .unwrap_or_default()
+}
+
+fn bot_friend_ext_no_check_scope_friend_deps(
+    friend_ext: &serde_json::Map<String, serde_json::Value>,
+) -> HashSet<String> {
+    bot_friend_ext_scope_friend_deps(friend_ext, "no_check_scope_friend_deps")
+}
+
+fn bot_friend_ext_view_scope_user_friend_deps(
+    friend_ext: &serde_json::Map<String, serde_json::Value>,
+) -> HashSet<String> {
+    bot_friend_ext_scope_friend_deps(friend_ext, "view_scope_user_friend_deps")
+}
+
+fn bot_friend_ext_view_scope_agent_friend_deps(
+    friend_ext: &serde_json::Map<String, serde_json::Value>,
+) -> HashSet<String> {
+    bot_friend_ext_scope_friend_deps(friend_ext, "view_scope_agent_friend_deps")
 }
 
 fn user_directory_lookup_context(request_auth: Option<&RequestAuthHeaders>) -> UserDirectoryLookupContext {
@@ -265,6 +299,31 @@ impl ConnectService for DbConnectService {
             return Err(ServiceError::Forbidden(format!(
                 "bot '{to_bot}' is not human-addable"
             )));
+        }
+
+        if caller_kind == ActorKind::Human && normalize_policy_value(&cfg.user_visibility) == "protected" {
+            let user_friend_scope = bot_friend_ext_view_scope_user_friend_deps(&cfg.friend_ext);
+            if !user_friend_scope.is_empty()
+                && !self
+                    .actor_department_matches_friend_scope(caller, &user_friend_scope, request_auth.as_ref())
+                    .await
+            {
+                return Err(ServiceError::Forbidden(format!(
+                    "caller '{caller}' is not within target bot '{to_bot}' friend scope"
+                )));
+            }
+        }
+        if caller_kind == ActorKind::Bot && normalize_policy_value(&cfg.visibility) == "protected" {
+            let agent_friend_scope = bot_friend_ext_view_scope_agent_friend_deps(&cfg.friend_ext);
+            if !agent_friend_scope.is_empty()
+                && !self
+                    .actor_department_matches_friend_scope(caller, &agent_friend_scope, request_auth.as_ref())
+                    .await
+            {
+                return Err(ServiceError::Forbidden(format!(
+                    "bot owner '{caller}' is not within target bot '{to_bot}' friend scope"
+                )));
+            }
         }
 
         let friend_strategy = normalize_policy_value(&cfg.friend_check_in_strategy);
@@ -801,6 +860,23 @@ impl DbConnectService {
             .any(|allowed| department_matches_allowlist_entry(&caller_department, allowed))
     }
 
+    async fn actor_department_matches_friend_scope(
+        &self,
+        actor: &str,
+        allowed_departments: &HashSet<String>,
+        request_auth: Option<&RequestAuthHeaders>,
+    ) -> bool {
+        if allowed_departments.is_empty() {
+            return false;
+        }
+        let Some(actor_department) = self.resolve_user_department_code(actor, request_auth).await else {
+            return false;
+        };
+        allowed_departments
+            .iter()
+            .any(|allowed| department_matches_allowlist_entry(&actor_department, allowed))
+    }
+
     fn target_notification_recipients(
         &self,
         cfg: &bcs_domain::edge_permission::BotActorConfig,
@@ -1215,6 +1291,31 @@ impl EdgePermissionFriendSyncService for DbConnectService {
 
 // ---- AdmissionService (T14) ----------------------------------------------
 
+#[async_trait]
+impl EdgePermissionFriendSyncService for DbConnectService {
+    async fn sync_add_friendship(&self, a: &str, b: &str) -> ServiceResult<()> {
+        let Some((caller, target, caller_kind, target_kind)) = normalize_friend_sync_pair(a, b)? else {
+            warn!(left = %a, right = %b, env = %self.env, "skip human-human friendship edge-permission sync");
+            return Ok(());
+        };
+        if self.edge_grants.has_friend_edge(caller, target, &self.env).await {
+            return Ok(());
+        }
+        self.build_connect_edges(caller, target, caller_kind, target_kind)
+            .await
+            .map(|_| ())
+    }
+
+    async fn sync_remove_friendship(&self, a: &str, b: &str) -> ServiceResult<()> {
+        let Some((caller, target, _, _)) = normalize_friend_sync_pair(a, b)? else {
+            return Ok(());
+        };
+        <Self as ConnectService>::revoke_friend(self, caller, target)
+            .await
+            .map(|_| ())
+    }
+}
+
 /// DB-backed [`AdmissionService`] implementation (spec §4.3 + §4.5 + §6.2).
 ///
 /// Unlike [`DbConnectService`] (which owns its env because `ConnectService`
@@ -1567,7 +1668,9 @@ mod tests {
                 name TEXT NOT NULL DEFAULT '', \
                 visibility TEXT NOT NULL DEFAULT 'public', \
                 user_visibility TEXT NOT NULL DEFAULT 'protected', \
+                friend_check_in_strategy TEXT NOT NULL DEFAULT 'APPROVAL', \
                 bot_info TEXT DEFAULT NULL, \
+                friend_ext TEXT DEFAULT NULL, \
                 status TEXT NOT NULL DEFAULT 'online', \
                 created_by TEXT, \
                 is_deleted INTEGER NOT NULL DEFAULT 0, \
@@ -1813,20 +1916,23 @@ mod tests {
         created_by: Option<&str>,
         friend_ext: serde_json::Map<String, serde_json::Value>,
     ) {
+        let friend_ext_json = serde_json::to_string(&friend_ext).expect("friend_ext json");
         let bot_info = serde_json::json!({
             "friend_check_in_strategy": friend_check_in_strategy,
             "friend_ext": friend_ext,
         });
         db.execute(DbStatement::with_params(
             "INSERT INTO bcs_bots \
-             (bot_uuid, env, name, visibility, user_visibility, bot_info, status, created_by) \
-             VALUES (?, 'dev', ?, ?, ?, ?, ?, ?)",
+             (bot_uuid, env, name, visibility, user_visibility, friend_check_in_strategy, bot_info, friend_ext, status, created_by) \
+             VALUES (?, 'dev', ?, ?, ?, ?, ?, ?, ?, ?)",
             vec![
                 DbValue::from(bot_uuid),
                 DbValue::from(bot_uuid),
                 DbValue::from(visibility),
                 DbValue::from(user_visibility),
+                DbValue::from(friend_check_in_strategy),
                 DbValue::from(serde_json::to_string(&bot_info).expect("bot_info json")),
+                DbValue::from(friend_ext_json),
                 DbValue::from(status),
                 match created_by {
                     Some(v) => DbValue::from(v),
@@ -1846,6 +1952,43 @@ mod tests {
         // of None — the direction gate in create_connect rejects invalid dirs,
         // not actor_kind_of.
         assert_eq!(actor_kind_of("plainbot"), ActorKind::Bot);
+    }
+
+    #[tokio::test]
+    async fn edge_permission_friend_sync_adds_and_removes_bot_friend_edges() {
+        let (eg, pp, rq, bc, db) = assemble().await;
+        seed_bot(&db, "x:syncA", "protected", "protected", "APPROVAL", "online", Some("85020")).await;
+        seed_bot(&db, "x:syncB", "protected", "protected", "APPROVAL", "online", Some("85020")).await;
+        let svc = service(&eg, &pp, &rq, &bc);
+
+        svc.sync_add_friendship("x:syncA", "x:syncB")
+            .await
+            .expect("sync add");
+
+        assert!(eg.has_friend_edge("x:syncA", "x:syncB", "dev").await);
+        assert_eq!(eg.list_active_grants("x:syncA", "x:syncB", "dev").await.len(), 1);
+        assert_eq!(eg.list_active_grants("x:syncB", "x:syncA", "dev").await.len(), 1);
+
+        svc.sync_remove_friendship("x:syncA", "x:syncB")
+            .await
+            .expect("sync remove");
+
+        assert!(!eg.has_friend_edge("x:syncA", "x:syncB", "dev").await);
+    }
+
+    #[tokio::test]
+    async fn edge_permission_friend_sync_normalizes_human_bot_direction() {
+        let (eg, pp, rq, bc, db) = assemble().await;
+        seed_bot(&db, "x:syncBot", "protected", "protected", "APPROVAL", "online", Some("85020")).await;
+        let svc = service(&eg, &pp, &rq, &bc);
+
+        svc.sync_add_friendship("x:syncBot", "human_1")
+            .await
+            .expect("sync add");
+
+        assert!(eg.has_friend_edge("human_1", "x:syncBot", "dev").await);
+        assert_eq!(eg.list_active_grants("human_1", "x:syncBot", "dev").await.len(), 1);
+        assert!(eg.list_active_grants("x:syncBot", "human_1", "dev").await.is_empty());
     }
 
     #[tokio::test]
@@ -1993,6 +2136,173 @@ mod tests {
         assert_eq!(res.edge_ids.len(), 1);
         assert!(eg.has_friend_edge("human_1", "x:privuvis", "dev").await);
     }
+
+    #[tokio::test]
+    async fn human_protected_view_scope_user_friend_deps_allows_matching_department() {
+        let (eg, pp, rq, bc, db) = assemble().await;
+        let mut target_friend_ext = serde_json::Map::new();
+        target_friend_ext.insert(
+            "view_scope_user_friend_deps".to_string(),
+            serde_json::Value::Array(vec![serde_json::Value::String(
+                "蚂蚁集团-大安全-大安全技术部-AI基础设施".to_string(),
+            )]),
+        );
+        seed_bot_with_friend_ext(
+            &db,
+            "x:user_scope_hit",
+            "protected",
+            "protected",
+            "OPEN",
+            "online",
+            Some("85020"),
+            target_friend_ext,
+        )
+        .await;
+        let departments = Arc::new(StaticUserDirectoryPlugin {
+            departments: Arc::new(std::collections::HashMap::from([(
+                "1".to_string(),
+                "蚂蚁集团-大安全-大安全技术部-AI基础设施-系统智能".to_string(),
+            )])),
+        });
+        let svc = service_with_departments(&eg, &pp, &rq, &bc, departments);
+        let res = svc
+            .create_connect("human_1", "x:user_scope_hit", None, None)
+            .await
+            .expect("protected user scope hit should auto-approve when OPEN");
+        assert_eq!(res.status, ConnectStatus::Approved);
+        assert!(res.auto_accepted);
+        assert_eq!(res.edge_ids.len(), 1);
+        assert_eq!(res.request_ids.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn human_protected_view_scope_user_friend_deps_blocks_out_of_scope_department() {
+        let (eg, pp, rq, bc, db) = assemble().await;
+        let mut target_friend_ext = serde_json::Map::new();
+        target_friend_ext.insert(
+            "view_scope_user_friend_deps".to_string(),
+            serde_json::Value::Array(vec![serde_json::Value::String(
+                "蚂蚁集团-大安全-大安全技术部-AI基础设施".to_string(),
+            )]),
+        );
+        seed_bot_with_friend_ext(
+            &db,
+            "x:user_scope_miss",
+            "protected",
+            "protected",
+            "OPEN",
+            "online",
+            Some("85020"),
+            target_friend_ext,
+        )
+        .await;
+        let departments = Arc::new(StaticUserDirectoryPlugin {
+            departments: Arc::new(std::collections::HashMap::from([(
+                "1".to_string(),
+                "蚂蚁集团-其他事业群-销售部".to_string(),
+            )])),
+        });
+        let svc = service_with_departments(&eg, &pp, &rq, &bc, departments);
+        let err = svc
+            .create_connect("human_1", "x:user_scope_miss", None, None)
+            .await
+            .expect_err("out-of-scope human applicant should be rejected");
+        assert!(matches!(err, ServiceError::Forbidden(_)), "got {err:?}");
+    }
+
+    #[tokio::test]
+    async fn bot_protected_view_scope_agent_friend_deps_allows_matching_owner_department() {
+        let (eg, pp, rq, bc, db) = assemble().await;
+        seed_bot(
+            &db,
+            "x:applicant",
+            "protected",
+            "protected",
+            "APPROVAL",
+            "online",
+            Some("owner_1"),
+        )
+        .await;
+        let mut target_friend_ext = serde_json::Map::new();
+        target_friend_ext.insert(
+            "view_scope_agent_friend_deps".to_string(),
+            serde_json::Value::Array(vec![serde_json::Value::String(
+                "蚂蚁集团-大安全-大安全技术部-AI基础设施".to_string(),
+            )]),
+        );
+        seed_bot_with_friend_ext(
+            &db,
+            "x:target_scope_hit",
+            "protected",
+            "protected",
+            "OPEN",
+            "online",
+            Some("85020"),
+            target_friend_ext,
+        )
+        .await;
+        let departments = Arc::new(StaticUserDirectoryPlugin {
+            departments: Arc::new(std::collections::HashMap::from([(
+                "owner_1".to_string(),
+                "蚂蚁集团-大安全-大安全技术部-AI基础设施-系统智能".to_string(),
+            )])),
+        });
+        let svc = service_with_departments(&eg, &pp, &rq, &bc, departments);
+        let res = svc
+            .create_connect("x:applicant", "x:target_scope_hit", None, None)
+            .await
+            .expect("protected agent scope hit should auto-approve when OPEN");
+        assert_eq!(res.status, ConnectStatus::Approved);
+        assert!(res.auto_accepted);
+        assert_eq!(res.edge_ids.len(), 2);
+        assert_eq!(res.request_ids.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn bot_protected_view_scope_agent_friend_deps_blocks_out_of_scope_owner_department() {
+        let (eg, pp, rq, bc, db) = assemble().await;
+        seed_bot(
+            &db,
+            "x:applicant",
+            "protected",
+            "protected",
+            "APPROVAL",
+            "online",
+            Some("owner_1"),
+        )
+        .await;
+        let mut target_friend_ext = serde_json::Map::new();
+        target_friend_ext.insert(
+            "view_scope_agent_friend_deps".to_string(),
+            serde_json::Value::Array(vec![serde_json::Value::String(
+                "蚂蚁集团-大安全-大安全技术部-AI基础设施".to_string(),
+            )]),
+        );
+        seed_bot_with_friend_ext(
+            &db,
+            "x:target_scope_miss",
+            "protected",
+            "protected",
+            "OPEN",
+            "online",
+            Some("85020"),
+            target_friend_ext,
+        )
+        .await;
+        let departments = Arc::new(StaticUserDirectoryPlugin {
+            departments: Arc::new(std::collections::HashMap::from([(
+                "owner_1".to_string(),
+                "蚂蚁集团-其他事业群-销售部".to_string(),
+            )])),
+        });
+        let svc = service_with_departments(&eg, &pp, &rq, &bc, departments);
+        let err = svc
+            .create_connect("x:applicant", "x:target_scope_miss", None, None)
+            .await
+            .expect_err("out-of-scope bot owner should be rejected");
+        assert!(matches!(err, ServiceError::Forbidden(_)), "got {err:?}");
+    }
+
 
     #[tokio::test]
     async fn public_auto_bot_returns_approved_edge() {

--- a/src/bcs/crates/services/bcs-edge-permission/src/lib.rs
+++ b/src/bcs/crates/services/bcs-edge-permission/src/lib.rs
@@ -1291,31 +1291,6 @@ impl EdgePermissionFriendSyncService for DbConnectService {
 
 // ---- AdmissionService (T14) ----------------------------------------------
 
-#[async_trait]
-impl EdgePermissionFriendSyncService for DbConnectService {
-    async fn sync_add_friendship(&self, a: &str, b: &str) -> ServiceResult<()> {
-        let Some((caller, target, caller_kind, target_kind)) = normalize_friend_sync_pair(a, b)? else {
-            warn!(left = %a, right = %b, env = %self.env, "skip human-human friendship edge-permission sync");
-            return Ok(());
-        };
-        if self.edge_grants.has_friend_edge(caller, target, &self.env).await {
-            return Ok(());
-        }
-        self.build_connect_edges(caller, target, caller_kind, target_kind)
-            .await
-            .map(|_| ())
-    }
-
-    async fn sync_remove_friendship(&self, a: &str, b: &str) -> ServiceResult<()> {
-        let Some((caller, target, _, _)) = normalize_friend_sync_pair(a, b)? else {
-            return Ok(());
-        };
-        <Self as ConnectService>::revoke_friend(self, caller, target)
-            .await
-            .map(|_| ())
-    }
-}
-
 /// DB-backed [`AdmissionService`] implementation (spec §4.3 + §4.5 + §6.2).
 ///
 /// Unlike [`DbConnectService`] (which owns its env because `ConnectService`

--- a/src/bcs/crates/services/bcs-edge-permission/src/lib.rs
+++ b/src/bcs/crates/services/bcs-edge-permission/src/lib.rs
@@ -47,7 +47,7 @@ use bcs_service_api::port::repo::{
     BotActorConfigRepoPort, EdgeGrantRepoPort, PermissionProfileRepoPort,
     PermissionRequestRepoPort,
 };
-use bcs_service_api::{ServiceError, ServiceResult};
+use bcs_service_api::{EdgePermissionFriendSyncService, ServiceError, ServiceResult};
 use bcs_user_directory_api::{UserDirectoryLookupContext, UserDirectoryPlugin};
 
 /// Generate a fresh external request id (a bare UUID v4, simple form — no
@@ -131,6 +131,11 @@ fn actor_kind_of(id: &str) -> ActorKind {
     } else {
         ActorKind::Bot
     }
+}
+
+fn is_lock_wait_timeout(err: &ServiceError) -> bool {
+    let message = err.to_string();
+    message.contains("1205") || message.to_ascii_lowercase().contains("lock wait timeout")
 }
 
 fn normalize_policy_value(value: &str) -> String {
@@ -1031,6 +1036,37 @@ impl DbConnectService {
         Ok((edge_ids, default_refs))
     }
 
+    async fn build_connect_edges_with_profile_retry(
+        &self,
+        caller: &str,
+        to_bot: &str,
+        caller_kind: ActorKind,
+        target_kind: ActorKind,
+    ) -> ServiceResult<(Vec<u64>, [u64; 2])> {
+        let mut attempts = 0;
+        loop {
+            match self
+                .build_connect_edges(caller, to_bot, caller_kind, target_kind)
+                .await
+            {
+                Ok(result) => return Ok(result),
+                Err(err) if is_lock_wait_timeout(&err) && attempts < 2 => {
+                    attempts += 1;
+                    warn!(
+                        caller = %caller,
+                        to_bot = %to_bot,
+                        env = %self.env,
+                        attempt = attempts,
+                        error = %err,
+                        "retrying edge-permission friend-edge sync after lock wait timeout"
+                    );
+                    tokio::time::sleep(std::time::Duration::from_millis(20 * attempts)).await;
+                }
+                Err(err) => return Err(err),
+            }
+        }
+    }
+
     /// Resolve a bot's default profile id, preferring the edge-grant cache and
     /// falling back to the profile store. Errors if still missing after an
     /// `ensure_default_profile` (caller's responsibility to ensure first).
@@ -1122,6 +1158,58 @@ impl DbConnectService {
         }
 
         Ok(request_ids)
+    }
+}
+
+#[async_trait]
+impl EdgePermissionFriendSyncService for DbConnectService {
+    async fn sync_add_friendship(&self, a: &str, b: &str) -> ServiceResult<()> {
+        if a == b {
+            warn!(actor = %a, env = %self.env, "skip edge-permission friendship sync for self friendship");
+            return Ok(());
+        }
+
+        let a_kind = actor_kind_of(a);
+        let b_kind = actor_kind_of(b);
+        let (caller, target, caller_kind, target_kind) = match (a_kind, b_kind) {
+            (ActorKind::Human, ActorKind::Bot) => (a, b, a_kind, b_kind),
+            (ActorKind::Bot, ActorKind::Human) => (b, a, b_kind, a_kind),
+            (ActorKind::Bot, ActorKind::Bot) => (a, b, a_kind, b_kind),
+            (ActorKind::Human, ActorKind::Human) => {
+                warn!(left = %a, right = %b, env = %self.env, "skip edge-permission friendship sync for unsupported human-human friendship");
+                return Ok(());
+            }
+        };
+
+        if caller_kind == ActorKind::Human
+            && self.edge_grants.has_friend_edge(caller, target, &self.env).await
+        {
+            return Ok(());
+        }
+
+        self.build_connect_edges_with_profile_retry(caller, target, caller_kind, target_kind)
+            .await?;
+        Ok(())
+    }
+
+    async fn sync_remove_friendship(&self, a: &str, b: &str) -> ServiceResult<()> {
+        if a == b {
+            return Ok(());
+        }
+
+        let a_kind = actor_kind_of(a);
+        let b_kind = actor_kind_of(b);
+        let (caller, target) = match (a_kind, b_kind) {
+            (ActorKind::Human, ActorKind::Bot) => (a, b),
+            (ActorKind::Bot, ActorKind::Human) => (b, a),
+            (ActorKind::Bot, ActorKind::Bot) => (a, b),
+            (ActorKind::Human, ActorKind::Human) => {
+                warn!(left = %a, right = %b, env = %self.env, "skip edge-permission friendship removal sync for unsupported human-human friendship");
+                return Ok(());
+            }
+        };
+
+        self.revoke_friend(caller, target).await.map(|_| ())
     }
 }
 
@@ -1506,6 +1594,16 @@ mod tests {
         requests: &Arc<dyn PermissionRequestRepoPort>,
         bot_config: &Arc<dyn BotActorConfigRepoPort>,
     ) -> DbConnectService {
+        service_in_env(edge_grants, profiles, requests, bot_config, "dev")
+    }
+
+    fn service_in_env(
+        edge_grants: &Arc<dyn EdgeGrantRepoPort>,
+        profiles: &Arc<dyn PermissionProfileRepoPort>,
+        requests: &Arc<dyn PermissionRequestRepoPort>,
+        bot_config: &Arc<dyn BotActorConfigRepoPort>,
+        env: &str,
+    ) -> DbConnectService {
         DbConnectService::new(
             edge_grants.clone(),
             profiles.clone(),
@@ -1513,7 +1611,7 @@ mod tests {
             bot_config.clone(),
             None,
             Arc::new(bcs_service_api::NoopFriendConnectNotificationPort),
-            "dev".to_string(),
+            env.to_string(),
         )
     }
 
@@ -2676,6 +2774,87 @@ mod tests {
         svc.cancel(&rid).await.expect("idempotent cancel ok");
         let r2 = rq.get(&rid, "dev").await.expect("request still exists");
         assert_eq!(r2.status, RequestStatus::Cancelled);
+    }
+
+    #[tokio::test]
+    async fn sync_add_friendship_bot_to_bot_writes_two_default_edges_idempotently() {
+        let (eg, pp, rq, bc, _db) = assemble().await;
+        let svc = service(&eg, &pp, &rq, &bc);
+
+        svc.sync_add_friendship("x:syncA", "x:syncB").await.expect("sync add");
+        svc.sync_add_friendship("x:syncA", "x:syncB").await.expect("sync add idempotent");
+
+        let a_to_b = eg.list_active_grants("x:syncA", "x:syncB", "dev").await;
+        let b_to_a = eg.list_active_grants("x:syncB", "x:syncA", "dev").await;
+        assert_eq!(a_to_b.len(), 1);
+        assert_eq!(b_to_a.len(), 1);
+        assert_eq!(
+            a_to_b[0].grant_ref_id,
+            pp.get_active_default("x:syncB", "dev").await.unwrap().permission_profile_id
+        );
+        assert_eq!(
+            b_to_a[0].grant_ref_id,
+            pp.get_active_default("x:syncA", "dev").await.unwrap().permission_profile_id
+        );
+    }
+
+    #[tokio::test]
+    async fn sync_add_friendship_normalizes_bot_human_to_human_bot_edge() {
+        let (eg, pp, rq, bc, _db) = assemble().await;
+        let svc = service(&eg, &pp, &rq, &bc);
+
+        svc.sync_add_friendship("x:human_target", "human_1").await.expect("sync add");
+
+        let human_to_bot = eg.list_active_grants("human_1", "x:human_target", "dev").await;
+        let bot_to_human = eg.list_active_grants("x:human_target", "human_1", "dev").await;
+        assert_eq!(human_to_bot.len(), 1);
+        assert!(bot_to_human.is_empty(), "Bot→Human edge must not be created");
+        assert_eq!(
+            human_to_bot[0].grant_ref_id,
+            pp.get_active_default("x:human_target", "dev").await.unwrap().permission_profile_id
+        );
+    }
+
+    #[tokio::test]
+    async fn sync_add_friendship_uses_service_env() {
+        let (eg, pp, rq, bc, _db) = assemble().await;
+        let svc = service_in_env(&eg, &pp, &rq, &bc, "pre");
+
+        svc.sync_add_friendship("x:envA", "x:envB").await.expect("sync add");
+
+        assert!(eg.has_friend_edge("x:envA", "x:envB", "pre").await);
+        assert!(!eg.has_friend_edge("x:envA", "x:envB", "dev").await);
+        assert!(pp.get_active_default("x:envA", "pre").await.is_some());
+        assert!(pp.get_active_default("x:envA", "dev").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn sync_remove_friendship_revokes_only_default_friend_edges() {
+        let (eg, pp, rq, bc, _db) = assemble().await;
+        let svc = service(&eg, &pp, &rq, &bc);
+
+        svc.sync_add_friendship("human_1", "x:sync_keep").await.expect("sync add");
+        eg.insert_grant(EdgeGrant {
+            edge_id: 0,
+            env: "dev".to_string(),
+            from_id: "human_1".to_string(),
+            to_id: "x:sync_keep".to_string(),
+            grant_kind: GrantKind::PermissionProfile,
+            grant_ref_id: 4002,
+            rules: None,
+            status: EdgeStatus::Approved,
+            originator_policy_type: OriginatorPolicyType::Any,
+            originator_policy_data: None,
+        })
+        .await
+        .expect("insert non-friend edge");
+
+        svc.sync_remove_friendship("human_1", "x:sync_keep").await.expect("sync remove");
+
+        assert!(!eg.has_friend_edge("human_1", "x:sync_keep", "dev").await);
+        let active = eg.list_active_grants("human_1", "x:sync_keep", "dev").await;
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].grant_ref_id, 4002);
     }
 
     #[tokio::test]

--- a/src/bcs/crates/services/bcs-friend/src/core/friend_core.rs
+++ b/src/bcs/crates/services/bcs-friend/src/core/friend_core.rs
@@ -3,7 +3,8 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use bcs_friend_store::MemoryFriendRepo;
 use bcs_service_api::{
-    FriendCoreService, FriendRepoPort, RelationCoreService, ServiceError, ServiceResult, Friendship,
+    EdgePermissionFriendSyncService, FriendCoreService, FriendRepoPort, RelationCoreService,
+    ServiceError, ServiceResult, Friendship,
 };
 use tracing::{error, info, warn};
 
@@ -15,6 +16,7 @@ use tracing::{error, info, warn};
 pub struct FriendCore {
     repo: Arc<dyn FriendRepoPort>,
     relation: Option<Arc<dyn RelationCoreService>>,
+    edge_permission_sync: Option<Arc<dyn EdgePermissionFriendSyncService>>,
 }
 
 impl FriendCore {
@@ -26,6 +28,7 @@ impl FriendCore {
         Self {
             repo,
             relation: None,
+            edge_permission_sync: None,
         }
     }
 
@@ -36,6 +39,16 @@ impl FriendCore {
     /// Inject the relation graph service for dual-write (F.1 + F.2).
     pub fn with_relation(mut self, relation: Arc<dyn RelationCoreService>) -> Self {
         self.relation = Some(relation);
+        self
+    }
+
+    /// Inject edge-permission friend-edge synchronization for the migration
+    /// window where legacy friendships and edge grants coexist.
+    pub fn with_edge_permission_sync(
+        mut self,
+        sync: Arc<dyn EdgePermissionFriendSyncService>,
+    ) -> Self {
+        self.edge_permission_sync = Some(sync);
         self
     }
 }
@@ -112,11 +125,28 @@ impl FriendCoreService for FriendCore {
             }
         }
 
+        if let Some(ref sync) = self.edge_permission_sync {
+            if let Err(err) = sync.sync_add_friendship(bot_a, bot_b).await {
+                warn!(
+                    left_bot = %bot_a,
+                    right_bot = %bot_b,
+                    step = "edge_permission_sync_add_friendship",
+                    error = %err,
+                    "friendship edge-permission sync failed; friendship repo already inserted"
+                );
+            }
+        }
+
         info!(left_bot = %bot_a, right_bot = %bot_b, "Friendship established");
         Ok(())
     }
 
     async fn remove_all_friendships(&self, bot_id: &str) -> ServiceResult<usize> {
+        let edge_permission_friends = if self.edge_permission_sync.is_some() {
+            self.repo.list_friends(bot_id).await?
+        } else {
+            Vec::new()
+        };
         let removed = self.repo.remove_all_friendships(bot_id).await?;
 
         if let Some(ref relation) = self.relation {
@@ -128,6 +158,19 @@ impl FriendCoreService for FriendCore {
                     error = %err,
                     "F.2: relation.remove_all_friend_edges failed; will be reconciled on next remove"
                 );
+            }
+        }
+
+        if let Some(ref sync) = self.edge_permission_sync {
+            for friend_id in edge_permission_friends {
+                if let Err(err) = sync.sync_remove_friendship(bot_id, &friend_id).await {
+                    warn!(
+                        left_bot = %bot_id,
+                        right_bot = %friend_id,
+                        error = %err,
+                        "edge_permission_sync.remove_friendship failed during remove_all; friendship repo already removed"
+                    );
+                }
             }
         }
 
@@ -161,6 +204,19 @@ impl FriendCoreService for FriendCore {
                     error = %err,
                     "F.2: relation.remove_friend_edges failed; friendship repo already removed, relation graph is inconsistent"
                 );
+            }
+        }
+
+        if removed {
+            if let Some(ref sync) = self.edge_permission_sync {
+                if let Err(err) = sync.sync_remove_friendship(bot_a, bot_b).await {
+                    warn!(
+                        left_bot = %bot_a,
+                        right_bot = %bot_b,
+                        error = %err,
+                        "edge_permission_sync.remove_friendship failed; friendship repo already removed"
+                    );
+                }
             }
         }
 

--- a/src/bcs/crates/services/bcs-friend/tests/conformance_friend_services.rs
+++ b/src/bcs/crates/services/bcs-friend/tests/conformance_friend_services.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use bcs_friend::{
@@ -7,8 +7,9 @@ use bcs_friend::{
 };
 use bcs_service_api::{
     ActorKind, ActorStatus, AgentCredentials, BotCapabilities, BotDynamicStatus,
-    BotRegistryCoreService, FriendCoreService, FriendRequestCoreService, FriendRequestDirection,
-    FriendRepoPort, FriendRequestRepoPort, FriendRequestStatus, FriendService, ListFriendsCommand,
+    BotRegistryCoreService, EdgePermissionFriendSyncService, FriendCoreService,
+    FriendRequestCoreService, FriendRequestDirection, FriendRepoPort, FriendRequestRepoPort,
+    FriendRequestStatus, FriendService, ListFriendsCommand,
     RegisteredBot, ServiceError, ServiceResult,
 };
 use bcs_test_support::{
@@ -56,6 +57,105 @@ async fn memory_friend_request_store_passes_core_contract() {
     )
     .await;
     bcs_test_support::contract::repo::friend_request_repo_contract_tests(repo.as_ref()).await;
+}
+
+
+#[derive(Default)]
+struct RecordingEdgePermissionFriendSync {
+    calls: Mutex<Vec<String>>,
+}
+
+impl RecordingEdgePermissionFriendSync {
+    fn calls(&self) -> Vec<String> {
+        self.calls.lock().expect("calls lock").clone()
+    }
+}
+
+#[async_trait]
+impl EdgePermissionFriendSyncService for RecordingEdgePermissionFriendSync {
+    async fn sync_add_friendship(&self, a: &str, b: &str) -> ServiceResult<()> {
+        self.calls
+            .lock()
+            .expect("calls lock")
+            .push(format!("add:{a}:{b}"));
+        Ok(())
+    }
+
+    async fn sync_remove_friendship(&self, a: &str, b: &str) -> ServiceResult<()> {
+        self.calls
+            .lock()
+            .expect("calls lock")
+            .push(format!("remove:{a}:{b}"));
+        Ok(())
+    }
+}
+
+
+struct FailingEdgePermissionFriendSync;
+
+#[async_trait]
+impl EdgePermissionFriendSyncService for FailingEdgePermissionFriendSync {
+    async fn sync_add_friendship(&self, _a: &str, _b: &str) -> ServiceResult<()> {
+        Err(ServiceError::InternalError("sync add failed".to_string()))
+    }
+
+    async fn sync_remove_friendship(&self, _a: &str, _b: &str) -> ServiceResult<()> {
+        Err(ServiceError::InternalError("sync remove failed".to_string()))
+    }
+}
+
+#[tokio::test]
+async fn friend_core_add_succeeds_when_edge_permission_sync_fails() {
+    let repo = Arc::new(MemoryFriendRepo::new());
+    let friend = FriendCore::with_repo(repo.clone())
+        .with_edge_permission_sync(Arc::new(FailingEdgePermissionFriendSync));
+
+    friend
+        .add_friendship("alice", "bob")
+        .await
+        .expect("legacy add should not fail on edge-permission sync error");
+
+    assert!(repo.are_friends("alice", "bob").await.expect("legacy friendship"));
+}
+
+#[tokio::test]
+async fn friend_core_does_not_sync_edge_permission_when_remove_is_noop() {
+    let sync = Arc::new(RecordingEdgePermissionFriendSync::default());
+    let friend = FriendCore::with_repo(Arc::new(MemoryFriendRepo::new()))
+        .with_edge_permission_sync(sync.clone());
+
+    let removed = friend
+        .remove_friendship("alice", "missing")
+        .await
+        .expect("remove");
+
+    assert!(!removed);
+    assert!(sync.calls().is_empty());
+}
+
+#[tokio::test]
+async fn friend_core_syncs_edge_permission_on_add_and_remove() {
+    let sync = Arc::new(RecordingEdgePermissionFriendSync::default());
+    let friend = FriendCore::with_repo(Arc::new(MemoryFriendRepo::new()))
+        .with_edge_permission_sync(sync.clone());
+
+    friend.add_friendship("alice", "bob").await.expect("add");
+    friend.remove_friendship("alice", "bob").await.expect("remove");
+    friend.add_friendship("alice", "carol").await.expect("add again");
+    friend
+        .remove_all_friendships("alice")
+        .await
+        .expect("remove all");
+
+    assert_eq!(
+        sync.calls(),
+        vec![
+            "add:alice:bob".to_string(),
+            "remove:alice:bob".to_string(),
+            "add:alice:carol".to_string(),
+            "remove:alice:carol".to_string(),
+        ]
+    );
 }
 
 struct FailingFriendRepo;

--- a/src/bcs/crates/services/bcs-jwt/src/lib.rs
+++ b/src/bcs/crates/services/bcs-jwt/src/lib.rs
@@ -21,6 +21,13 @@ pub struct Claims {
     pub iat: u64,
     /// Expiration (unix seconds).
     pub exp: u64,
+    /// Display-name snapshot of the session user, for external JWT-only
+    /// verifiers (e.g. a gateway that authenticates the `bcs_session` cookie
+    /// without reading `bcs_user_identities`). BCS's own verify still reads the
+    /// live name from the identity row. Omitted from the payload when `None`,
+    /// so legacy tokens stay byte-identical and decode with `name = None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
 }
 
 impl Claims {

--- a/src/bcs/crates/services/bcs-jwt/tests/group_session_jwt.rs
+++ b/src/bcs/crates/services/bcs-jwt/tests/group_session_jwt.rs
@@ -150,6 +150,7 @@ fn rejects_wrong_key_and_login_jwt_token_confusion() {
         src: "oauth".into(),
         iat: NOW,
         exp: NOW + TTL_SECONDS,
+        name: None,
     }) {
         Ok(value) => value,
         Err(_) => panic!("login JWT fixture must sign"),

--- a/src/bcs/crates/services/bcs-jwt/tests/jwt_tests.rs
+++ b/src/bcs/crates/services/bcs-jwt/tests/jwt_tests.rs
@@ -6,6 +6,7 @@ fn make_claims(exp: u64) -> Claims {
         src: "google".into(),
         iat: 1000,
         exp,
+        name: None,
     }
 }
 
@@ -21,6 +22,7 @@ fn sign_and_verify_roundtrip() {
         src: "google".into(),
         iat: now,
         exp: now + 3600,
+        name: None,
     };
     let token = svc.sign(&claims).expect("sign");
     let verified = svc.verify(&token).expect("verify");
@@ -43,6 +45,7 @@ fn verify_rejects_wrong_secret() {
         src: "test".into(),
         iat: now,
         exp: now + 3600,
+        name: None,
     };
     let token = svc_a.sign(&claims).expect("sign");
     let result = svc_b.verify(&token);
@@ -78,20 +81,34 @@ fn verify_rejects_malformed_token() {
 
 #[test]
 fn claims_serialization_minimal() {
+    // `name: None` is omitted (skip_serializing_if), so the base 4 claims stay.
     let claims = Claims {
         sub: "s".into(),
         src: "g".into(),
         iat: 1,
         exp: 2,
+        name: None,
     };
     let json = serde_json::to_value(&claims).expect("serde");
-    // Exactly 4 fields
     let obj = json.as_object().expect("object");
     assert_eq!(obj.len(), 4);
     assert_eq!(obj["sub"], "s");
     assert_eq!(obj["src"], "g");
     assert_eq!(obj["iat"], 1);
     assert_eq!(obj["exp"], 2);
+
+    // `name: Some` adds a 5th key.
+    let claims = Claims {
+        sub: "s".into(),
+        src: "g".into(),
+        iat: 1,
+        exp: 2,
+        name: Some("大苹果".into()),
+    };
+    let json = serde_json::to_value(&claims).expect("serde");
+    let obj = json.as_object().expect("object");
+    assert_eq!(obj.len(), 5);
+    assert_eq!(obj["name"], "大苹果");
 }
 
 #[test]
@@ -102,6 +119,7 @@ fn should_refresh_at_50_percent_threshold() {
         src: "test".into(),
         iat: 0,
         exp: 1800,
+        name: None,
     };
 
     // now=800 → elapsed 800 < 900 → no refresh
@@ -123,4 +141,52 @@ fn verify_no_exp_allows_expired_token() {
     let result = svc.verify_no_exp(&token);
     assert!(result.is_ok());
     assert_eq!(result.expect("ok").sub, "bot-42");
+}
+
+#[test]
+fn name_claim_roundtrips() {
+    let svc = JwtService::new("secret");
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("epoch")
+        .as_secs();
+    let claims = Claims {
+        sub: "human_1".into(),
+        src: "alipay".into(),
+        iat: now,
+        exp: now + 3600,
+        name: Some("大苹果".into()),
+    };
+    let token = svc.sign(&claims).expect("sign");
+    let verified = svc.verify(&token).expect("verify");
+    assert_eq!(verified.name.as_deref(), Some("大苹果"));
+}
+
+#[test]
+fn name_none_roundtrips_to_none() {
+    let svc = JwtService::new("secret");
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("epoch")
+        .as_secs();
+    let claims = Claims {
+        sub: "bot".into(),
+        src: "test".into(),
+        iat: now,
+        exp: now + 3600,
+        name: None,
+    };
+    let token = svc.sign(&claims).expect("sign");
+    let verified = svc.verify(&token).expect("verify");
+    assert_eq!(verified.name, None);
+}
+
+#[test]
+fn legacy_payload_without_name_decodes_name_none() {
+    // A pre-name-claim payload must still deserialize thanks to `#[serde(default)]`.
+    let json = r#"{"sub":"x","src":"google","iat":1000,"exp":2000}"#;
+    let claims: Claims = serde_json::from_str(json).expect("decode legacy");
+    assert_eq!(claims.sub, "x");
+    assert_eq!(claims.src, "google");
+    assert_eq!(claims.name, None);
 }

--- a/src/gateway/src/gateway/community/plugins/authn/oauth_session/_strategy.py
+++ b/src/gateway/src/gateway/community/plugins/authn/oauth_session/_strategy.py
@@ -2,7 +2,8 @@
 
 The gateway's browser/session path uses the same signed JWT that BCS issues at
 login time. This strategy reads the ``bcs_session`` cookie, verifies its HS256
-signature locally, and maps the ``sub`` claim onto a ``UserPrincipal``.
+signature locally, and maps the ``sub`` claim onto the user id and the
+``name`` claim onto the login name of a ``UserPrincipal``.
 
 Absent cookie → ``None`` (not applicable).
 Present but invalid cookie → ``AuthError`` (hard failure, no fallback).
@@ -85,12 +86,17 @@ class OauthSessionStrategy:
             logger.warning("bcs_session cookie missing sub claim")
             raise AuthError("invalid bcs session cookie") from exc
 
+        username = str(claims.get("name") or subject_id)
+
         logger.debug(
-            "bcs_session resolved: sub=%s src=%s", subject_id, claims.get("src")
+            "bcs_session resolved: sub=%s username=%s src=%s",
+            subject_id,
+            username,
+            claims.get("src"),
         )
         return UserPrincipal(
             subject=AuthenticatedUser(
                 id=subject_id,
-                username=subject_id,
+                username=username,
             )
         )

--- a/src/gateway/tests/contracts/spi/test_auth_strategy.py
+++ b/src/gateway/tests/contracts/spi/test_auth_strategy.py
@@ -106,6 +106,9 @@ class TestGoogleUserStrategy(AuthStrategyContract):
 
         result = await self.strategy.build(self.applicable_creds)  # type: ignore[attr-defined]
         assert isinstance(result, UserPrincipal)
+        assert result.subject.id == "g-1"
+        assert result.subject.username == "a@example.com"
+        assert result.subject.display_name == "A"
 
 
 class TestOauthSessionStrategy(AuthStrategyContract):
@@ -118,6 +121,7 @@ class TestOauthSessionStrategy(AuthStrategyContract):
             {
                 "sub": "user-123",
                 "src": "google",
+                "name": "alice",
                 "iat": int(now.timestamp()),
                 "exp": int((now + timedelta(minutes=5)).timestamp()),
             },
@@ -134,6 +138,8 @@ class TestOauthSessionStrategy(AuthStrategyContract):
 
         result = await self.strategy.build(self.applicable_creds)  # type: ignore[attr-defined]
         assert isinstance(result, UserPrincipal)
+        assert result.subject.id == "user-123"
+        assert result.subject.username == "alice"
 
 
 class TestBotTokenStrategy(AuthStrategyContract):

--- a/src/gateway/tests/unit/plugins/test_oauth_session_strategy.py
+++ b/src/gateway/tests/unit/plugins/test_oauth_session_strategy.py
@@ -19,11 +19,14 @@ def _creds(token: str | None) -> CredentialBundle:
     return CredentialBundle(headers={}, cookies=cookies, query={})
 
 
-def _token(*, sub: str = "user-123", src: str = "google") -> str:
+def _token(
+    *, sub: str = "user-123", src: str = "google", name: str = "alice"
+) -> str:
     now = datetime.now(tz=UTC)
     claims = {
         "sub": sub,
         "src": src,
+        "name": name,
         "iat": int(now.timestamp()),
         "exp": int((now + timedelta(minutes=5)).timestamp()),
     }
@@ -43,7 +46,7 @@ async def test_valid_cookie_builds_user_principal() -> None:
 
     assert isinstance(result, UserPrincipal)
     assert result.subject.id == "user-123"
-    assert result.subject.username == "user-123"
+    assert result.subject.username == "alice"
     assert result.subject.display_name is None
 
 
@@ -74,6 +77,28 @@ async def test_empty_secret_value_raises_auth_error() -> None:
 
     with pytest.raises(AuthError):
         await strategy.build(_creds(_token()))
+
+
+@pytest.mark.asyncio
+async def test_valid_cookie_without_name_falls_back_to_subject_id() -> None:
+    strategy = OauthSessionStrategy(jwt_secret=_TEST_SECRET)
+    now = datetime.now(tz=UTC)
+    token = jwt.encode(
+        {
+            "sub": "user-123",
+            "src": "google",
+            "iat": int(now.timestamp()),
+            "exp": int((now + timedelta(minutes=5)).timestamp()),
+        },
+        _TEST_SECRET,
+        algorithm="HS256",
+    )
+
+    result = await strategy.build(_creds(token))
+
+    assert isinstance(result, UserPrincipal)
+    assert result.subject.id == "user-123"
+    assert result.subject.username == "user-123"
 
 
 @pytest.mark.asyncio

--- a/src/gateway/tests/unit/plugins/test_oauth_session_strategy.py
+++ b/src/gateway/tests/unit/plugins/test_oauth_session_strategy.py
@@ -19,9 +19,7 @@ def _creds(token: str | None) -> CredentialBundle:
     return CredentialBundle(headers={}, cookies=cookies, query={})
 
 
-def _token(
-    *, sub: str = "user-123", src: str = "google", name: str = "alice"
-) -> str:
+def _token(*, sub: str = "user-123", src: str = "google", name: str = "alice") -> str:
     now = datetime.now(tz=UTC)
     claims = {
         "sub": sub,


### PR DESCRIPTION
## Problem

  当前分支补齐了 BCS session JWT 与好友申请链路的几个问题：

  1. Gateway 读取 `bcs_session` 时没有消费 JWT 中的用户展示名，导致下游只能拿到用户 id。
  2. 旧 `friends` 关系需要同步到 edge-permission，否则新权限模型下已有好友关系无法直接生效。
  3. friend-connect 判断好友审批策略时错误依赖 `bot_info` JSON，没有读取 `bcs_bots.friend_check_in_strategy` 独立列。
  4. `friend_ext` 已经是 `bcs_bots` 独立字段，但此前读取路径没有优先使用该列，导致可见范围和免审批部门配置可能不生效。
  5. 受保护可见性下，用户/Bot 发起好友申请前缺少部门范围校验。

  ## Solution

  本 PR 做了以下修复：

  - `bcs_session` JWT 增加并透传用户展示名 claim。
  - Gateway 的 OAuth session strategy 读取 BCS session name claim，并映射到 authenticated user。
  - 增加 legacy friends 到 edge permissions 的同步能力：
    - 支持新增好友关系时同步创建 edge permission friend edge。
    - 支持删除好友关系时同步撤销对应 edge。
    - 支持 human→bot / bot↔bot 方向归一化。
  - 修正 bot 好友策略配置读取：
    - `friend_check_in_strategy` 从 `bcs_bots.friend_check_in_strategy` 列读取。
    - `friend_ext` 优先从 `bcs_bots.friend_ext` 列读取。
    - 保留 `bot_info.friend_ext` 作为旧数据兼容兜底。
  - 补齐 friend-connect 前置范围校验：
    - human 申请 bot 时，如果目标 bot `user_visibility=protected` 且 `view_scope_user_friend_deps` 非空，则校验申请人部门是否在允许范围内。
    - bot 申请 bot 时，如果目标 bot `visibility=protected` 且 `view_scope_agent_friend_deps` 非空，则校验申请 bot owner 部门是否在允许范围内。
  - 保持后续审批策略逻辑：
    - `OPEN`：免审批。
    - `APPROVAL`：走审批。
    - `DEPT_FREE`：申请人部门命中 `no_check_scope_friend_deps` 时免审批，否则走审批。

  ## Validation

  已完成当前分支 rebase 到最新 `dev`。

  已跑过定向测试：

  ```bash
  cargo test --package bcs-edge-permission-store --lib bot_actor_config_reads_friend_strategy_from_column -- --nocapture
  cargo test --package bcs-edge-permission --lib view_scope -- --nocapture

  验证结果：

  - 仓储层确认 friend_check_in_strategy 从独立列读取。
  - 仓储层确认 friend_ext 优先从独立列读取。
  - 权限逻辑层确认 protected scope 校验用例通过。

  本次 rebase 后未重新跑全量测试。

  ## Compatibility and risk

  - 数据兼容：
      - 新逻辑优先读取 bcs_bots.friend_ext 独立列。
      - 旧数据仍可通过 bot_info.friend_ext 兜底读取。

  - 行为变化：
      - friend-connect 会按 user_visibility / visibility 和 friend_ext 中的部门范围做前置拒绝。
      - friend_check_in_strategy=OPEN 的 bot 会正确自动通过好友申请。
      - DEPT_FREE 会按 no_check_scope_friend_deps 判断是否免审批。

  - 风险点：
      - 如果线上数据中 created_by 或部门信息缺失，部门范围校验和通知接收人解析可能受影响。
      - 好友申请通知依赖 friend_work_order_base_url 配置和 backend work-order 服务连通性；该链路失败不会影响本 PR 的策略读取修复本身，但会影响通知落库。


  如果你想短一点，也可以用这版：

  ```markdown
  ## Problem

  修复 BCS session JWT 用户展示名透传、legacy friends 到 edge-permission 同步，以及 friend-connect 好友审批策略读取错误问题。此前 `friend_check_in_strategy` / `friend_ext` 没有正确
  从 `bcs_bots` 独立列读取，导致 `OPEN` 免审批和部门范围配置可能不生效。

  ## Solution

  - BCS session JWT 增加用户展示名 claim，Gateway 读取并映射。
  - legacy friends 新增/删除时同步 edge-permission friend edges。
  - `friend_check_in_strategy` 改为读取 `bcs_bots.friend_check_in_strategy`。
  - `friend_ext` 优先读取 `bcs_bots.friend_ext`，保留 `bot_info.friend_ext` 兼容旧数据。
  - 补齐 human→bot / bot→bot 好友申请前的 protected 部门范围校验。
  - 保持 `OPEN` / `APPROVAL` / `DEPT_FREE` 审批策略语义。