### PR TITLE
fix(evolvetrace): allow production CORS and repair image build

### DIFF
--- a/docker/services/evolvetrace.dockerfile
+++ b/docker/services/evolvetrace.dockerfile
@@ -7,20 +7,32 @@
 #   docker build -f docker/evolvetrace.Dockerfile -t evolvetrace:local .
 
 # --- Build stage: install deps, build Vite frontend, compile TS server ---
-FROM node:20-bookworm AS builder
+FROM node:22-bookworm AS builder
+
+# Native dependencies such as better-sqlite3 may compile during npm install.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends python3 build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+ARG NPM_CONFIG_REGISTRY=https://registry.npmjs.org
+ARG NODEJS_DIST_URL=https://nodejs.org/dist
+ENV npm_config_registry=${NPM_CONFIG_REGISTRY} \
+    npm_config_disturl=${NODEJS_DIST_URL} \
+    npm_config_python=/usr/bin/python3
 
 WORKDIR /build
 
 # Copy package metadata first for layer caching.
 COPY src/evolverun/evolvetrace/package.json src/evolverun/evolvetrace/package-lock.json ./
-RUN npm ci
+RUN npm ci --no-audit --no-fund
 
 # Copy source and build both frontend and server.
 COPY src/evolverun/evolvetrace/ ./
-RUN npm run build && npm run build:server
+RUN npm run build && npm run build:server \
+    && npm prune --omit=dev
 
 # --- Runtime stage ---
-FROM node:20-bookworm-slim
+FROM node:22-bookworm-slim
 
 ENV NODE_ENV=production \
     EVOLVETRACE_ENV=prod \
@@ -45,9 +57,7 @@ COPY --from=builder --chown=appuser:appuser /build/configs ./configs
 COPY --from=builder --chown=appuser:appuser /build/scripts ./scripts
 COPY --from=builder --chown=appuser:appuser /build/package.json ./package.json
 COPY --from=builder --chown=appuser:appuser /build/package-lock.json ./package-lock.json
-
-# Install production dependencies only (mysql2 etc.).
-RUN npm ci --omit=dev && rm -rf ~/.npm
+COPY --from=builder --chown=appuser:appuser /build/node_modules ./node_modules
 
 # The service runs as appuser (non-root). Root stays available for debugging —
 # it is merely password-locked, and container exec needs no password:

--- a/src/evolverun/evolvetrace/.env.example
+++ b/src/evolverun/evolvetrace/.env.example
@@ -4,6 +4,10 @@
 # Server
 PORT=3001
 
+# Comma-separated browser origins allowed to call the HTTP API.
+# Example: https://avernet.example.com,https://preview.example.com
+CORS_ALLOWED_ORIGINS=
+
 # Database: sqlite | mysql | noop
 DATABASE_MODE=sqlite
 SQLITE_PATH=~/.evolvetrace/engine.db

--- a/src/evolverun/evolvetrace/package-lock.json
+++ b/src/evolverun/evolvetrace/package-lock.json
@@ -33,7 +33,7 @@
         "zustand": "^5.0.13"
       },
       "devDependencies": {
-        "@eslint/js": "^10.0.1",
+        "@eslint/js": "^9.39.5",
         "@tailwindcss/vite": "^4.3.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -1130,24 +1130,16 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
-      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://eslint.org/donate"
-      },
-      "peerDependencies": {
-        "eslint": "^10.0.0"
-      },
-      "peerDependenciesMeta": {
-        "eslint": {
-          "optional": true
-        }
       }
     },
     "node_modules/@eslint/object-schema": {
@@ -1912,6 +1904,72 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.3.tgz",
@@ -1987,6 +2045,43 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
@@ -2048,6 +2143,13 @@
       "peerDependencies": {
         "@testing-library/dom": ">=7.21.4"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2324,7 +2426,6 @@
       "version": "22.20.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
       "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2348,7 +2449,6 @@
       "version": "19.2.18",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
       "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2358,7 +2458,7 @@
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -3613,7 +3713,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/d3-color": {
@@ -4167,19 +4266,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint/node_modules/@eslint/js": {
-      "version": "9.39.5",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
-      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/espree": {
@@ -5579,6 +5665,16 @@
         "url": "https://github.com/sponsors/wellwelwel"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -6965,6 +7061,34 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -7068,6 +7192,13 @@
       "peerDependencies": {
         "react": "^19.2.8"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -8100,7 +8231,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unified": {

--- a/src/evolverun/evolvetrace/package.json
+++ b/src/evolverun/evolvetrace/package.json
@@ -41,7 +41,7 @@
     "zustand": "^5.0.13"
   },
   "devDependencies": {
-    "@eslint/js": "^10.0.1",
+    "@eslint/js": "^9.39.5",
     "@tailwindcss/vite": "^4.3.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/src/evolverun/evolvetrace/server/cors.test.ts
+++ b/src/evolverun/evolvetrace/server/cors.test.ts
@@ -1,0 +1,81 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { createServer } from "node:net";
+import { afterEach, describe, expect, it } from "vitest";
+
+const children = new Set<ChildProcess>();
+
+async function reservePort(): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    const server = createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close();
+        reject(new Error("failed to reserve a TCP port"));
+        return;
+      }
+      server.close((error) => error ? reject(error) : resolve(address.port));
+    });
+  });
+}
+
+async function waitForHealth(port: number, child: ChildProcess): Promise<void> {
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) {
+      throw new Error(`evolvetrace exited with code ${child.exitCode}`);
+    }
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/health`);
+      if (response.ok) return;
+    } catch {
+      // The server may still be starting.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error("timed out waiting for evolvetrace health endpoint");
+}
+
+afterEach(async () => {
+  for (const child of children) {
+    if (child.exitCode === null) child.kill("SIGTERM");
+  }
+  children.clear();
+});
+
+describe("Evolvetrace CORS configuration", () => {
+  it("allows a configured origin without admitting other origins", async () => {
+    const port = await reservePort();
+    const child = spawn(
+      process.execPath,
+      ["--import", "tsx", "server/index.ts"],
+      {
+        cwd: process.cwd(),
+        env: {
+          ...process.env,
+          PORT: String(port),
+          DATABASE_MODE: "noop",
+          CORS_ALLOWED_ORIGINS: "https://avernet.alipay.com",
+        },
+        stdio: "ignore",
+      },
+    );
+    children.add(child);
+    await waitForHealth(port, child);
+
+    const response = await fetch(`http://127.0.0.1:${port}/health`, {
+      headers: { Origin: "https://avernet.alipay.com" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("access-control-allow-origin"))
+      .toBe("https://avernet.alipay.com");
+
+    const rejected = await fetch(`http://127.0.0.1:${port}/health`, {
+      headers: { Origin: "https://untrusted.example.com" },
+    });
+    expect(rejected.status).toBe(500);
+    expect(rejected.headers.get("access-control-allow-origin")).toBeNull();
+  }, 15_000);
+});

--- a/src/evolverun/evolvetrace/server/env.ts
+++ b/src/evolverun/evolvetrace/server/env.ts
@@ -2,3 +2,13 @@
 export function getCurrentEnv(): string {
   return process.env.EVOLVETRACE_ENV ?? "dev";
 }
+
+/** Additional browser origins allowed to call the Evolvetrace HTTP API. */
+export function getCorsAllowedOrigins(): Set<string> {
+  return new Set(
+    (process.env.CORS_ALLOWED_ORIGINS ?? "")
+      .split(",")
+      .map((origin) => origin.trim())
+      .filter(Boolean),
+  );
+}

--- a/src/evolverun/evolvetrace/server/index.ts
+++ b/src/evolverun/evolvetrace/server/index.ts
@@ -36,6 +36,7 @@ import { adminAuthMiddleware } from "./middleware/admin-auth.js";
 import { requestLogger } from "./middleware/request-logger.js";
 import { errorLogger } from "./middleware/error-logger.js";
 import { initSchema } from "./schema.js";
+import { getCorsAllowedOrigins } from "./env.js";
 
 function resolvePort(): number {
   const envPort = process.env.PORT;
@@ -88,12 +89,14 @@ async function main(extensions?: EvolvetraceExtensions): Promise<void> {
   const sandboxQueryService = new SandboxQueryService();
 
   const app = express();
+  const allowedCorsOrigins = getCorsAllowedOrigins();
 
   app.use(cors({
     origin: (origin, callback) => {
       if (!origin) return callback(null, "*");
       if (/^https?:\/\/localhost(:\d+)?$/.test(origin)) return callback(null, origin);
       if (/^https?:\/\/127\.0\.0\.1(:\d+)?$/.test(origin)) return callback(null, origin);
+      if (allowedCorsOrigins.has(origin)) return callback(null, origin);
       callback(new Error("CORS not allowed"));
     },
     credentials: true,


### PR DESCRIPTION
## Problem

Workflow saves routed through the Avernet Gateway reached Evolvetrace but failed with `500 CORS not allowed` because Evolvetrace only allowed localhost origins.

The Evolvetrace image also failed to build due to mismatched ESLint dependencies and a Node 20 runtime incompatible with `better-sqlite3@13`.

## Solution

- Add `CORS_ALLOWED_ORIGINS` support while preserving localhost defaults.
- Add a regression test covering allowed and rejected origins.
- Align `@eslint/js` with ESLint 9.
- Use Node 22 for the Evolvetrace build and runtime stages.
- Install and prune dependencies in the builder stage, then copy production `node_modules` into the slim runtime image.
- Avoid rebuilding native dependencies inside the slim runtime image.

## Validation

- `npm ci --ignore-scripts` passed.
- `npm test` passed: 1 test.
- `npm run build:server` passed.
- `npm run build` passed: 354 modules transformed.
- `git diff --check` passed.
- The OCB pre-push lint-only gate passed.
- Final Docker image build must be confirmed on the xhunter build host, where Docker is available.

## Compatibility and risk

- No API or database schema changes.
- Production must set:

  `CORS_ALLOWED_ORIGINS=https://avernet.alipay.com`

- The deployment must use a newly built image containing commit `638f3b798`.