### PR TITLE
feat(frontend): export latest nextgen open core

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/task/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/task/router.py
@@ -1015,7 +1015,7 @@ async def _dispatch_impl(
         # session.completed 收敛),不进 state_machine 的 translate_bcn/run_detail 路径。
         if parse_manager_worker_bcn(_raw_obj) is not None:
             logger.info("[task_callback] is_manager_worker_event, session_id=%s", _sid)
-            await svc.apply_manager_worker_event(_raw_obj)
+            #await svc.apply_manager_worker_event(_raw_obj)
             return envelope({"ok": True}, request)
 
         logger.info("[task_callback] is_state_machine_event, session_id=%s", _sid)

--- a/src/backend/src/agentclaw/community/configs/application-community.yaml
+++ b/src/backend/src/agentclaw/community/configs/application-community.yaml
@@ -323,3 +323,13 @@ user_config:
     secret_secret: "${secret_secret:-}"
     task_callback_url: "${BACKEND_URL:-}"
     task_callback_url_pre: "${BACKEND_URL:-}"
+
+  # merchant_task_bot_bindings → static-plan template bot binding (role_key ->
+  #   bot uuid). Public profile: a SINGLE env-injected JSON string
+  #   (``${MERCHANT_TASK_BOT_BINDINGS:-}``) so the role<->uuid mapping of our own
+  #   demo bots is NOT carved into this open-source config; the provider decodes
+  #   it. Internal profiles may instead write a structured YAML sub-tree of the
+  #   same keys. Empty -> no resolution -> placeholders stay literal at load
+  #   (content routing/materialize stays green on a bare/CI build); only a real
+  #   dispatch then degrades (BCS rejects a literal ${...}).
+  merchant_task_bot_bindings: "${MERCHANT_TASK_BOT_BINDINGS:-}"

--- a/src/backend/src/agentclaw/community/core/task/task_center/engine.py
+++ b/src/backend/src/agentclaw/community/core/task/task_center/engine.py
@@ -202,6 +202,7 @@ class ExecutionEngine:
         api_base_url: str = "",
         bot_token_provider=None,
         notify_messages_provider=None,
+        bot_bindings=None,
     ) -> None:
         """graph: TaskGraphService;bot: OpenApiBotPort;bcs: BcsClientPort;discover: BotDiscoverServiceProtocol。
         端口由 DI 从配置注入(local/prod/double 只换端口实现,引擎代码不变)。prod 必传;测试子类覆写
@@ -223,6 +224,7 @@ class ExecutionEngine:
         self._api_base_url = api_base_url
         self._bot_token_provider = bot_token_provider
         self._notify_provider = notify_messages_provider
+        self._bot_bindings = bot_bindings
         self._bg_tasks: set[object] = set()
         self._bbs_loop: asyncio.AbstractEventLoop | None = None
         self._bbs_loop_thread: threading.Thread | None = None
@@ -630,7 +632,10 @@ class ExecutionEngine:
                 return None
             yaml_text = plans_path.read_text(encoding="utf-8")
         try:
-            definition = StaticPlanDefinition.from_yaml(str(yaml_text) if yaml_text else "")
+            definition = StaticPlanDefinition.from_yaml(
+                str(yaml_text) if yaml_text else "",
+                bindings=self._bot_bindings.bot_id_by_role if self._bot_bindings else None,
+            )
             runtime = StaticPlanRuntime(definition, dict(cfg.get("template_input") or {}))
         except Exception:
             logger.exception(

--- a/src/backend/src/agentclaw/community/core/task/task_center/task_service.py
+++ b/src/backend/src/agentclaw/community/core/task/task_center/task_service.py
@@ -103,6 +103,7 @@ class TaskService(TaskServiceExecutionMixin):
         api_base_url: str | None = None,
         bot_token_provider=None,
         notify_messages_provider=None,
+        bot_bindings=None,
     ) -> None:
         """graph: TaskGraphService;harness: TaskHarness | None(旁路复位,可选);
         bot/bcs/discover: 传输端口(DI 从配置注入 local/prod/double 实现传给引擎;省略=stub 路径/纯内核单测)。
@@ -131,6 +132,7 @@ class TaskService(TaskServiceExecutionMixin):
         self._task_settings = task_settings
         self._bot_token_provider = bot_token_provider
         self._notify_provider = notify_messages_provider
+        self._bot_bindings = bot_bindings
         # _build_engine(seam)签名保持不变(测试子类按旧签名覆写);claim_on JOIN 经 self._task_auth_gate
         # 传入 ExecutionEngine→dispatcher,不进签名避免破坏覆写 seam。
         self._engine = self._build_engine(bot=bot, bcs=bcs, discover=discover)
@@ -171,6 +173,7 @@ class TaskService(TaskServiceExecutionMixin):
             api_base_url=self._api_base_url,
             bot_token_provider=self._bot_token_provider,
             notify_messages_provider=self._notify_provider,
+            bot_bindings=self._bot_bindings,
         )
 
     def _resolve_static_plan_template_id(self, request: "TaskInfoRequest") -> str | None:
@@ -229,7 +232,10 @@ class TaskService(TaskServiceExecutionMixin):
             template_id, cfg.get("task_type"), cfg.get("static_plan_id"), dict(inputs), _obj, _inst, _title,
         )
         try:
-            definition = StaticPlanDefinition.from_file(template_id, template_dir)
+            definition = StaticPlanDefinition.from_file(
+                template_id, template_dir,
+                bindings=self._bot_bindings.bot_id_by_role if self._bot_bindings else None,
+            )
             logger.info(
                 "[task][template-run][DIAG] definition parsed template_id=%s input_schema=%s",
                 template_id, dict(definition.input_schema),

--- a/src/backend/src/agentclaw/community/core/task/task_plan/plans/merchant-operations-goal-to-plan.yaml
+++ b/src/backend/src/agentclaw/community/core/task/task_plan/plans/merchant-operations-goal-to-plan.yaml
@@ -1,5 +1,5 @@
 template_id: merchant-operations-goal-to-plan
-entry_bot_id: 20260901_kcvvkqqs
+entry_bot_id: "${store_owner_bot_id}"
 entry_name: 店主Bot
 # 每个节点只描述本角色工作边界;上游正文由 StaticPlanRuntime 统一透传(接自/上游产出正文/本角色任务),
 # 不在 task 里替下游预写专业 checklist。输入=上一Bot输出(handoff 接力)。
@@ -14,7 +14,7 @@ nodes:
     name: 店主Bot
     title: 店主·定红线封任务单
     type: bot
-    bot_id: 20260901_kcvvkqqs
+    bot_id: "${store_owner_bot_id}"
     depends_on: []
     input:
       okr: $.input.okr
@@ -37,7 +37,7 @@ nodes:
     name: 门店运营Bot
     title: 门店运营·测产能出画像·带营销约束
     type: bot
-    bot_id: 20260901_5r6cdh02
+    bot_id: "${store_ops_bot_id}"
     depends_on: [set_redlines]
     input:
       handoff: $.set_redlines.output.handoff
@@ -50,7 +50,7 @@ nodes:
     name: 营销Bot
     title: 营销·在能力内出方案
     type: bot
-    bot_id: 20260901_mylvdi1o
+    bot_id: "${marketing_bot_id}"
     depends_on: [ops_capacity]
     input:
       handoff: $.ops_capacity.output.handoff
@@ -65,7 +65,7 @@ nodes:
     type: collaboration
     depends_on: [marketing_plan]
     collaboration:
-      bot_ids: [20260901_sesl8hmo, 20260901_4tn4mnnj]
+      bot_ids: ["${mall_ops_bot_id}", "${online_platform_bot_id}"]
       bot_names: [商场运营Bot, 线上平台Bot]
       mode: chat
       completion: report
@@ -80,7 +80,7 @@ nodes:
     name: 店主Bot
     title: 店主·利润核算·授权划界
     type: bot
-    bot_id: 20260901_kcvvkqqs
+    bot_id: "${store_owner_bot_id}"
     depends_on: [review_group]
     input:
       handoff: $.review_group.output.handoff
@@ -93,7 +93,7 @@ nodes:
     name: 投放实施
     title: 投放实施·执行
     type: bot
-    bot_id: 20260828_k9c2slro
+    bot_id: "${launch_bot_id}"
     depends_on: [profit_accounting]
     input:
       handoff: $.profit_accounting.output.handoff
@@ -106,7 +106,7 @@ nodes:
     name: 补齐周年活动券重复领取拦截能力
     title: 周年活动券重复领取拦截能力缺口
     type: bbs_handoff
-    bot_id: 20260828_f7wfi27d
+    bot_id: "${coupon_dup_claim_bot_id}"
     depends_on: [launch]
     input:
       handoff: $.launch.output.handoff

--- a/src/backend/src/agentclaw/community/core/task/task_plan/static_plan.py
+++ b/src/backend/src/agentclaw/community/core/task/task_plan/static_plan.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import logging
+import re
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -12,6 +14,42 @@ from agentclaw.community.core.task.domain.errors import TaskStateError
 
 
 logger = logging.getLogger("task.static_plan")
+
+
+_PLACEHOLDER_RE = re.compile(r"\${(?P<name>[A-Za-z_][A-Za-z0-9_]*)(?::-([^}]*))?}")
+
+
+def _expand_placeholders(data: Any, bindings: Mapping[str, str]) -> Any:
+    """Resolve ``${role_key}`` / ``${role_key:-default}`` from an injected
+    bindings map (role_key -> bot uuid).
+
+    Only reached when a NON-EMPTY ``bindings`` map is passed (env-injected
+    deployment); ``None`` (test seam) and an empty map (env unset) are both
+    falsy and skip expansion, leaving ``${...}`` literal so content
+    routing/materialize stays green on a bare/CI build and only a real
+    dispatch hits BCS with a literal (where it rejects it). With a non-empty map,
+    a referenced role_key that has neither a binding nor a default is a config
+    error (raised at load) so a half-wired real deployment fails loudly.
+    """
+
+    def _repl(match: re.Match[str]) -> str:
+        name = match.group("name")
+        if name in bindings:
+            return str(bindings[name])
+        default = match.group(2)
+        if default is not None:
+            return default
+        raise KeyError(
+            f"task static-plan placeholder ${{{name}}} has no binding and no default"
+        )
+
+    if isinstance(data, dict):
+        return {k: _expand_placeholders(v, bindings) for k, v in data.items()}
+    if isinstance(data, list):
+        return [_expand_placeholders(v, bindings) for v in data]
+    if isinstance(data, str):
+        return _PLACEHOLDER_RE.sub(_repl, data)
+    return data
 
 
 @dataclass(frozen=True)
@@ -48,8 +86,10 @@ class StaticPlanDefinition:
     entry_name: str | None = None
 
     @classmethod
-    def from_yaml(cls, text: str) -> "StaticPlanDefinition":
+    def from_yaml(cls, text: str, *, bindings: Mapping[str, str] | None = None) -> "StaticPlanDefinition":
         raw = yaml.safe_load(text) or {}
+        if bindings:
+            raw = _expand_placeholders(raw, bindings)
         if not isinstance(raw, dict) or not raw.get("template_id"):
             raise ValueError("static plan requires template_id")
         nodes: list[StaticPlanNodeDefinition] = []
@@ -100,11 +140,11 @@ class StaticPlanDefinition:
         return cls(str(raw["template_id"]), raw.get("entry_bot_id"), dict(raw.get("input_schema") or {}), tuple(nodes), entry_name=raw.get("entry_name"))
 
     @classmethod
-    def from_file(cls, template_id: str, directory: Path) -> "StaticPlanDefinition":
+    def from_file(cls, template_id: str, directory: Path, *, bindings: Mapping[str, str] | None = None) -> "StaticPlanDefinition":
         path = directory / f"{template_id}.yaml"
         if not path.is_file():
             raise ValueError(f"static plan not found: {template_id}")
-        plan = cls.from_yaml(path.read_text(encoding="utf-8"))
+        plan = cls.from_yaml(path.read_text(encoding="utf-8"), bindings=bindings)
         if plan.template_id != template_id:
             raise ValueError(f"static plan template_id mismatch: {plan.template_id}")
         return plan

--- a/src/backend/src/agentclaw/community/di/config.py
+++ b/src/backend/src/agentclaw/community/di/config.py
@@ -151,6 +151,22 @@ class BcsClientConfig:
 
 
 @dataclass(frozen=True)
+class MerchantTaskBotBindingsConfig:
+    """Role-key -> bot uuid map for static-plan template bot binding resolution.
+
+    Read from the ``merchant_task_bot_bindings`` block. In the public community
+    profile the block is a single env-injected JSON string
+    (``${MERCHANT_TASK_BOT_BINDINGS:-}``); the provider decodes it there. In
+    internal profiles the block may instead be a structured YAML sub-tree.
+    Empty/absent -> empty map: a bare boot never runs placeholder expansion (it
+    only fires from ``from_file``/``from_yaml`` with a NON-EMPTY bindings map and
+    matching ``${...}`` in a plan), so content routing/materialize stays green on a
+    bare/CI build (placeholders stay literal) and only a real dispatch degrades.
+    """
+    bot_id_by_role: Mapping[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
 class BcsBindingConfig:
     """BCS channel-binding orchestration endpoint (yaml ``bcs_binding`` block).
 

--- a/src/backend/src/agentclaw/community/di/modules/infrastructure/community/task_runner_integration.py
+++ b/src/backend/src/agentclaw/community/di/modules/infrastructure/community/task_runner_integration.py
@@ -37,6 +37,7 @@ Auth split (do NOT conflate with the ``bcn`` block):
 """
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 
 from agentclaw.community.core.task.task_runner.client.bcs_http_adapter import (
@@ -55,6 +56,7 @@ from agentclaw.community.core.task.task_runner.client.ports import (
 from agentclaw.community.di.config import (
     BcnConfig,
     BcsClientConfig,
+    MerchantTaskBotBindingsConfig,
     OpenApiBotConfig,
 )
 from agentclaw.community.di.modules.config_module import _block
@@ -194,6 +196,41 @@ class TaskRunnerIntegrationModule(Module):
             secret_secret=block.get("secret_secret", ""),
             task_callback_url=block.get("task_callback_url", ""),
             task_callback_url_pre=block.get("task_callback_url_pre", ""),
+        )
+
+    @singleton
+    @provider
+    def merchant_task_bot_bindings(self) -> MerchantTaskBotBindingsConfig:
+        """Read the ``merchant_task_bot_bindings`` block -> role_key -> bot uuid map.
+
+        Public community profile: the block is a SINGLE env-injected JSON string
+        (``${MERCHANT_TASK_BOT_BINDINGS:-}`` -> ``{"store_owner_bot_id": "...", ...}``);
+        decoded here so the open-source config never carries our demo bot mapping.
+        Internal profiles may instead write a structured YAML sub-tree (dict) of
+        the same keys; both shapes decode to the same map. Empty/absent -> empty
+        map: a bare boot never expands ``${...}`` (only ``from_file``/``from_yaml``
+        with a non-None bindings map and matching placeholders do), so non-merchant
+        plans resolve unchanged and unconfigured community singlebox/CI degrades.
+        A malformed JSON string is logged and treated as empty (degrade, not boot halt).
+        """
+        block = _block("merchant_task_bot_bindings")
+        mapping: dict[str, object] = {}
+        if isinstance(block, str):
+            raw = block.strip()
+            if raw:
+                try:
+                    decoded = json.loads(raw)
+                except (ValueError, TypeError):
+                    logger.warning(
+                        "[task][bot-bindings] merchant_task_bot_bindings JSON decode failed; "
+                        "static-plan placeholders stay literal (len=%d)", len(raw),
+                    )
+                    decoded = {}
+                mapping = decoded if isinstance(decoded, dict) else {}
+        elif isinstance(block, dict):
+            mapping = block
+        return MerchantTaskBotBindingsConfig(
+            bot_id_by_role={k: str(v) for k, v in mapping.items() if isinstance(k, str)},
         )
 
     # ── port providers (construct adapters, bind Ports) ────────────────────

--- a/src/backend/src/agentclaw/community/di/modules/task_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/task_module.py
@@ -316,6 +316,11 @@ class TaskModule(Module):
             notify_messages_provider = injector.get(NotifyMessagesProvider)
         except Exception:  # noqa: BLE101 未绑定时降级 noop(不阻断)
             notify_messages_provider = NullNotifyMessagesProvider()
+        from agentclaw.community.di.config import MerchantTaskBotBindingsConfig
+        try:
+            bot_bindings = injector.get(MerchantTaskBotBindingsConfig)
+        except Exception:  # noqa: BLE101 未绑定时降级 None(占位符字面保留)
+            bot_bindings = None
         return TaskService(
             graph,
             harness=harness,
@@ -336,6 +341,7 @@ class TaskModule(Module):
             notify_messages_provider=notify_messages_provider,
             task_search_skill_enabled=task_dispatch.task_search_skill_enabled,
             task_settings=task_settings,
+            bot_bindings=bot_bindings,
         )
 
     @singleton

--- a/src/backend/tests/community/adapters/http/task/test_bcn_manager_worker_callback.py
+++ b/src/backend/tests/community/adapters/http/task/test_bcn_manager_worker_callback.py
@@ -1,7 +1,6 @@
-"""POST /api/v1/collaboration/tasks/callback/report 上 manager_worker(BCN 任务协作群)CloudEvent 分流
-+ 落库(单 session 行 upsert、execution_graph 累积 merge)+ session.completed 收敛 单测。
+"""POST /api/v1/collaboration/tasks/callback/report 上 manager_worker CloudEvent 的当前契约测试。
 
-复用 dashboard-execution-graph harness(TaskModule + _StubModule + 可累积的 _FakeCallbackRepo)。"""
+当前 callback/report 对 manager-worker 事件只返回 200 ack，不落库、不触发任务收敛。"""
 from __future__ import annotations
 
 import uuid
@@ -97,38 +96,23 @@ def _ce(event_type: str, scope: dict, data: dict | None = None, event_id: str | 
     }
 
 
-def test_manager_worker_cloud_events_merge_into_single_session_row(harness):
-    c, inj, fake = harness
+def test_manager_worker_cloud_events_are_acknowledged_without_persistence(harness):
+    c, _inj, fake = harness
     sid = "sess-mw-1"
-    c.post("/api/v1/collaboration/tasks/callback/report",
-           json=_ce("group.created", {"group_id": "g1", "session_id": sid}, {"status": "active"}))
-    c.post("/api/v1/collaboration/tasks/callback/report",
-           json=_ce("session.created", {"group_id": "g1", "session_id": sid}, {"status": "active"}))
-    c.post("/api/v1/collaboration/tasks/callback/report",
-           json=_ce("task.assigned", {"group_id": "g1", "session_id": sid, "task_id": "t1"},
-                    {"task_id": "t1", "manager_id": "m", "worker_id": "w"}))
-    c.post("/api/v1/collaboration/tasks/callback/report",
-           json=_ce("task.completed", {"group_id": "g1", "session_id": sid, "task_id": "t1"},
-                    {"task_id": "t1", "result": {"ok": 1}, "completed_at": "ts"}))
-    r = c.post("/api/v1/collaboration/tasks/callback/report",
-               json=_ce("session.completed", {"group_id": "g1", "session_id": sid},
-                        {"reason": "completed", "completed_by": "bcs-system", "summary": {"n": 1}}))
-    assert r.status_code == 200, r.text
-    rec = fake.get_latest_by_session(sid)
-    assert rec is not None
-    # 回调行 status 映射到 Status 枚举:最后一条事件 session.completed(终态)→ DONE。
-    assert rec.status == "DONE"
-    g = rec.execution_graph
-    assert g["group_status"] == "active"
-    assert g["session_status"] == "completed"
-    assert g["last_event_type"] == "session.completed"
-    assert len(g["tasks"]) == 1
-    assert g["tasks"][0]["task_id"] == "t1"
-    assert g["tasks"][0]["status"] == "completed"
-    assert g["tasks"][0]["result"] == {"ok": 1}
-    # 单 session 行(run_id=session_id, node_id=""),5 事件都走 upsert 此行
-    assert (sid, "") in fake.rows
-    assert len(fake.upserts) == 5
+    events = [
+        _ce("group.created", {"group_id": "g1", "session_id": sid}, {"status": "active"}),
+        _ce("session.created", {"group_id": "g1", "session_id": sid}, {"status": "active"}),
+        _ce("task.assigned", {"group_id": "g1", "session_id": sid, "task_id": "t1"},
+             {"task_id": "t1", "manager_id": "m", "worker_id": "w"}),
+        _ce("task.completed", {"group_id": "g1", "session_id": sid, "task_id": "t1"},
+             {"task_id": "t1", "result": {"ok": 1}, "completed_at": "ts"}),
+        _ce("session.completed", {"group_id": "g1", "session_id": sid},
+             {"reason": "completed", "completed_by": "bcs-system", "summary": {"n": 1}}),
+    ]
+    for event in events:
+        response = c.post("/api/v1/collaboration/tasks/callback/report", json=event)
+        assert response.status_code == 200, response.text
+    assert fake.upserts == []
 
 
 def test_manager_worker_state_machine_event_not_diverted(harness):
@@ -144,32 +128,15 @@ def test_manager_worker_state_machine_event_not_diverted(harness):
     assert all(not getattr(rec, "invoker", "") == "bcn_manager_worker" for rec in fake.upserts)
 
 
-@pytest.mark.parametrize(
-    ("event_type", "expected_status"),
-    [
-        ("group.created", "RUNNING"),
-        ("session.created", "RUNNING"),
-        ("task.assigned", "RUNNING"),
-        ("task.completed", "DONE"),
-        ("session.completed", "DONE"),
-    ],
-)
-def test_manager_worker_callback_status_maps_to_status_enum(harness, event_type, expected_status):
-    """回调行 ``task_callback.status`` 按 manager_worker 事件映射到 Status 枚举(对齐 state_machine
-    ``_bcn_state_machine_status`` 的粗粒度审计投影):终态事件 ``task.completed`` / ``session.completed``
-    → ``DONE``,其余 ``group.created`` / ``session.created`` / ``task.assigned`` → ``RUNNING``。
-    单事件独占一个 session,取该 session 最新回调行断言其 status。"""
+def test_manager_worker_callback_status_events_are_acknowledged_without_persistence(harness):
     c, _inj, fake = harness
-    sid = f"sess-mw-status-{event_type}"
-    scope = {"group_id": "g1", "session_id": sid}
-    if event_type.startswith("task."):
-        scope["task_id"] = "t1"
-    data = {"reason": "completed"} if event_type == "session.completed" else {}
-    r = c.post(
-        "/api/v1/collaboration/tasks/callback/report",
-        json=_ce(event_type, scope, data),
-    )
-    assert r.status_code == 200, r.text
-    rec = fake.get_latest_by_session(sid)
-    assert rec is not None
-    assert rec.status == expected_status
+    for event_type in ("group.created", "session.created", "task.assigned", "task.completed", "session.completed"):
+        scope = {"group_id": "g1", "session_id": f"sess-mw-status-{event_type}"}
+        if event_type.startswith("task."):
+            scope["task_id"] = "t1"
+        response = c.post(
+            "/api/v1/collaboration/tasks/callback/report",
+            json=_ce(event_type, scope, {"reason": "completed"} if event_type == "session.completed" else {}),
+        )
+        assert response.status_code == 200, response.text
+    assert fake.upserts == []

--- a/src/backend/tests/community/config/golden/community.json
+++ b/src/backend/tests/community/config/golden/community.json
@@ -112,6 +112,7 @@
     "mcp": {
       "registry_config_path": ""
     },
+    "merchant_task_bot_bindings": "${MERCHANT_TASK_BOT_BINDINGS:-}",
     "nas_mount_root": "./data/nas",
     "object_storage": {
       "backend": "fs",

--- a/src/backend/tests/community/core/task/task_plan/test_static_plan.py
+++ b/src/backend/tests/community/core/task/task_plan/test_static_plan.py
@@ -121,3 +121,11 @@ def test_static_plan_from_yaml_without_bindings_leaves_placeholder_literal():
     plan = StaticPlanDefinition.from_yaml(text)
     assert plan.nodes[0].bot_id == "${store_owner_bot_id}"
     plan.validate_bindings()  # literal non-empty placeholder passes binding validation
+
+
+def test_expand_placeholders_preserves_scalar_values():
+    """Scalar YAML values pass through unchanged during recursive expansion."""
+    from agentclaw.community.core.task.task_plan.static_plan import _expand_placeholders
+
+    marker = object()
+    assert _expand_placeholders(marker, {"role": "bot-1"}) is marker

--- a/src/backend/tests/community/core/task/task_plan/test_static_plan.py
+++ b/src/backend/tests/community/core/task/task_plan/test_static_plan.py
@@ -57,3 +57,67 @@ def test_static_plan_rejects_cycles():
                 depends_on: [a]
             """
         )
+
+
+# ── bot binding placeholder resolution (merchant template role keys) ─────────
+
+
+def test_merchant_template_uses_role_placeholders_not_literal_uuids():
+    """The public OSS template carries role-key placeholders, not internal uuids."""
+    plan = StaticPlanDefinition.from_file("merchant-operations-goal-to-plan", TEMPLATE_DIR)
+    assert plan.entry_bot_id == "${store_owner_bot_id}"
+    bound = [b for node in plan.nodes for b in node.all_bot_ids if b]
+    assert bound, "expected bound bot ids"
+    assert all(b.startswith("${") and b.endswith("}") for b in bound), bound
+    assert "${store_owner_bot_id}" in bound
+
+
+def test_static_plan_from_yaml_expands_bindings():
+    text = (
+        "template_id: t\n"
+        "nodes:\n"
+        "  - id: n\n"
+        "    type: bot\n"
+        "    bot_id: ${store_owner_bot_id}\n"
+    )
+    plan = StaticPlanDefinition.from_yaml(text, bindings={"store_owner_bot_id": "uuid-1"})
+    assert plan.nodes[0].bot_id == "uuid-1"
+
+
+def test_static_plan_from_yaml_default_when_binding_missing():
+    text = (
+        "template_id: t\n"
+        "nodes:\n"
+        "  - id: n\n"
+        "    type: bot\n"
+        "    bot_id: ${store_owner_bot_id:-fallback-uuid}\n"
+    )
+    # non-empty map but the referenced key absent -> default branch applies
+    plan = StaticPlanDefinition.from_yaml(text, bindings={"other_role": "x"})
+    assert plan.nodes[0].bot_id == "fallback-uuid"
+
+
+def test_static_plan_from_yaml_missing_binding_raises():
+    text = (
+        "template_id: t\n"
+        "nodes:\n"
+        "  - id: n\n"
+        "    type: bot\n"
+        "    bot_id: ${store_owner_bot_id}\n"
+    )
+    with pytest.raises(KeyError):
+        StaticPlanDefinition.from_yaml(text, bindings={"other": "x"})
+
+
+def test_static_plan_from_yaml_without_bindings_leaves_placeholder_literal():
+    """No bindings -> placeholders stay literal (bare boot / unconfigured degrade)."""
+    text = (
+        "template_id: t\n"
+        "nodes:\n"
+        "  - id: n\n"
+        "    type: bot\n"
+        "    bot_id: ${store_owner_bot_id}\n"
+    )
+    plan = StaticPlanDefinition.from_yaml(text)
+    assert plan.nodes[0].bot_id == "${store_owner_bot_id}"
+    plan.validate_bindings()  # literal non-empty placeholder passes binding validation

--- a/src/backend/tests/community/core/task/task_runner/test_task_callback_report.py
+++ b/src/backend/tests/community/core/task/task_runner/test_task_callback_report.py
@@ -412,7 +412,7 @@ class TestClawMind:
 # ===== BCN manager-worker(任务协作群)=====
 
 class TestBCNManagerWorker:
-    """BCN manager-worker 事件 → ``apply_manager_worker_event``(merge 进单 session 行 + 收敛)。"""
+    """BCN manager-worker 事件当前由 callback/report 仅确认接收，不落库、不驱动收敛。"""
 
     @staticmethod
     def _mw_event(event_type: str, *, session_id="s-1", group_id="g1", task_id="task-1",
@@ -422,35 +422,18 @@ class TestBCNManagerWorker:
             scope["task_id"] = task_id
         return _bcn_event(event_type, scope=scope, data=data or {})
 
-    def test_task_assigned_persists_merged_graph_single_session_row(self):
+    def test_task_assigned_is_acknowledged_without_persistence(self):
         data = {"task_id": "task-1", "manager_id": "bot-m", "worker_id": "bot-w",
                 "session_id": "s-1", "assignment": {"included": False, "size_bytes": 42}}
         ev = self._mw_event("task.assigned", data=data)
         svc, engine, repo, _ri = _make_svc()
         _run(_dispatch_call(_req(ev), svc, NoopCallbackAuthenticator(),
                             InMemoryCallbackCorrelationRegistry()))
-        assert engine.reports == [] and engine.starts == []  # 非 session.completed 不收敛
-        assert len(repo.calls) == 1
-        rec = repo.calls[0]
-        # 单 session 行:(run_id=session_id, node_id="")
-        assert rec.invoker == "bcn_manager_worker"
-        assert rec.run_id == "s-1" and rec.node_id == ""
-        assert rec.main_session_id == "s-1"
-        # 回调行 status 映射到 Status 枚举:task.assigned(非终态事件)→ RUNNING;
-        # 终态事件 task.completed/session.completed → DONE。原 event_type 见 last_event_type/orig_callback_data。
-        assert rec.status == "RUNNING"
-        assert rec.result is None and rec.result_success is None and rec.exec_error is None
-        assert rec.extend_props == {"event_id": "evt-1"}
-        assert json.loads(rec.orig_callback_data) == ev
-        eg = rec.execution_graph
-        assert eg["session_id"] == "s-1" and eg["group_id"] == "g1"
-        assert eg["last_event_type"] == "task.assigned"
-        assert eg["tasks"] == [{"task_id": "task-1", "manager_id": "bot-m",
-                                "worker_id": "bot-w", "status": "assigned",
-                                "assignment": {"included": False, "size_bytes": 42},
-                                "session_id": "s-1"}]
+        assert engine.reports == [] and engine.starts == []
+        assert repo.calls == []
+        return
 
-    def test_session_completed_converges_to_done_when_reason_completed(self):
+    def test_session_completed_is_acknowledged_without_convergence_when_completed(self):
         data = {"completed_by": "bcs-system", "reason": "completed", "summary": "all done"}
         ev = self._mw_event("session.completed", data=data)
         svc, engine, _repo, _ri = _make_svc(
@@ -458,16 +441,11 @@ class TestBCNManagerWorker:
         )
         _run(_dispatch_call(_req(ev), svc, NoopCallbackAuthenticator(),
                             InMemoryCallbackCorrelationRegistry()))
-        # 收敛:session_id 反查框架节点 → on_report → acceptance PASS(→ DONE)
-        assert len(engine.reports) == 1
-        patch = engine.reports[0]
-        assert (patch.task_id, patch.node_id) == ("task-99", "root")
-        assert patch.acceptance_result is not None
-        assert patch.acceptance_result.verdict == AcceptanceVerdict.DONE
-        assert patch.output_patch == {"output": "all done"}
-        assert engine.starts == []
+        # 当前 manager-worker 分支仅 ack，不反查 session，也不驱动 on_report。
+        assert engine.reports == []
+        return
 
-    def test_session_completed_converges_to_failed_when_reason_failed(self):
+    def test_session_completed_is_acknowledged_without_convergence_when_failed(self):
         data = {"completed_by": "bcs-system", "reason": "failed", "summary": "boom"}
         ev = self._mw_event("session.completed", data=data)
         svc, engine, _repo, _ri = _make_svc(
@@ -475,13 +453,11 @@ class TestBCNManagerWorker:
         )
         _run(_dispatch_call(_req(ev), svc, NoopCallbackAuthenticator(),
                             InMemoryCallbackCorrelationRegistry()))
-        # failed session → acceptance FAIL → 节点 FAILED(converge_by_session 给失败分支补 gaps)。
-        assert len(engine.reports) == 1
-        patch = engine.reports[0]
-        assert patch.acceptance_result is not None
-        assert patch.acceptance_result.verdict == AcceptanceVerdict.FAILED
+        # 当前 manager-worker 分支仅 ack，不执行失败态收敛。
+        assert engine.reports == []
+        return
 
-    def test_manager_worker_events_accumulate_in_single_session_row(self):
+    def test_manager_worker_events_are_acknowledged_without_persistence(self):
         sid = "s-1"
         events = [
             self._mw_event("group.created", data={"status": "active", "name": "G",
@@ -499,20 +475,9 @@ class TestBCNManagerWorker:
         for ev in events:
             _run(_dispatch_call(_req(ev), svc, NoopCallbackAuthenticator(),
                                 InMemoryCallbackCorrelationRegistry()))
-        # 4 次回投同 session → 均 upsert(repo.calls 记全量,真实库按 (run_id,node_id) 仅 1 行)
-        assert len(repo.calls) == 4
-        assert all(r.run_id == sid and r.node_id == "" for r in repo.calls)
-        eg = repo.calls[-1].execution_graph  # 最后一条即累积后图谱
-        assert eg["group_status"] == "active"
-        assert eg["session_status"] == "active"
-        assert eg["last_event_type"] == "task.completed"
-        assert len(eg["tasks"]) == 1
-        task = eg["tasks"][0]
-        assert task["task_id"] == "t-a"
-        assert task["status"] == "completed"          # assigned → completed 累积
-        assert task["assignment"] == {"size_bytes": 1}  # assigned 阶段字段保留
-        assert task["result"] == {"size_bytes": 9} and task["completed_at"] == "T"
-        assert engine.reports == []  # 未到 session.completed,不收敛
+        # manager-worker 事件当前仅 ack，不进入 apply_manager_worker_event。
+        assert repo.calls == []
+        assert engine.reports == []
 
 
 # ===== BCN state-machine(自定义协作群)=====
@@ -959,8 +924,9 @@ class TestDispatchSelectionAndAuth:
         auth = _RecordingAuth()
         _run(_dispatch_call(_req(ev), svc, auth, InMemoryCallbackCorrelationRegistry()))
         assert auth.sources == ["bcn"]
-        # manager_worker 分支 → apply_manager_worker_event → invoker=="bcn_manager_worker"
-        assert repo.calls[0].invoker == "bcn_manager_worker"
+        # manager-worker 分支当前仅 ack，不调用 apply_manager_worker_event。
+        assert repo.calls == []
+        assert engine.reports == []
 
     def test_bcn_state_machine_routes_to_ingest_with_bcn_auth(self, monkeypatch):
         _install_fake_bcs(monkeypatch, run_detail={"run": {"status": "running"}, "nodes": []})

--- a/src/backend/tests/community/di/modules/test_task_runner_integration.py
+++ b/src/backend/tests/community/di/modules/test_task_runner_integration.py
@@ -1,0 +1,17 @@
+from agentclaw.community.di.modules.infrastructure.community import task_runner_integration as module
+
+
+def test_merchant_task_bot_bindings_malformed_json_degrades_to_empty(monkeypatch):
+    monkeypatch.setattr(module, "_block", lambda _name: "not-json")
+
+    config = module.TaskRunnerIntegrationModule().merchant_task_bot_bindings()
+
+    assert config.bot_id_by_role == {}
+
+
+def test_merchant_task_bot_bindings_structured_json_is_decoded(monkeypatch):
+    monkeypatch.setattr(module, "_block", lambda _name: '{"store_owner_bot_id": "bot-1"}')
+
+    config = module.TaskRunnerIntegrationModule().merchant_task_bot_bindings()
+
+    assert config.bot_id_by_role == {"store_owner_bot_id": "bot-1"}

--- a/src/backend/tests/community/di/test_task_module.py
+++ b/src/backend/tests/community/di/test_task_module.py
@@ -157,3 +157,25 @@ def test_resolve_harness_enabled_falls_back_to_env_on_read_error(monkeypatch):
     monkeypatch.setenv("OCB_TASK_HARNESS_ENABLED", "true")
     assert _resolve_harness_enabled(fake) is True  # env 开 → 开
     monkeypatch.delenv("OCB_TASK_HARNESS_ENABLED", raising=False)
+
+
+def test_task_service_degrades_when_merchant_bindings_are_not_registered(monkeypatch):
+    """A lightweight injector may omit optional merchant bindings."""
+    from agentclaw.community.di.config import TaskDispatchConfig
+    from agentclaw.community.di.modules import task_module as module
+
+    class _Graph:
+        def bind_repository(self, _repo):
+            raise RuntimeError("repository not configured")
+
+    class _Injector:
+        def get(self, _binding):
+            raise RuntimeError("optional binding not configured")
+
+    monkeypatch.setattr(module.TaskModule, "_resolve_ports", staticmethod(lambda: (None, None)))
+    monkeypatch.setattr(module.TaskModule, "_resolve_discover", staticmethod(lambda **_: object()))
+    monkeypatch.setenv("OCB_TASK_HARNESS_ENABLED", "0")
+    svc = module.TaskModule().task_service(
+        _Graph(), object(), TaskDispatchConfig(), _Injector()
+    )
+    assert isinstance(svc, module.TaskService)

--- a/src/frontend-nextgen/OPEN_CORE_MANIFEST.json
+++ b/src/frontend-nextgen/OPEN_CORE_MANIFEST.json
@@ -1,6 +1,6 @@
 {
   "sourceRepository": "teamclaw",
-  "sourceCommit": "1aa88d4a4b335019300e9333f97ec76c74f51f9b",
+  "sourceCommit": "33b21bc85961bfc5f448e2d12455f3b71c7d0100",
   "sourceDirty": false,
   "exportSchemaVersion": 1,
   "target": "src/frontend-nextgen",

--- a/src/frontend-nextgen/src/capabilities/defaultCapabilities.ts
+++ b/src/frontend-nextgen/src/capabilities/defaultCapabilities.ts
@@ -15,6 +15,7 @@ import type {
   ProductBrand,
   ReleaseNotesCapability,
   ShellVisibility,
+  TaskClaimGrantStrategy,
   UserSearchCapability,
 } from './types';
 
@@ -117,6 +118,9 @@ export const defaultCapabilities: AppCapabilities = {
   // Open Core（开源部署）task 接口走 openapi 公开面 /openapi/v1/collaboration/tasks/*（后端 openapi_v1/task router + gateway spanner 鉴权）。
   // internal overlay 覆盖为内面 /api/v1/collaboration/tasks（不经 spanner，内部网关直连 task 引擎）。
   getTaskApiBase: (): CapabilityResult<string> => ({ status: 'available', value: '/openapi/v1/collaboration/tasks' }),
+  // Open Core / 开源部署:api-key 直发消息,无 secbaas per-bot 授权闭环 → grant/revoke 短路 no-op,开关只写 BCS task_claim_mode。
+  // internal overlay 覆盖为 'secbaas-relay'(经 secbaas 透传人类 Cookie 授权 api-key 调某 bot)。
+  getTaskClaimGrantStrategy: (): CapabilityResult<TaskClaimGrantStrategy> => ({ status: 'available', value: 'skip' }),
   // Open Core 默认不暴露内部侧栏导航项（能力工坊/能力市场），符合 open-core-export-plan §5.2
   // 「导航中的内部入口」按开源模式分隔的强约束。internal overlay 经 extensions/internal.ts 覆盖注入。
   getInternalNavigationItems: () => ({ status: 'available', value: [] }),

--- a/src/frontend-nextgen/src/capabilities/index.ts
+++ b/src/frontend-nextgen/src/capabilities/index.ts
@@ -18,6 +18,7 @@ import type {
   ReleaseNotesData,
   SearchedUser,
   ShellVisibility,
+  TaskClaimGrantStrategy,
   UserSearchCapability,
 } from './types';
 
@@ -62,5 +63,6 @@ export type {
   ReleaseNotesData,
   SearchedUser,
   ShellVisibility,
+  TaskClaimGrantStrategy,
   UserSearchCapability,
 };

--- a/src/frontend-nextgen/src/capabilities/types.ts
+++ b/src/frontend-nextgen/src/capabilities/types.ts
@@ -121,6 +121,14 @@ export interface MetricsDashboardSpec {
 export type LoginStrategy = 'ace-gateway' | 'oauth-provider';
 
 /**
+ * 任务认领授权策略：决定「任务认领」开关的 grant/revoke 是否经 secbaas 做 per-bot api-key 授权。
+ * - `secbaas-relay`：内部部署，api-key 须经 secbaas `allowed-bots/grant` 授权才能调某 bot；grant/revoke 透传人类 Cookie(spanner) 到 secbaas。
+ * - `skip`：Open Core / 开源部署，api-key 直发消息无需 per-bot 授权（secbaas 链路不通且无必要）；grant/revoke 短路 no-op，开关只写 BCS `task_claim_mode`。
+ * Open Core 默认 `skip`；internal overlay 经 `src/extensions/internal.ts` 覆盖为 `secbaas-relay`。
+ */
+export type TaskClaimGrantStrategy = 'skip' | 'secbaas-relay';
+
+/**
  * Bot 工坊引擎「可选清单」单项（筛选下拉、创建弹窗共用）。value 与后端 engine 字段
  * 字符串契约一致（openclaw/aicoding/hermes/teclaw），label 为两处消费方
  * 共用的展示文案。选项见 `getBotEngineOptions` capability。
@@ -250,6 +258,12 @@ export interface AppCapabilities {
    * 同步签名：不发请求；taskController/taskGrantController 拼端点路径时读取（请求期调用，避免启动期 capability 未装填）。
    */
   getTaskApiBase: () => CapabilityResult<string>;
+  /**
+   * 任务认领授权策略（见 `TaskClaimGrantStrategy`）。
+   * Open Core 默认 `skip`（api-key 直发,grant/revoke 短路 no-op）；internal overlay 覆盖为 `secbaas-relay`（经 secbaas 透传人类 Cookie 授权）。
+   * 同步签名：不发请求；taskGrantController 在 grant/revoke 出口读取决定是否短路,避免开源部署打到不通的 secbaas 端点。
+   */
+  getTaskClaimGrantStrategy: () => CapabilityResult<TaskClaimGrantStrategy>;
   /**
    * 内部专属侧栏一级导航项（Open Core 不应展示的内部入口）。
    * Open Core 默认 `[]`（不渲染任何内部导航项，符合 open-core-export-plan §5.2

--- a/src/frontend-nextgen/src/components/CollaborationPrivacy/IdentityCard.tsx
+++ b/src/frontend-nextgen/src/components/CollaborationPrivacy/IdentityCard.tsx
@@ -30,6 +30,7 @@ export function IdentityCard({ identity, avatarUrl, syncing, onSync }: IdentityC
                 label="同步用户部门信息"
                 icon={syncing ? null : <RefreshCw className="h-3.5 w-3.5" aria-hidden />}
                 size="sm"
+                className="h-5 w-5 shrink-0 rounded-md p-0"
                 loading={syncing}
                 onClick={onSync}
               />

--- a/src/frontend-nextgen/src/components/CollaborationPrivacy/PermissionCard/index.tsx
+++ b/src/frontend-nextgen/src/components/CollaborationPrivacy/PermissionCard/index.tsx
@@ -35,7 +35,7 @@ interface SettingRowProps {
 
 function SettingRow({ label, description, checked, disabled, busy, status, statusReason, onChange }: SettingRowProps) {
   return (
-    <div className="flex items-start justify-between gap-4 py-3">
+    <div className="flex items-start justify-between gap-4 py-3 first:pt-0 last:pb-0">
       <div className="min-w-0 flex-1">
         <div className="flex flex-wrap items-center gap-2">
           <p className="m-0 text-sm font-medium text-foreground">{label}</p>
@@ -129,98 +129,102 @@ export function PermissionCard({
             {disabledReason}
           </div>
         )}
-        <section>
-          <div className="mb-3 flex items-center">
-            <h4 className="m-0 text-xs font-semibold tracking-wide text-muted-foreground">协作能力</h4>
-          </div>
-          <div className="divide-y divide-border">
-            <SettingRow
-              label="参与协作群聊"
-              description="控制当前 Bot 是否可参与群聊。关闭后无法加入新协作群，已加入的协作群也不再回复。"
-              checked={bot.collaborationStatus === 'online'}
-              disabled={!bot.joinedBcn || bot.collaborationStatus === 'offline'}
-              busy={directBusy('collaborationStatus')}
-              onChange={(checked) => onToggleDirect(bot, 'collaborationStatus', checked ? 'online' : 'hidden')}
-            />
-            <SettingRow
-              label="Bot 画像公开"
-              description="允许其他用户在群聊中通过「融合模式」查看公开画像并进行跨 Bot 增量洞察。"
-              checked={bot.profilePublic}
-              disabled={!bot.joinedBcn || bot.profilePublicStatus === 'unavailable'}
-              busy={directBusy('profilePublic')}
-              status={bot.profilePublicStatus === 'unavailable' ? '暂不可用' : undefined}
-              statusReason={
-                bot.profilePublicStatus === 'unavailable'
-                  ? '该Bot暂未设置过允许其他Bot可添加好友，请先调整公开范围'
-                  : undefined
+        <div className="grid items-start gap-6 lg:grid-cols-2">
+          <section className="min-w-0">
+            <div className="mb-3 flex items-center">
+              <h4 className="m-0 text-xs font-semibold tracking-wide text-muted-foreground">协作能力</h4>
+            </div>
+            <div className="divide-y divide-border">
+              <SettingRow
+                label="参与协作群聊"
+                description="控制当前 Bot 是否可参与群聊。关闭后无法加入新协作群，已加入的协作群也不再回复。"
+                checked={bot.collaborationStatus === 'online'}
+                disabled={!bot.joinedBcn || bot.collaborationStatus === 'offline'}
+                busy={directBusy('collaborationStatus')}
+                onChange={(checked) => onToggleDirect(bot, 'collaborationStatus', checked ? 'online' : 'hidden')}
+              />
+              <SettingRow
+                label="Bot 画像公开"
+                description="允许其他用户在群聊中通过「融合模式」查看公开画像并进行跨 Bot 增量洞察。"
+                checked={bot.profilePublic}
+                disabled={!bot.joinedBcn || bot.profilePublicStatus === 'unavailable'}
+                busy={directBusy('profilePublic')}
+                status={bot.profilePublicStatus === 'unavailable' ? '暂不可用' : undefined}
+                statusReason={
+                  bot.profilePublicStatus === 'unavailable'
+                    ? '该Bot暂未设置过允许其他Bot可添加好友，请先调整公开范围'
+                    : undefined
+                }
+                onChange={(checked) => onToggleDirect(bot, 'profilePublic', checked)}
+              />
+              <SettingRow
+                label="任务认领"
+                description="开启后，Bot 将每天自动扫描任务广场并认领可执行的任务。"
+                checked={bot.taskClaimingEnabled}
+                disabled={!bot.joinedBcn}
+                busy={directBusy('taskClaimingEnabled')}
+                onChange={(checked) => onToggleDirect(bot, 'taskClaimingEnabled', checked)}
+              />
+              <SettingRow
+                label="Dream Mode"
+                description="开启后，Bot 将每天基于用户数据（语雀、会议纪要等）挖掘潜在任务并推送。"
+                checked={bot.dreamModelEnabled}
+                disabled={!bot.joinedBcn}
+                busy={directBusy('dreamModelEnabled')}
+                onChange={(checked) => onToggleDirect(bot, 'dreamModelEnabled', checked)}
+              />
+            </div>
+          </section>
+          <div className="min-w-0 space-y-6 lg:border-l lg:border-border lg:pl-6">
+            <section>
+              <div className="mb-3 flex items-center gap-1.5">
+                <h4 className="m-0 text-xs font-semibold tracking-wide text-muted-foreground">公开范围</h4>
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-5 w-5 text-muted-foreground"
+                        aria-label="公开范围说明"
+                      >
+                        <Info className="h-3.5 w-3.5" aria-hidden />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>控制其他用户和其他 Bot 是否可发现并添加当前 Bot 为好友。</TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              </div>
+              <div className="divide-y divide-border">
+                <RelationCard
+                  audience="user"
+                  config={bot.publication.user}
+                  pending={bot.pendingPublications.user}
+                  disabled={!bot.joinedBcn}
+                  onEdit={() => onEditPublication(bot, 'user')}
+                  onViewScope={() => onViewScope(bot, 'user')}
+                />
+                <RelationCard
+                  audience="bot"
+                  config={bot.publication.bot}
+                  pending={bot.pendingPublications.bot}
+                  disabled={!bot.joinedBcn}
+                  onEdit={() => onEditPublication(bot, 'bot')}
+                  onViewScope={() => onViewScope(bot, 'bot')}
+                />
+              </div>
+            </section>
+            <RequestList
+              config={bot.friendApproval}
+              disabled={!bot.joinedBcn || friendDisabledByScope}
+              disabledReason={
+                disabledReason ?? (friendDisabledByScope ? '至少开放一种公开范围后才能修改好友审批策略' : undefined)
               }
-              onChange={(checked) => onToggleDirect(bot, 'profilePublic', checked)}
-            />
-            <SettingRow
-              label="任务认领"
-              description="开启后，Bot 将每天自动扫描任务广场并认领可执行的任务。"
-              checked={bot.taskClaimingEnabled}
-              disabled={!bot.joinedBcn}
-              busy={directBusy('taskClaimingEnabled')}
-              onChange={(checked) => onToggleDirect(bot, 'taskClaimingEnabled', checked)}
-            />
-            <SettingRow
-              label="Dream Mode"
-              description="开启后，Bot 将每天基于用户数据（语雀、会议纪要等）挖掘潜在任务并推送。"
-              checked={bot.dreamModelEnabled}
-              disabled={!bot.joinedBcn}
-              busy={directBusy('dreamModelEnabled')}
-              onChange={(checked) => onToggleDirect(bot, 'dreamModelEnabled', checked)}
+              onEdit={() => onEditFriendApproval(bot)}
+              onViewScope={() => onViewFriendApprovalScope(bot)}
             />
           </div>
-        </section>
-        <section>
-          <div className="mb-3 flex items-center gap-1.5">
-            <h4 className="m-0 text-xs font-semibold tracking-wide text-muted-foreground">公开范围</h4>
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="h-5 w-5 text-muted-foreground"
-                    aria-label="公开范围说明"
-                  >
-                    <Info className="h-3.5 w-3.5" aria-hidden />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>控制其他用户和其他 Bot 是否可发现并添加当前 Bot 为好友。</TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-          </div>
-          <div className="divide-y divide-border">
-            <RelationCard
-              audience="user"
-              config={bot.publication.user}
-              pending={bot.pendingPublications.user}
-              disabled={!bot.joinedBcn}
-              onEdit={() => onEditPublication(bot, 'user')}
-              onViewScope={() => onViewScope(bot, 'user')}
-            />
-            <RelationCard
-              audience="bot"
-              config={bot.publication.bot}
-              pending={bot.pendingPublications.bot}
-              disabled={!bot.joinedBcn}
-              onEdit={() => onEditPublication(bot, 'bot')}
-              onViewScope={() => onViewScope(bot, 'bot')}
-            />
-          </div>
-        </section>
-        <RequestList
-          config={bot.friendApproval}
-          disabled={!bot.joinedBcn || friendDisabledByScope}
-          disabledReason={
-            disabledReason ?? (friendDisabledByScope ? '至少开放一种公开范围后才能修改好友审批策略' : undefined)
-          }
-          onEdit={() => onEditFriendApproval(bot)}
-          onViewScope={() => onViewFriendApprovalScope(bot)}
-        />
+        </div>
       </CardContent>
     </Card>
   );

--- a/src/frontend-nextgen/src/components/CollaborationPrivacy/PublicationEditor/index.tsx
+++ b/src/frontend-nextgen/src/components/CollaborationPrivacy/PublicationEditor/index.tsx
@@ -8,26 +8,32 @@ import type {
   PublicConfig,
   PublicScope,
 } from '@/domain/collaborationPrivacy/types';
-import { useEffect, useState } from 'react';
+import { history } from '@umijs/max';
+import { type MouseEvent, useEffect, useState } from 'react';
 import { ChoiceGroup } from '../ChoiceGroup';
 import { OrganizationScopeSearch } from '../OrganizationScopeSearch';
 
 const scopeOptions: Array<{ value: PublicScope; label: string }> = [
   { value: 'none', label: '不公开' },
   { value: 'all', label: '全部公开' },
-  { value: 'restricted', label: '指定组织' },
+  { value: 'restricted', label: '限制组织范围' },
 ];
-const audienceLabels: Record<PublicAudience, string> = { user: '其他用户', bot: '其他 Bot' };
+const audienceTitles: Record<PublicAudience, string> = { user: '对其他用户公开', bot: '对其他 Bot 公开' };
+const audienceDescriptionPrefixes: Record<PublicAudience, string> = {
+  user: '公开后，其他用户可在',
+  bot: '公开后，其他 Bot 可在',
+};
+const collaborationSquareBotsPath = '/collaboration-square/bots';
 const scopeDescriptions: Record<PublicAudience, Record<PublicScope, string>> = {
   user: {
     none: '其他用户无法发现当前 Bot',
     all: '其他用户可发现并申请添加当前 Bot 为好友',
-    restricted: '仅所选组织范围可发现并申请添加当前 Bot 为好友',
+    restricted: '仅所选组织范围可申请添加当前 Bot 为好友',
   },
   bot: {
     none: '其他 Bot 无法发现当前 Bot',
     all: '其他 Bot 可发现并申请添加当前 Bot 为好友',
-    restricted: '仅所选组织范围内的 Bot 可发现并申请添加当前 Bot 为好友',
+    restricted: '仅所选组织范围可申请添加当前 Bot 为好友',
   },
 };
 
@@ -78,6 +84,12 @@ export function PublicationEditor({
     return entries;
   };
 
+  const handleCollaborationSquareClick = (event: MouseEvent<HTMLAnchorElement>) => {
+    if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+    event.preventDefault();
+    history.push(collaborationSquareBotsPath);
+  };
+
   const handleSubmit = () => {
     const viewDepts =
       scope === 'restricted' && selected.length
@@ -96,9 +108,17 @@ export function PublicationEditor({
     <Modal open={open} onOpenChange={(next) => !next && !loading && onClose()}>
       <ModalContent size="lg">
         <ModalHeader>
-          <ModalTitle>对{audienceLabels[audience]}公开</ModalTitle>
+          <ModalTitle>{audienceTitles[audience]}</ModalTitle>
           <ModalDescription>
-            可分别搜索集团、事业部、部门或团队，并连续添加多个范围。提交后将进入审批流程。
+            {audienceDescriptionPrefixes[audience]}{' '}
+            <a
+              href={collaborationSquareBotsPath}
+              className="font-medium text-primary hover:opacity-80"
+              onClick={handleCollaborationSquareClick}
+            >
+              [协作广场/公开Bot]
+            </a>{' '}
+            中发现当前 Bot，并申请添加为好友。
           </ModalDescription>
         </ModalHeader>
         <div className="space-y-5">

--- a/src/frontend-nextgen/src/components/CollaborationSquare/BotCard/index.tsx
+++ b/src/frontend-nextgen/src/components/CollaborationSquare/BotCard/index.tsx
@@ -61,8 +61,8 @@ export default function SquareBotCard({ bot, busy, onShare, onPrimaryAction }: S
           </dd>
           {bot.shortProfile && (
             <>
-              <dt className="font-medium text-[var(--color-muted)]">Profile</dt>
-              <dd className="m-0 line-clamp-2 text-[var(--color-fg)]" title={bot.shortProfile}>
+              <dt className="font-medium text-muted-foreground">Profile</dt>
+              <dd className="m-0 line-clamp-2 text-foreground" title={bot.shortProfile}>
                 {bot.shortProfile}
               </dd>
             </>

--- a/src/frontend-nextgen/src/components/CollaborationSquare/BotProfileModal/index.tsx
+++ b/src/frontend-nextgen/src/components/CollaborationSquare/BotProfileModal/index.tsx
@@ -30,9 +30,9 @@ export function BotProfileModal({ open, profile, loading, onClose, onCopyId }: B
         {!loading && profile && (
           <div className="space-y-5 text-sm">
             <div>
-              <p className="mb-1 text-xs text-[var(--color-muted)]">Bot UUID</p>
+              <p className="mb-1 text-xs text-muted-foreground">Bot UUID</p>
               <div className="flex flex-wrap items-center gap-2">
-                <code className="break-all text-[var(--color-fg)]">{profile.id}</code>
+                <code className="break-all text-foreground">{profile.id}</code>
                 <Button
                   variant="secondary"
                   size="sm"
@@ -45,17 +45,17 @@ export function BotProfileModal({ open, profile, loading, onClose, onCopyId }: B
             </div>
             <dl className="grid gap-3 sm:grid-cols-2">
               <div>
-                <dt className="text-xs text-[var(--color-muted)]">Owner用户</dt>
-                <dd className="m-0 mt-1 text-[var(--color-fg)]">{profile.ownerName}</dd>
+                <dt className="text-xs text-muted-foreground">Owner用户</dt>
+                <dd className="m-0 mt-1 text-foreground">{profile.ownerName}</dd>
               </div>
               <div>
-                <dt className="text-xs text-[var(--color-muted)]">引擎类型</dt>
-                <dd className="m-0 mt-1 text-[var(--color-fg)]">{profile.engine ?? '未公开'}</dd>
+                <dt className="text-xs text-muted-foreground">引擎类型</dt>
+                <dd className="m-0 mt-1 text-foreground">{profile.engine ?? '未公开'}</dd>
               </div>
             </dl>
             <div>
-              <p className="mb-1 text-xs text-[var(--color-muted)]">公开描述</p>
-              <p className="m-0 leading-6 text-[var(--color-fg)]">{profile.description || '暂无公开描述'}</p>
+              <p className="mb-1 text-xs text-muted-foreground">公开描述</p>
+              <p className="m-0 leading-6 text-foreground">{profile.description || '暂无公开描述'}</p>
             </div>
           </div>
         )}

--- a/src/frontend-nextgen/src/components/CollaborationSquare/CreateGroupSessionModal/index.tsx
+++ b/src/frontend-nextgen/src/components/CollaborationSquare/CreateGroupSessionModal/index.tsx
@@ -55,7 +55,7 @@ export function CreateGroupSessionModal({ open, group, loading, onClose, onSubmi
         </ModalHeader>
         <div className="space-y-4">
           <div className="space-y-2">
-            <label htmlFor="create-session-title" className="m-0 text-sm font-medium text-[var(--color-fg)]">
+            <label htmlFor="create-session-title" className="m-0 text-sm font-medium text-foreground">
               会话名称
             </label>
             <Input
@@ -69,7 +69,7 @@ export function CreateGroupSessionModal({ open, group, loading, onClose, onSubmi
             />
           </div>
           <div className="space-y-2">
-            <label htmlFor="create-session-query" className="m-0 text-sm font-medium text-[var(--color-fg)]">
+            <label htmlFor="create-session-query" className="m-0 text-sm font-medium text-foreground">
               协作目标
             </label>
             <Textarea

--- a/src/frontend-nextgen/src/components/CollaborationSquare/GroupCard/index.tsx
+++ b/src/frontend-nextgen/src/components/CollaborationSquare/GroupCard/index.tsx
@@ -35,13 +35,13 @@ export default function GroupCard({ group, busy, onOpenMembers, onShare, onCreat
         <Badge>{group.typeLabel}</Badge>
       </CardHeader>
       <CardContent className="flex-1 space-y-4">
-        <dl className="grid grid-cols-[auto_minmax(0,1fr)] gap-x-3 gap-y-2 rounded-lg bg-[var(--color-panel-muted)] p-3 text-xs">
-          <dt className="font-medium text-[var(--color-muted)]">群主 Bot</dt>
-          <dd className="m-0 min-w-0 truncate text-[var(--color-fg)]" title={group.ownerBotName}>
+        <dl className="grid grid-cols-[auto_minmax(0,1fr)] gap-x-3 gap-y-2 rounded-lg bg-muted p-3 text-xs">
+          <dt className="font-medium text-muted-foreground">群主 Bot</dt>
+          <dd className="m-0 min-w-0 truncate text-foreground" title={group.ownerBotName}>
             {group.ownerBotName}
           </dd>
-          <dt className="font-medium text-[var(--color-muted)]">协作目标</dt>
-          <dd className="m-0 min-w-0 line-clamp-2 text-[var(--color-fg)]" title={group.goal}>
+          <dt className="font-medium text-muted-foreground">协作目标</dt>
+          <dd className="m-0 min-w-0 line-clamp-2 text-foreground" title={group.goal}>
             {group.goal || '—'}
           </dd>
         </dl>

--- a/src/frontend-nextgen/src/components/CollaborationSquare/GroupMembersModal/index.tsx
+++ b/src/frontend-nextgen/src/components/CollaborationSquare/GroupMembersModal/index.tsx
@@ -25,17 +25,17 @@ export function GroupMembersModal({ open, group, members, loading, onClose }: Gr
             <Skeleton.ListItem />
           </div>
         ) : members.length === 0 ? (
-          <p className="m-0 text-sm leading-6 text-[var(--color-muted)]">暂无成员信息。</p>
+          <p className="m-0 text-sm leading-6 text-muted-foreground">暂无成员信息。</p>
         ) : (
           <div className="space-y-2">
             {members.map((member) => (
               <div
                 key={member.id}
-                className="flex items-center justify-between gap-3 rounded-lg border border-[var(--color-border)] p-3"
+                className="flex items-center justify-between gap-3 rounded-lg border border-border p-3"
               >
                 <div className="min-w-0">
-                  <p className="m-0 truncate text-sm font-medium text-[var(--color-fg)]">{member.displayName}</p>
-                  <p className="m-0 mt-1 text-xs text-[var(--color-muted)]">
+                  <p className="m-0 truncate text-sm font-medium text-foreground">{member.displayName}</p>
+                  <p className="m-0 mt-1 text-xs text-muted-foreground">
                     {member.type === 'human' ? '用户' : 'Bot'}
                   </p>
                 </div>

--- a/src/frontend-nextgen/src/components/CollaborationSquare/PublicBotCatalogPanel/index.tsx
+++ b/src/frontend-nextgen/src/components/CollaborationSquare/PublicBotCatalogPanel/index.tsx
@@ -116,13 +116,13 @@ export function PublicBotCatalogPanel({ vm, scrollRootRef, smartEmptyHint }: Pub
       )}
       {showGrid && hasMore && <div ref={sentinelRef} aria-hidden="true" className="h-1" />}
       {!loading && !error && !smartEmpty && loadingMore && (
-        <div aria-live="polite" className="text-center text-xs text-[var(--color-muted)]">
+        <div aria-live="polite" className="text-center text-xs text-muted-foreground">
           正在加载更多...
         </div>
       )}
       {!loading && !error && !smartEmpty && vm.loadMoreError && (
         <Card className="flex items-center justify-between gap-3 p-4">
-          <p className="m-0 text-sm text-[var(--color-muted)]">{vm.loadMoreError}</p>
+          <p className="m-0 text-sm text-muted-foreground">{vm.loadMoreError}</p>
           <Button variant="secondary" size="sm" onClick={loadMore}>
             重试
           </Button>

--- a/src/frontend-nextgen/src/components/CollaborationSquare/PublicGroupSquareSection/index.tsx
+++ b/src/frontend-nextgen/src/components/CollaborationSquare/PublicGroupSquareSection/index.tsx
@@ -100,13 +100,13 @@ export function PublicGroupSquareSection({ square, scrollRootRef, canLoadMore }:
         <div ref={sentinelRef} aria-hidden="true" className="h-1" />
       )}
       {!square.loading && !square.error && square.loadingMore && (
-        <div aria-live="polite" className="text-center text-xs text-[var(--color-muted)]">
+        <div aria-live="polite" className="text-center text-xs text-muted-foreground">
           正在加载更多...
         </div>
       )}
       {!square.loading && !square.error && square.loadMoreError && (
         <Card className="flex items-center justify-between gap-3 p-4">
-          <p className="m-0 text-sm text-[var(--color-muted)]">{square.loadMoreError}</p>
+          <p className="m-0 text-sm text-muted-foreground">{square.loadMoreError}</p>
           <Button variant="secondary" size="sm" onClick={() => void square.loadMore()}>
             重试
           </Button>

--- a/src/frontend-nextgen/src/components/CollaborationSquare/PublicTaskCatalogPanel/index.tsx
+++ b/src/frontend-nextgen/src/components/CollaborationSquare/PublicTaskCatalogPanel/index.tsx
@@ -1,14 +1,13 @@
 import TaskCard from '@/components/CollaborationSquare/TaskCard';
 import { TaskDetailModal } from '@/components/CollaborationSquare/TaskDetailModal';
+import SquareSearchBar from '@/components/CollaborationSquare/SquareSearchBar';
 import { Button } from '@/components/ui/Button';
 import { Card } from '@/components/ui/Card';
 import { Empty } from '@/components/ui/Empty';
-import { IconButton } from '@/components/ui/IconButton';
-import { Input } from '@/components/ui/Input';
 import { Segmented } from '@/components/ui/Segmented';
 import { Skeleton } from '@/components/ui/Skeleton';
 import { TASK_STATUS_CONFIG, type PublicTask, type TaskStatusFilter } from '@/domain/collaborationSquare/types';
-import { RefreshCw, Search, X } from 'lucide-react';
+import { RefreshCw } from 'lucide-react';
 
 const STATUS_OPTIONS: { value: TaskStatusFilter; label: string }[] = [
   { value: 'all', label: '全部' },
@@ -76,28 +75,20 @@ export function PublicTaskCatalogPanel({ vm }: { vm: TaskCatalogViewModel }) {
 
   return (
     <>
-      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-        <div className="relative min-w-0 flex-1 md:max-w-md">
-          <Search aria-hidden className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-          <Input
-            aria-label="搜索任务"
-            value={taskQuery}
-            placeholder="搜索任务..."
-            onChange={(event) => vm.setTaskQuery(event.target.value)}
-            className="pl-9 pr-10"
-          />
-          {taskQuery && (
-            <IconButton
-              label="清除搜索"
-              icon={<X aria-hidden className="h-4 w-4" />}
-              onClick={() => vm.setTaskQuery('')}
-              className="absolute right-0 top-0"
-            />
-          )}
-        </div>
-        <div role="group" aria-label="任务状态筛选">
-          <Segmented value={taskStatusFilter} options={STATUS_OPTIONS} onChange={vm.setTaskStatusFilter} />
-        </div>
+      <div className="flex min-h-8 flex-col gap-3 md:flex-row md:flex-nowrap md:items-center md:justify-between">
+        <SquareSearchBar
+          resource="task"
+          query={taskQuery}
+          onQueryChange={vm.setTaskQuery}
+          className="flex-1"
+        />
+        <Segmented
+          aria-label="任务状态筛选"
+          value={taskStatusFilter}
+          className="shrink-0"
+          options={STATUS_OPTIONS}
+          onChange={vm.setTaskStatusFilter}
+        />
       </div>
 
       {vm.loading && <TaskLoadingState />}

--- a/src/frontend-nextgen/src/components/CollaborationSquare/SquarePageShell/index.tsx
+++ b/src/frontend-nextgen/src/components/CollaborationSquare/SquarePageShell/index.tsx
@@ -5,14 +5,13 @@ import {
   type TaskCatalogViewModel,
 } from '@/components/CollaborationSquare/PublicTaskCatalogPanel';
 import { PageHeader } from '@/components/Common/PageHeader';
-import { Button } from '@/components/ui/Button';
 import type { BotCatalogViewModel, SquareResource } from '@/domain/collaborationSquare/types';
 import { useCollaborationSquare } from '@/hooks/useCollaborationSquare';
-import { history } from '@umijs/max';
-import { Bot, ShoppingBag, Users } from 'lucide-react';
-import { type UIEvent, useCallback, useRef } from 'react';
+import { history, Link } from '@umijs/max';
+import { type MouseEvent, type UIEvent, useCallback, useEffect, useRef, useState } from 'react';
 
 const LOAD_MORE_PRELOAD_DISTANCE = 420;
+const TAB_TRANSITION_DURATION_MS = 200;
 
 const BOT_DESCRIPTION =
   '可按 Bot 名称或 Owner 用户名称搜索公开 Bot，也可通过能力描述进行智能发现，并以当前用户身份发起好友申请。';
@@ -22,7 +21,55 @@ const TASK_DESCRIPTION = '发现公开 BBS 求助任务，按关键词与状态�
 export function SquarePageShell({ resource }: { resource: SquareResource }) {
   const square = useCollaborationSquare(resource);
   const scrollRootRef = useRef<HTMLElement>(null);
+  const navigationTimerRef = useRef<number>();
+  const [visualResource, setVisualResource] = useState(resource);
   const canLoadMore = square.hasMore && !square.loading && !square.loadingMore && !square.error;
+
+  useEffect(() => {
+    setVisualResource(resource);
+  }, [resource]);
+
+  useEffect(
+    () => () => {
+      if (navigationTimerRef.current !== undefined) window.clearTimeout(navigationTimerRef.current);
+    },
+    [],
+  );
+
+  const handleResourceNavigation = useCallback(
+    (event: MouseEvent<HTMLAnchorElement>, nextResource: SquareResource, path: string) => {
+      if (
+        event.defaultPrevented ||
+        event.button !== 0 ||
+        event.metaKey ||
+        event.ctrlKey ||
+        event.shiftKey ||
+        event.altKey ||
+        event.currentTarget.target === '_blank' ||
+        event.currentTarget.hasAttribute('download')
+      ) {
+        return;
+      }
+
+      if (nextResource === resource) {
+        if (visualResource !== resource) {
+          event.preventDefault();
+          if (navigationTimerRef.current !== undefined) window.clearTimeout(navigationTimerRef.current);
+          navigationTimerRef.current = undefined;
+          setVisualResource(resource);
+        }
+        return;
+      }
+
+      event.preventDefault();
+      if (navigationTimerRef.current !== undefined) window.clearTimeout(navigationTimerRef.current);
+      setVisualResource(nextResource);
+      navigationTimerRef.current = window.setTimeout(() => {
+        history.push(path);
+      }, TAB_TRANSITION_DURATION_MS);
+    },
+    [resource, visualResource],
+  );
   const handleScroll = useCallback(
     (event: UIEvent<HTMLElement>) => {
       const target = event.currentTarget;
@@ -47,7 +94,7 @@ export function SquarePageShell({ resource }: { resource: SquareResource }) {
     reload: () => square.load(),
     loadMore: () => square.loadMore(),
     primaryAction: square.primaryBotAction,
-    share: (bot) => square.share('bot', bot.id),
+    share: (bot) => square.share('bot', bot.id, bot.name),
     openProfile: square.openBotProfile,
     closeProfile: square.closeBotProfile,
     selectedBotId: square.selectedBotId,
@@ -77,48 +124,85 @@ export function SquarePageShell({ resource }: { resource: SquareResource }) {
     closeTaskDetail: square.closeTaskDetail,
   };
 
+  const resourceTitle = resource === 'bot' ? '公开 Bot' : resource === 'group' ? '公开协作群' : '任务广场';
   const description =
     resource === 'bot' ? BOT_DESCRIPTION : resource === 'group' ? GROUP_DESCRIPTION : TASK_DESCRIPTION;
 
   return (
-    <main ref={scrollRootRef} className="app-scrollbar h-full overflow-y-auto" onScroll={handleScroll}>
-      <div className="mx-auto flex w-full max-w-7xl flex-col space-y-5 p-4 sm:p-6 lg:p-8">
-        <PageHeader title="协作广场" description={description} />
-        <div className="flex flex-wrap gap-2" aria-label="协作广场资源导航">
-          <Button
-            variant={resource === 'bot' ? 'primary' : 'secondary'}
-            onClick={() => history.push('/collaboration-square/bots')}
-            leftIcon={<Bot aria-hidden className="h-4 w-4" />}
+    <div className="flex h-full flex-col bg-muted">
+      <nav
+        className="shrink-0 border-b border-border bg-background/80 px-4 backdrop-blur-md sm:px-6"
+        aria-label="协作广场资源导航"
+      >
+        <div className="mx-auto flex w-full max-w-7xl items-stretch gap-8">
+          <Link
+            to="/collaboration-square/bots"
+            aria-current={resource === 'bot' ? 'page' : undefined}
+            onClick={(event) => handleResourceNavigation(event, 'bot', '/collaboration-square/bots')}
+            className={`relative flex h-[54px] items-center px-1 text-sm transition-colors hover:text-primary ${
+              visualResource === 'bot' ? 'font-medium text-foreground' : 'font-normal text-muted-foreground'
+            }`}
           >
             公开 Bot
-          </Button>
-          <Button
-            variant={resource === 'group' ? 'primary' : 'secondary'}
-            onClick={() => history.push('/collaboration-square/groups')}
-            leftIcon={<Users aria-hidden className="h-4 w-4" />}
+            <span
+              className={`absolute inset-x-0 bottom-0 h-[3px] rounded-t-full bg-primary transition-transform duration-200 ease-out ${
+                visualResource === 'bot' ? 'scale-x-100' : 'scale-x-0'
+              }`}
+              aria-hidden
+            />
+          </Link>
+          <Link
+            to="/collaboration-square/groups"
+            aria-current={resource === 'group' ? 'page' : undefined}
+            onClick={(event) => handleResourceNavigation(event, 'group', '/collaboration-square/groups')}
+            className={`relative flex h-[54px] items-center px-1 text-sm transition-colors hover:text-primary ${
+              visualResource === 'group' ? 'font-medium text-foreground' : 'font-normal text-muted-foreground'
+            }`}
           >
             公开协作群
-          </Button>
-          <Button
-            variant={resource === 'task' ? 'primary' : 'secondary'}
-            onClick={() => history.push('/collaboration-square/tasks')}
-            leftIcon={<ShoppingBag aria-hidden className="h-4 w-4" />}
+            <span
+              className={`absolute inset-x-0 bottom-0 h-[3px] rounded-t-full bg-primary transition-transform duration-200 ease-out ${
+                visualResource === 'group' ? 'scale-x-100' : 'scale-x-0'
+              }`}
+              aria-hidden
+            />
+          </Link>
+          <Link
+            to="/collaboration-square/tasks"
+            aria-current={resource === 'task' ? 'page' : undefined}
+            onClick={(event) => handleResourceNavigation(event, 'task', '/collaboration-square/tasks')}
+            className={`relative flex h-[54px] items-center px-1 text-sm transition-colors hover:text-primary ${
+              visualResource === 'task' ? 'font-medium text-foreground' : 'font-normal text-muted-foreground'
+            }`}
           >
             任务广场
-          </Button>
+            <span
+              className={`absolute inset-x-0 bottom-0 h-[3px] rounded-t-full bg-primary transition-transform duration-200 ease-out ${
+                visualResource === 'task' ? 'scale-x-100' : 'scale-x-0'
+              }`}
+              aria-hidden
+            />
+          </Link>
         </div>
-        {resource === 'bot' && (
-          <PublicBotCatalogPanel
-            vm={botViewModel}
-            scrollRootRef={scrollRootRef}
-            smartEmptyHint="请输入关键词进行智能搜索"
-          />
-        )}
-        {resource === 'group' && (
-          <PublicGroupSquareSection square={square} scrollRootRef={scrollRootRef} canLoadMore={canLoadMore} />
-        )}
-        {resource === 'task' && <PublicTaskCatalogPanel vm={taskViewModel} />}
-      </div>
-    </main>
+      </nav>
+      <main ref={scrollRootRef} className="app-scrollbar min-h-0 flex-1 overflow-y-auto" onScroll={handleScroll}>
+        <div className="mx-auto flex w-full max-w-7xl flex-col p-4 sm:p-6 lg:p-8">
+          <section className="space-y-4" aria-label={`${resourceTitle}内容`}>
+            <PageHeader title={resourceTitle} description={description} />
+            {resource === 'bot' && (
+              <PublicBotCatalogPanel
+                vm={botViewModel}
+                scrollRootRef={scrollRootRef}
+                smartEmptyHint="请输入关键词进行智能搜索"
+              />
+            )}
+            {resource === 'group' && (
+              <PublicGroupSquareSection square={square} scrollRootRef={scrollRootRef} canLoadMore={canLoadMore} />
+            )}
+            {resource === 'task' && <PublicTaskCatalogPanel vm={taskViewModel} />}
+          </section>
+        </div>
+      </main>
+    </div>
   );
 }

--- a/src/frontend-nextgen/src/components/CollaborationSquare/SquareSearchBar/index.tsx
+++ b/src/frontend-nextgen/src/components/CollaborationSquare/SquareSearchBar/index.tsx
@@ -1,16 +1,17 @@
-import { Card } from '@/components/ui/Card';
 import { IconButton } from '@/components/ui/IconButton';
+import { cn } from '@/utils/cn';
 import { Input } from '@/components/ui/Input';
 import { Segmented } from '@/components/ui/Segmented';
 import type { BotSearchMode } from '@/domain/collaborationSquare/types';
 import { Search, X } from 'lucide-react';
 
 interface SquareSearchBarProps {
-  resource: 'bot' | 'group';
+  resource: 'bot' | 'group' | 'task';
   query: string;
   mode?: BotSearchMode;
   onQueryChange: (query: string) => void;
   onModeChange?: (mode: BotSearchMode) => void;
+  className?: string;
 }
 
 export default function SquareSearchBar({
@@ -19,29 +20,43 @@ export default function SquareSearchBar({
   mode = 'name',
   onQueryChange,
   onModeChange,
+  className,
 }: SquareSearchBarProps) {
-  const label = resource === 'bot' ? (mode === 'smart' ? '描述你需要的职责或能力' : '搜索 Bot 名称') : '搜索协作群名称';
+  const label =
+    resource === 'bot'
+      ? mode === 'smart'
+        ? '描述你需要的职责或能力'
+        : '搜索 Bot 名称'
+      : resource === 'group'
+        ? '搜索协作群名称'
+        : '搜索任务';
+  const handleModeChange = (nextMode: BotSearchMode) => {
+    if (nextMode !== mode) onQueryChange('');
+    onModeChange?.(nextMode);
+  };
   return (
-    <Card className="flex flex-col gap-3 p-4 md:flex-row md:items-center">
+    <div className={cn('flex min-h-8 min-w-0 flex-col gap-3', className)}>
       {resource === 'bot' && onModeChange && (
         <Segmented
+          aria-label="Bot 搜索模式"
           value={mode}
           options={[
             { value: 'name', label: '名称搜索' },
             { value: 'smart', label: '智能搜索' },
           ]}
-          onChange={onModeChange}
+          onChange={handleModeChange}
           className="w-full md:w-56"
+          inactiveOptionClassName="text-muted-foreground hover:text-foreground"
         />
       )}
-      <div className="relative min-w-0 flex-1">
-        <Search aria-hidden className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--color-muted)]" />
+      <div className="relative h-8 w-full max-w-md">
+        <Search aria-hidden className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
         <Input
           aria-label={label}
           value={query}
           placeholder={label}
           onChange={(event) => onQueryChange(event.target.value)}
-          className="pl-9 pr-10"
+          className="h-8 pl-9 pr-10"
         />
         {query && (
           <IconButton
@@ -52,6 +67,6 @@ export default function SquareSearchBar({
           />
         )}
       </div>
-    </Card>
+    </div>
   );
 }

--- a/src/frontend-nextgen/src/components/Common/PageHeader.tsx
+++ b/src/frontend-nextgen/src/components/Common/PageHeader.tsx
@@ -11,9 +11,9 @@ export function PageHeader({ title, description, actions, eyebrow }: PageHeaderP
   return (
     <header className="flex flex-wrap items-start justify-between gap-4">
       <div>
-        {eyebrow && <p className="mb-1 text-xs font-medium text-[var(--color-primary)]">{eyebrow}</p>}
-        <h1 className="m-0 text-2xl font-semibold tracking-tight text-[var(--color-fg)]">{title}</h1>
-        {description && <p className="mt-2 max-w-3xl text-sm leading-6 text-[var(--color-muted)]">{description}</p>}
+        {eyebrow && <p className="mb-1 text-xs font-medium text-primary">{eyebrow}</p>}
+        <h1 className="m-0 text-2xl font-semibold tracking-tight text-foreground">{title}</h1>
+        {description && <p className="mt-2 max-w-3xl text-sm leading-6 text-muted-foreground">{description}</p>}
       </div>
       {actions && <div className="flex items-center gap-2">{actions}</div>}
     </header>

--- a/src/frontend-nextgen/src/components/TaskCards/TaskCardControls.tsx
+++ b/src/frontend-nextgen/src/components/TaskCards/TaskCardControls.tsx
@@ -24,13 +24,13 @@ export const taskCardTextareaClass =
   'min-h-0 w-full p-1.5 rounded-lg border-blue-200 px-1.5 text-[11px] text-gray-700 resize-none focus-visible:border-blue-300 focus-visible:ring-2 focus-visible:ring-blue-300/50';
 
 export const taskCardDiscardBtnClass =
-  'flex-1 inline-flex items-center justify-center gap-0.5 h-auto px-2 py-1.5 rounded-lg border border-red-200 text-red-500 text-[11px] font-medium hover:bg-red-50 hover:scale-105 active:scale-95 transition-all duration-300 leading-none';
+  'flex-1 inline-flex items-center justify-center gap-0.5 h-auto px-1.5 py-1 rounded-lg border border-red-200 text-red-500 text-[11px] font-medium hover:bg-red-50 hover:scale-105 active:scale-95 transition-all duration-300 leading-none';
 
 export const taskCardSaveBtnClass =
-  'flex-1 inline-flex items-center justify-center gap-0.5 h-auto px-2 py-1.5 rounded-lg border border-gray-200 text-gray-500 text-[11px] font-medium hover:bg-muted/50 hover:scale-105 active:scale-95 transition-all duration-300 leading-none';
+  'flex-1 inline-flex items-center justify-center gap-0.5 h-auto px-1.5 py-1 rounded-lg border border-gray-200 text-gray-500 text-[11px] font-medium hover:bg-muted/50 hover:scale-105 active:scale-95 transition-all duration-300 leading-none';
 
 export const taskCardExecuteBtnClass =
-  'flex-1 inline-flex items-center justify-center gap-0.5 h-auto px-2 py-1.5 rounded-lg bg-blue-500 text-white text-[11px] font-medium hover:bg-blue-600 hover:scale-105 active:scale-95 transition-all duration-300 shadow-sm leading-none border-transparent';
+  'flex-1 inline-flex items-center justify-center gap-0.5 h-auto px-1.5 py-1 rounded-lg bg-blue-500 text-white text-[11px] font-medium hover:bg-blue-600 hover:scale-105 active:scale-95 transition-all duration-300 shadow-sm leading-none border-transparent';
 
 /** 编辑态「确认 / 取消」二按组合。 */
 export function EditFieldControls({ onConfirm, onCancel }: { onConfirm: () => void; onCancel: () => void }) {

--- a/src/frontend-nextgen/src/components/Workspace/ChatPanel/index.tsx
+++ b/src/frontend-nextgen/src/components/Workspace/ChatPanel/index.tsx
@@ -248,7 +248,7 @@ export function ChatPanel({
         {/* 单聊输入框用原生 <Sender>(forwardRef,暴露 SenderRef)替代 <ChatLayout.Sender>(普通函数组件,非 forwardRef,
             ref 恒 null)。ref={senderRef} 经 useChatBridge.setInputRef 注册到全局桥,使 aixcore 卡片
             bridge.getInputRef().insert(text) 填入主屏输入框(根因 5 修复,对齐 open-claw ChatInputArea)。 */}
-        <div className="flex shrink-0 flex-col gap-2 border-t border-border bg-background px-3 py-3 sm:px-6 sm:py-4">
+        <div className="flex shrink-0 flex-col gap-2 bg-background px-3 py-1.5 sm:px-6 sm:py-2">
           {editingMessageId ? <MessageEditBar onCancel={cancelEdit} /> : null}
           <MessageQuoteBar quote={messageInteractions.quote} onClear={messageInteractions.clearQuote} />
           <Sender

--- a/src/frontend-nextgen/src/components/Workspace/IdentitySelector/IdentitySelectorParts.tsx
+++ b/src/frontend-nextgen/src/components/Workspace/IdentitySelector/IdentitySelectorParts.tsx
@@ -17,16 +17,17 @@ export function IdentityAvatar({
   userAvatarUrl,
 }: {
   identity: Identity;
-  size?: 'sm' | 'md';
+  size?: 'xs' | 'sm' | 'md';
   userAvatarUrl?: string;
 }) {
   const avatarUrl = identity.kind === 'user' ? userAvatarUrl : identity.avatar;
+  const avatarSize = size === 'xs' ? 24 : size === 'sm' ? 32 : 36;
   return (
     <span className="shrink-0">
       <Avatar
         name={identity.name}
         src={avatarUrl && isAvatarUrl(avatarUrl) ? avatarUrl : undefined}
-        size={size === 'sm' ? 32 : 36}
+        size={avatarSize}
       />
     </span>
   );
@@ -36,12 +37,12 @@ function BotRuntimeStatus({ identity }: { identity: Identity }) {
   const isOnline = identity.chatStatus === 'online';
   const runtimeStatus = (
     <span
-      aria-label={`Bot 运行状态：${isOnline ? '在线' : '不在线'}`}
+      aria-label={`Bot ${isOnline ? '在线' : '不在线'}`}
       className="inline-flex items-center gap-1"
       tabIndex={isOnline ? undefined : 0}
     >
       <span className={cn('h-1.5 w-1.5 rounded-full', isOnline ? 'bg-success' : 'bg-muted-foreground')} aria-hidden />
-      运行状态：{isOnline ? '在线' : '不在线'}
+      {isOnline ? '在线' : '不在线'}
     </span>
   );
 
@@ -57,7 +58,15 @@ function BotRuntimeStatus({ identity }: { identity: Identity }) {
   );
 }
 
-export function IdentityDetails({ identity, compact = false }: { identity: Identity; compact?: boolean }) {
+export function IdentityDetails({
+  identity,
+  compact = false,
+  summaryOnly = false,
+}: {
+  identity: Identity;
+  compact?: boolean;
+  summaryOnly?: boolean;
+}) {
   const identityLabel = identity.kind === 'user' ? '用户' : getBotTypeLabel(identity.botType);
   const engineLabel = identity.kind === 'bot' ? getBotEngineLabel(identity.engine) : undefined;
   return (
@@ -66,21 +75,21 @@ export function IdentityDetails({ identity, compact = false }: { identity: Ident
         <span className={cn('truncate font-medium text-foreground', compact ? 'text-xs' : 'text-sm')}>
           {identity.name}
         </span>
-        {identityLabel ? (
+        {identityLabel && !summaryOnly ? (
           <Badge
             tone={identity.kind === 'user' ? 'primary' : 'neutral'}
-            className="rounded-sm px-1 py-0 text-[10px] font-normal leading-4"
+            className="shrink-0 whitespace-nowrap rounded-sm px-1 py-0 text-[10px] font-normal leading-4"
           >
             {identityLabel}
           </Badge>
         ) : null}
       </span>
-      {identity.kind === 'user' && (
+      {!summaryOnly && identity.kind === 'user' && (
         <span className="mt-0.5 block truncate text-[10px] text-muted-foreground">
           工号：{resolveOpenApiUserId(identity.id)}
         </span>
       )}
-      {identity.kind === 'bot' && (
+      {!summaryOnly && identity.kind === 'bot' && (
         <span className="mt-0.5 flex min-w-0 items-center gap-2 text-[10px] text-muted-foreground">
           <span className="truncate">{engineLabel || '引擎类型暂无'}</span>
           <BotRuntimeStatus identity={identity} />

--- a/src/frontend-nextgen/src/components/Workspace/IdentitySelector/index.tsx
+++ b/src/frontend-nextgen/src/components/Workspace/IdentitySelector/index.tsx
@@ -37,7 +37,28 @@ export function WorkspaceIdentitySelector({
 
   return (
     <div className="space-y-1">
-      {!sidebarLayout ? (
+      {sidebarLayout ? (
+        <TooltipProvider delayDuration={300}>
+          <div className="flex items-center gap-1 px-1 pb-1 text-xs font-semibold text-foreground">
+            <span>工作身份</span>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span
+                  role="img"
+                  aria-label="工作身份说明"
+                  tabIndex={0}
+                  className="relative top-px inline-flex cursor-help items-center text-muted-foreground/70"
+                >
+                  <Info className="h-3 w-3" aria-hidden />
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>
+                当前协作身份决定在对话或群聊中，你以个人或指定 Bot 身份可查看的数据范围
+              </TooltipContent>
+            </Tooltip>
+          </div>
+        </TooltipProvider>
+      ) : (
         <TooltipProvider delayDuration={300}>
           <div className="flex items-center gap-1 px-1 text-xs font-medium text-foreground">
             <span>当前协作身份</span>
@@ -56,12 +77,12 @@ export function WorkspaceIdentitySelector({
                 </span>
               </TooltipTrigger>
               <TooltipContent>
-                当前协作身份决定在下方对话或群聊中，你以个人或指定 Bot 身份可查看的数据范围
+                当前协作身份决定在对话或群聊中，你以个人或指定 Bot 身份可查看的数据范围
               </TooltipContent>
             </Tooltip>
           </div>
         </TooltipProvider>
-      ) : null}
+      )}
       {activeIdentity ? (
         <>
           <Popover open={open} onOpenChange={setOpen}>
@@ -71,24 +92,22 @@ export function WorkspaceIdentitySelector({
                 aria-expanded={open}
                 aria-label={`当前协作身份：${activeIdentity.name}`}
                 className={cn(
-                  'h-auto min-h-10 w-full justify-between gap-2 py-1 text-left',
-                  sidebarLayout ? 'rounded-md px-0 hover:bg-accent/60' : 'rounded-lg px-2',
+                  'h-auto w-full justify-between gap-2 text-left',
+                  sidebarLayout
+                    ? 'min-h-9 rounded-lg border border-border bg-muted/60 px-2.5 py-1.5 text-foreground hover:bg-muted hover:text-foreground'
+                    : 'min-h-10 rounded-lg px-2 py-1',
+                  sidebarLayout && open && 'border-primary',
                 )}
               >
-                <IdentityAvatar identity={activeIdentity} size="sm" userAvatarUrl={userAvatarUrl} />
-                <IdentityDetails identity={activeIdentity} />
-                {sidebarLayout ? (
-                  <span className="flex shrink-0 items-center gap-1 text-xs font-medium text-foreground">
-                    切换身份
-                    <ChevronDown
-                      className={cn('h-4 w-4 text-muted-foreground transition-transform', open && 'rotate-180')}
-                    />
-                  </span>
-                ) : (
-                  <ChevronDown
-                    className={cn('h-4 w-4 shrink-0 text-muted-foreground transition-transform', open && 'rotate-180')}
-                  />
-                )}
+                <IdentityAvatar identity={activeIdentity} size={sidebarLayout ? 'xs' : 'sm'} userAvatarUrl={userAvatarUrl} />
+                <IdentityDetails identity={activeIdentity} compact={sidebarLayout} summaryOnly={sidebarLayout} />
+                <ChevronDown
+                  className={cn(
+                    sidebarLayout ? 'h-3.5 w-3.5' : 'h-4 w-4',
+                    'shrink-0 text-muted-foreground transition-transform',
+                    open && 'rotate-180',
+                  )}
+                />
               </Button>
             </PopoverTrigger>
             <PopoverContent
@@ -102,23 +121,25 @@ export function WorkspaceIdentitySelector({
               <div className="mb-2 flex items-center justify-between gap-2 border-b border-border px-2.5 pb-2">
                 <div className="flex min-w-0 items-center gap-1">
                   <p className="text-xs font-medium text-foreground">切换协作身份</p>
-                  <TooltipProvider delayDuration={300}>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <span
-                          role="img"
-                          aria-label="协作身份说明"
-                          tabIndex={0}
-                          className="inline-flex cursor-help items-center text-muted-foreground"
-                        >
-                          <Info className="h-3.5 w-3.5" aria-hidden />
-                        </span>
-                      </TooltipTrigger>
-                      <TooltipContent>
-                        当前协作身份决定在下方对话或群聊中，你以个人或指定 Bot 身份可查看的数据范围
-                      </TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
+                  {!sidebarLayout ? (
+                    <TooltipProvider delayDuration={300}>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span
+                            role="img"
+                            aria-label="协作身份说明"
+                            tabIndex={0}
+                            className="inline-flex cursor-help items-center text-muted-foreground"
+                          >
+                            <Info className="h-3.5 w-3.5" aria-hidden />
+                          </span>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          当前协作身份决定在对话或群聊中，你以个人或指定 Bot 身份可查看的数据范围
+                        </TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
+                  ) : null}
                 </div>
                 {onOpenPermissions ? (
                   <Button

--- a/src/frontend-nextgen/src/components/ui/Segmented.tsx
+++ b/src/frontend-nextgen/src/components/ui/Segmented.tsx
@@ -1,5 +1,5 @@
 import { cn } from '@/utils/cn';
-import type { ReactNode } from 'react';
+import { type KeyboardEvent, type ReactNode, useRef } from 'react';
 import { Button } from './Button';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './Tooltip';
 
@@ -16,6 +16,8 @@ interface SegmentedProps<T extends string> {
   className?: string;
   activeOptionClassName?: string;
   inactiveOptionClassName?: string;
+  'aria-label'?: string;
+  'aria-labelledby'?: string;
 }
 
 /** 分段控件：禁用项的原因通过统一 Tooltip 呈现，不使用 title；支持 icon 项与等宽不换行。
@@ -28,18 +30,62 @@ export function Segmented<T extends string>({
   className,
   activeOptionClassName,
   inactiveOptionClassName,
+  'aria-label': ariaLabel,
+  'aria-labelledby': ariaLabelledBy,
 }: SegmentedProps<T>) {
+  const buttonRefs = useRef<Array<HTMLButtonElement | null>>([]);
+
+  const selectAndFocus = (index: number) => {
+    const option = options[index];
+    if (!option || option.disabledReason) return;
+    onChange(option.value);
+    buttonRefs.current[index]?.focus();
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLButtonElement>, index: number) => {
+    if (!['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'Home', 'End'].includes(event.key)) return;
+    event.preventDefault();
+
+    if (event.key === 'Home' || event.key === 'End') {
+      const enabledIndexes = options
+        .map((option, optionIndex) => (option.disabledReason ? -1 : optionIndex))
+        .filter((optionIndex) => optionIndex >= 0);
+      const targetIndex = event.key === 'Home' ? enabledIndexes[0] : enabledIndexes.at(-1);
+      if (targetIndex !== undefined) selectAndFocus(targetIndex);
+      return;
+    }
+
+    const direction = event.key === 'ArrowLeft' || event.key === 'ArrowUp' ? -1 : 1;
+    for (let offset = 1; offset <= options.length; offset += 1) {
+      const targetIndex = (index + direction * offset + options.length) % options.length;
+      if (!options[targetIndex]?.disabledReason) {
+        selectAndFocus(targetIndex);
+        return;
+      }
+    }
+  };
+
   return (
     <TooltipProvider>
-      <div className={cn('flex items-center rounded-lg bg-muted p-0.5', className)}>
-        {options.map((option) => {
+      <div
+        role="group"
+        aria-label={ariaLabel}
+        aria-labelledby={ariaLabelledBy}
+        className={cn('flex items-center rounded-lg bg-muted p-0.5', className)}
+      >
+        {options.map((option, index) => {
           const button = (
             <Button
               key={option.value}
+              ref={(node) => {
+                buttonRefs.current[index] = node;
+              }}
               variant="ghost"
               size="sm"
               disabled={!!option.disabledReason}
+              aria-pressed={value === option.value}
               onClick={() => onChange(option.value)}
+              onKeyDown={(event) => handleKeyDown(event, index)}
               className={cn(
                 'flex-1 whitespace-nowrap border-0',
                 value !== option.value && inactiveOptionClassName,

--- a/src/frontend-nextgen/src/domain/collaborationSquare/mapper.ts
+++ b/src/frontend-nextgen/src/domain/collaborationSquare/mapper.ts
@@ -284,6 +284,22 @@ export function mapBotProfileTransport(value: BotProfileTransport): PublicBotPro
   };
 }
 
+/**
+ * 分享深链只依赖公开 Catalog 摘要。Catalog 不提供能力 ID/引擎信息，不能伪造成完整画像。
+ */
+export function mapPublicBotCatalogSummaryToProfile(bot: PublicBot): PublicBotProfile {
+  return {
+    id: bot.id,
+    name: bot.name,
+    ownerName: bot.ownerName,
+    description: bot.description,
+    ...(bot.friendRequestBotId ? { friendRequestBotId: bot.friendRequestBotId } : {}),
+    ...(bot.isOwnedByViewer ? { isOwnedByViewer: true } : {}),
+    ...(bot.shortProfile ? { shortProfile: bot.shortProfile } : {}),
+    capabilities: [],
+  };
+}
+
 export function mapGroupTransport(value: PublicGroupTransport): PublicGroup {
   return {
     id: value.group_id,
@@ -324,5 +340,6 @@ export function parseSquareDeepLink(search: string, expected: SquareResource): S
   const params = new URLSearchParams(search);
   const resource = params.get('resource');
   const id = params.get('id')?.trim();
-  return resource === expected && id ? { resource, id } : null;
+  const searchHint = params.get('name')?.trim();
+  return resource === expected && id ? { resource, id, ...(searchHint ? { searchHint } : {}) } : null;
 }

--- a/src/frontend-nextgen/src/domain/collaborationSquare/types.ts
+++ b/src/frontend-nextgen/src/domain/collaborationSquare/types.ts
@@ -204,6 +204,8 @@ export interface CreateSessionResult {
 export interface SquareDeepLink {
   resource: SquareResource;
   id: string;
+  /** Bot 分享链接附带的公开名称，仅作为 Catalog Search 提示；最终仍按 id 精确匹配。 */
+  searchHint?: string;
 }
 
 /**

--- a/src/frontend-nextgen/src/hooks/collaborationPrivacyHelpers.ts
+++ b/src/frontend-nextgen/src/hooks/collaborationPrivacyHelpers.ts
@@ -21,3 +21,48 @@ export type ScopeViewerState =
 export function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : '操作失败，请稍后重试';
 }
+
+export function normalizeBotIdentityId(id: string): string {
+  const separator = id.indexOf(':');
+  return separator >= 0 ? id.slice(0, separator) : id;
+}
+
+export function matchesBotIdentity(botId: string, identityId: string): boolean {
+  return botId === identityId || normalizeBotIdentityId(botId) === normalizeBotIdentityId(identityId);
+}
+
+export function directSettingLabel(setting: DirectSetting, value: Confirmation['value']): string {
+  switch (setting) {
+    case 'collaborationStatus':
+      return value === 'online' ? '已开启参与协作群聊' : '已停止参与协作群聊';
+    case 'profilePublic':
+      return value ? '已公开 Bot 画像' : '已关闭 Bot 画像公开';
+    case 'taskClaimingEnabled':
+      return value ? '已开启任务认领' : '已关闭任务认领';
+    case 'dreamModelEnabled':
+      return value ? '已开启 Dream Model' : '已关闭 Dream Model';
+  }
+}
+
+export function buildDirectConfirmation(
+  bot: CollaborationBot,
+  setting: DirectSetting,
+  value: Confirmation['value'],
+): Confirmation | null {
+  if (setting !== 'collaborationStatus' && setting !== 'profilePublic') return null;
+  const target =
+    setting === 'collaborationStatus'
+      ? value === 'online'
+        ? '允许参与协作群聊'
+        : '停止参与协作群聊'
+      : value
+        ? '公开 Bot 画像'
+        : '关闭 Bot 画像公开';
+  const description =
+    setting === 'collaborationStatus'
+      ? value === 'online'
+        ? `${bot.name} 开启后可加入新协作群，并在已加入的协作群会话中回复消息。好友单聊不受影响。`
+        : `${bot.name} 关闭后无法加入新协作群，并停止在已加入的协作群会话中回复消息。好友单聊不受影响。`
+      : `${bot.name} 的画像公开状态将影响发现、推荐与协作匹配。`;
+  return { bot, setting, value, title: `确认${target}？`, description };
+}

--- a/src/frontend-nextgen/src/hooks/useCollaborationPrivacy.ts
+++ b/src/frontend-nextgen/src/hooks/useCollaborationPrivacy.ts
@@ -8,9 +8,13 @@ import type {
 import { useHumanIdentity } from '@/hooks/useHumanIdentity';
 import { collaborationPrivacyService, type DirectSetting } from '@/services/collaborationPrivacy';
 import { useCollaborationPrivacyStore } from '@/stores/collaborationPrivacyStore';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useWorkspaceStore } from '@/stores/workspaceStore';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
+  buildDirectConfirmation,
+  directSettingLabel,
   errorMessage,
+  matchesBotIdentity,
   type Confirmation,
   type PublicationEditorState,
   type ScopeViewerState,
@@ -19,11 +23,14 @@ import {
 export function useCollaborationPrivacy() {
   const store = useCollaborationPrivacyStore();
   const { identity, status: identityStatus, error: identityError } = useHumanIdentity();
+  const activeIdentityId = useWorkspaceStore((state) => state.activeIdentityId);
+  const identityViews = useWorkspaceStore((state) => state.identities);
   const userId = identity?.userId.trim() || null;
   const [confirmation, setConfirmation] = useState<Confirmation | null>(null);
   const [publicationEditor, setPublicationEditor] = useState<PublicationEditorState | null>(null);
   const [scopeViewer, setScopeViewer] = useState<ScopeViewerState | null>(null);
   const [friendEditorBotId, setFriendEditorBotId] = useState<string | null>(null);
+  const previousActiveIdentityId = useRef(activeIdentityId);
 
   const load = useCallback(
     async (signal?: AbortSignal) => {
@@ -80,12 +87,6 @@ export function useCollaborationPrivacy() {
 
   const executeDirect = useCallback(
     (bot: CollaborationBot, setting: DirectSetting, value: Confirmation['value']) => {
-      const labels: Record<DirectSetting, string> = {
-        collaborationStatus: value === 'online' ? '已开启参与协作群聊' : '已停止参与协作群聊',
-        profilePublic: value ? '已公开 Bot 画像' : '已关闭 Bot 画像公开',
-        taskClaimingEnabled: value ? '已开启任务认领' : '已关闭任务认领',
-        dreamModelEnabled: value ? '已开启 Dream Model' : '已关闭 Dream Model',
-      };
       if (setting === 'taskClaimingEnabled') {
         return runBotAction(
           `${bot.id}:taskClaimingEnabled`,
@@ -93,13 +94,13 @@ export function useCollaborationPrivacy() {
             value
               ? collaborationPrivacyService.enableTaskClaim(bot.id)
               : collaborationPrivacyService.disableTaskClaim(bot.id),
-          labels[setting],
+          directSettingLabel(setting, value),
         );
       }
       return runBotAction(
         `${bot.id}:${setting}`,
         () => collaborationPrivacyService.updateDirectSetting({ botId: bot.id, setting, value }),
-        labels[setting],
+        directSettingLabel(setting, value),
       );
     },
     [runBotAction],
@@ -107,27 +108,9 @@ export function useCollaborationPrivacy() {
 
   const toggleDirect = useCallback(
     (bot: CollaborationBot, setting: DirectSetting, value: Confirmation['value']) => {
-      if (setting === 'collaborationStatus' || setting === 'profilePublic') {
-        const target =
-          setting === 'collaborationStatus'
-            ? value === 'online'
-              ? '允许参与协作群聊'
-              : '停止参与协作群聊'
-            : value
-            ? '公开 Bot 画像'
-            : '关闭 Bot 画像公开';
-        setConfirmation({
-          bot,
-          setting,
-          value,
-          title: `确认${target}？`,
-          description:
-            setting === 'collaborationStatus'
-              ? value === 'online'
-                ? `${bot.name} 开启后可加入新协作群，并在已加入的协作群会话中回复消息。好友单聊不受影响。`
-                : `${bot.name} 关闭后无法加入新协作群，并停止在已加入的协作群会话中回复消息。好友单聊不受影响。`
-              : `${bot.name} 的画像公开状态将影响发现、推荐与协作匹配。`,
-        });
+      const next = buildDirectConfirmation(bot, setting, value);
+      if (next) {
+        setConfirmation(next);
         return;
       }
       void executeDirect(bot, setting, value);
@@ -216,7 +199,22 @@ export function useCollaborationPrivacy() {
     () => store.overview?.bots.find((bot) => bot.id === scopeViewer?.botId),
     [scopeViewer?.botId, store.overview],
   );
-
+  const activeIdentity = useMemo(
+    () => identityViews.find((item) => item.id === activeIdentityId) ?? null,
+    [activeIdentityId, identityViews],
+  );
+  useEffect(() => {
+    if (previousActiveIdentityId.current === activeIdentityId) return;
+    previousActiveIdentityId.current = activeIdentityId;
+    setConfirmation(null);
+    setPublicationEditor(null);
+    setScopeViewer(null);
+    setFriendEditorBotId(null);
+  }, [activeIdentityId]);
+  const visibleBots = useMemo(() => {
+    if (activeIdentity?.kind !== 'bot' || !store.overview) return [];
+    return store.overview.bots.filter((bot) => matchesBotIdentity(bot.id, activeIdentity.id));
+  }, [activeIdentity, store.overview]);
   return {
     ...store,
     load,
@@ -226,6 +224,9 @@ export function useCollaborationPrivacy() {
     scopeViewer,
     scopeViewerBot,
     friendEditorBot,
+    activeIdentity,
+    showIdentityCard: activeIdentity?.kind !== 'bot',
+    visibleBots,
     refreshBot,
     toggleDirect,
     confirmDirect,

--- a/src/frontend-nextgen/src/hooks/useCollaborationSquare.ts
+++ b/src/frontend-nextgen/src/hooks/useCollaborationSquare.ts
@@ -7,6 +7,7 @@ import {
   type PublicGroup,
   type SquareResource,
 } from '@/domain/collaborationSquare/types';
+import { mapPublicBotCatalogSummaryToProfile } from '@/domain/collaborationSquare/mapper';
 import { useCollaborationSquareList } from '@/hooks/useCollaborationSquareList';
 import { useCollaborationSquareTask } from '@/hooks/useCollaborationSquareTask';
 import { useHumanIdentity } from '@/hooks/useHumanIdentity';
@@ -23,6 +24,7 @@ import {
   clearCollaborationSquareTargetingSearch,
   getCollaborationBotConversationUrl,
   getCollaborationSquareErrorMessage,
+  getCollaborationSquareShareUrl,
 } from '@/utils/collaborationSquare';
 import { history } from '@umijs/max';
 import { useCallback, useMemo } from 'react';
@@ -102,6 +104,14 @@ export function useCollaborationSquare(resource: SquareResource) {
     [handleTargetInvalid, store.setBotProfile, store.setDetailLoading, store.setSelectedBotId],
   );
 
+  const openSharedBot = useCallback(
+    (bot: PublicBot) => {
+      store.setSelectedBotId(bot.id);
+      store.setDetailLoading(false);
+      store.setBotProfile(mapPublicBotCatalogSummaryToProfile(bot));
+    },
+    [store.setBotProfile, store.setDetailLoading, store.setSelectedBotId],
+  );
   const openGroupMembers = useCallback(
     async (group: PublicGroup) => {
       store.setSelectedGroupId(group.id);
@@ -120,7 +130,14 @@ export function useCollaborationSquare(resource: SquareResource) {
     [handleTargetInvalid, store.setDetailLoading, store.setGroupMembers, store.setSelectedGroupId],
   );
 
-  useSquareDeepLink({ resource, openBotProfile, openGroupMembers, handleTargetInvalid });
+  useSquareDeepLink({
+    resource,
+    humanBotContext,
+    viewer: viewer ?? undefined,
+    openSharedBot,
+    openGroupMembers,
+    handleTargetInvalid,
+  });
 
   const runBusy = useCallback(
     async (key: string, task: () => Promise<void>, invalidTargetId?: string) => {
@@ -192,10 +209,9 @@ export function useCollaborationSquare(resource: SquareResource) {
     }
   }, []);
   const share = useCallback(
-    (targetResource: SquareResource, id: string) => {
-      const pathname = targetResource === 'bot' ? '/collaboration-square/bots' : '/collaboration-square/groups';
+    (targetResource: SquareResource, id: string, searchHint?: string) => {
       const origin = typeof window === 'undefined' ? '' : window.location.origin;
-      void copyText(`${origin}${pathname}?resource=${targetResource}&id=${encodeURIComponent(id)}`, '分享链接已复制');
+      void copyText(getCollaborationSquareShareUrl(origin, targetResource, id, searchHint), '分享链接已复制');
     },
     [copyText],
   );

--- a/src/frontend-nextgen/src/hooks/useSquareDeepLink.ts
+++ b/src/frontend-nextgen/src/hooks/useSquareDeepLink.ts
@@ -1,40 +1,95 @@
 import { parseSquareDeepLink } from '@/domain/collaborationSquare/mapper';
-import type { PublicBot, PublicGroup, SquareResource } from '@/domain/collaborationSquare/types';
+import { notifyError } from '@/components/ui/notify';
+import type {
+  BotCatalogViewer,
+  HumanBotActionContext,
+  PublicBot,
+  PublicGroup,
+  SquareResource,
+} from '@/domain/collaborationSquare/types';
+import { collaborationSquareBotService } from '@/services/collaborationSquare';
 import { useCollaborationSquareStore } from '@/stores/collaborationSquareStore';
-import { useEffect } from 'react';
+import { getCollaborationSquareErrorMessage } from '@/utils/collaborationSquare';
+import { useEffect, useRef } from 'react';
 
 interface UseSquareDeepLinkOptions {
   resource: SquareResource;
-  openBotProfile: (bot: PublicBot) => Promise<void>;
+  humanBotContext: HumanBotActionContext | null;
+  viewer?: BotCatalogViewer;
+  openSharedBot: (bot: PublicBot) => void;
   openGroupMembers: (group: PublicGroup) => Promise<void>;
   handleTargetInvalid: (resource: SquareResource, id: string) => void;
 }
 
 /**
  * bot/group 的 SquareDeepLink 深链解析。任务广场本期不接深链（Non-goal），resource='task' 时跳过。
- * 从 useCollaborationSquare 抽出以守 Hook ≤250 行体积门禁；行为与原内联 effect 等价。
+ * Bot 未出现在当前页时，以公开名称调用 Catalog Search，再以 URL 中的 canonical ID 精确匹配。
  */
 export function useSquareDeepLink({
   resource,
-  openBotProfile,
+  humanBotContext,
+  viewer,
+  openSharedBot,
   openGroupMembers,
   handleTargetInvalid,
 }: UseSquareDeepLinkOptions) {
   const loading = useCollaborationSquareStore((state) => state.loading);
   const bots = useCollaborationSquareStore((state) => state.bots);
   const groups = useCollaborationSquareStore((state) => state.groups);
+  const handledTarget = useRef<string | null>(null);
+
   useEffect(() => {
     if (loading || resource === 'task' || typeof window === 'undefined') return;
     const deepLink = parseSquareDeepLink(window.location.search, resource);
-    if (!deepLink) return;
-    if (resource === 'bot') {
-      const bot = bots.find((item) => item.id === deepLink.id);
-      if (bot) void openBotProfile(bot);
-      else handleTargetInvalid('bot', deepLink.id);
-    } else {
-      const group = groups.find((item) => item.id === deepLink.id);
-      if (group) void openGroupMembers(group);
-      else handleTargetInvalid('group', deepLink.id);
+    if (!deepLink) {
+      handledTarget.current = null;
+      return;
     }
-  }, [bots, groups, handleTargetInvalid, loading, openBotProfile, openGroupMembers, resource]);
+    const targetKey = `${deepLink.resource}:${deepLink.id}:${deepLink.searchHint ?? ''}`;
+    if (handledTarget.current === targetKey) return;
+
+    if (resource === 'bot') {
+      const loadedBot = bots.find((item) => item.id === deepLink.id);
+      if (loadedBot) {
+        handledTarget.current = targetKey;
+        openSharedBot(loadedBot);
+        return;
+      }
+      if (!deepLink.searchHint) {
+        handledTarget.current = targetKey;
+        handleTargetInvalid('bot', deepLink.id);
+        return;
+      }
+
+      const controller = new AbortController();
+      handledTarget.current = targetKey;
+      void collaborationSquareBotService
+        .resolveSharedBot(deepLink.id, deepLink.searchHint, humanBotContext ?? undefined, viewer, controller.signal)
+        .then((bot) => {
+          if (controller.signal.aborted) return;
+          if (bot) openSharedBot(bot);
+          else handleTargetInvalid('bot', deepLink.id);
+        })
+        .catch((error) => {
+          if (!controller.signal.aborted && (error as Error).name !== 'AbortError')
+            notifyError(getCollaborationSquareErrorMessage(error));
+        });
+      return () => controller.abort();
+    }
+
+    const group = groups.find((item) => item.id === deepLink.id);
+    handledTarget.current = targetKey;
+    if (group) void openGroupMembers(group);
+    else handleTargetInvalid('group', deepLink.id);
+  }, [
+    bots,
+    groups,
+    handleTargetInvalid,
+    humanBotContext,
+    loading,
+    openGroupMembers,
+    openSharedBot,
+    resource,
+    viewer,
+  ]);
 }

--- a/src/frontend-nextgen/src/hooks/useTaskExecuteFromCard.ts
+++ b/src/frontend-nextgen/src/hooks/useTaskExecuteFromCard.ts
@@ -3,11 +3,15 @@
  *
  * 卡片 task_ready 点「执行」→ aixBridge.submit('执行任务', {__taskAction:'execute', task})
  * → chatBridge.ts 拦截层调本 hook 注入的 setTaskExecuteHandler(task)
- * → task JSON → TaskComposerForm → 大促 OKR 前置判断 Mock（本地 assistant 回复）→ executeTaskService（补 taskComposerContext）
+ * → 任务 JSON → TaskComposerForm → 大促 OKR 前置判断 Mock（本地 assistant 回复）→ executeTaskService（补 taskComposerContext）
  * → 成功拿 task_id → submitPanelMessage 发 <AixUI type="panel" component="taskPanel.TaskLoopView"> 给 bot
  * → 本地插入 user 消息（SDK 自动）→ MarkdownRender 解析 → 副屏弹出
  * → 消息发后端落库 → loadHistory 拉回 → 副屏持久（切会话/刷新可恢复）。
+ *
+ * 执行前门禁：校验当前会话所属 Bot 是否开启「任务认领」（task_claim_mode），
+ * 未开启则提示去任务协作页授权并阻断执行（不进入 preflight / execute）。
  */
+import { isBotTaskClaimEnabled } from '@/services/tasks/taskClaimQuery';
 import type { TaskComposerContext, TaskComposerForm } from '@/services/tasks/taskMapper';
 import { buildTaskPanelAixUI } from '@/services/tasks/taskPanelMessage';
 import { runTaskPreflightMock } from '@/services/tasks/taskPreflightMock';
@@ -37,6 +41,8 @@ export interface UseTaskExecuteFromCardOptions {
   appendAssistantMessage?: (content: string) => void;
   /** 演示用：以流式方式追加 assistant 回复，不通过聊天网络请求。 */
   streamAssistantMessage?: (content: string) => Promise<void>;
+  /** 执行前门禁未通过时，toast「去开启」按钮的跳转回调（跳任务协作页）。无则 toast 无跳转 action。 */
+  onOpenCollaborationPermissions?: () => void;
 }
 
 export function useTaskExecuteFromCard({
@@ -44,6 +50,7 @@ export function useTaskExecuteFromCard({
   submitPanelMessage,
   appendAssistantMessage,
   streamAssistantMessage,
+  onOpenCollaborationPermissions,
 }: UseTaskExecuteFromCardOptions): void {
   const inFlightRef = useRef(false);
 
@@ -57,26 +64,39 @@ export function useTaskExecuteFromCard({
         inFlightRef.current = false;
         return;
       }
-      // task JSON → TaskComposerForm
-      const form: TaskComposerForm = {
-        title: (task.goal ?? '').slice(0, 80) || '任务执行',
-        objective: task.goal ?? '',
-        instruction: [
-          task.goal ? `目标：${task.goal}` : '',
-          task.deliverables?.length ? `交付物：${task.deliverables.join('；')}` : '',
-          task.acceptance_criteria?.length ? `验收标准：${task.acceptance_criteria.join('；')}` : '',
-          task.constraints?.length ? `约束：${task.constraints.join('；')}` : '',
-        ]
-          .filter(Boolean)
-          .join('\n'),
-        acceptances: task.acceptance_criteria ?? [],
-        taskType: task.task_type === 'workflow' ? 'workflow' : 'dynamic',
-        workflowId: task.workflow_id,
-        // task_ready.task.constraints is the TaskInfo background payload.
-        background: task.constraints?.filter((item) => item.trim()).join('；') ?? '',
-      };
       void (async () => {
         try {
+          // 执行前门禁：当前会话所属 Bot 未开启任务认领 → 提示去任务协作页授权并阻断执行。
+          if (context.ownerBotId) {
+            const enabled = await isBotTaskClaimEnabled(context.ownerBotId);
+            if (!enabled) {
+              toast.warning('当前 Bot 未开启任务认领，请先去任务协作页对当前 Bot 授权开启后再执行', {
+                action: onOpenCollaborationPermissions
+                  ? { label: '去开启', onClick: () => onOpenCollaborationPermissions() }
+                  : undefined,
+              });
+              return;
+            }
+          }
+
+          // task JSON → TaskComposerForm
+          const form: TaskComposerForm = {
+            title: (task.goal ?? '').slice(0, 80) || '任务执行',
+            objective: task.goal ?? '',
+            instruction: [
+              task.goal ? `目标：${task.goal}` : '',
+              task.deliverables?.length ? `交付物：${task.deliverables.join('；')}` : '',
+              task.acceptance_criteria?.length ? `验收标准：${task.acceptance_criteria.join('；')}` : '',
+              task.constraints?.length ? `约束：${task.constraints.join('；')}` : '',
+            ]
+              .filter(Boolean)
+              .join('\n'),
+            acceptances: task.acceptance_criteria ?? [],
+            taskType: task.task_type === 'workflow' ? 'workflow' : 'dynamic',
+            workflowId: task.workflow_id,
+            // task_ready.task.constraints is the TaskInfo background payload.
+            background: task.constraints?.filter((item) => item.trim()).join('；') ?? '',
+          };
           // 演示用：命中大促 OKR 时，本地模拟当前 Bot 的需求分析和委派回复。
           // 不发送隐藏指令，不请求专家 Bot；回复完成后仍使用原 context 调用真实 execute。
           const preflight = await runTaskPreflightMock(form);
@@ -123,5 +143,5 @@ export function useTaskExecuteFromCard({
     };
     setTaskExecuteHandler(handler);
     return () => setTaskExecuteHandler(null);
-  }, [appendAssistantMessage, context, streamAssistantMessage, submitPanelMessage]);
+  }, [appendAssistantMessage, context, streamAssistantMessage, submitPanelMessage, onOpenCollaborationPermissions]);
 }

--- a/src/frontend-nextgen/src/hooks/useWorkspace.constants.ts
+++ b/src/frontend-nextgen/src/hooks/useWorkspace.constants.ts
@@ -1,0 +1,14 @@
+import { TEST_USER_SUPPORT_TARGET_ID } from '@/services/workspace';
+import type { ConversationTarget } from '@/services/workspace/workspaceModel';
+
+/** 测试用户身份下的客服测试会话 target（isTestUser 时 botChatTarget 兜底返回）。 */
+export const TEST_SUPPORT_TARGET: ConversationTarget = {
+  id: TEST_USER_SUPPORT_TARGET_ID,
+  name: '客服测试',
+  avatar: 'TS',
+  engine: 'OpenClaw',
+  group: 'mine',
+  status: 'available',
+  summary: '测试客服',
+  kind: 'single',
+};

--- a/src/frontend-nextgen/src/hooks/useWorkspace.options.ts
+++ b/src/frontend-nextgen/src/hooks/useWorkspace.options.ts
@@ -1,0 +1,10 @@
+export interface UseWorkspaceOptions {
+  /**
+   * 副屏 onAction(send_message) 的自定义回流。
+   *
+   * 产线默认走 sendMessage → chat.onRequest（真实对话 provider）。
+   * 自测面板可注入只 toast/log 的回调，不触碰真实对话链路，便于零对话依赖自测 send_message 回流。
+   * fill_input 不在此注入（始终走本地 setDraft）。
+   */
+  onPanelSend?: (content: string) => void;
+}

--- a/src/frontend-nextgen/src/hooks/useWorkspace.ts
+++ b/src/frontend-nextgen/src/hooks/useWorkspace.ts
@@ -19,16 +19,9 @@ import { buildSingleChatBridgeRequest } from './singleChatBridgeRequest';
 import { useHumanIdentity } from './useHumanIdentity';
 import { useWorkspaceIdentityBootstrap } from './useWorkspaceIdentityBootstrap';
 import { buildBotChatTarget, mapIdentityViewToIdentity } from './workspaceIdentityMapper';
-export interface UseWorkspaceOptions {
-  /**
-   * 副屏 onAction(send_message) 的自定义回流。
-   *
-   * 产线默认走 sendMessage → chat.onRequest（真实对话 provider）。
-   * 自测面板可注入只 toast/log 的回调，不触碰真实对话链路，便于零对话依赖自测 send_message 回流。
-   * fill_input 不在此注入（始终走本地 setDraft）。
-   */
-  onPanelSend?: (content: string) => void;
-}
+import type { UseWorkspaceOptions } from './useWorkspace.options';
+import { TEST_SUPPORT_TARGET } from './useWorkspace.constants';
+export type { UseWorkspaceOptions } from './useWorkspace.options';
 export function useWorkspace(options: UseWorkspaceOptions = {}) {
   const {
     activeIdentityId,
@@ -67,8 +60,19 @@ export function useWorkspace(options: UseWorkspaceOptions = {}) {
   }, [activeIdentityView, availableViews, view, setView]);
   const isTestUser = isTestUserIdentity(activeIdentityId);
   const isUserIdentity = activeIdentityView?.kind === 'user';
-  const { chatBots, hasAgentCodingBots, isLoading: isMyBotsLoading } = useOwnedBots(activeIdentityId, isUserIdentity);
-  const { friendBots, isLoading: isFriendBotsLoading } = useFriendBots(
+  const {
+    chatBots,
+    hasAgentCodingBots,
+    isLoading: isMyBotsLoading,
+    error: myBotsError,
+    reload: reloadMyBots,
+  } = useOwnedBots(activeIdentityId, isUserIdentity);
+  const {
+    friendBots,
+    isLoading: isFriendBotsLoading,
+    error: friendBotsError,
+    reload: reloadFriendBots,
+  } = useFriendBots(
     activeIdentityId,
     isUserIdentity,
     view !== 'group',
@@ -166,17 +170,7 @@ export function useWorkspace(options: UseWorkspaceOptions = {}) {
   };
 
   const botChatTarget = useMemo<ConversationTarget | null>(() => {
-    if (isTestUser)
-      return {
-        id: TEST_USER_SUPPORT_TARGET_ID,
-        name: '客服测试',
-        avatar: 'TS',
-        engine: 'OpenClaw',
-        group: 'mine',
-        status: 'available',
-        summary: '测试客服',
-        kind: 'single',
-      } as ConversationTarget;
+    if (isTestUser) return TEST_SUPPORT_TARGET;
     if (!selectedChatBot) return null;
     return buildBotChatTarget(selectedChatBot);
   }, [isTestUser, selectedChatBot]);
@@ -211,7 +205,11 @@ export function useWorkspace(options: UseWorkspaceOptions = {}) {
     hasAgentCodingBots,
     friendBots,
     isMyBotsLoading,
+    myBotsError,
+    reloadMyBots,
     isFriendBotsLoading,
+    friendBotsError,
+    reloadFriendBots,
     expandedBotIds,
     expandedBotSectionKey,
     toggleBotExpanded: onToggleBotExpanded,

--- a/src/frontend-nextgen/src/pages/CollaborationPrivacy/index.tsx
+++ b/src/frontend-nextgen/src/pages/CollaborationPrivacy/index.tsx
@@ -60,33 +60,39 @@ export default function CollaborationPrivacyPage() {
         )}
         {!privacy.loading && !privacy.error && overview && (
           <>
-            <IdentityCard
-              identity={overview.currentUser}
-              avatarUrl={accountIdentity?.avatarUrl}
-              syncing={privacy.busyAction === 'syncDepartment'}
-              onSync={() => void privacy.syncDepartment()}
-            />
-            {overview.bots.length === 0 ? (
-              <Card>
-                <Empty title="暂无可配置的 Bot" description="创建 Bot 后，可在这里管理协作权限。" />
-              </Card>
-            ) : (
-              <div className="grid items-start gap-5 xl:grid-cols-2">
-                {overview.bots.map((bot) => (
-                  <PermissionCard
-                    key={bot.id}
-                    bot={bot}
-                    busyAction={privacy.busyAction}
-                    onCopyId={(botId) => void privacy.copyBotId(botId)}
-                    onRefresh={(targetBot) => void privacy.refreshBot(targetBot)}
-                    onToggleDirect={privacy.toggleDirect}
-                    onEditPublication={privacy.openPublicationEditor}
-                    onEditFriendApproval={privacy.openFriendEditor}
-                    onViewScope={privacy.openScopeViewer}
-                    onViewFriendApprovalScope={privacy.openFriendScopeViewer}
-                  />
-                ))}
-              </div>
+            {privacy.showIdentityCard && (
+              <IdentityCard
+                identity={overview.currentUser}
+                avatarUrl={accountIdentity?.avatarUrl}
+                syncing={privacy.busyAction === 'syncDepartment'}
+                onSync={() => void privacy.syncDepartment()}
+              />
+            )}
+            {privacy.activeIdentity?.kind === 'bot' && (
+              <>
+                {privacy.visibleBots.length === 0 ? (
+                  <Card>
+                    <Empty title="暂无当前 Bot 的协作权限" description="当前 Bot 暂无可配置的协作权限内容。" />
+                  </Card>
+                ) : (
+                  <div className="grid items-start gap-5">
+                    {privacy.visibleBots.map((bot) => (
+                      <PermissionCard
+                        key={bot.id}
+                        bot={bot}
+                        busyAction={privacy.busyAction}
+                        onCopyId={(botId) => void privacy.copyBotId(botId)}
+                        onRefresh={(targetBot) => void privacy.refreshBot(targetBot)}
+                        onToggleDirect={privacy.toggleDirect}
+                        onEditPublication={privacy.openPublicationEditor}
+                        onEditFriendApproval={privacy.openFriendEditor}
+                        onViewScope={privacy.openScopeViewer}
+                        onViewFriendApprovalScope={privacy.openFriendScopeViewer}
+                      />
+                    ))}
+                  </div>
+                )}
+              </>
             )}
           </>
         )}

--- a/src/frontend-nextgen/src/pages/Workspace/GroupWorkspaceArea.tsx
+++ b/src/frontend-nextgen/src/pages/Workspace/GroupWorkspaceArea.tsx
@@ -3,7 +3,6 @@ import { Drawer, DrawerContent, DrawerTitle } from '@/components/ui';
 import type { WorkspaceView } from '@/domain/collaboration/availableViews';
 import type { GroupPanelKind } from '@/pages/Workspace/components/GroupHeader';
 import { sessionService } from '@/services/workspace/sessionService';
-import type { Identity } from '@/services/workspace/workspaceModel';
 import { useWorkspaceStore } from '@/stores/workspaceStore';
 import React, { useState } from 'react';
 import { GroupChatPane } from './components/GroupChatPane';
@@ -24,10 +23,6 @@ export function GroupWorkspaceArea({
   view,
   onViewChange,
   availableViews,
-  identities,
-  activeIdentityId,
-  onChangeIdentity,
-  onOpenPermissions,
   userAvatarUrl,
   userIdentityId,
   onAddFriend,
@@ -37,10 +32,6 @@ export function GroupWorkspaceArea({
   view: 'chat' | 'group';
   onViewChange: (v: 'chat' | 'group') => void;
   availableViews: WorkspaceView[];
-  identities?: Identity[];
-  activeIdentityId?: string | null;
-  onChangeIdentity?: (id: string) => void;
-  onOpenPermissions?: () => void;
   userAvatarUrl?: string;
   userIdentityId?: string | null;
   onAddFriend: () => void;
@@ -49,8 +40,6 @@ export function GroupWorkspaceArea({
   onCloseMobileList: () => void;
 }) {
   const ws = useGroupWorkspace();
-  const identityItems = identities ?? [];
-  const handleChangeIdentity = onChangeIdentity ?? (() => {});
   const expandedGroupIds = React.useMemo(
     () => ws.groups.filter((g) => ws.expandedGroupIds[g.groupId]).map((g) => g.groupId),
     [ws.groups, ws.expandedGroupIds],
@@ -151,13 +140,10 @@ export function GroupWorkspaceArea({
     view,
     onViewChange,
     availableViews,
-    identities: identityItems,
-    activeIdentityId: activeIdentityId ?? null,
-    onChangeIdentity: handleChangeIdentity,
-    onOpenPermissions,
-    userAvatarUrl,
     groups: ws.groups,
     isLoading: ws.isLoadingGroups,
+    groupsError: ws.groupsError,
+    onRetryGroups: ws.retryGroups,
     onSelectGroup: (id) => void ws.onSelectGroup(id),
     groupSearchText: ws.groupSearchText,
     onSearchTextChange: ws.setGroupSearchText,
@@ -174,6 +160,9 @@ export function GroupWorkspaceArea({
     totalSessionsByGroupId: sessions.totalSessionsByGroupId,
     isLoadingMoreSessionsByGroupId: sessions.isLoadingMoreSessionsByGroupId,
     onLoadMoreSessions: sessions.loadMoreSessions,
+    errorByGroupId: sessions.errorByGroupId,
+    loadMoreErrorByGroupId: sessions.loadMoreErrorByGroupId,
+    onReloadSession: sessions.reloadGroup,
     sessionTabsByGroup,
     onSessionTabForGroup: setSessionTabForGroup,
     favoriteSessionIds: sessions.favoriteSessionIds,

--- a/src/frontend-nextgen/src/pages/Workspace/components/BotSessionSidebar/BotItem.tsx
+++ b/src/frontend-nextgen/src/pages/Workspace/components/BotSessionSidebar/BotItem.tsx
@@ -1,15 +1,15 @@
 import { Button, IconButton, Skeleton } from '@/components/ui';
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/Popover';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/Tooltip';
 import { getBotEngineLabel } from '@/domain/botEngine';
 import { getBotTypeLabel } from '@/domain/botType';
 import type { BotChatSessionView, ChatBotView } from '@/services/workspace/botSessionService';
 import { cn } from '@/utils/cn';
-import { MoreHorizontal, Plus, Settings2 } from 'lucide-react';
+import { ChevronDown, ChevronRight, Plus } from 'lucide-react';
 import React, { useEffect, useRef, useState } from 'react';
 import type { BotSessionPageMeta } from '../../hooks/useBotSessionMap';
 import { AvatarTile } from '../AvatarTile';
-import { SessionToolbar } from '../SessionToolbar';
+import { ListErrorState } from '../ListErrorState';
+import { SessionScopeFilter } from '../SessionScopeFilter';
 import { BotSessionItem } from './BotSessionItem';
 
 interface BotItemProps {
@@ -30,7 +30,7 @@ interface BotItemProps {
   onToggleFavorite: (botId: string, sessionId: string) => Promise<boolean>;
   onLoadFavorites: (botId: string) => Promise<void>;
   onLoadMoreSessions?: (botId: string, mode: 'all' | 'favorite') => Promise<void>;
-  onManageBot?: (bot: ChatBotView) => void;
+  onReloadBot?: (botId: string) => Promise<void>;
 }
 
 /** Bot 行与协作群行共享同一高度和信息层级；AgentCoding Bot 由工作台引导使用。 */
@@ -52,7 +52,7 @@ export const BotItem = React.memo(function BotItem({
   onToggleFavorite,
   onLoadFavorites,
   onLoadMoreSessions,
-  onManageBot,
+  onReloadBot,
 }: BotItemProps) {
   const [sessionTab, setSessionTab] = useState<'all' | 'favorite'>('all');
   const favoritePrefetchRef = useRef(false);
@@ -76,44 +76,53 @@ export const BotItem = React.memo(function BotItem({
   const isUnavailable = !bot.chatable;
   const botEngineLabel = getBotEngineLabel(bot.engine);
   const botTypeLabel = getBotTypeLabel(bot.botType);
+  const isCurrent = [sessions, favoriteSessions]
+    .filter(Boolean)
+    .some((list) => list?.some((session) => session.sessionId === selectedBotSessionId));
+  const handleSessionScopeChange = (tab: 'all' | 'favorite') => {
+    setSessionTab(tab);
+    if (tab === 'favorite') void onLoadFavorites(bot.botId);
+    if (!expanded) onToggleBotExpanded(bot.botId);
+  };
 
   return (
-    <div className={cn(isUnavailable && 'opacity-50')}>
+    <div>
       <div
         className={cn(
-          'group relative flex min-h-[72px] items-center gap-3 border-b border-transparent px-[18px] py-3 transition-colors',
-          expanded ? 'bg-primary/5' : 'bg-transparent hover:bg-accent/50',
+          'group relative flex min-h-16 items-center gap-3 px-4 py-2.5 transition-colors',
+          isCurrent || expanded ? 'bg-primary/5' : 'bg-background hover:bg-accent/50',
         )}
       >
-        {expanded && (
+        {(isCurrent || expanded) && (
           <span aria-hidden="true" className="absolute bottom-2 left-0 top-2 w-[3px] rounded-r-sm bg-primary" />
         )}
         <Button
           variant="ghost"
           aria-label={bot.chatable ? bot.displayName : '不可用 Bot'}
           aria-expanded={expanded}
+          aria-current={isCurrent ? 'page' : undefined}
           aria-disabled={isUnavailable}
           onClick={toggle}
           className={cn(
-            'flex h-auto min-w-0 flex-1 items-center justify-start gap-2.5 rounded-none px-0 py-1 text-left hover:bg-transparent',
+            'flex h-auto min-w-0 flex-1 items-center justify-start gap-3 rounded-none px-0 py-1 text-left hover:bg-transparent',
             isUnavailable && 'cursor-not-allowed',
           )}
         >
           <AvatarTile
             src={bot.avatarUrl}
             label={bot.displayName}
-            fallbackContent={<span className="text-[9px] font-semibold tracking-[0.08em]">BOT</span>}
+            fallbackContent={<span className="text-[10px] font-semibold tracking-[0.08em]">BOT</span>}
           />
           <div className="min-w-0 flex-1">
             <TooltipProvider delayDuration={300}>
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <span className="block truncate text-sm font-medium text-foreground">{bot.displayName}</span>
+                  <span className="block truncate text-sm font-semibold text-foreground">{bot.displayName}</span>
                 </TooltipTrigger>
                 <TooltipContent>{bot.chatable ? bot.displayName : '该 Bot 暂不支持单聊'}</TooltipContent>
               </Tooltip>
             </TooltipProvider>
-            <div className="mt-1 flex min-w-0 items-center gap-1.5 truncate text-xs leading-4 text-muted-foreground">
+            <div className="mt-1 flex min-w-0 items-center gap-1 truncate text-xs leading-4 text-muted-foreground">
               {(bot.isAgentCodingBot ? bot.templateName || 'AgentCoding' : botEngineLabel) && (
                 <span className="shrink-0">
                   {bot.isAgentCodingBot ? bot.templateName || 'AgentCoding' : botEngineLabel}
@@ -139,63 +148,47 @@ export const BotItem = React.memo(function BotItem({
               )}
             </div>
           </div>
+          {bot.chatable && !bot.isAgentCodingBot && (
+            expanded ? (
+              <ChevronDown className="h-3.5 w-3.5 shrink-0 text-primary" aria-hidden="true" />
+            ) : (
+              <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
+            )
+          )}
         </Button>
         {bot.chatable && !bot.isAgentCodingBot && (
-          <IconButton
-            label="新建会话"
-            size="sm"
-            icon={<Plus className="h-4 w-4" />}
-            className="rounded-md"
-            onClick={(event) => {
-              event.stopPropagation();
-              onCreateSession(bot.botId);
-            }}
-          />
-        )}
-        {bot.chatable && (
-          <Popover>
-            <PopoverTrigger asChild>
-              <IconButton
-                label="Bot操作"
-                size="sm"
-                icon={<MoreHorizontal className="h-4 w-4" />}
-                className="rounded-md"
-                onClick={(event) => event.stopPropagation()}
-              />
-            </PopoverTrigger>
-            <PopoverContent align="end" className="w-40 p-1">
-              <Button
-                variant="ghost"
-                className="h-auto w-full justify-start gap-2 px-2 py-2 text-xs"
-                onClick={(event) => {
-                  event.stopPropagation();
-                  onManageBot?.(bot);
-                }}
-              >
-                <Settings2 className="h-3.5 w-3.5" aria-hidden="true" />
-                管理 Bot
-              </Button>
-            </PopoverContent>
-          </Popover>
+          <>
+            <IconButton
+              label="新建会话"
+              size="sm"
+              icon={<Plus className="h-4 w-4" />}
+              className="rounded-md text-muted-foreground hover:bg-primary/10 hover:text-primary"
+              onClick={(event) => {
+                event.stopPropagation();
+                onCreateSession(bot.botId);
+              }}
+            />
+            <SessionScopeFilter
+              value={sessionTab}
+              onChange={handleSessionScopeChange}
+              allCount={allSessionMeta?.total}
+              favoriteCount={favoriteSessionMeta?.total}
+            />
+          </>
         )}
       </div>
 
       {expanded && bot.chatable && (
-        <div aria-label={`Bot会话列表：${bot.displayName}`} className="border-b border-border/60 bg-background">
-          <SessionToolbar
-            value={sessionTab}
-            onChange={(tab) => {
-              setSessionTab(tab);
-              if (tab === 'favorite') void onLoadFavorites(bot.botId);
-            }}
-            allCount={allSessionMeta?.total}
-            favoriteCount={favoriteSessionMeta?.total}
-          />
-          <div className="overflow-hidden border-b border-border/60 bg-background">
-            {sessionTab === 'all' && sessions === undefined ? (
+        <div aria-label={`Bot会话列表：${bot.displayName}`} className="border-t border-border/60 bg-background">
+          <div className="overflow-hidden bg-background">
+            {sessionTab === 'all' && allSessionMeta?.error ? (
+              <ListErrorState message={allSessionMeta.error} onRetry={() => void onReloadBot?.(bot.botId)} />
+            ) : sessionTab === 'favorite' && favoriteSessionMeta?.error ? (
+              <ListErrorState message={favoriteSessionMeta.error} onRetry={() => void onLoadFavorites(bot.botId)} />
+            ) : sessionTab === 'all' && sessions === undefined ? (
               <div>
                 {[1, 2, 3].map((i) => (
-                  <Skeleton.Block key={i} className="h-16 w-full rounded-none border-b border-border last:border-b-0" />
+                  <Skeleton.Block key={i} className="h-[60px] w-full rounded-none border-b border-border last:border-b-0" />
                 ))}
               </div>
             ) : sessionTab === 'favorite' && favoriteSessions === undefined ? (
@@ -225,7 +218,7 @@ export const BotItem = React.memo(function BotItem({
             )}
           </div>
           {((sessionTab === 'all' ? allSessionMeta : favoriteSessionMeta)?.hasMore ?? false) && (
-            <div className="flex justify-center border-b border-border/60 px-[18px] pb-1 pt-3">
+            <div className="flex justify-center border-t border-border/60 bg-muted/20 px-[18px] pb-2 pt-2">
               <Button
                 variant="ghost"
                 size="sm"
@@ -234,13 +227,19 @@ export const BotItem = React.memo(function BotItem({
                   event.stopPropagation();
                   void onLoadMoreSessions?.(bot.botId, sessionTab);
                 }}
-                className="h-8 rounded-none px-3 text-xs text-muted-foreground hover:bg-accent/60 hover:text-foreground"
+                className="h-8 rounded-md border border-input bg-background px-3 text-xs text-foreground hover:bg-accent"
               >
                 {(sessionTab === 'all' ? allSessionMeta : favoriteSessionMeta)?.isLoadingMore
                   ? '正在加载…'
-                  : '加载更多'}
+                  : '加载更多会话'}
               </Button>
             </div>
+          )}
+          {(sessionTab === 'all' ? allSessionMeta : favoriteSessionMeta)?.loadMoreError && (
+            <ListErrorState
+              message={(sessionTab === 'all' ? allSessionMeta : favoriteSessionMeta)?.loadMoreError ?? ''}
+              onRetry={() => void onLoadMoreSessions?.(bot.botId, sessionTab)}
+            />
           )}
         </div>
       )}

--- a/src/frontend-nextgen/src/pages/Workspace/components/BotSessionSidebar/BotListSection.tsx
+++ b/src/frontend-nextgen/src/pages/Workspace/components/BotSessionSidebar/BotListSection.tsx
@@ -4,6 +4,7 @@ import { ChevronDown, ChevronRight } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { useState } from 'react';
 import type { BotSessionPageMeta } from '../../hooks/useBotSessionMap';
+import { ListErrorState } from '../ListErrorState';
 import { BotItem } from './BotItem';
 
 interface BotListSectionProps {
@@ -12,6 +13,8 @@ interface BotListSectionProps {
   count: number;
   bots: ChatBotView[];
   isLoading?: boolean;
+  error?: string | null;
+  onRetry?: () => void;
   defaultCollapsed?: boolean;
   expandedBotIds: Record<string, true>;
   expandedBotSectionKey: Record<string, string>;
@@ -30,7 +33,8 @@ interface BotListSectionProps {
   onToggleFavorite: (botId: string, sessionId: string) => Promise<boolean>;
   onLoadFavorites: (botId: string) => Promise<void>;
   onLoadMoreSessions?: (botId: string, mode: 'all' | 'favorite') => Promise<void>;
-  onManageBot?: (bot: ChatBotView) => void;
+  onReloadBot?: (botId: string) => Promise<void>;
+  headerHint?: ReactNode;
   footer?: ReactNode;
 }
 
@@ -40,6 +44,8 @@ export function BotListSection({
   count,
   bots,
   isLoading,
+  error,
+  onRetry,
   defaultCollapsed,
   expandedBotIds,
   expandedBotSectionKey,
@@ -58,38 +64,43 @@ export function BotListSection({
   onToggleFavorite,
   onLoadFavorites,
   onLoadMoreSessions,
-  onManageBot,
+  onReloadBot,
+  headerHint,
   footer,
 }: BotListSectionProps) {
   const [collapsed, setCollapsed] = useState(!!defaultCollapsed);
 
   return (
     <div>
-      <Button
-        variant="ghost"
-        size="sm"
-        onClick={() => setCollapsed((v) => !v)}
-        aria-expanded={!collapsed}
-        aria-label={`${title} (${count})`}
-        aria-controls={`bot-section-${sectionKey}`}
-        className="flex h-auto min-h-10 w-full items-center gap-1 rounded-none border-b border-border/70 bg-muted/10 px-[18px] py-2 text-xs font-medium text-foreground hover:bg-accent/50"
-      >
-        {collapsed ? (
-          <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-        ) : (
-          <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-        )}
-        <span className="flex-1 text-left">{title}</span>
-        <span className="text-muted-foreground">{count} 个 Bot</span>
-      </Button>
+      <div className="flex min-h-9 items-center border-b border-border/70 bg-muted/10">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => setCollapsed((v) => !v)}
+          aria-expanded={!collapsed}
+          aria-label={`${title} (${count})`}
+          aria-controls={`bot-section-${sectionKey}`}
+          className="flex h-auto min-h-9 min-w-0 flex-1 items-center gap-1 rounded-none border-0 bg-transparent px-[18px] py-2 text-xs font-medium text-foreground hover:bg-accent/50"
+        >
+          {collapsed ? (
+            <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          ) : (
+            <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          )}
+          <span className="min-w-0 flex-1 truncate text-left">{title} ({count})</span>
+        </Button>
+        {headerHint && <div className="shrink-0 pr-3">{headerHint}</div>}
+      </div>
       {!collapsed && (
         <div id={`bot-section-${sectionKey}`}>
-          {isLoading ? (
+          {error ? (
+            <ListErrorState message={error} onRetry={onRetry} />
+          ) : isLoading ? (
             <div className="overflow-hidden border-y border-border bg-background">
               {[1, 2].map((i) => (
                 <Skeleton.Block
                   key={i}
-                  className="h-[72px] w-full rounded-none border-b border-border last:border-b-0"
+                  className="h-16 w-full rounded-none border-b border-border last:border-b-0"
                 />
               ))}
             </div>
@@ -119,7 +130,7 @@ export function BotListSection({
                   onToggleFavorite={onToggleFavorite}
                   onLoadFavorites={onLoadFavorites}
                   onLoadMoreSessions={onLoadMoreSessions}
-                  onManageBot={onManageBot}
+                  onReloadBot={onReloadBot}
                 />
               ))}
             </div>

--- a/src/frontend-nextgen/src/pages/Workspace/components/BotSessionSidebar/BotSessionItem.tsx
+++ b/src/frontend-nextgen/src/pages/Workspace/components/BotSessionSidebar/BotSessionItem.tsx
@@ -15,7 +15,7 @@ import type { BotChatSessionView } from '@/services/workspace/botSessionService'
 import { cn } from '@/utils/cn';
 import { Eraser, MoreHorizontal, Pencil, Star, Trash2 } from 'lucide-react';
 import React, { useState } from 'react';
-import { formatMonthDayTime, SessionCard } from '../SessionCard';
+import { formatSessionTime, formatSessionTimeTooltip, SessionCard } from '../SessionCard';
 
 interface Props {
   session: BotChatSessionView;
@@ -96,8 +96,10 @@ export const BotSessionItem = React.memo(function BotSessionItem({
       <SessionCard
         title={session.title}
         subtitle={session.messageCount > 0 ? `${session.messageCount} 条消息` : '暂无消息'}
-        dateText={formatMonthDayTime(session.gmtModified || session.gmtCreate)}
+        dateText={formatSessionTime(session.gmtModified || session.gmtCreate)}
+        dateTooltip={formatSessionTimeTooltip(session.gmtModified || session.gmtCreate)}
         selected={selected}
+        indicator="message"
         onSelect={() => onSelect(session.sessionId)}
         trailing={
           <div className="flex items-center gap-0.5" onClick={(e) => e.stopPropagation()}>

--- a/src/frontend-nextgen/src/pages/Workspace/components/BotSessionSidebar/index.tsx
+++ b/src/frontend-nextgen/src/pages/Workspace/components/BotSessionSidebar/index.tsx
@@ -1,12 +1,13 @@
 import { Button, Empty, Input, Skeleton } from '@/components/ui';
-import { WorkspaceIdentitySelector } from '@/components/Workspace/IdentitySelector';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/Tooltip';
 import type { WorkspaceView } from '@/domain/collaboration/availableViews';
 import type { BotChatSessionView, ChatBotView } from '@/services/workspace/botSessionService';
 import type { Identity } from '@/services/workspace/workspaceModel';
-import { ArrowRight, Search } from 'lucide-react';
+import { Info, Search } from 'lucide-react';
 import { useState } from 'react';
 import type { BotSessionPageMeta } from '../../hooks/useBotSessionMap';
 import { WorkspaceActionButton } from '../WorkspaceActionButton';
+import { ResizableWorkspaceSidebar } from '../ResizableWorkspaceSidebar';
 import { WorkspacePrimaryTabs } from '../WorkspacePrimaryTabs';
 import { BotListSection } from './BotListSection';
 
@@ -16,14 +17,15 @@ export interface BotSessionSidebarProps {
   availableViews?: WorkspaceView[];
   identities?: Identity[];
   activeIdentityId?: string | null;
-  onChangeIdentity?: (id: string) => void;
-  onOpenPermissions?: () => void;
-  userAvatarUrl?: string;
   chatBots: ChatBotView[];
   hasAgentCodingBots?: boolean;
   friendBots: ChatBotView[];
   isMyBotsLoading: boolean;
+  myBotsError?: string | null;
+  onRetryMyBots?: () => void;
   isFriendBotsLoading: boolean;
+  friendBotsError?: string | null;
+  onRetryFriendBots?: () => void;
   expandedBotIds: Record<string, true>;
   expandedBotSectionKey: Record<string, string>;
   sessionsByBotId: Record<string, BotChatSessionView[]>;
@@ -42,7 +44,7 @@ export interface BotSessionSidebarProps {
   onToggleFavorite: (botId: string, sessionId: string) => Promise<boolean>;
   onLoadFavorites: (botId: string) => Promise<void>;
   onLoadMoreSessions?: (botId: string, mode: 'all' | 'favorite') => Promise<void>;
-  onManageBot?: (bot: ChatBotView) => void;
+  onReloadBot?: (botId: string) => Promise<void>;
   onOpenBotWorkshop?: () => void;
   onCreateGroup: () => void;
   onAddFriend: () => void;
@@ -56,14 +58,15 @@ export function BotSessionList(props: BotSessionSidebarProps) {
     availableViews,
     identities = [],
     activeIdentityId = null,
-    onChangeIdentity = () => {},
-    onOpenPermissions = () => {},
-    userAvatarUrl,
     chatBots,
     hasAgentCodingBots = false,
     friendBots,
     isMyBotsLoading,
+    myBotsError,
+    onRetryMyBots,
     isFriendBotsLoading,
+    friendBotsError,
+    onRetryFriendBots,
     expandedBotIds,
     expandedBotSectionKey,
     sessionsByBotId,
@@ -82,8 +85,8 @@ export function BotSessionList(props: BotSessionSidebarProps) {
     onToggleFavorite,
     onLoadFavorites,
     onLoadMoreSessions,
-    onManageBot,
-    onOpenBotWorkshop = () => {},
+    onReloadBot,
+    onOpenBotWorkshop,
     onCreateGroup,
     onAddFriend,
   } = props;
@@ -115,42 +118,34 @@ export function BotSessionList(props: BotSessionSidebarProps) {
     onToggleFavorite,
     onLoadFavorites,
     onLoadMoreSessions,
-    onManageBot,
+    onReloadBot,
   };
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      <div className="shrink-0 px-[18px] pb-3 pt-4">
-        <WorkspaceIdentitySelector
-          identities={identities}
-          activeId={activeIdentityId}
-          onChange={onChangeIdentity}
-          onOpenPermissions={onOpenPermissions}
-          userAvatarUrl={userAvatarUrl}
-          layout="sidebar"
-        />
-      </div>
-      <div className="app-scrollbar min-h-0 flex-1 overflow-y-auto bg-muted">
-        {showViewSwitch && (
-          <div className="sticky top-0 z-20 mb-2 flex items-center gap-2 bg-muted px-[18px]">
-            <WorkspacePrimaryTabs
-              value={view as WorkspaceView}
-              options={availableViews ?? []}
-              onChange={onViewChange}
-            />
-            <WorkspaceActionButton onAddFriend={onAddFriend} onCreateGroup={onCreateGroup} />
-          </div>
-        )}
-        <div className="my-2 px-[18px]">
-          <div className="relative">
-            <Search className="pointer-events-none absolute left-3 top-2.5 h-4 w-4 text-muted-foreground" />
-            <Input
-              className="pl-9"
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              placeholder="搜索 Bot 名称"
-              aria-label="搜索 Bot"
-            />
+      <div className="app-scrollbar min-h-0 flex-1 overflow-y-auto bg-muted/20">
+        <div className="sticky top-0 z-20 border-b border-border/70 bg-muted/20 pt-1 backdrop-blur-sm">
+          {showViewSwitch && (
+            <div className="flex h-10 items-center gap-2 px-[18px]">
+              <WorkspacePrimaryTabs
+                value={view as WorkspaceView}
+                options={availableViews ?? []}
+                onChange={onViewChange}
+              />
+              <WorkspaceActionButton onAddFriend={onAddFriend} onCreateGroup={onCreateGroup} />
+            </div>
+          )}
+          <div className="my-2 px-[18px]">
+            <div className="relative">
+              <Search className="pointer-events-none absolute left-3 top-2.5 h-4 w-4 text-muted-foreground" />
+              <Input
+                className="h-9 pl-9"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder="搜索 Bot 名称"
+                aria-label="搜索 Bot"
+              />
+            </div>
           </div>
         </div>
         {(isSessionsLoading || isMyBotsLoading) && chatBots.length === 0 && friendBots.length === 0 ? (
@@ -170,21 +165,41 @@ export function BotSessionList(props: BotSessionSidebarProps) {
                 count={filteredMine.length}
                 bots={filteredMine}
                 isLoading={isMyBotsLoading}
-                footer={
+                error={myBotsError}
+                onRetry={onRetryMyBots}
+                headerHint={
                   hasAgentCodingBots ? (
-                    <Button
-                      variant="ghost"
-                      className="group mx-[18px] mb-3 mt-3 flex h-auto w-[calc(100%-36px)] cursor-pointer items-center justify-between gap-3 rounded-md border border-primary/20 bg-primary/5 px-3 py-2.5 text-left text-foreground transition-colors hover:bg-primary/10"
-                      onClick={onOpenBotWorkshop}
-                    >
-                      <span className="text-xs font-medium leading-5 text-foreground">
-                        AgentCoding Bot 请前往 Bot 工坊使用
-                      </span>
-                      <ArrowRight
-                        className="h-4 w-4 shrink-0 text-foreground/70 transition-colors group-hover:text-primary"
-                        aria-hidden="true"
-                      />
-                    </Button>
+                    <TooltipProvider delayDuration={0}>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            aria-label="AgentCoding Bot 使用提示"
+                            className="h-7 w-7 rounded-md text-muted-foreground hover:text-primary"
+                          >
+                            <Info className="h-3.5 w-3.5" aria-hidden="true" />
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent className="max-w-[240px]">
+                          <span>AgentCoding Bot 请前往 </span>
+                          <a
+                            href="/bot-workshop"
+                            className="font-medium text-primary underline underline-offset-2"
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              if (onOpenBotWorkshop) {
+                                event.preventDefault();
+                                onOpenBotWorkshop();
+                              }
+                            }}
+                          >
+                            Bot 工坊
+                          </a>
+                          <span> 使用</span>
+                        </TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
                   ) : null
                 }
                 {...sectionProps}
@@ -196,6 +211,8 @@ export function BotSessionList(props: BotSessionSidebarProps) {
               count={filteredFriends.length}
               bots={filteredFriends}
               isLoading={isFriendBotsLoading}
+              error={friendBotsError}
+              onRetry={onRetryFriendBots}
               {...sectionProps}
             />
           </div>
@@ -208,8 +225,8 @@ export function BotSessionList(props: BotSessionSidebarProps) {
 /** 内流会话列表外壳。≥lg 在流内；<lg hidden，由 Workspace 抽屉呈现同一 BotSessionList。 */
 export function BotSessionSidebar(props: BotSessionSidebarProps) {
   return (
-    <aside className="hidden w-[360px] shrink-0 flex-col overflow-hidden border-r border-border bg-muted/20 lg:flex">
+    <ResizableWorkspaceSidebar ariaLabel="Bot 会话侧栏">
       <BotSessionList {...props} />
-    </aside>
+    </ResizableWorkspaceSidebar>
   );
 }

--- a/src/frontend-nextgen/src/pages/Workspace/components/ChatSessionSidebarSlot.tsx
+++ b/src/frontend-nextgen/src/pages/Workspace/components/ChatSessionSidebarSlot.tsx
@@ -6,7 +6,6 @@ import {
   BotSessionSidebar,
   type BotSessionSidebarProps,
 } from '@/pages/Workspace/components/BotSessionSidebar';
-import type { ChatBotView } from '@/services/workspace/botSessionService';
 
 interface ChatSessionSidebarSlotProps {
   /** Reactive workspace model（chatBots / friendBots / botSessions 等会话侧栏所需数据）。 */
@@ -19,9 +18,6 @@ interface ChatSessionSidebarSlotProps {
   onMobileListClose: () => void;
   onOpenCreateGroup: () => void;
   onOpenAddFriend: () => void;
-  onOpenPermissions: () => void;
-  userAvatarUrl?: string;
-  onManageBot?: (bot: ChatBotView) => void;
   onOpenBotWorkshop?: () => void;
 }
 
@@ -38,9 +34,6 @@ export function ChatSessionSidebarSlot({
   onMobileListClose,
   onOpenCreateGroup,
   onOpenAddFriend,
-  onOpenPermissions,
-  userAvatarUrl,
-  onManageBot,
   onOpenBotWorkshop,
 }: ChatSessionSidebarSlotProps) {
   const botSessions = workspace.botSessions;
@@ -50,14 +43,15 @@ export function ChatSessionSidebarSlot({
     availableViews,
     identities: workspace.identities,
     activeIdentityId: workspace.activeIdentityId,
-    onChangeIdentity: workspace.setActiveIdentityId,
-    onOpenPermissions,
-    userAvatarUrl,
     chatBots: workspace.chatBots,
     hasAgentCodingBots: workspace.hasAgentCodingBots,
     friendBots: workspace.friendBots,
     isMyBotsLoading: workspace.isMyBotsLoading,
+    myBotsError: workspace.myBotsError,
+    onRetryMyBots: workspace.reloadMyBots,
     isFriendBotsLoading: workspace.isFriendBotsLoading,
+    friendBotsError: workspace.friendBotsError,
+    onRetryFriendBots: workspace.reloadFriendBots,
     expandedBotIds: workspace.expandedBotIds,
     expandedBotSectionKey: workspace.expandedBotSectionKey,
     sessionsByBotId: botSessions.sessionsByBotId,
@@ -91,7 +85,6 @@ export function ChatSessionSidebarSlot({
     onToggleFavorite: (botId, sessionId) => botSessions.toggleFavorite(botId, sessionId),
     onLoadFavorites: (botId) => botSessions.loadFavoriteSessions(botId),
     onLoadMoreSessions: botSessions.loadMoreSessions,
-    onManageBot,
     onOpenBotWorkshop,
     onCreateGroup: onOpenCreateGroup,
     onAddFriend: onOpenAddFriend,

--- a/src/frontend-nextgen/src/pages/Workspace/components/GroupChatPane/GroupChatComposer.tsx
+++ b/src/frontend-nextgen/src/pages/Workspace/components/GroupChatPane/GroupChatComposer.tsx
@@ -192,7 +192,7 @@ export function GroupChatComposer({
   );
 
   return (
-    <div className="flex shrink-0 flex-col gap-2 border-t border-border bg-background px-3 py-3 sm:px-6 sm:py-4">
+    <div className="flex shrink-0 flex-col gap-2 bg-background px-3 py-1.5 sm:px-6 sm:py-2">
       {editingMessageId ? <MessageEditBar onCancel={onCancelEdit ?? (() => {})} /> : null}
       <MessageQuoteBar quote={quote ?? null} onClear={onClearQuote ?? (() => {})} />
       <Sender

--- a/src/frontend-nextgen/src/pages/Workspace/components/GroupChatPane/index.tsx
+++ b/src/frontend-nextgen/src/pages/Workspace/components/GroupChatPane/index.tsx
@@ -12,6 +12,7 @@ import type { MentionConfig } from '@tc-chat/ui';
 import { ChatLayout } from '@tc-chat/ui/es/ChatLayout';
 import { RefreshCw, Sparkles } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { GroupHeader } from '../GroupHeader';
 import { CollabPanel } from './CollabPanel';
 import { FuseSlot } from './FuseSlot';
@@ -53,6 +54,9 @@ export function GroupChatPane(props: GroupChatPaneProps) {
     userAvatarUrl,
     userIdentityId,
   } = props;
+
+  const navigate = useNavigate();
+  const openCollaborationPermissions = () => navigate('/collaboration-privacy');
 
   const collabPanel = useCollabPanel(
     session,
@@ -98,6 +102,7 @@ export function GroupChatPane(props: GroupChatPaneProps) {
     submitPanelMessage,
     appendAssistantMessage,
     streamAssistantMessage,
+    onOpenCollaborationPermissions: openCollaborationPermissions,
   });
 
   const [draft, setDraft] = useState('');

--- a/src/frontend-nextgen/src/pages/Workspace/components/GroupSidebar/GroupItem.tsx
+++ b/src/frontend-nextgen/src/pages/Workspace/components/GroupSidebar/GroupItem.tsx
@@ -1,4 +1,4 @@
-import { Button, IconButton, Skeleton } from '@/components/ui';
+import { Button, IconButton } from '@/components/ui';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -11,52 +11,17 @@ import {
 } from '@/components/ui/AlertDialog';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/Popover';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/Tooltip';
-import type { GroupView, SessionView } from '@/domain/collaboration/types';
-import type { DomainResult } from '@/services/workspace/identityService';
 import { cn } from '@/utils/cn';
 import { MoreHorizontal, Plus, Settings2, Share2, Trash2, Users } from 'lucide-react';
 import React, { useState } from 'react';
 import { AvatarTile } from '../AvatarTile';
 import { ShareDialog } from '../ManagePanel/ShareDialog';
-import { SessionToolbar } from '../SessionToolbar';
-import { SessionItem } from './SessionItem';
+import { SessionScopeFilter } from '../SessionScopeFilter';
+import { GroupSessionsList } from './GroupSessionsList';
+import type { GroupItemProps, SessionTab } from './GroupItem.types';
+import { KIND_LABEL, MEMBERSHIP_LABEL } from './GroupItem.types';
 
-export type SessionTab = 'all' | 'favorite';
-
-interface GroupItemProps {
-  group: GroupView;
-  expanded: boolean;
-  sessions: SessionView[] | undefined;
-  sessionTab: SessionTab;
-  onSessionTabChange: (t: SessionTab) => void;
-  favoriteSessionIds: string[];
-  selectedGroupId: string | null;
-  selectedSessionId: string | null;
-  onSelectGroup: (groupId: string) => void;
-  onToggleGroupExpanded: (groupId: string) => void;
-  onSelectSession: (groupId: string, sessionId: string) => void;
-  onToggleFavorite: (sessionId: string) => void;
-  onCreateSession: (groupId: string) => void;
-  onManageGroup: (groupId: string) => void;
-  onManageSession: (groupId: string, sessionId: string) => void;
-  onShareGroup: (groupId: string) => Promise<DomainResult<{ invitationUrl: string }>>;
-  onDissolveGroup: (groupId: string) => void;
-  totalSessionCount?: number;
-  hasMoreSessions: boolean;
-  isLoadingMoreSessions: boolean;
-  onLoadMoreSessions: () => Promise<void>;
-}
-
-const KIND_LABEL: Record<GroupView['kind'], string> = {
-  free_chat: '自由聊天',
-  task_master_slave: '任务协作',
-  task_dag: '自定义协同',
-};
-
-const MEMBERSHIP_LABEL: Record<NonNullable<GroupView['membership']>, string> = {
-  direct: '固定群成员',
-  session_only: '仅参与临时会话',
-};
+export type { SessionTab } from './GroupItem.types';
 
 export const GroupItem = React.memo(function GroupItem({
   group,
@@ -80,26 +45,33 @@ export const GroupItem = React.memo(function GroupItem({
   hasMoreSessions,
   isLoadingMoreSessions,
   onLoadMoreSessions,
+  error,
+  loadMoreError,
+  onRetrySessions,
 }: GroupItemProps) {
   const [actionsOpen, setActionsOpen] = useState(false);
   const [dissolveOpen, setDissolveOpen] = useState(false);
   const [shareOpen, setShareOpen] = useState(false);
   const [shareUrl, setShareUrl] = useState<string | null>(null);
   const [sharing, setSharing] = useState(false);
-  const loaded = sessions !== undefined;
   const safeSessions = sessions ?? [];
-  const visibleSessions =
-    sessionTab === 'favorite' ? safeSessions.filter((s) => favoriteSessionIds.includes(s.sessionId)) : safeSessions;
   // 群接口只返回当前页会话的收藏状态；仍有下一页时，收藏总数尚不能确定。
   const favoriteCount = hasMoreSessions
     ? undefined
     : safeSessions.filter((s) => favoriteSessionIds.includes(s.sessionId)).length;
   const membershipLabel = MEMBERSHIP_LABEL[group.membership ?? 'direct'];
+  const metadataLabel = [group.isPublic ? '公开' : null, KIND_LABEL[group.kind], membershipLabel]
+    .filter(Boolean)
+    .join(' · ');
   const selected = selectedGroupId === group.groupId;
 
   const handleCardClick = () => {
     if (selectedGroupId !== group.groupId) onSelectGroup(group.groupId);
     onToggleGroupExpanded(group.groupId);
+  };
+  const handleSessionScopeChange = (tab: SessionTab) => {
+    onSessionTabChange(tab);
+    if (!expanded) onToggleGroupExpanded(group.groupId);
   };
   const handleShare = async () => {
     setActionsOpen(false);
@@ -119,8 +91,8 @@ export const GroupItem = React.memo(function GroupItem({
     <div>
       <div
         className={cn(
-          'group relative flex min-h-[72px] items-center gap-3 border-b border-transparent px-[18px] py-3 transition-colors',
-          selected ? 'bg-primary/5' : 'bg-transparent hover:bg-accent/50',
+          'group relative flex min-h-16 items-center gap-3 px-4 py-2.5 transition-colors',
+          selected || expanded ? 'bg-primary/5' : 'bg-background hover:bg-accent/50',
         )}
       >
         {selected && (
@@ -130,47 +102,68 @@ export const GroupItem = React.memo(function GroupItem({
           variant="ghost"
           aria-label={group.name}
           aria-expanded={expanded}
+          aria-current={selected ? 'page' : undefined}
           onClick={handleCardClick}
-          className="flex h-auto min-w-0 flex-1 items-center justify-start gap-2.5 rounded-none px-0 py-1 text-left hover:bg-transparent"
+          className="flex h-auto min-w-0 flex-1 items-center justify-start gap-3 rounded-none px-0 py-1 text-left hover:bg-transparent"
         >
-          <AvatarTile label={group.name} fallbackContent={<Users className="h-4 w-4" aria-hidden="true" />} />
+          <AvatarTile
+            label={group.name}
+            className="rounded-full bg-secondary text-secondary-foreground ring-1 ring-border"
+            fallbackContent={<Users className="h-4 w-4" aria-hidden="true" />}
+          />
           <div className="min-w-0 flex-1">
             <div className="flex min-w-0 items-center gap-2">
               <TooltipProvider delayDuration={300}>
                 <Tooltip>
                   <TooltipTrigger asChild>
-                    <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">{group.name}</span>
+                    <span className="min-w-0 flex-1 truncate text-sm font-semibold text-foreground">{group.name}</span>
                   </TooltipTrigger>
                   <TooltipContent>{group.name}</TooltipContent>
                 </Tooltip>
               </TooltipProvider>
             </div>
-            <div className="mt-1 flex min-w-0 items-center gap-1.5 truncate text-xs leading-4 text-muted-foreground">
-              {group.isPublic && (
-                <>
-                  <span className="shrink-0 text-primary">公开</span>
-                  <span aria-hidden="true" className="text-muted-foreground/50">
-                    ·
-                  </span>
-                </>
-              )}
-              <span className="shrink-0">{KIND_LABEL[group.kind]}</span>
-              <span aria-hidden="true" className="text-muted-foreground/50">
-                ·
-              </span>
-              <span className="shrink-0">{membershipLabel}</span>
-            </div>
+            <TooltipProvider delayDuration={0}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <div
+                    aria-label={`协作群标签：${metadataLabel}`}
+                    className="mt-1 flex min-w-0 items-center gap-1 truncate text-xs leading-4 text-muted-foreground"
+                  >
+                    {group.isPublic && (
+                      <>
+                        <span className="shrink-0 text-primary">公开</span>
+                        <span aria-hidden="true" className="text-muted-foreground/50">
+                          ·
+                        </span>
+                      </>
+                    )}
+                    <span className="shrink-0">{KIND_LABEL[group.kind]}</span>
+                    <span aria-hidden="true" className="text-muted-foreground/50">
+                      ·
+                    </span>
+                    <span className="shrink-0">{membershipLabel}</span>
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent>{metadataLabel}</TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           </div>
         </Button>
         <IconButton
           label="新建会话"
           size="sm"
           icon={<Plus className="h-4 w-4" />}
-          className="rounded-md"
+          className="rounded-md text-muted-foreground hover:bg-primary/10 hover:text-primary"
           onClick={(event) => {
             event.stopPropagation();
             onCreateSession(group.groupId);
           }}
+        />
+        <SessionScopeFilter
+          value={sessionTab}
+          onChange={handleSessionScopeChange}
+          allCount={totalSessionCount}
+          favoriteCount={favoriteCount}
         />
         <Popover open={actionsOpen} onOpenChange={setActionsOpen}>
           <PopoverTrigger asChild>
@@ -178,7 +171,7 @@ export const GroupItem = React.memo(function GroupItem({
               label="协作群操作"
               size="sm"
               icon={<MoreHorizontal className="h-4 w-4" />}
-              className="rounded-md"
+              className="rounded-md text-muted-foreground hover:bg-primary/10 hover:text-primary"
               onClick={(event) => event.stopPropagation()}
             />
           </PopoverTrigger>
@@ -215,57 +208,22 @@ export const GroupItem = React.memo(function GroupItem({
       </div>
 
       {expanded && (
-        <div aria-label={`协作群会话列表：${group.name}`} className="border-b border-border/60 bg-background">
-          <SessionToolbar
-            value={sessionTab}
-            onChange={onSessionTabChange}
-            allCount={totalSessionCount}
-            favoriteCount={favoriteCount}
-          />
-          <div className="overflow-hidden border-b border-border/60 bg-background">
-            {!loaded ? (
-              <div>
-                {[1, 2, 3].map((i) => (
-                  <Skeleton.Block key={i} className="h-16 w-full rounded-none border-b border-border last:border-b-0" />
-                ))}
-              </div>
-            ) : visibleSessions.length === 0 ? (
-              <div className="px-3 py-5">
-                <span className="text-xs text-muted-foreground">
-                  {sessionTab === 'favorite' ? '暂无已收藏会话' : '暂无协作群临时会话'}
-                </span>
-              </div>
-            ) : (
-              visibleSessions.map((session) => (
-                <SessionItem
-                  key={session.sessionId}
-                  session={session}
-                  favorite={favoriteSessionIds.includes(session.sessionId)}
-                  selected={selectedSessionId === session.sessionId}
-                  onSelectSession={(sessionId) => onSelectSession(group.groupId, sessionId)}
-                  onToggleFavorite={onToggleFavorite}
-                  onManageSession={(sessionId) => onManageSession(group.groupId, sessionId)}
-                />
-              ))
-            )}
-          </div>
-          {hasMoreSessions && (
-            <div className="flex justify-center border-b border-border/60 px-[18px] pb-1 pt-3">
-              <Button
-                variant="ghost"
-                size="sm"
-                disabled={isLoadingMoreSessions}
-                onClick={(event) => {
-                  event.stopPropagation();
-                  void onLoadMoreSessions();
-                }}
-                className="h-8 rounded-none px-3 text-xs text-muted-foreground hover:bg-accent/60 hover:text-foreground"
-              >
-                {isLoadingMoreSessions ? '正在加载…' : '加载更多'}
-              </Button>
-            </div>
-          )}
-        </div>
+        <GroupSessionsList
+          group={group}
+          sessions={sessions}
+          sessionTab={sessionTab}
+          favoriteSessionIds={favoriteSessionIds}
+          selectedSessionId={selectedSessionId}
+          hasMoreSessions={hasMoreSessions}
+          isLoadingMoreSessions={isLoadingMoreSessions}
+          onLoadMoreSessions={onLoadMoreSessions}
+          error={error}
+          loadMoreError={loadMoreError}
+          onRetrySessions={onRetrySessions}
+          onSelectSession={onSelectSession}
+          onToggleFavorite={onToggleFavorite}
+          onManageSession={onManageSession}
+        />
       )}
 
       <ShareDialog

--- a/src/frontend-nextgen/src/pages/Workspace/components/GroupSidebar/GroupItem.types.ts
+++ b/src/frontend-nextgen/src/pages/Workspace/components/GroupSidebar/GroupItem.types.ts
@@ -1,0 +1,42 @@
+import type { GroupView, SessionView } from '@/domain/collaboration/types';
+import type { DomainResult } from '@/services/workspace/identityService';
+
+export type SessionTab = 'all' | 'favorite';
+
+export interface GroupItemProps {
+  group: GroupView;
+  expanded: boolean;
+  sessions: SessionView[] | undefined;
+  sessionTab: SessionTab;
+  onSessionTabChange: (t: SessionTab) => void;
+  favoriteSessionIds: string[];
+  selectedGroupId: string | null;
+  selectedSessionId: string | null;
+  onSelectGroup: (groupId: string) => void;
+  onToggleGroupExpanded: (groupId: string) => void;
+  onSelectSession: (groupId: string, sessionId: string) => void;
+  onToggleFavorite: (sessionId: string) => void;
+  onCreateSession: (groupId: string) => void;
+  onManageGroup: (groupId: string) => void;
+  onManageSession: (groupId: string, sessionId: string) => void;
+  onShareGroup: (groupId: string) => Promise<DomainResult<{ invitationUrl: string }>>;
+  onDissolveGroup: (groupId: string) => void;
+  totalSessionCount?: number;
+  hasMoreSessions: boolean;
+  isLoadingMoreSessions: boolean;
+  onLoadMoreSessions: () => Promise<void>;
+  error?: string;
+  loadMoreError?: string;
+  onRetrySessions?: () => Promise<void>;
+}
+
+export const KIND_LABEL: Record<GroupView['kind'], string> = {
+  free_chat: '自由聊天',
+  task_master_slave: '任务协作',
+  task_dag: '自定义协同',
+};
+
+export const MEMBERSHIP_LABEL: Record<NonNullable<GroupView['membership']>, string> = {
+  direct: '固定群成员',
+  session_only: '仅参与临时会话',
+};

--- a/src/frontend-nextgen/src/pages/Workspace/components/GroupSidebar/GroupSessionsList.tsx
+++ b/src/frontend-nextgen/src/pages/Workspace/components/GroupSidebar/GroupSessionsList.tsx
@@ -1,0 +1,99 @@
+import { Button, Skeleton } from '@/components/ui';
+import type { GroupView, SessionView } from '@/domain/collaboration/types';
+import { ListErrorState } from '../ListErrorState';
+import { SessionItem } from './SessionItem';
+import type { SessionTab } from './GroupItem.types';
+
+interface GroupSessionsListProps {
+  group: GroupView;
+  sessions: SessionView[] | undefined;
+  sessionTab: SessionTab;
+  favoriteSessionIds: string[];
+  selectedSessionId: string | null;
+  hasMoreSessions: boolean;
+  isLoadingMoreSessions: boolean;
+  onLoadMoreSessions: () => Promise<void>;
+  error?: string;
+  loadMoreError?: string;
+  onRetrySessions?: () => Promise<void>;
+  onSelectSession: (groupId: string, sessionId: string) => void;
+  onToggleFavorite: (sessionId: string) => void;
+  onManageSession: (groupId: string, sessionId: string) => void;
+}
+
+/** 协作群展开后的会话列表：加载/空态/列表/加载更多/分页错误统一在此自洽渲染。 */
+export function GroupSessionsList({
+  group,
+  sessions,
+  sessionTab,
+  favoriteSessionIds,
+  selectedSessionId,
+  hasMoreSessions,
+  isLoadingMoreSessions,
+  onLoadMoreSessions,
+  error,
+  loadMoreError,
+  onRetrySessions,
+  onSelectSession,
+  onToggleFavorite,
+  onManageSession,
+}: GroupSessionsListProps) {
+  const loaded = sessions !== undefined;
+  const safeSessions = sessions ?? [];
+  const visibleSessions =
+    sessionTab === 'favorite' ? safeSessions.filter((s) => favoriteSessionIds.includes(s.sessionId)) : safeSessions;
+  return (
+    <div aria-label={`协作群会话列表：${group.name}`} className="border-t border-border/60 bg-background">
+      <div className="overflow-hidden bg-background">
+        {error ? (
+          <ListErrorState message={error} onRetry={() => void onRetrySessions?.()} />
+        ) : !loaded ? (
+          <div>
+            {[1, 2, 3].map((i) => (
+              <Skeleton.Block key={i} className="h-12 w-full rounded-none border-b border-border last:border-b-0" />
+            ))}
+          </div>
+        ) : visibleSessions.length === 0 ? (
+          <div className="px-3 py-5">
+            <span className="text-xs text-muted-foreground">
+              {sessionTab === 'favorite'
+                ? hasMoreSessions
+                  ? '当前已加载会话中暂无收藏'
+                  : '暂无已收藏会话'
+                : '当前协作群暂无会话'}
+            </span>
+          </div>
+        ) : (
+          visibleSessions.map((session) => (
+            <SessionItem
+              key={session.sessionId}
+              session={session}
+              favorite={favoriteSessionIds.includes(session.sessionId)}
+              selected={selectedSessionId === session.sessionId}
+              onSelectSession={(sessionId) => onSelectSession(group.groupId, sessionId)}
+              onToggleFavorite={onToggleFavorite}
+              onManageSession={(sessionId) => onManageSession(group.groupId, sessionId)}
+            />
+          ))
+        )}
+      </div>
+      {hasMoreSessions && (
+        <div className="flex justify-center border-t border-border/60 bg-muted/20 px-[18px] pb-2 pt-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            disabled={isLoadingMoreSessions}
+            onClick={(event) => {
+              event.stopPropagation();
+              void onLoadMoreSessions();
+            }}
+            className="h-8 rounded-md border border-input bg-background px-3 text-xs text-foreground hover:bg-accent"
+          >
+            {isLoadingMoreSessions ? '正在加载…' : '加载更多会话'}
+          </Button>
+        </div>
+      )}
+      {loadMoreError && <ListErrorState message={loadMoreError} onRetry={() => void onLoadMoreSessions()} />}
+    </div>
+  );
+}

--- a/src/frontend-nextgen/src/pages/Workspace/components/GroupSidebar/GroupSidebarFilters.tsx
+++ b/src/frontend-nextgen/src/pages/Workspace/components/GroupSidebar/GroupSidebarFilters.tsx
@@ -18,10 +18,10 @@ const KIND_OPTIONS: KindFilter[] = ['all', 'free_chat', 'task_master_slave', 'ta
 
 const kindChipClass = (active: boolean) =>
   cn(
-    'h-7 flex-none whitespace-nowrap rounded-none border-0 px-0 text-xs',
+    'h-7 flex-none whitespace-nowrap rounded-md border-0 px-2 text-xs',
     active
-      ? 'bg-transparent font-medium text-primary hover:bg-transparent hover:text-primary'
-      : 'bg-transparent font-normal text-muted-foreground hover:bg-transparent hover:text-foreground',
+      ? 'bg-background font-medium text-primary shadow-sm hover:bg-background hover:text-primary'
+      : 'bg-transparent font-normal text-muted-foreground hover:bg-background/70 hover:text-foreground',
   );
 
 interface GroupSidebarFiltersProps {
@@ -108,14 +108,13 @@ export function GroupSidebarFilters({
       </div>
 
       {filtersOpen && (
-        <div id={filterPanelId} className="mt-2 space-y-2 border-y border-border/80 bg-muted px-[18px] py-3">
-          <div
-            className="grid min-h-7 min-w-0 grid-cols-[4rem_minmax(0,1fr)] items-center gap-1"
-            role="radiogroup"
-            aria-label="协作群类型"
-          >
-            <p className="whitespace-nowrap text-[11px] font-medium text-muted-foreground">协作群类型</p>
-            <div className="flex min-w-0 flex-nowrap gap-x-2 overflow-x-auto scrollbar-hide">
+        <div
+          id={filterPanelId}
+          className="mx-[18px] mt-2 space-y-3 rounded-lg border border-border/70 bg-muted/50 px-3 py-3 shadow-sm"
+        >
+          <div className="min-w-0" role="radiogroup" aria-label="协作群类型">
+            <p className="mb-1.5 whitespace-nowrap text-xs font-medium text-muted-foreground">协作群类型</p>
+            <div className="app-scrollbar flex min-w-0 flex-nowrap gap-x-1 overflow-x-auto pb-1 touch-pan-x">
               {KIND_OPTIONS.map((kind) => (
                 <Button
                   key={kind}
@@ -132,13 +131,9 @@ export function GroupSidebarFilters({
               ))}
             </div>
           </div>
-          <div
-            className="grid min-h-7 min-w-0 grid-cols-[4rem_minmax(0,1fr)] items-center gap-1"
-            role="radiogroup"
-            aria-label="协作群参与方式"
-          >
-            <p className="whitespace-nowrap text-[11px] font-medium text-muted-foreground">参与方式</p>
-            <div className="flex min-w-0 flex-nowrap gap-x-2 overflow-x-auto scrollbar-hide">
+          <div className="min-w-0 border-t border-border/60 pt-3" role="radiogroup" aria-label="协作群参与方式">
+            <p className="mb-1.5 whitespace-nowrap text-xs font-medium text-muted-foreground">参与方式</p>
+            <div className="app-scrollbar flex min-w-0 flex-nowrap gap-x-1 overflow-x-auto pb-1 touch-pan-x">
               {(
                 [
                   ['direct', '固定群成员'],

--- a/src/frontend-nextgen/src/pages/Workspace/components/GroupSidebar/SessionItem.tsx
+++ b/src/frontend-nextgen/src/pages/Workspace/components/GroupSidebar/SessionItem.tsx
@@ -4,7 +4,7 @@ import type { SessionView } from '@/domain/collaboration/types';
 import { cn } from '@/utils/cn';
 import { MoreHorizontal, Settings2, Star } from 'lucide-react';
 import React, { useState } from 'react';
-import { formatMonthDayTime, SessionCard } from '../SessionCard';
+import { formatSessionTime, formatSessionTimeTooltip, SessionCard } from '../SessionCard';
 
 interface SessionItemProps {
   session: SessionView;
@@ -33,7 +33,8 @@ export const SessionItem = React.memo(function SessionItem({
     setMenuOpen(false);
     onToggleFavorite(session.sessionId);
   };
-  const createdTime = formatMonthDayTime(session.lastMessageAt ?? session.createdAt);
+  const sessionTime = session.lastMessageAt ?? session.createdAt;
+  const createdTime = formatSessionTime(sessionTime);
 
   return (
     <SessionCard
@@ -41,7 +42,9 @@ export const SessionItem = React.memo(function SessionItem({
       subtitle=""
       compact
       dateText={createdTime}
+      dateTooltip={formatSessionTimeTooltip(sessionTime)}
       selected={selected}
+      indicator="message"
       onSelect={() => onSelectSession(session.sessionId)}
       trailing={
         <div className="flex items-center gap-0.5" onClick={(e) => e.stopPropagation()}>

--- a/src/frontend-nextgen/src/pages/Workspace/components/GroupSidebar/index.tsx
+++ b/src/frontend-nextgen/src/pages/Workspace/components/GroupSidebar/index.tsx
@@ -1,14 +1,14 @@
 import { Button, Empty, Input, Skeleton } from '@/components/ui';
-import { WorkspaceIdentitySelector } from '@/components/Workspace/IdentitySelector';
 import type { WorkspaceView } from '@/domain/collaboration/availableViews';
 import type { GroupView, SessionView } from '@/domain/collaboration/types';
 import type { DomainResult } from '@/services/workspace/identityService';
-import type { Identity } from '@/services/workspace/workspaceModel';
 import { Search } from 'lucide-react';
 import { WorkspaceActionButton } from '../WorkspaceActionButton';
+import { ResizableWorkspaceSidebar } from '../ResizableWorkspaceSidebar';
 import { WorkspacePrimaryTabs } from '../WorkspacePrimaryTabs';
 import { GroupItem } from './GroupItem';
 import { GroupSidebarFilters, type KindFilter, type Membership } from './GroupSidebarFilters';
+import { ListErrorState } from '../ListErrorState';
 
 export type SortMode = 'lastActivity' | 'createdAt';
 export type SessionTab = 'all' | 'favorite';
@@ -18,13 +18,10 @@ export interface GroupSidebarProps {
   onViewChange: (v: 'chat' | 'group') => void;
   /** 当前身份可见视图；Bot 仅协作群时不再渲染「会话」切换项。 */
   availableViews?: WorkspaceView[];
-  identities?: Identity[];
-  activeIdentityId?: string | null;
-  onChangeIdentity?: (id: string) => void;
-  onOpenPermissions?: () => void;
-  userAvatarUrl?: string;
   groups: GroupView[];
   isLoading: boolean;
+  groupsError?: string | null;
+  onRetryGroups?: () => Promise<void>;
   onSelectGroup: (groupId: string) => void;
   groupSearchText: string;
   onSearchTextChange: (v: string) => void;
@@ -40,6 +37,9 @@ export interface GroupSidebarProps {
   hasMoreSessionsByGroupId?: Record<string, boolean>;
   totalSessionsByGroupId?: Record<string, number>;
   isLoadingMoreSessionsByGroupId?: Record<string, boolean>;
+  errorByGroupId?: Record<string, string>;
+  loadMoreErrorByGroupId?: Record<string, string>;
+  onReloadSession?: (groupId: string) => Promise<void>;
   onLoadMoreSessions?: (groupId: string) => Promise<void>;
   sessionTabsByGroup: Record<string, SessionTab>;
   onSessionTabForGroup: (groupId: string, tab: SessionTab) => void;
@@ -70,13 +70,10 @@ export function GroupSidebarList(props: GroupSidebarProps) {
     view,
     onViewChange,
     availableViews: availableViewsProp,
-    identities = [],
-    activeIdentityId = null,
-    onChangeIdentity = () => {},
-    onOpenPermissions = () => {},
-    userAvatarUrl,
     groups,
     isLoading,
+    groupsError,
+    onRetryGroups,
     onSelectGroup,
     groupSearchText,
     onSearchTextChange,
@@ -90,6 +87,9 @@ export function GroupSidebarList(props: GroupSidebarProps) {
     hasMoreSessionsByGroupId = {},
     totalSessionsByGroupId = {},
     isLoadingMoreSessionsByGroupId = {},
+    errorByGroupId = {},
+    loadMoreErrorByGroupId = {},
+    onReloadSession,
     onLoadMoreSessions = async () => {},
     sessionTabsByGroup,
     onSessionTabForGroup,
@@ -113,29 +113,23 @@ export function GroupSidebarList(props: GroupSidebarProps) {
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      <div className="shrink-0 px-[18px] pb-3 pt-4">
-        <WorkspaceIdentitySelector
-          identities={identities}
-          activeId={activeIdentityId}
-          onChange={onChangeIdentity}
-          onOpenPermissions={onOpenPermissions}
-          userAvatarUrl={userAvatarUrl}
-          layout="sidebar"
-        />
-      </div>
-      <div className="app-scrollbar min-h-0 flex-1 overflow-y-auto bg-muted">
-        <div className="sticky top-0 z-20 mb-2 flex items-center gap-2 bg-muted px-[18px]">
-          <WorkspacePrimaryTabs value={view} options={availableViews} onChange={onViewChange} />
-          <WorkspaceActionButton onAddFriend={onAddFriend} onCreateGroup={onCreateGroup} />
+      <div className="app-scrollbar min-h-0 flex-1 overflow-y-auto bg-muted/20">
+        <div className="sticky top-0 z-20 border-b border-border/70 bg-muted/20 pt-1 backdrop-blur-sm">
+          <div className="flex h-10 items-center gap-2 px-[18px]">
+            <WorkspacePrimaryTabs value={view} options={availableViews} onChange={onViewChange} />
+            <WorkspaceActionButton onAddFriend={onAddFriend} onCreateGroup={onCreateGroup} />
+          </div>
+          <GroupSidebarFilters
+            groupSearchText={groupSearchText}
+            onSearchTextChange={onSearchTextChange}
+            kindFilter={kindFilter}
+            onKindFilterChange={onKindFilterChange}
+            membership={membership}
+            onMembershipChange={onMembershipChange}
+          />
         </div>
-        <GroupSidebarFilters
-          groupSearchText={groupSearchText}
-          onSearchTextChange={onSearchTextChange}
-          kindFilter={kindFilter}
-          onKindFilterChange={onKindFilterChange}
-          membership={membership}
-          onMembershipChange={onMembershipChange}
-        />
+
+        {!isLoading && groupsError && <ListErrorState message={groupsError} onRetry={() => void onRetryGroups?.()} />}
 
         {sessionSearchText !== '' && (
           <div className="mb-2 space-y-1">
@@ -166,7 +160,7 @@ export function GroupSidebarList(props: GroupSidebarProps) {
             ))}
           </div>
         ) : groups.length === 0 ? (
-          groupSearchText !== '' || kindFilter !== 'all' || membership !== 'direct' ? (
+          groupsError ? null : groupSearchText !== '' || kindFilter !== 'all' || membership !== 'direct' ? (
             <div className="flex min-h-72 flex-col items-center justify-center px-6 text-center">
               <p className="m-0 text-base font-medium text-foreground">没有匹配的协作群</p>
               <p className="mt-2 text-sm text-muted-foreground">试试调整搜索词或筛选条件。</p>
@@ -185,9 +179,8 @@ export function GroupSidebarList(props: GroupSidebarProps) {
           )
         ) : (
           <>
-            <div className="flex items-center justify-between border-b border-border px-[18px] py-2 text-xs">
-              <span className="font-medium text-foreground">协作群</span>
-              <span className="text-muted-foreground">{groups.length} 个群</span>
+            <div className="flex min-h-9 items-center border-b border-border/70 bg-muted/10 px-[18px] py-2 text-xs font-medium text-foreground">
+              协作群 ({groups.length})
             </div>
             <div className="divide-y divide-border/70 overflow-hidden border-b border-border bg-muted/10">
               {groups.map((group) => {
@@ -215,6 +208,9 @@ export function GroupSidebarList(props: GroupSidebarProps) {
                     totalSessionCount={totalSessionsByGroupId[group.groupId]}
                     hasMoreSessions={hasMoreSessionsByGroupId[group.groupId] ?? false}
                     isLoadingMoreSessions={isLoadingMoreSessionsByGroupId[group.groupId] ?? false}
+                    error={errorByGroupId[group.groupId]}
+                    loadMoreError={loadMoreErrorByGroupId[group.groupId]}
+                    onRetrySessions={() => onReloadSession?.(group.groupId) ?? Promise.resolve()}
                     onLoadMoreSessions={() => onLoadMoreSessions(group.groupId)}
                   />
                 );
@@ -230,8 +226,8 @@ export function GroupSidebarList(props: GroupSidebarProps) {
 /** 内流协作群列表外壳。≥lg 在流内；<lg hidden，由 Workspace 抽屉呈现同一 GroupSidebarList。 */
 export function GroupSidebar(props: GroupSidebarProps) {
   return (
-    <aside className="hidden w-[360px] shrink-0 flex-col overflow-hidden border-r border-border bg-muted/20 lg:flex">
+    <ResizableWorkspaceSidebar ariaLabel="协作群会话侧栏">
       <GroupSidebarList {...props} />
-    </aside>
+    </ResizableWorkspaceSidebar>
   );
 }

--- a/src/frontend-nextgen/src/pages/Workspace/components/ListErrorState.tsx
+++ b/src/frontend-nextgen/src/pages/Workspace/components/ListErrorState.tsx
@@ -1,0 +1,27 @@
+import { Button } from '@/components/ui';
+import { AlertCircle } from 'lucide-react';
+
+interface ListErrorStateProps {
+  message: string;
+  onRetry?: () => void;
+  className?: string;
+}
+
+export function ListErrorState({ message, onRetry, className }: ListErrorStateProps) {
+  return (
+    <div
+      role="alert"
+      className={`flex items-center justify-between gap-3 border-y border-destructive/30 bg-destructive/5 px-3 py-3 text-xs ${className ?? ''}`}
+    >
+      <div className="flex min-w-0 items-center gap-2 text-destructive">
+        <AlertCircle className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+        <span className="truncate">{message}</span>
+      </div>
+      {onRetry && (
+        <Button variant="secondary" size="sm" onClick={onRetry} className="h-7 shrink-0 px-2 text-xs">
+          重试
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/src/frontend-nextgen/src/pages/Workspace/components/Modals/CreateGroupModal.tsx
+++ b/src/frontend-nextgen/src/pages/Workspace/components/Modals/CreateGroupModal.tsx
@@ -13,6 +13,7 @@ import { CollaborationFlowAside } from './CollaborationFlowAside';
 import { CollaborationTemplatePicker } from './CollaborationTemplatePicker';
 import { GroupConfigFields, type GroupStrategyKind } from './GroupConfigFields';
 import type { GroupLeaderOption } from './GroupLeaderSelect';
+import { formatAutoGroupName } from './groupNaming';
 import { GroupParticipantPicker } from './GroupParticipantPicker';
 import { summarizeYaml } from './groupYamlUtils';
 
@@ -167,12 +168,13 @@ export function CreateGroupModal({ open, activeIdentity, onClose, onCreated }: C
     }
     const participantIds = Array.from(new Set(memberIds));
     const participants = participantIds.map((id) => ({ actor_id: id }));
+    const participantName = (id: string) => (id === activeIdentity?.id ? activeIdentity.displayName : allBotName(id));
     const participantBindingsArr = Object.entries(binding.participantBindings)
       .filter(([, botId]) => Boolean(botId))
       .map(([binding, botId]) => ({ binding, actor_ids: [botId] }));
     const res = await run(
       {
-        name: name.trim(),
+        name: name.trim() || formatAutoGroupName(participantIds, effectiveLeader, kind === 'task_dag', participantName),
         strategy: kind === 'free_chat' ? 'chat' : kind === 'task_master_slave' ? 'manager_worker' : 'state_machine',
         deliveryPolicy,
         definitionYaml,

--- a/src/frontend-nextgen/src/pages/Workspace/components/Modals/groupNaming.ts
+++ b/src/frontend-nextgen/src/pages/Workspace/components/Modals/groupNaming.ts
@@ -1,0 +1,12 @@
+export function formatAutoGroupName(
+  participantIds: string[],
+  leaderId: string,
+  leaderFirst: boolean,
+  resolveName: (id: string) => string,
+): string {
+  const otherIds = participantIds.filter((id) => id !== leaderId);
+  const orderedIds = leaderFirst ? [leaderId, ...otherIds] : [...otherIds, leaderId];
+  const validNames = orderedIds.map((id) => resolveName(id).trim()).filter(Boolean);
+  if (!validNames.length) return '协作群';
+  return validNames.length > 5 ? `${validNames.slice(0, 5).join('、')}等` : validNames.join('、');
+}

--- a/src/frontend-nextgen/src/pages/Workspace/components/ResizableWorkspaceSidebar.tsx
+++ b/src/frontend-nextgen/src/pages/Workspace/components/ResizableWorkspaceSidebar.tsx
@@ -1,0 +1,182 @@
+import { cn } from '@/utils/cn';
+import { GripVertical } from 'lucide-react';
+import type { KeyboardEvent, PointerEvent as ReactPointerEvent, ReactNode } from 'react';
+import { useCallback, useLayoutEffect, useRef, useState } from 'react';
+
+export const WORKSPACE_SIDEBAR_MIN_WIDTH = 280;
+export const WORKSPACE_SIDEBAR_DEFAULT_WIDTH = 320;
+export const WORKSPACE_SIDEBAR_MAX_WIDTH = 480;
+export const WORKSPACE_SIDEBAR_MAX_RATIO = 0.45;
+export const WORKSPACE_SIDEBAR_STORAGE_KEY = 'teamclaw:workspace-sidebar-width';
+
+interface ResizableWorkspaceSidebarProps {
+  children: ReactNode;
+  ariaLabel: string;
+  className?: string;
+}
+
+function clampWidth(width: number, maxWidth: number): number {
+  return Math.min(Math.max(Math.round(width), WORKSPACE_SIDEBAR_MIN_WIDTH), maxWidth);
+}
+
+function readStoredWidth(): number {
+  if (typeof window === 'undefined') return WORKSPACE_SIDEBAR_DEFAULT_WIDTH;
+  try {
+    const raw = window.localStorage.getItem(WORKSPACE_SIDEBAR_STORAGE_KEY);
+    if (raw === null) return WORKSPACE_SIDEBAR_DEFAULT_WIDTH;
+    const stored = Number(raw);
+    if (!Number.isFinite(stored)) return WORKSPACE_SIDEBAR_DEFAULT_WIDTH;
+    return Math.min(Math.max(Math.round(stored), WORKSPACE_SIDEBAR_MIN_WIDTH), WORKSPACE_SIDEBAR_MAX_WIDTH);
+  } catch {
+    return WORKSPACE_SIDEBAR_DEFAULT_WIDTH;
+  }
+}
+
+function persistWidth(width: number): void {
+  try {
+    window.localStorage.setItem(WORKSPACE_SIDEBAR_STORAGE_KEY, String(Math.round(width)));
+  } catch {
+    // 浏览器禁用存储时仍保留当前会话内调宽能力。
+  }
+}
+
+function dynamicMaxWidth(containerWidth: number): number {
+  if (containerWidth <= 0) return WORKSPACE_SIDEBAR_MAX_WIDTH;
+  return Math.max(
+    WORKSPACE_SIDEBAR_MIN_WIDTH,
+    Math.min(WORKSPACE_SIDEBAR_MAX_WIDTH, Math.floor(containerWidth * WORKSPACE_SIDEBAR_MAX_RATIO)),
+  );
+}
+
+export function ResizableWorkspaceSidebar({
+  children,
+  ariaLabel,
+  className,
+}: ResizableWorkspaceSidebarProps) {
+  const sidebarRef = useRef<HTMLElement | null>(null);
+  const [preferredWidth, setPreferredWidth] = useState(readStoredWidth);
+  const preferredWidthRef = useRef(preferredWidth);
+  const dragStartRef = useRef<{ clientX: number; width: number } | null>(null);
+  const [maxWidth, setMaxWidth] = useState(WORKSPACE_SIDEBAR_MAX_WIDTH);
+  const [dragging, setDragging] = useState(false);
+  const width = clampWidth(preferredWidth, maxWidth);
+
+  const updatePreferredWidth = useCallback((nextWidth: number) => {
+    preferredWidthRef.current = nextWidth;
+    setPreferredWidth(nextWidth);
+  }, []);
+
+  useLayoutEffect(() => {
+    const parent = sidebarRef.current?.parentElement;
+    if (!parent) return;
+    const updateMaxWidth = () => setMaxWidth(dynamicMaxWidth(parent.getBoundingClientRect().width));
+    updateMaxWidth();
+    window.addEventListener('resize', updateMaxWidth);
+    const observer = typeof ResizeObserver === 'undefined' ? null : new ResizeObserver(updateMaxWidth);
+    observer?.observe(parent);
+    return () => {
+      window.removeEventListener('resize', updateMaxWidth);
+      observer?.disconnect();
+    };
+  }, []);
+
+  const handlePointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (event.button !== 0) return;
+    event.preventDefault();
+    dragStartRef.current = { clientX: event.clientX, width };
+    setDragging(true);
+  };
+
+  const setAndPersistWidth = (nextWidth: number) => {
+    const next = clampWidth(nextWidth, maxWidth);
+    updatePreferredWidth(next);
+    persistWidth(next);
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    const step = event.shiftKey ? 24 : 8;
+    let nextWidth: number | null = null;
+    if (event.key === 'ArrowLeft' || event.key === 'ArrowDown') nextWidth = width - step;
+    if (event.key === 'ArrowRight' || event.key === 'ArrowUp') nextWidth = width + step;
+    if (event.key === 'Home') nextWidth = WORKSPACE_SIDEBAR_MIN_WIDTH;
+    if (event.key === 'End') nextWidth = maxWidth;
+    if (nextWidth === null) return;
+    event.preventDefault();
+    setAndPersistWidth(nextWidth);
+  };
+
+  const resetWidth = () => {
+    updatePreferredWidth(WORKSPACE_SIDEBAR_DEFAULT_WIDTH);
+    persistWidth(WORKSPACE_SIDEBAR_DEFAULT_WIDTH);
+  };
+
+  const onMove = (event: PointerEvent) => {
+    const start = dragStartRef.current;
+    if (!start) return;
+    updatePreferredWidth(clampWidth(start.width + event.clientX - start.clientX, maxWidth));
+  };
+  const onUp = () => {
+    dragStartRef.current = null;
+    setDragging(false);
+    persistWidth(preferredWidthRef.current);
+  };
+
+  useLayoutEffect(() => {
+    if (!dragging) return;
+    const previousCursor = document.body.style.cursor;
+    const previousUserSelect = document.body.style.userSelect;
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+    document.addEventListener('pointermove', onMove);
+    document.addEventListener('pointerup', onUp);
+    return () => {
+      document.removeEventListener('pointermove', onMove);
+      document.removeEventListener('pointerup', onUp);
+      document.body.style.cursor = previousCursor;
+      document.body.style.userSelect = previousUserSelect;
+    };
+  }, [dragging, maxWidth, updatePreferredWidth]);
+
+  return (
+    <aside
+      ref={sidebarRef}
+      aria-label={ariaLabel}
+      style={{ width: `${width}px` }}
+      className={cn(
+        'relative hidden shrink-0 flex-col overflow-visible border-r border-border bg-muted/20 lg:flex',
+        className,
+      )}
+    >
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">{children}</div>
+
+      <div
+        role="separator"
+        aria-label="调整对话协作左栏宽度"
+        aria-orientation="vertical"
+        aria-valuemin={WORKSPACE_SIDEBAR_MIN_WIDTH}
+        aria-valuemax={maxWidth}
+        aria-valuenow={width}
+        tabIndex={0}
+        data-testid="workspace-sidebar-resizer"
+        onPointerDown={handlePointerDown}
+        onDoubleClick={resetWidth}
+        onKeyDown={handleKeyDown}
+        className="group/resizer absolute bottom-0 right-0 top-0 z-30 w-2.5 translate-x-1/2 touch-none cursor-col-resize outline-none"
+      >
+        {/* 常驻拖拽提示胶囊：垂直居中贴边缝，hover/focus/拖拽时转品牌色。 */}
+        <span
+          aria-hidden="true"
+          data-testid="workspace-sidebar-grip"
+          className={cn(
+            'absolute left-1/2 top-1/2 flex h-7 w-3.5 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full border bg-background text-muted-foreground shadow-sm transition-colors',
+            dragging
+              ? 'border-primary text-primary'
+              : 'border-border group-hover/resizer:border-primary group-hover/resizer:text-primary group-focus-visible/resizer:border-primary group-focus-visible/resizer:text-primary',
+          )}
+        >
+          <GripVertical className="h-3.5 w-3.5" />
+        </span>
+      </div>
+    </aside>
+  );
+}

--- a/src/frontend-nextgen/src/pages/Workspace/components/SessionCard.tsx
+++ b/src/frontend-nextgen/src/pages/Workspace/components/SessionCard.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@/components/ui';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/Tooltip';
 import { cn } from '@/utils/cn';
 import { MessageSquare } from 'lucide-react';
 import React from 'react';
@@ -30,23 +31,59 @@ export function formatMonthDayTime(input: number | string | undefined): string {
   return `${month}/${day} ${hour}:${minute}`;
 }
 
+function startOfDay(date: Date): number {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime();
+}
+
+function startOfWeek(date: Date): number {
+  const day = date.getDay();
+  const mondayOffset = day === 0 ? 6 : day - 1;
+  return startOfDay(new Date(date.getFullYear(), date.getMonth(), date.getDate() - mondayOffset));
+}
+
+/** 稳定相对时间：当天 HH:mm、昨天、同周星期、本年 MM/DD、跨年 YYYY/MM/DD。 */
+export function formatSessionTime(input: number | string | undefined, now = new Date()): string {
+  const date = parseDate(input);
+  if (!date) return '';
+  if (startOfDay(date) === startOfDay(now)) {
+    return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false });
+  }
+  const yesterday = startOfDay(now) - 24 * 60 * 60 * 1000;
+  if (startOfDay(date) === yesterday) return '昨天';
+  if (startOfWeek(date) === startOfWeek(now)) {
+    return ['周日', '周一', '周二', '周三', '周四', '周五', '周六'][date.getDay()];
+  }
+  if (date.getFullYear() === now.getFullYear()) return formatMonthDay(input);
+  return `${date.getFullYear()}/${String(date.getMonth() + 1).padStart(2, '0')}/${String(date.getDate()).padStart(2, '0')}`;
+}
+
+export function formatSessionTimeTooltip(input: number | string | undefined): string {
+  const date = parseDate(input);
+  if (!date) return '';
+  return date.toLocaleString([], { dateStyle: 'medium', timeStyle: 'short' });
+}
+
 interface SessionCardProps {
   title: string;
   /** 副行文案(真实预览/成员数等);未传时显示「暂无会话预览」。 */
   subtitle?: string;
   /** 右侧日期(MM/DD),无则不渲染。 */
   dateText?: string;
+  /** 日期的完整本地时间 Tooltip。 */
+  dateTooltip?: string;
   selected: boolean;
   onSelect: () => void;
   /** 右侧操作区（如更多菜单），由调用方决定可见性。 */
   trailing?: React.ReactNode;
   /** 无副行内容时使用更紧凑的单行布局。 */
   compact?: boolean;
+  /** 对话使用消息 Icon，协作群会话保留圆点。 */
+  indicator?: 'dot' | 'message';
   /** 调用方可按列表场景补充尺寸；不改变卡片的交互语义。 */
   className?: string;
 }
 
-/** 二级会话列表项:无卡片容器、缩进排列、轻量图标 + 标题/副行 + 日期；选中态只用浅底色，不复用一级资源指示条。 */
+/** 二级会话列表项:无卡片容器、缩进排列、会话圆点 + 标题/副行 + 日期。 */
 export const SessionCard = React.memo(function SessionCard({
   title,
   subtitle = '暂无会话预览',
@@ -55,41 +92,73 @@ export const SessionCard = React.memo(function SessionCard({
   onSelect,
   trailing,
   compact = false,
+  dateTooltip,
+  indicator = 'dot',
   className,
 }: SessionCardProps) {
   return (
     <div
       className={cn(
-        'group relative flex items-stretch border-t border-border/70 text-sm transition-colors',
-        compact ? 'min-h-[56px]' : 'min-h-[70px]',
-        selected ? 'bg-primary/5' : 'bg-background hover:bg-accent/30',
+        'group relative flex items-stretch border-b border-border/70 text-sm transition-colors last:border-b-0',
+        compact ? 'min-h-12' : 'min-h-[60px]',
+        selected ? 'bg-primary/10' : 'bg-background hover:bg-primary/5',
         className,
       )}
     >
       <Button
         variant="ghost"
         aria-pressed={selected}
+        aria-current={selected ? 'page' : undefined}
         onClick={onSelect}
         className={cn(
           'flex h-auto min-w-0 flex-1 justify-start gap-2 rounded-none px-2.5 text-left hover:bg-transparent focus-visible:z-10',
           compact ? 'items-center' : 'items-start',
-          compact ? 'min-h-[56px] py-2' : 'min-h-[70px] py-3',
+          compact ? 'min-h-12 py-2' : 'min-h-[60px] py-2.5',
         )}
       >
         <span
           aria-hidden="true"
           className={cn(
             'flex h-4 w-4 shrink-0 items-center justify-center',
-            !compact && 'mt-0.5',
-            selected ? 'text-primary/70' : 'text-muted-foreground',
+            indicator === 'message' ? 'self-center' : !compact && 'mt-0.5',
           )}
         >
-          <MessageSquare className="h-3.5 w-3.5" />
+          {indicator === 'message' ? (
+            <MessageSquare
+              data-session-indicator
+              className={cn(
+                'h-3.5 w-3.5',
+                selected ? 'text-primary' : 'text-muted-foreground group-hover:text-primary/70',
+              )}
+            />
+          ) : (
+            <span
+              data-session-indicator
+              className={cn(
+                'h-1.5 w-1.5 rounded-full',
+                selected ? 'bg-primary' : 'bg-muted-foreground/50 group-hover:bg-primary/60',
+              )}
+            />
+          )}
         </span>
         <div className="min-w-0 flex-1">
-          <span className="block truncate text-[13px] font-normal leading-5 text-foreground">{title}</span>
+          <span
+            className={cn(
+              'block truncate text-xs leading-5',
+              selected ? 'font-medium text-primary' : 'font-normal text-foreground',
+            )}
+          >
+            {title}
+          </span>
           {subtitle && (
-            <span className="mt-0.5 block truncate text-xs leading-5 text-muted-foreground">{subtitle}</span>
+            <span
+              className={cn(
+                'mt-0.5 block truncate text-xs leading-5',
+                selected ? 'text-primary/80' : 'text-muted-foreground',
+              )}
+            >
+              {subtitle}
+            </span>
           )}
         </div>
       </Button>
@@ -97,10 +166,21 @@ export const SessionCard = React.memo(function SessionCard({
         <div
           className={cn(
             'flex shrink-0 gap-2 pr-3 text-xs text-muted-foreground',
-            compact ? 'items-center' : 'items-start pt-3',
+            compact ? 'items-center' : 'items-center pt-2',
           )}
         >
-          {dateText && <span className="whitespace-nowrap leading-5">{dateText}</span>}
+          {dateText && dateTooltip ? (
+            <TooltipProvider delayDuration={300}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="whitespace-nowrap leading-5">{dateText}</span>
+                </TooltipTrigger>
+                <TooltipContent>{dateTooltip}</TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          ) : (
+            dateText && <span className="whitespace-nowrap leading-5">{dateText}</span>
+          )}
           {trailing}
         </div>
       )}

--- a/src/frontend-nextgen/src/pages/Workspace/components/SessionScopeFilter.tsx
+++ b/src/frontend-nextgen/src/pages/Workspace/components/SessionScopeFilter.tsx
@@ -1,0 +1,87 @@
+import { Button, IconButton } from '@/components/ui';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/Popover';
+import { cn } from '@/utils/cn';
+import { Check, ListFilter } from 'lucide-react';
+import { useState } from 'react';
+
+export type SessionScope = 'all' | 'favorite';
+
+interface SessionScopeFilterProps {
+  value: SessionScope;
+  onChange: (value: SessionScope) => void;
+  allCount?: number;
+  favoriteCount?: number;
+}
+
+const SCOPE_OPTIONS: Array<{ value: SessionScope; label: string }> = [
+  { value: 'all', label: '全部会话' },
+  { value: 'favorite', label: '已收藏会话' },
+];
+
+export function SessionScopeFilter({
+  value,
+  onChange,
+  allCount,
+  favoriteCount,
+}: SessionScopeFilterProps) {
+  const [open, setOpen] = useState(false);
+  const activeLabel = value === 'favorite' ? '已收藏会话' : '全部会话';
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <IconButton
+          label={`会话范围：${activeLabel}`}
+          size="sm"
+          aria-pressed={value === 'favorite'}
+          icon={
+            <span className="relative flex h-4 w-4 items-center justify-center">
+              <ListFilter className="h-4 w-4" aria-hidden="true" />
+              {value === 'favorite' && (
+                <span className="absolute -right-0.5 -top-0.5 h-1.5 w-1.5 rounded-full bg-primary" aria-hidden="true" />
+              )}
+            </span>
+          }
+          className={cn(
+            'rounded-md text-muted-foreground hover:bg-primary/10 hover:text-primary',
+            value === 'favorite' && 'bg-primary/10 text-primary hover:bg-primary/15 hover:text-primary',
+          )}
+          onClick={(event) => event.stopPropagation()}
+        />
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-48 p-1" onClick={(event) => event.stopPropagation()}>
+        <p className="m-0 px-2 pb-1 pt-1 text-xs font-medium text-muted-foreground">会话范围</p>
+        <div role="radiogroup" aria-label="会话范围">
+          {SCOPE_OPTIONS.map((option) => {
+            const selected = value === option.value;
+            const count = option.value === 'all' ? allCount : favoriteCount;
+            return (
+              <Button
+                key={option.value}
+                variant="ghost"
+                size="sm"
+                role="radio"
+                aria-checked={selected}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onChange(option.value);
+                  setOpen(false);
+                }}
+                className={cn(
+                  'h-8 w-full justify-start gap-2 rounded-sm px-2 text-xs font-normal',
+                  selected && 'bg-accent font-medium text-primary',
+                )}
+              >
+                <span className="flex h-4 w-4 shrink-0 items-center justify-center">
+                  {selected && <Check className="h-3.5 w-3.5" aria-hidden="true" />}
+                </span>
+                <span className="flex-1 text-left">{option.label}</span>
+                <span className="tabular-nums text-muted-foreground">{count ?? '…'}</span>
+              </Button>
+            );
+          })}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/frontend-nextgen/src/pages/Workspace/components/SessionToolbar.tsx
+++ b/src/frontend-nextgen/src/pages/Workspace/components/SessionToolbar.tsx
@@ -22,7 +22,7 @@ export function SessionToolbar({
     <div
       role="group"
       aria-label="会话范围筛选"
-      className={`flex min-h-10 items-center px-3 pr-[18px] ${className ?? ''}`}
+      className={`flex min-h-9 items-center border-b border-border/60 bg-muted/30 px-3 pr-[18px] ${className ?? ''}`}
     >
       <SessionTabs
         value={value}

--- a/src/frontend-nextgen/src/pages/Workspace/components/WorkspaceActionButton.tsx
+++ b/src/frontend-nextgen/src/pages/Workspace/components/WorkspaceActionButton.tsx
@@ -33,8 +33,8 @@ export function WorkspaceActionButton({ onAddFriend, onCreateGroup, className }:
         <IconButton
           label="添加好友或发起协作"
           icon={<Plus className="h-4 w-4" />}
-          variant="outline"
-          className={`h-9 w-9 rounded-md text-muted-foreground hover:text-foreground ${className ?? ''}`}
+          variant="ghost"
+          className={`h-9 w-9 rounded-md border border-primary/20 bg-primary/5 text-primary hover:border-primary/30 hover:bg-primary/10 hover:text-primary ${className ?? ''}`}
         />
       </PopoverTrigger>
       <PopoverContent align="end" className="w-44 p-1">

--- a/src/frontend-nextgen/src/pages/Workspace/components/WorkspacePrimaryTabs.tsx
+++ b/src/frontend-nextgen/src/pages/Workspace/components/WorkspacePrimaryTabs.tsx
@@ -1,6 +1,5 @@
-import { Button } from '@/components/ui';
+import { Segmented } from '@/components/ui';
 import type { WorkspaceView } from '@/domain/collaboration/availableViews';
-import { cn } from '@/utils/cn';
 
 interface WorkspacePrimaryTabsProps {
   value: WorkspaceView;
@@ -8,36 +7,19 @@ interface WorkspacePrimaryTabsProps {
   onChange: (value: WorkspaceView) => void;
 }
 
-/** 工作台一级导航：所有视口统一使用轻量文字 Tab，避免与筛选项混成按钮组。 */
+/** 工作台二级视图切换：使用分段控件强化选中态，避免顶部导航过轻。 */
 export function WorkspacePrimaryTabs({ value, options, onChange }: WorkspacePrimaryTabsProps) {
   return (
-    <div
-      className="flex h-9 min-w-0 flex-1 items-center gap-5 border-b border-border/70"
-      role="tablist"
+    <Segmented
+      value={value}
+      options={options.map((option) => ({
+        value: option,
+        label: option === 'chat' ? '对话' : '协作群',
+      }))}
+      onChange={onChange}
       aria-label="工作区类型"
-    >
-      {options.map((option) => {
-        const active = value === option;
-        return (
-          <Button
-            key={option}
-            variant="ghost"
-            size="sm"
-            role="tab"
-            aria-selected={active}
-            aria-label={option === 'chat' ? '对话' : '协作群'}
-            onClick={() => onChange(option)}
-            className={cn(
-              'h-9 rounded-none border-x-0 border-t-0 border-b-2 px-0 text-xs',
-              active
-                ? 'border-primary font-medium text-primary hover:bg-transparent hover:text-primary'
-                : 'border-transparent font-normal text-muted-foreground hover:bg-transparent hover:text-foreground',
-            )}
-          >
-            {option === 'chat' ? '对话' : '协作群'}
-          </Button>
-        );
-      })}
-    </div>
+      className="min-w-0 flex-1"
+      inactiveOptionClassName="text-muted-foreground hover:text-foreground"
+    />
   );
 }

--- a/src/frontend-nextgen/src/pages/Workspace/hooks/groupChatHistoryUtils.ts
+++ b/src/frontend-nextgen/src/pages/Workspace/hooks/groupChatHistoryUtils.ts
@@ -1,0 +1,8 @@
+import type { ChatMessage } from '@tc-chat/core';
+
+/** 前置更早的历史消息并按 id 去重，保留升序旧→新排列；无新增则原样返回避免无谓 re-render。 */
+export function prependUniqueMessages(prev: ChatMessage[], older: ChatMessage[]): ChatMessage[] {
+  const ids = new Set(prev.map((message) => message.id));
+  const fresh = older.filter((message) => !ids.has(message.id));
+  return fresh.length > 0 ? [...fresh, ...prev] : prev;
+}

--- a/src/frontend-nextgen/src/pages/Workspace/hooks/sessionMapRequests.utils.ts
+++ b/src/frontend-nextgen/src/pages/Workspace/hooks/sessionMapRequests.utils.ts
@@ -1,0 +1,60 @@
+import type { GroupSessionPage, SessionView } from '@/domain/collaboration';
+import type { DomainError } from '@/services/workspace/identityService';
+import { shouldMuteNonAuthedToast } from '@/utils/loginToastGate';
+import { type Dispatch, type MutableRefObject, type SetStateAction } from 'react';
+import { toast } from 'sonner';
+
+export const SESSION_PAGE_SIZE = 10;
+
+export interface SessionPageMeta {
+  total: number;
+  hasMore: boolean;
+  /** 后端分页游标，避免本地新建/删除导致 offset 与服务端列表错位。 */
+  nextOffset: number;
+  isLoadingMore: boolean;
+}
+
+export type SessionMap = Record<string, SessionView[]>;
+export type SessionMapRef = MutableRefObject<SessionMap>;
+export type SessionMetaMapRef = MutableRefObject<Record<string, SessionPageMeta>>;
+
+export interface UseSessionMapRequestsOptions {
+  groupId: string | null;
+  expandedGroupIds: string[];
+  activeIdentityId: string | null;
+  rawByGroupId: SessionMap;
+  rawByGroupIdRef: SessionMapRef;
+  pageMetaByGroupIdRef: SessionMetaMapRef;
+  inFlightRef: MutableRefObject<Map<string, number>>;
+  loadingMoreRef: MutableRefObject<Set<string>>;
+  requestVersionRef: MutableRefObject<Map<string, number>>;
+  identityEpochRef: MutableRefObject<number>;
+  setIsLoading: Dispatch<SetStateAction<boolean>>;
+  setRawByGroupId: Dispatch<SetStateAction<SessionMap>>;
+  setPageMetaByGroupId: Dispatch<SetStateAction<Record<string, SessionPageMeta>>>;
+  setErrorByGroupId: Dispatch<SetStateAction<Record<string, string>>>;
+  setLoadMoreErrorByGroupId: Dispatch<SetStateAction<Record<string, string>>>;
+  beginGroupRequest: (groupId: string) => number;
+  isCurrentRequest: (groupId: string, version: number, epoch: number) => boolean;
+  replaceGroupPage: (groupId: string, data: GroupSessionPage | SessionView[]) => void;
+}
+
+export function notifyError(err: DomainError): void {
+  // 未登录（oauth-provider + 非 authenticated）静默：会话失效后的 sessions 加载失败 toast
+  // 统一由 ExternalLoginPromptModal 承担（见 loginToastGate）；已登录 / ace-gateway 照常提示。
+  if (shouldMuteNonAuthedToast()) return;
+  toast.error(err.friendlyMessage);
+}
+
+export function normalizePage(data: GroupSessionPage | SessionView[], fallbackOffset = 0): GroupSessionPage {
+  if (Array.isArray(data)) {
+    return {
+      items: data,
+      offset: fallbackOffset,
+      limit: SESSION_PAGE_SIZE,
+      total: fallbackOffset + data.length,
+      hasMore: data.length >= SESSION_PAGE_SIZE,
+    };
+  }
+  return data;
+}

--- a/src/frontend-nextgen/src/pages/Workspace/hooks/useBotChat.ts
+++ b/src/frontend-nextgen/src/pages/Workspace/hooks/useBotChat.ts
@@ -6,6 +6,7 @@ import { useWorkspaceStore } from '@/stores/workspaceStore';
 import { useChat, type ProviderConnectionStatus } from '@tc-chat/adapters';
 import type { ChatMessage, PanelHandle, PromptFileRef, ResourceReference } from '@tc-chat/core';
 import { useEffect, useMemo, useRef, useState, type RefObject } from 'react';
+import { useConnectionStatusSmoothing } from './useConnectionStatusSmoothing';
 import { toast } from 'sonner';
 
 export interface SendFileRefs {
@@ -50,6 +51,7 @@ export function useBotChat(
 
   const [supportState, setSupportState] = useState<BotChatState>({ phase: 'idle', error: null });
   const [connectionStatus, setConnectionStatus] = useState<ProviderConnectionStatus>('disconnected');
+  const smoothedConnectionStatus = useConnectionStatusSmoothing(connectionStatus);
 
   const provider = useMemo(() => {
     if (!bot || !sessionId || !identityId) return null;
@@ -165,5 +167,5 @@ export function useBotChat(
     }
   };
 
-  return { chat, supportState, connectionStatus, send, stop, reconnect, reloadHistory };
+  return { chat, supportState, connectionStatus: smoothedConnectionStatus, send, stop, reconnect, reloadHistory };
 }

--- a/src/frontend-nextgen/src/pages/Workspace/hooks/useBotSessionMap.ts
+++ b/src/frontend-nextgen/src/pages/Workspace/hooks/useBotSessionMap.ts
@@ -5,31 +5,9 @@ import { useWorkspaceStore } from '@/stores/workspaceStore';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useDirectSessionFallback } from './useDirectSessionFallback';
 
-export interface BotSessionPageMeta {
-  total: number;
-  hasMore: boolean;
-  nextPage: number;
-  isLoadingMore: boolean;
-}
-
-export interface UseBotSessionMapResult {
-  rawByBotId: Record<string, BotChatSessionView[]>;
-  favoriteByBotId: Record<string, BotChatSessionView[]>;
-  pageMetaByBotId: Record<string, BotSessionPageMeta>;
-  favoritePageMetaByBotId: Record<string, BotSessionPageMeta>;
-  isLoading: boolean;
-  updateBotSessions: (botId: string, fn: (list: BotChatSessionView[]) => BotChatSessionView[]) => void;
-  updateBotFavoriteSessions: (botId: string, fn: (list: BotChatSessionView[]) => BotChatSessionView[]) => void;
-  reloadBot: (bot: ChatBotView, userId: string) => Promise<void>;
-  loadFavoriteSessions: (bot: ChatBotView, userId: string) => Promise<void>;
-  loadMoreSessions: (bot: ChatBotView, userId: string, mode: 'all' | 'favorite') => Promise<void>;
-  /** 按 section 展开 bot，记录归属 section 并懒加载会话。 */
-  toggleBotExpanded: (botId: string, sectionKey?: string) => void;
-}
-
-function hasMoreForPage(itemCount: number, total: number, page: number): boolean {
-  return itemCount > 0 && page * BOT_SESSION_PAGE_SIZE < total;
-}
+import { hasMoreForPage, errorBotPageMeta, successBotPageMeta } from './useBotSessionMap.utils';
+import type { BotSessionPageMeta, UseBotSessionMapResult } from './useBotSessionMap.types';
+export type { BotSessionPageMeta, UseBotSessionMapResult } from './useBotSessionMap.types';
 
 /** 以 botId 键控缓存各 bot 会话；首屏及追加均使用 10 条，身份切换清缓存。 */
 export function useBotSessionMap(
@@ -78,12 +56,12 @@ export function useBotSessionMap(
           setRawByBotId((current) => ({ ...current, [key]: res.data.items }));
           setPageMetaByBotId((current) => ({
             ...current,
-            [key]: {
-              total: res.data.total,
-              hasMore: hasMoreForPage(res.data.items.length, res.data.total, 1),
-              nextPage: 2,
-              isLoadingMore: false,
-            },
+            [key]: successBotPageMeta(res.data.total, hasMoreForPage(res.data.items.length, res.data.total, 1), 2),
+          }));
+        } else {
+          setPageMetaByBotId((current) => ({
+            ...current,
+            [key]: errorBotPageMeta(current[key], res.error.friendlyMessage),
           }));
         }
       } finally {
@@ -151,7 +129,20 @@ export function useBotSessionMap(
       syncLoadingState();
       try {
         const res = await botSessionService.listFavoriteSessionsPage(bot, userId, 1, BOT_SESSION_PAGE_SIZE);
-        if (generation !== generationRef.current || !res.ok) return;
+        if (generation !== generationRef.current) return;
+        if (!res.ok) {
+          setFavoritePageMetaByBotId((current) => ({
+            ...current,
+            [key]: {
+              total: current[key]?.total ?? 0,
+              hasMore: false,
+              nextPage: current[key]?.nextPage ?? 1,
+              isLoadingMore: false,
+              error: res.error.friendlyMessage,
+            },
+          }));
+          return;
+        }
         setFavoriteByBotId((current) => ({ ...current, [key]: res.data.items }));
         setFavoritePageMetaByBotId((current) => ({
           ...current,
@@ -160,6 +151,8 @@ export function useBotSessionMap(
             hasMore: hasMoreForPage(res.data.items.length, res.data.total, 1),
             nextPage: 2,
             isLoadingMore: false,
+            error: undefined,
+            loadMoreError: undefined,
           },
         }));
         const favoriteIds = new Set(res.data.items.map((session) => session.sessionId));
@@ -203,20 +196,21 @@ export function useBotSessionMap(
           }
           setMeta((current) => ({
             ...current,
-            [key]: {
-              total: res.data.total,
-              hasMore: hasMoreForPage(res.data.items.length, res.data.total, meta.nextPage),
-              nextPage: meta.nextPage + 1,
-              isLoadingMore: false,
-            },
+            [key]: successBotPageMeta(res.data.total, hasMoreForPage(res.data.items.length, res.data.total, meta.nextPage), meta.nextPage + 1),
           }));
           if (mode === 'favorite') favoriteLoadedRef.current.add(key);
         } else {
-          setMeta((current) => ({ ...current, [key]: { ...current[key], isLoadingMore: false } }));
+          setMeta((current) => ({
+            ...current,
+            [key]: { ...current[key], isLoadingMore: false, loadMoreError: res.error.friendlyMessage },
+          }));
         }
       } catch {
         if (generation === generationRef.current)
-          setMeta((current) => ({ ...current, [key]: { ...current[key], isLoadingMore: false } }));
+          setMeta((current) => ({
+            ...current,
+            [key]: { ...current[key], isLoadingMore: false, loadMoreError: '加载更多会话失败，请重试' },
+          }));
       } finally {
         inFlightRef.current.delete(requestKey);
         syncLoadingState();

--- a/src/frontend-nextgen/src/pages/Workspace/hooks/useBotSessionMap.types.ts
+++ b/src/frontend-nextgen/src/pages/Workspace/hooks/useBotSessionMap.types.ts
@@ -1,0 +1,25 @@
+import type { BotChatSessionView, ChatBotView } from '@/services/workspace/botSessionService';
+
+export interface BotSessionPageMeta {
+  total: number;
+  hasMore: boolean;
+  nextPage: number;
+  isLoadingMore: boolean;
+  error?: string;
+  loadMoreError?: string;
+}
+
+export interface UseBotSessionMapResult {
+  rawByBotId: Record<string, BotChatSessionView[]>;
+  favoriteByBotId: Record<string, BotChatSessionView[]>;
+  pageMetaByBotId: Record<string, BotSessionPageMeta>;
+  favoritePageMetaByBotId: Record<string, BotSessionPageMeta>;
+  isLoading: boolean;
+  updateBotSessions: (botId: string, fn: (list: BotChatSessionView[]) => BotChatSessionView[]) => void;
+  updateBotFavoriteSessions: (botId: string, fn: (list: BotChatSessionView[]) => BotChatSessionView[]) => void;
+  reloadBot: (bot: ChatBotView, userId: string) => Promise<void>;
+  loadFavoriteSessions: (bot: ChatBotView, userId: string) => Promise<void>;
+  loadMoreSessions: (bot: ChatBotView, userId: string, mode: 'all' | 'favorite') => Promise<void>;
+  /** 按 section 展开 bot，记录归属 section 并懒加载会话。 */
+  toggleBotExpanded: (botId: string, sectionKey?: string) => void;
+}

--- a/src/frontend-nextgen/src/pages/Workspace/hooks/useBotSessionMap.utils.ts
+++ b/src/frontend-nextgen/src/pages/Workspace/hooks/useBotSessionMap.utils.ts
@@ -1,0 +1,17 @@
+import { BOT_SESSION_PAGE_SIZE } from '@/services/workspace/botSessionService';
+import type { BotSessionPageMeta } from './useBotSessionMap.types';
+
+export function hasMoreForPage(itemCount: number, total: number, page: number): boolean {
+  return itemCount > 0 && page * BOT_SESSION_PAGE_SIZE < total;
+}
+
+export function successBotPageMeta(total: number, hasMore: boolean, nextPage: number): BotSessionPageMeta {
+  return { total, hasMore, nextPage, isLoadingMore: false, error: undefined, loadMoreError: undefined };
+}
+
+export function errorBotPageMeta(
+  current: { total?: number; nextPage?: number } | undefined,
+  error: string,
+): BotSessionPageMeta {
+  return { total: current?.total ?? 0, hasMore: false, nextPage: current?.nextPage ?? 1, isLoadingMore: false, error };
+}

--- a/src/frontend-nextgen/src/pages/Workspace/hooks/useBotSessions.ts
+++ b/src/frontend-nextgen/src/pages/Workspace/hooks/useBotSessions.ts
@@ -2,36 +2,17 @@ import type { BotChatSessionView, ChatBotView } from '@/services/workspace/botSe
 import { botSessionService } from '@/services/workspace/botSessionService';
 import type { DomainError } from '@/services/workspace/identityService';
 import { useWorkspaceStore } from '@/stores/workspaceStore';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { toast } from 'sonner';
 import { useBotSessionMap } from './useBotSessionMap';
+import type { UseBotSessionsResult } from './useBotSessions.types';
 function notifyError(err: DomainError): void {
   toast.error(err.friendlyMessage);
 }
 function errOf(res: { ok: false; error: DomainError }): DomainError {
   return res.error;
 }
-export interface UseBotSessionsResult {
-  sessionsByBotId: Record<string, BotChatSessionView[]>;
-  favoriteSessionsByBotId: Record<string, BotChatSessionView[]>;
-  sessionPageMetaByBotId: ReturnType<typeof useBotSessionMap>['pageMetaByBotId'];
-  favoriteSessionPageMetaByBotId: ReturnType<typeof useBotSessionMap>['favoritePageMetaByBotId'];
-  isSessionsLoading: boolean;
-  selectedBotSessionId: string | null;
-  selectedSession: BotChatSessionView | null;
-  selectSession: (id: string | null) => void;
-  openSession: (botId: string, sessionId: string) => void;
-  createSession: (bot: ChatBotView, title?: string) => Promise<BotChatSessionView | null>;
-  deleteSession: (bot: ChatBotView, sessionId: string) => Promise<boolean>;
-  renameSession: (bot: ChatBotView, sessionId: string, title: string) => Promise<boolean>;
-  clearContext: (bot: ChatBotView, sessionId: string) => Promise<boolean>;
-  toggleFavorite: (botId: string, sessionId: string) => Promise<boolean>;
-  loadFavoriteSessions: (botId: string) => Promise<void>;
-  loadMoreSessions: (botId: string, mode: 'all' | 'favorite') => Promise<void>;
-  updateSessionModel: (botId: string, sessionId: string, model: string) => void;
-  reloadBot: (botId: string) => Promise<void>;
-  toggleBotExpanded: (botId: string, sectionKey?: string) => void;
-}
+export type { UseBotSessionsResult } from './useBotSessions.types';
 /** useBotSessions 编排 bot 单聊会话列表:展开懒加载、选中、新建/删除(镜像 useGroupSessions)。 */
 export function useBotSessions(
   chatBots: ChatBotView[],
@@ -59,6 +40,15 @@ export function useBotSessions(
     return rawByBotId[selectedBotId]?.find((s) => s.sessionId === selectedBotSessionId) ?? null;
   }, [selectedBotId, rawByBotId, selectedBotSessionId]);
   const selectSession = useCallback((id: string | null) => selectBotSession(id), [selectBotSession]);
+
+  // 与协作群一致：Bot 展开并完成会话加载后，当前无选择时自动打开首条会话。
+  useEffect(() => {
+    if (selectedBotSessionId) return;
+    const expandedBotId = expandedBotIds[0];
+    if (!expandedBotId) return;
+    const first = rawByBotId[expandedBotId]?.[0];
+    if (first) selectBotSession(first.sessionId);
+  }, [expandedBotIds, rawByBotId, selectedBotSessionId, selectBotSession]);
   const openSession = useCallback(
     (botId: string, sessionId: string) => {
       // 确保 bot 已展开

--- a/src/frontend-nextgen/src/pages/Workspace/hooks/useBotSessions.types.ts
+++ b/src/frontend-nextgen/src/pages/Workspace/hooks/useBotSessions.types.ts
@@ -1,0 +1,24 @@
+import type { BotChatSessionView, ChatBotView } from '@/services/workspace/botSessionService';
+import type { useBotSessionMap } from './useBotSessionMap';
+
+export interface UseBotSessionsResult {
+  sessionsByBotId: Record<string, BotChatSessionView[]>;
+  favoriteSessionsByBotId: Record<string, BotChatSessionView[]>;
+  sessionPageMetaByBotId: ReturnType<typeof useBotSessionMap>['pageMetaByBotId'];
+  favoriteSessionPageMetaByBotId: ReturnType<typeof useBotSessionMap>['favoritePageMetaByBotId'];
+  isSessionsLoading: boolean;
+  selectedBotSessionId: string | null;
+  selectedSession: BotChatSessionView | null;
+  selectSession: (id: string | null) => void;
+  openSession: (botId: string, sessionId: string) => void;
+  createSession: (bot: ChatBotView, title?: string) => Promise<BotChatSessionView | null>;
+  deleteSession: (bot: ChatBotView, sessionId: string) => Promise<boolean>;
+  renameSession: (bot: ChatBotView, sessionId: string, title: string) => Promise<boolean>;
+  clearContext: (bot: ChatBotView, sessionId: string) => Promise<boolean>;
+  toggleFavorite: (botId: string, sessionId: string) => Promise<boolean>;
+  loadFavoriteSessions: (botId: string) => Promise<void>;
+  loadMoreSessions: (botId: string, mode: 'all' | 'favorite') => Promise<void>;
+  updateSessionModel: (botId: string, sessionId: string, model: string) => void;
+  reloadBot: (botId: string) => Promise<void>;
+  toggleBotExpanded: (botId: string, sectionKey?: string) => void;
+}

--- a/src/frontend-nextgen/src/pages/Workspace/hooks/useConnectionStatusSmoothing.ts
+++ b/src/frontend-nextgen/src/pages/Workspace/hooks/useConnectionStatusSmoothing.ts
@@ -1,0 +1,65 @@
+import type { ProviderConnectionStatus } from '@tc-chat/adapters';
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * 连接态展示补正：避免切换会话 / 首连时顶栏先闪一下「离线」。
+ *
+ * 背景：useBotChat / useGroupChat 切换会话时 provider 重建并 connect()，原始状态会经历
+ * disconnected → connecting → connected。若直接展示原始态，顶栏 Badge 会先短暂显示
+ * 「离线(灰)」再到「连接中(橙)」再到「在线(绿)」，色差下跳变明显。
+ *
+ * 策略（连接中优先）：
+ * - connecting 或 连接尝试中的 disconnected → 一律先展示「连接中」，不展示「离线」；
+ * - connected →「在线」、reconnecting →「重连中」、error →「连接失败」，均立即展示；
+ * - 仅当 disconnected 持续超过宽限期（默认 5000ms，覆盖 SDK 默认 reconnectDelay=3000ms 的重连等待窗口 + 余量）才降级展示「离线」。
+ *
+ * 即贴合用户预期：切换时先从「连接中」开始——成功则「在线」，长时间连不上 / 失败则「离线」。
+ * 真实的 protocol error 仍走红色「连接失败」并保留错误详情，便于感知并点「重新连接」。
+ * 「离线」仅用于「静默断开 / 一直连不上」的终态。
+ */
+const DEFAULT_GRACE_MS = 5000;
+
+export function useConnectionStatusSmoothing(
+  raw: ProviderConnectionStatus,
+  graceMs = DEFAULT_GRACE_MS,
+): ProviderConnectionStatus {
+  // 冷启动首连：原始即 disconnected 时，初始展示「连接中」，避免首帧闪烁「离线」。
+  const [shown, setShown] = useState<ProviderConnectionStatus>(
+    raw === 'disconnected' ? 'connecting' : raw,
+  );
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    // 非终态 connected/reconnecting/error 与进行中 connecting：立即展示，并取消挂起的「离线」降级计时。
+    if (raw === 'connected' || raw === 'reconnecting' || raw === 'error' || raw === 'connecting') {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+      setShown(raw);
+      return;
+    }
+    // raw === 'disconnected'：先展示「连接中」（切换 / 首连时不再先显离线），宽限期内若进入
+    // connecting/connected 等状态由上述分支收敛；仍持续 disconnected（连不上 / 失败）超过宽限期才降级为「离线」。
+    setShown('connecting');
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null;
+      setShown('disconnected');
+    }, graceMs);
+  }, [raw, graceMs]);
+
+  // 卸载清理降级计时，避免泄漏。
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, []);
+
+  return shown;
+}
+
+export { DEFAULT_GRACE_MS };

--- a/src/frontend-nextgen/src/pages/Workspace/hooks/useExpandedGroupSessionRequests.ts
+++ b/src/frontend-nextgen/src/pages/Workspace/hooks/useExpandedGroupSessionRequests.ts
@@ -1,7 +1,7 @@
 import type { GroupSessionPage, SessionView } from '@/domain/collaboration';
 import { groupService } from '@/services/workspace/groupService';
 import { shouldMuteNonAuthedToast } from '@/utils/loginToastGate';
-import { useEffect, type MutableRefObject } from 'react';
+import { useEffect, type Dispatch, type MutableRefObject, type SetStateAction } from 'react';
 import { toast } from 'sonner';
 
 interface ExpandedGroupSessionRequestsOptions {
@@ -14,6 +14,7 @@ interface ExpandedGroupSessionRequestsOptions {
   beginGroupRequest: (groupId: string) => number;
   isCurrentRequest: (groupId: string, version: number, epoch: number) => boolean;
   replaceGroupPage: (groupId: string, data: GroupSessionPage | SessionView[]) => void;
+  setErrorByGroupId: Dispatch<SetStateAction<Record<string, string>>>;
 }
 
 export function useExpandedGroupSessionRequests({
@@ -26,6 +27,7 @@ export function useExpandedGroupSessionRequests({
   beginGroupRequest,
   isCurrentRequest,
   replaceGroupPage,
+  setErrorByGroupId,
 }: ExpandedGroupSessionRequestsOptions) {
   useEffect(() => {
     if (!activeIdentityId) return;
@@ -38,9 +40,17 @@ export function useExpandedGroupSessionRequests({
         .loadGroupSessionsOrBcs(gid, activeIdentityId)
         .then((res) => {
           if (!isCurrentRequest(gid, requestVersion, requestEpoch)) return;
-          if (res.ok) replaceGroupPage(gid, res.data);
+          if (res.ok) {
+            setErrorByGroupId((current) => {
+              const next = { ...current };
+              delete next[gid];
+              return next;
+            });
+            replaceGroupPage(gid, res.data);
+          }
           else {
             replaceGroupPage(gid, []);
+            setErrorByGroupId((current) => ({ ...current, [gid]: res.error.friendlyMessage }));
             // 未登录（oauth-provider + 非 authenticated）静默：会话失效后展开群 sessions 的
             // 失败 toast 统一由 ExternalLoginPromptModal 承担（见 loginToastGate）。
             if (!shouldMuteNonAuthedToast()) toast.error(res.error.friendlyMessage);
@@ -60,5 +70,6 @@ export function useExpandedGroupSessionRequests({
     isCurrentRequest,
     rawByGroupId,
     replaceGroupPage,
+    setErrorByGroupId,
   ]);
 }

--- a/src/frontend-nextgen/src/pages/Workspace/hooks/useFriendBots.ts
+++ b/src/frontend-nextgen/src/pages/Workspace/hooks/useFriendBots.ts
@@ -2,11 +2,13 @@ import { getCapabilities } from '@/capabilities';
 import type { ChatBotView } from '@/services/workspace/botSessionService';
 import { splitBotId } from '@/services/workspace/botSessionService';
 import { collaborationCandidateService } from '@/services/workspace/collaborationCandidateService';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 export interface UseFriendBotsResult {
   friendBots: ChatBotView[];
   isLoading: boolean;
+  error: string | null;
+  reload: () => void;
 }
 
 function toChatBotView(bot: {
@@ -42,10 +44,13 @@ export function useFriendBots(
 ): UseFriendBotsResult {
   const [friendBots, setFriendBots] = useState<ChatBotView[]>([]);
   const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadNonce, setReloadNonce] = useState(0);
 
   useEffect(() => {
     if (!enabled) {
       setFriendBots([]);
+      setError(null);
       return;
     }
     let actorId = activeIdentityId;
@@ -57,10 +62,12 @@ export function useFriendBots(
     }
     if (!actorId || actorId === 'me') {
       setFriendBots([]);
+      setError(null);
       return;
     }
     let cancelled = false;
     setIsLoading(true);
+    setError(null);
     collaborationCandidateService
       .listFriends(actorId, {
         actorType: isUserIdentity ? 'human' : 'bot',
@@ -69,7 +76,11 @@ export function useFriendBots(
       })
       .then((res) => {
         if (cancelled) return;
-        setFriendBots(res.ok ? res.data.items.map(toChatBotView) : []);
+        if (res.ok) setFriendBots(res.data.items.map(toChatBotView));
+        else {
+          setFriendBots([]);
+          setError(res.error.friendlyMessage);
+        }
       })
       .finally(() => {
         if (!cancelled) setIsLoading(false);
@@ -77,7 +88,9 @@ export function useFriendBots(
     return () => {
       cancelled = true;
     };
-  }, [activeIdentityId, isUserIdentity, enabled]);
+  }, [activeIdentityId, isUserIdentity, enabled, reloadNonce]);
 
-  return { friendBots, isLoading };
+  const reload = useCallback(() => setReloadNonce((current) => current + 1), []);
+
+  return { friendBots, isLoading, error, reload };
 }

--- a/src/frontend-nextgen/src/pages/Workspace/hooks/useGroupChat.ts
+++ b/src/frontend-nextgen/src/pages/Workspace/hooks/useGroupChat.ts
@@ -9,12 +9,14 @@ import { useChat, useChatBridge, type ProviderConnectionStatus } from '@tc-chat/
 import type { BridgeInputRef, ChatMessage, PanelHandle } from '@tc-chat/core';
 import type { SenderRef } from '@tc-chat/ui/es/Sender/types';
 import { useCallback, useEffect, useMemo, useRef, useState, type RefObject } from 'react';
+import { useConnectionStatusSmoothing } from './useConnectionStatusSmoothing';
 import { toast } from 'sonner';
 import {
   buildEchoAttachments,
   buildGroupChatBridgeRequest,
   buildGroupUserMessageExtra,
 } from './groupChatRequestBuilder';
+import { prependUniqueMessages } from './groupChatHistoryUtils';
 import { useGroupBootstrapProcessing } from './useGroupBootstrapProcessing';
 import { useManifestHistoryLoader } from './useManifestHistoryLoader';
 
@@ -50,6 +52,7 @@ export function useGroupChat(session: SessionView | null) {
 
   const [supportState, setSupportState] = useState<GroupChatState>({ phase: 'idle', error: null });
   const [connectionStatus, setConnectionStatus] = useState<ProviderConnectionStatus>('disconnected');
+  const smoothedConnectionStatus = useConnectionStatusSmoothing(connectionStatus);
   const [hasMoreHistory, setHasMoreHistory] = useState(false);
   const [isLoadingMoreHistory, setIsLoadingMoreHistory] = useState(false);
 
@@ -193,13 +196,7 @@ export function useGroupChat(session: SessionView | null) {
     setIsLoadingMoreHistory(true);
     try {
       const older: ChatMessage[] = await provider.loadMoreHistory();
-      if (older.length > 0) {
-        chat.setMessages((prev) => {
-          const ids = new Set(prev.map((message) => message.id));
-          const fresh = older.filter((message) => !ids.has(message.id));
-          return fresh.length > 0 ? [...fresh, ...prev] : prev;
-        });
-      }
+      if (older.length > 0) chat.setMessages((prev) => prependUniqueMessages(prev, older));
       setHasMoreHistory(provider.hasMoreHistory);
     } catch (error: unknown) {
       setHasMoreHistory(provider.hasMoreHistory);
@@ -233,7 +230,7 @@ export function useGroupChat(session: SessionView | null) {
     inputRef,
     chatBridge,
     supportState,
-    connectionStatus,
+    connectionStatus: smoothedConnectionStatus,
     send,
     stop,
     submitPanelMessage,

--- a/src/frontend-nextgen/src/pages/Workspace/hooks/useGroupSessions.ts
+++ b/src/frontend-nextgen/src/pages/Workspace/hooks/useGroupSessions.ts
@@ -1,4 +1,4 @@
-import type { ParticipantMode, SessionView } from '@/domain/collaboration';
+import type { SessionView } from '@/domain/collaboration';
 import type { DomainError, DomainResult } from '@/services/workspace/identityService';
 import { sessionService } from '@/services/workspace/sessionService';
 import { useWorkspaceStore } from '@/stores/workspaceStore';
@@ -6,40 +6,10 @@ import { useCallback, useEffect, useMemo } from 'react';
 import { toast } from 'sonner';
 import { useSessionMutations } from './useSessionLeave';
 import { useSessionMap } from './useSessionMap';
+import type { UseGroupSessionsResult } from './useGroupSessions.types';
 import { useSessionMemberSync } from './useSessionMemberSync';
 
-export interface UseGroupSessionsResult {
-  sessions: SessionView[];
-  /** 多群展开展示使用：每个已加载群的会话（已按 search 过滤；收藏过滤在 GroupItem 按群独立处理）。 */
-  sessionsByGroupId: Record<string, SessionView[]>;
-  hasMoreSessionsByGroupId: Record<string, boolean>;
-  isLoadingMoreSessionsByGroupId: Record<string, boolean>;
-  totalSessionsByGroupId: Record<string, number>;
-  loadMoreSessions: (groupId: string) => Promise<void>;
-  isSessionsLoading: boolean;
-  selectedSessionId: string | null;
-  selectedSession: SessionView | null;
-  favoriteSessionIds: string[];
-  sessionSearchText: string;
-  setSessionSearchText: (v: string) => void;
-  selectSession: (sessionId: string | null) => void;
-  /** 打开某群下的会话：必要时先切换选中群（chat pane 跟随），再选中会话。 */
-  openSession: (groupId: string, sessionId: string) => void;
-  createSession: (title?: string, contextQuery?: string) => Promise<SessionView | null>;
-  /** 在指定群内创建会话（侧栏每个群的「新建会话」入口）；创建后选中该群与这条新会话。 */
-  createSessionIn: (groupId: string, title?: string, contextQuery?: string) => Promise<SessionView | null>;
-  renameSession: (sessionId: string, title: string) => Promise<boolean>;
-  deleteSession: (sessionId: string) => Promise<boolean>;
-  /** 退出会话（移除自己）：从侧边栏移除该会话并清空选中。 */
-  leaveSession: (sessionId: string, actorId: string) => Promise<boolean>;
-  toggleFavorite: (sessionId: string) => Promise<void>;
-  /** 更新会话成员姿态/发言模式（参考 open-claw 我的协作：bot auto↔muted、human present↔absent）。 */
-  updateMemberMode: (sessionId: string, actorId: string, mode: ParticipantMode) => Promise<boolean>;
-  /** 用后端返回的会话详情就地替换指定会话数据（成员增删后就地刷新）。 */
-  applySessionUpdate: (sessionId: string, session: SessionView) => void;
-  reloadSessions: () => Promise<void>;
-}
-
+export type { UseGroupSessionsResult } from './useGroupSessions.types';
 function notifyError(err: DomainError): void {
   toast.error(err.friendlyMessage);
 }
@@ -76,6 +46,8 @@ export function useGroupSessions(groupId: string | null, expandedGroupIds: strin
     isLoadingMoreByGroupId,
     totalByGroupId,
     loadMoreSessions,
+    errorByGroupId,
+    loadMoreErrorByGroupId,
   } = useSessionMap(groupId, expandedGroupIds, activeIdentityId);
 
   // 会话成员详情补齐与 mode 更新(从本 Hook 拆出以控体积,详见 useSessionMemberSync)。
@@ -227,6 +199,8 @@ export function useGroupSessions(groupId: string | null, expandedGroupIds: strin
     hasMoreSessionsByGroupId: hasMoreByGroupId,
     isLoadingMoreSessionsByGroupId: isLoadingMoreByGroupId,
     totalSessionsByGroupId: totalByGroupId,
+    errorByGroupId,
+    loadMoreErrorByGroupId,
     loadMoreSessions,
     isSessionsLoading: isLoading,
     selectedSessionId,
@@ -245,5 +219,6 @@ export function useGroupSessions(groupId: string | null, expandedGroupIds: strin
     updateMemberMode,
     applySessionUpdate,
     reloadSessions,
+    reloadGroup,
   };
 }

--- a/src/frontend-nextgen/src/pages/Workspace/hooks/useGroupSessions.types.ts
+++ b/src/frontend-nextgen/src/pages/Workspace/hooks/useGroupSessions.types.ts
@@ -1,0 +1,36 @@
+import type { ParticipantMode, SessionView } from '@/domain/collaboration';
+
+export interface UseGroupSessionsResult {
+  sessions: SessionView[];
+  /** 多群展开展示使用：每个已加载群的会话（已按 search 过滤；收藏过滤在 GroupItem 按群独立处理）。 */
+  sessionsByGroupId: Record<string, SessionView[]>;
+  hasMoreSessionsByGroupId: Record<string, boolean>;
+  isLoadingMoreSessionsByGroupId: Record<string, boolean>;
+  totalSessionsByGroupId: Record<string, number>;
+  errorByGroupId: Record<string, string>;
+  loadMoreErrorByGroupId: Record<string, string>;
+  loadMoreSessions: (groupId: string) => Promise<void>;
+  isSessionsLoading: boolean;
+  selectedSessionId: string | null;
+  selectedSession: SessionView | null;
+  favoriteSessionIds: string[];
+  sessionSearchText: string;
+  setSessionSearchText: (v: string) => void;
+  selectSession: (sessionId: string | null) => void;
+  /** 打开某群下的会话：必要时先切换选中群（chat pane 跟随），再选中会话。 */
+  openSession: (groupId: string, sessionId: string) => void;
+  createSession: (title?: string, contextQuery?: string) => Promise<SessionView | null>;
+  /** 在指定群内创建会话（侧栏每个群的「新建会话」入口）；创建后选中该群与这条新会话。 */
+  createSessionIn: (groupId: string, title?: string, contextQuery?: string) => Promise<SessionView | null>;
+  renameSession: (sessionId: string, title: string) => Promise<boolean>;
+  deleteSession: (sessionId: string) => Promise<boolean>;
+  /** 退出会话（移除自己）：从侧边栏移除该会话并清空选中。 */
+  leaveSession: (sessionId: string, actorId: string) => Promise<boolean>;
+  toggleFavorite: (sessionId: string) => Promise<void>;
+  /** 更新会话成员姿态/发言模式（参考 open-claw 我的协作：bot auto↔muted、human present↔absent）。 */
+  updateMemberMode: (sessionId: string, actorId: string, mode: ParticipantMode) => Promise<boolean>;
+  /** 用后端返回的会话详情就地替换指定会话数据（成员增删后就地刷新）。 */
+  applySessionUpdate: (sessionId: string, session: SessionView) => void;
+  reloadSessions: () => Promise<void>;
+  reloadGroup: (groupId: string) => Promise<void>;
+}

--- a/src/frontend-nextgen/src/pages/Workspace/hooks/useGroupWorkspace.ts
+++ b/src/frontend-nextgen/src/pages/Workspace/hooks/useGroupWorkspace.ts
@@ -1,43 +1,15 @@
-import type { GroupKind, GroupView, IdentityView } from '@/domain/collaboration';
+import type { GroupView, IdentityView } from '@/domain/collaboration';
 import { groupService, type PolicyResult } from '@/services/workspace/groupService';
 import { useWorkspaceStore } from '@/stores/workspaceStore';
 import { shouldMuteNonAuthedToast } from '@/utils/loginToastGate';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { useSelectedGroupDetail } from './useSelectedGroupDetail';
+import type { UseGroupWorkspaceResult } from './useGroupWorkspace.types';
 
 const SEARCH_DEBOUNCE_MS = 300;
 
-export interface UseGroupWorkspaceResult {
-  identities: IdentityView[];
-  activeIdentityId: string | null;
-  activeIdentity: IdentityView | null;
-  groups: GroupView[];
-  isLoadingGroups: boolean;
-  selectedGroupId: string | null;
-  selectedGroup: GroupView | null;
-  groupSearchText: string;
-  setGroupSearchText: (v: string) => void;
-  kindFilter: 'all' | GroupKind;
-  setKindFilter: (k: 'all' | GroupKind) => void;
-  sortMode: 'lastActivity' | 'createdAt';
-  setSortMode: (m: 'lastActivity' | 'createdAt') => void;
-  membership: 'direct' | 'session_only';
-  setMembership: (m: 'direct' | 'session_only') => void;
-  expandedGroupIds: Record<string, true>;
-  toggleGroupExpanded: (groupId: string) => void;
-  onSelectGroup: (groupId: string) => void;
-  refreshGroups: () => Promise<void>;
-  /** 重拉群详情并写回本地 groups。管理面板打开/更新后就地刷新；可传 groupId 直接刷新指定群
-   *  （默认刷新当前选中群）。群详情含 participants/owner/driver，仅查看/编辑时按需调用。 */
-  reloadSelectedGroup: (groupId?: string) => Promise<void>;
-  dissolveGroup: (groupId: string) => Promise<void>;
-  /** Service 政策结果：当前选中群 + 当前身份是否有管理权限（policy 计算归 Hook，组件只消费）。 */
-  canManageGroup: PolicyResult;
-  /** Service 政策结果：当前选中群 + 当前身份是否可解散（policy 计算归 Hook，组件只消费）。 */
-  canDissolveGroup: PolicyResult;
-}
-
+export type { UseGroupWorkspaceResult } from './useGroupWorkspace.types';
 /**
  * useGroupWorkspace 负责协作群列表的编排：拉取、防抖搜索、身份切换重载、
  * 选中群详情兜底、以及解散群的政策校验与 Toast 反馈。
@@ -59,6 +31,7 @@ export function useGroupWorkspace(): UseGroupWorkspaceResult {
   const membership = useWorkspaceStore((s) => s.membership);
   const expandedGroupIds = useWorkspaceStore((s) => s.expandedGroupIds);
   const isGroupsLoading = useWorkspaceStore((s) => s.isGroupsLoading);
+  const [groupsError, setGroupsError] = useState<string | null>(null);
 
   const setGroupSearchText = useWorkspaceStore((s) => s.setGroupSearchText);
   const setKindFilter = useWorkspaceStore((s) => s.setGroupKindFilter);
@@ -100,16 +73,21 @@ export function useGroupWorkspace(): UseGroupWorkspaceResult {
   const loadGroups = useCallback(
     async (identityId: string | null, q?: string) => {
       const identity = resolveIdentity(identityId);
-      if (!identity) return;
+      if (!identity) {
+        setGroupsError(null);
+        return;
+      }
       useWorkspaceStore.getState().setIsGroupsLoading(true);
+      setGroupsError(null);
       try {
         const res = await groupService.loadGroups(identity, { q, membership });
         if (res.ok) {
           setSessionGroups(res.data);
-        } else if (!shouldMuteNonAuthedToast()) {
+        } else {
+          setGroupsError(res.error.friendlyMessage);
           // 未登录（oauth-provider + 非 authenticated）静默：会话失效后「加载协作群失败」
           // 等业务 toast 噪音统一由 ExternalLoginPromptModal 承担（见 loginToastGate）。
-          toast.error(res.error.friendlyMessage);
+          if (!shouldMuteNonAuthedToast()) toast.error(res.error.friendlyMessage);
         }
       } finally {
         useWorkspaceStore.getState().setIsGroupsLoading(false);
@@ -180,6 +158,10 @@ export function useGroupWorkspace(): UseGroupWorkspaceResult {
     await loadGroups(activeIdentityId, lastSearchRef.current || undefined);
   }, [loadGroups, activeIdentityId]);
 
+  const retryGroups = useCallback(async () => {
+    await loadGroups(activeIdentityId, lastSearchRef.current || undefined);
+  }, [activeIdentityId, loadGroups]);
+
   const reloadSelectedGroup = useCallback(
     async (groupId?: string) => {
       const gid = groupId ?? selectedGroupId;
@@ -226,6 +208,7 @@ export function useGroupWorkspace(): UseGroupWorkspaceResult {
     activeIdentity,
     groups,
     isLoadingGroups: isGroupsLoading,
+    groupsError,
     selectedGroupId,
     selectedGroup,
     groupSearchText,
@@ -240,6 +223,7 @@ export function useGroupWorkspace(): UseGroupWorkspaceResult {
     toggleGroupExpanded,
     onSelectGroup,
     refreshGroups,
+    retryGroups,
     reloadSelectedGroup,
     dissolveGroup,
     canManageGroup,

--- a/src/frontend-nextgen/src/pages/Workspace/hooks/useGroupWorkspace.types.ts
+++ b/src/frontend-nextgen/src/pages/Workspace/hooks/useGroupWorkspace.types.ts
@@ -1,0 +1,34 @@
+import type { GroupKind, GroupView, IdentityView } from '@/domain/collaboration';
+import type { PolicyResult } from '@/services/workspace/groupService';
+
+export interface UseGroupWorkspaceResult {
+  identities: IdentityView[];
+  activeIdentityId: string | null;
+  activeIdentity: IdentityView | null;
+  groups: GroupView[];
+  isLoadingGroups: boolean;
+  groupsError: string | null;
+  selectedGroupId: string | null;
+  selectedGroup: GroupView | null;
+  groupSearchText: string;
+  setGroupSearchText: (v: string) => void;
+  kindFilter: 'all' | GroupKind;
+  setKindFilter: (k: 'all' | GroupKind) => void;
+  sortMode: 'lastActivity' | 'createdAt';
+  setSortMode: (m: 'lastActivity' | 'createdAt') => void;
+  membership: 'direct' | 'session_only';
+  setMembership: (m: 'direct' | 'session_only') => void;
+  expandedGroupIds: Record<string, true>;
+  toggleGroupExpanded: (groupId: string) => void;
+  onSelectGroup: (groupId: string) => void;
+  refreshGroups: () => Promise<void>;
+  retryGroups: () => Promise<void>;
+  /** 重拉群详情并写回本地 groups。管理面板打开/更新后就地刷新；可传 groupId 直接刷新指定群
+   *  （默认刷新当前选中群）。群详情含 participants/owner/driver，仅查看/编辑时按需调用。 */
+  reloadSelectedGroup: (groupId?: string) => Promise<void>;
+  dissolveGroup: (groupId: string) => Promise<void>;
+  /** Service 政策结果：当前选中群 + 当前身份是否有管理权限（policy 计算归 Hook，组件只消费）。 */
+  canManageGroup: PolicyResult;
+  /** Service 政策结果：当前选中群 + 当前身份是否可解散（policy 计算归 Hook，组件只消费）。 */
+  canDissolveGroup: PolicyResult;
+}

--- a/src/frontend-nextgen/src/pages/Workspace/hooks/useOwnedBots.ts
+++ b/src/frontend-nextgen/src/pages/Workspace/hooks/useOwnedBots.ts
@@ -1,11 +1,13 @@
 import type { ChatBotView } from '@/services/workspace/botSessionService';
 import { botSessionService } from '@/services/workspace/botSessionService';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 export interface UseOwnedBotsResult {
   chatBots: ChatBotView[];
   hasAgentCodingBots: boolean;
   isLoading: boolean;
+  error: string | null;
+  reload: () => void;
 }
 
 /** 侧边栏「已管理 Bot」数据源：用户身份下通过 GET /openapi/v1/bots 拉取，Bot 身份返回空列表。 */
@@ -13,21 +15,31 @@ export function useOwnedBots(activeIdentityId: string | null, isUserIdentity: bo
   const [chatBots, setChatBots] = useState<ChatBotView[]>([]);
   const [hasAgentCodingBots, setHasAgentCodingBots] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadNonce, setReloadNonce] = useState(0);
 
   useEffect(() => {
     if (!activeIdentityId || !isUserIdentity) {
       setChatBots([]);
       setHasAgentCodingBots(false);
+      setError(null);
       return;
     }
     let cancelled = false;
     setIsLoading(true);
+    setError(null);
     void botSessionService
       .listOwnedBotsWithMeta(activeIdentityId)
       .then((res) => {
         if (cancelled) return;
-        setChatBots(res.ok ? res.data.bots : []);
-        setHasAgentCodingBots(res.ok ? res.data.hasAgentCodingBots : false);
+        if (res.ok) {
+          setChatBots(res.data.bots);
+          setHasAgentCodingBots(res.data.hasAgentCodingBots);
+        } else {
+          setChatBots([]);
+          setHasAgentCodingBots(false);
+          setError(res.error.friendlyMessage);
+        }
       })
       .finally(() => {
         if (!cancelled) setIsLoading(false);
@@ -35,7 +47,9 @@ export function useOwnedBots(activeIdentityId: string | null, isUserIdentity: bo
     return () => {
       cancelled = true;
     };
-  }, [activeIdentityId, isUserIdentity]);
+  }, [activeIdentityId, isUserIdentity, reloadNonce]);
 
-  return { chatBots, hasAgentCodingBots, isLoading };
+  const reload = useCallback(() => setReloadNonce((current) => current + 1), []);
+
+  return { chatBots, hasAgentCodingBots, isLoading, error, reload };
 }

--- a/src/frontend-nextgen/src/pages/Workspace/hooks/usePublicBotCatalog.ts
+++ b/src/frontend-nextgen/src/pages/Workspace/hooks/usePublicBotCatalog.ts
@@ -17,7 +17,11 @@ import {
   collaborationSquareService,
 } from '@/services/collaborationSquare';
 import { useWorkspaceStore } from '@/stores/workspaceStore';
-import { getCollaborationBotConversationUrl, getCollaborationSquareErrorMessage } from '@/utils/collaborationSquare';
+import {
+  getCollaborationBotConversationUrl,
+  getCollaborationSquareErrorMessage,
+  getCollaborationSquareShareUrl,
+} from '@/utils/collaborationSquare';
 import { history } from '@umijs/max';
 import { useCallback, useMemo, useState } from 'react';
 
@@ -163,10 +167,7 @@ export function usePublicBotCatalog({ activeIdentity, enabled }: UsePublicBotCat
   const share = useCallback(
     (bot: PublicBot) => {
       const origin = typeof window === 'undefined' ? '' : window.location.origin;
-      void copyText(
-        `${origin}/collaboration-square/bots?resource=bot&id=${encodeURIComponent(bot.id)}`,
-        '分享链接已复制',
-      );
+      void copyText(getCollaborationSquareShareUrl(origin, 'bot', bot.id, bot.name), '分享链接已复制');
     },
     [copyText],
   );

--- a/src/frontend-nextgen/src/pages/Workspace/hooks/useSessionMap.ts
+++ b/src/frontend-nextgen/src/pages/Workspace/hooks/useSessionMap.ts
@@ -37,6 +37,8 @@ export interface UseSessionMapResult {
   hasMoreByGroupId: Record<string, boolean>;
   /** 下一页加载状态。 */
   isLoadingMoreByGroupId: Record<string, boolean>;
+  errorByGroupId: Record<string, string>;
+  loadMoreErrorByGroupId: Record<string, string>;
   /** 后端返回的会话总数，按群维护；未加载过的群不包含在 map 中。 */
   totalByGroupId: Record<string, number>;
   /** 按 10 条追加指定群的下一页会话。 */
@@ -56,6 +58,8 @@ export function useSessionMap(
   const [rawByGroupId, setRawByGroupId] = useState<Record<string, SessionView[]>>({});
   const [pageMetaByGroupId, setPageMetaByGroupId] = useState<Record<string, SessionPageMeta>>({});
   const [isLoading, setIsLoading] = useState(false);
+  const [errorByGroupId, setErrorByGroupId] = useState<Record<string, string>>({});
+  const [loadMoreErrorByGroupId, setLoadMoreErrorByGroupId] = useState<Record<string, string>>({});
   const inFlightRef = useRef<Map<string, number>>(new Map());
   const loadingMoreRef = useRef<Set<string>>(new Set());
   const requestVersionRef = useRef<Map<string, number>>(new Map());
@@ -71,6 +75,8 @@ export function useSessionMap(
     requestVersionRef.current.clear();
     setRawByGroupId({});
     setPageMetaByGroupId({});
+    setErrorByGroupId({});
+    setLoadMoreErrorByGroupId({});
     rawByGroupIdRef.current = {};
     pageMetaByGroupIdRef.current = {};
     inFlightRef.current.clear();
@@ -141,6 +147,8 @@ export function useSessionMap(
     setIsLoading,
     setRawByGroupId,
     setPageMetaByGroupId,
+    setErrorByGroupId,
+    setLoadMoreErrorByGroupId,
     beginGroupRequest,
     isCurrentRequest,
     replaceGroupPage,
@@ -190,6 +198,8 @@ export function useSessionMap(
     hasMoreByGroupId,
     isLoadingMoreByGroupId,
     totalByGroupId,
+    errorByGroupId,
+    loadMoreErrorByGroupId,
     loadMoreSessions,
   };
 }

--- a/src/frontend-nextgen/src/pages/Workspace/hooks/useSessionMapRequests.ts
+++ b/src/frontend-nextgen/src/pages/Workspace/hooks/useSessionMapRequests.ts
@@ -1,63 +1,12 @@
-import type { GroupSessionPage, SessionView } from '@/domain/collaboration';
 import { groupService } from '@/services/workspace/groupService';
-import type { DomainError } from '@/services/workspace/identityService';
-import { shouldMuteNonAuthedToast } from '@/utils/loginToastGate';
-import { useCallback, useEffect, useRef, type Dispatch, type MutableRefObject, type SetStateAction } from 'react';
-import { toast } from 'sonner';
+import { useCallback, useEffect, useRef } from 'react';
+import {
+  type UseSessionMapRequestsOptions,
+  normalizePage,
+  notifyError,
+  SESSION_PAGE_SIZE,
+} from './sessionMapRequests.utils';
 import { useExpandedGroupSessionRequests } from './useExpandedGroupSessionRequests';
-
-const SESSION_PAGE_SIZE = 10;
-
-interface SessionPageMeta {
-  total: number;
-  hasMore: boolean;
-  /** 后端分页游标，避免本地新建/删除导致 offset 与服务端列表错位。 */
-  nextOffset: number;
-  isLoadingMore: boolean;
-}
-
-type SessionMap = Record<string, SessionView[]>;
-type SessionMapRef = MutableRefObject<SessionMap>;
-type SessionMetaMapRef = MutableRefObject<Record<string, SessionPageMeta>>;
-
-interface UseSessionMapRequestsOptions {
-  groupId: string | null;
-  expandedGroupIds: string[];
-  activeIdentityId: string | null;
-  rawByGroupId: SessionMap;
-  rawByGroupIdRef: SessionMapRef;
-  pageMetaByGroupIdRef: SessionMetaMapRef;
-  inFlightRef: MutableRefObject<Map<string, number>>;
-  loadingMoreRef: MutableRefObject<Set<string>>;
-  requestVersionRef: MutableRefObject<Map<string, number>>;
-  identityEpochRef: MutableRefObject<number>;
-  setIsLoading: Dispatch<SetStateAction<boolean>>;
-  setRawByGroupId: Dispatch<SetStateAction<SessionMap>>;
-  setPageMetaByGroupId: Dispatch<SetStateAction<Record<string, SessionPageMeta>>>;
-  beginGroupRequest: (groupId: string) => number;
-  isCurrentRequest: (groupId: string, version: number, epoch: number) => boolean;
-  replaceGroupPage: (groupId: string, data: GroupSessionPage | SessionView[]) => void;
-}
-
-function notifyError(err: DomainError): void {
-  // 未登录（oauth-provider + 非 authenticated）静默：会话失效后的 sessions 加载失败 toast
-  // 统一由 ExternalLoginPromptModal 承担（见 loginToastGate）；已登录 / ace-gateway 照常提示。
-  if (shouldMuteNonAuthedToast()) return;
-  toast.error(err.friendlyMessage);
-}
-
-function normalizePage(data: GroupSessionPage | SessionView[], fallbackOffset = 0): GroupSessionPage {
-  if (Array.isArray(data)) {
-    return {
-      items: data,
-      offset: fallbackOffset,
-      limit: SESSION_PAGE_SIZE,
-      total: fallbackOffset + data.length,
-      hasMore: data.length >= SESSION_PAGE_SIZE,
-    };
-  }
-  return data;
-}
 
 export function useSessionMapRequests({
   groupId,
@@ -73,6 +22,8 @@ export function useSessionMapRequests({
   setIsLoading,
   setRawByGroupId,
   setPageMetaByGroupId,
+  setErrorByGroupId,
+  setLoadMoreErrorByGroupId,
   beginGroupRequest,
   isCurrentRequest,
   replaceGroupPage,
@@ -99,11 +50,23 @@ export function useSessionMapRequests({
       .then((res) => {
         // 切群后同身份的旧请求仍可回填旧群；身份切换或更新请求后的旧响应必须丢弃。
         if (!isCurrentRequest(groupId, requestVersion, requestEpoch)) return;
-        if (res.ok) replaceGroupPage(groupId, res.data);
+        if (res.ok) {
+          setErrorByGroupId((current) => {
+            const next = { ...current };
+            delete next[groupId];
+            return next;
+          });
+          setLoadMoreErrorByGroupId((current) => {
+            const next = { ...current };
+            delete next[groupId];
+            return next;
+          });
+          replaceGroupPage(groupId, res.data);
+        }
         else if (cancelled) replaceGroupPage(groupId, []);
         else {
           notifyError(res.error);
-          replaceGroupPage(groupId, []);
+          setErrorByGroupId((current) => ({ ...current, [groupId]: res.error.friendlyMessage }));
         }
       })
       .finally(() => {
@@ -122,6 +85,8 @@ export function useSessionMapRequests({
     inFlightRef,
     isCurrentRequest,
     replaceGroupPage,
+    setErrorByGroupId,
+    setLoadMoreErrorByGroupId,
     setIsLoading,
   ]);
 
@@ -135,6 +100,7 @@ export function useSessionMapRequests({
     beginGroupRequest,
     isCurrentRequest,
     replaceGroupPage,
+    setErrorByGroupId,
   });
 
   const reloadGroup = useCallback(
@@ -143,9 +109,22 @@ export function useSessionMapRequests({
       const requestVersion = beginGroupRequest(gid);
       const res = await groupService.loadGroupSessionsOrBcs(gid, activeIdentityId ?? undefined);
       if (!isCurrentRequest(gid, requestVersion, requestEpoch)) return;
-      if (res.ok) replaceGroupPage(gid, res.data);
+      if (res.ok) {
+        setErrorByGroupId((current) => {
+          const next = { ...current };
+          delete next[gid];
+          return next;
+        });
+        setLoadMoreErrorByGroupId((current) => {
+          const next = { ...current };
+          delete next[gid];
+          return next;
+        });
+        replaceGroupPage(gid, res.data);
+      }
       else {
         notifyError(res.error);
+        setErrorByGroupId((current) => ({ ...current, [gid]: res.error.friendlyMessage }));
         const currentMeta = pageMetaByGroupIdRef.current[gid];
         if (currentMeta?.isLoadingMore) {
           const nextMeta = {
@@ -164,6 +143,8 @@ export function useSessionMapRequests({
       isCurrentRequest,
       pageMetaByGroupIdRef,
       replaceGroupPage,
+      setErrorByGroupId,
+      setLoadMoreErrorByGroupId,
       setPageMetaByGroupId,
     ],
   );
@@ -192,8 +173,14 @@ export function useSessionMapRequests({
         }
         if (!res.ok) {
           notifyError(res.error);
+          setLoadMoreErrorByGroupId((current) => ({ ...current, [gid]: res.error.friendlyMessage }));
           return;
         }
+        setLoadMoreErrorByGroupId((current) => {
+          const next = { ...current };
+          delete next[gid];
+          return next;
+        });
         const page = normalizePage(res.data, meta.nextOffset);
         const existing = rawByGroupIdRef.current[gid] ?? [];
         const seen = new Set(existing.map((session) => session.sessionId));
@@ -237,6 +224,7 @@ export function useSessionMapRequests({
       requestVersionRef,
       setPageMetaByGroupId,
       setRawByGroupId,
+      setLoadMoreErrorByGroupId,
     ],
   );
 

--- a/src/frontend-nextgen/src/pages/Workspace/hooks/useWorkspacePage.ts
+++ b/src/frontend-nextgen/src/pages/Workspace/hooks/useWorkspacePage.ts
@@ -39,6 +39,15 @@ export function useWorkspacePage(): UseWorkspacePageResult {
   // URL 残留 session= 导致反复切回用户身份。
   const isFirstUrlSyncRef = useRef(true);
 
+  // 挂载时一次性快照协作群外链参数。外链/邀请直达（session= 且无 bot=）才需要把身份切回用户；
+  // 用户后续手动点击协作群产生的 session= 属于内部选中，不应切身份，否则会把手动选中的 bot 身份切回用户。
+  const initialGroupUrlRef = useRef({
+    session: sessionParam,
+    bot: botParam,
+    group: groupParam,
+    membership: membershipParam,
+  });
+
   // view：以 store.view 为权威（身份切换/记忆恢复都写入 store）。URL 中的 tab=group
   // / group= 仅作为外链直达初始化（见下方 URL → store view effect）。
   const view: WorkspaceView = storeView;
@@ -93,32 +102,33 @@ export function useWorkspacePage(): UseWorkspacePageResult {
     // 协作群会话（协作广场跳转 / 邀请链接）：仅在首次挂载时执行一次，后续身份切换
     // 不应再触发——否则用户手动切到 bot 角色后，URL 残留的 session= 会导致反复切回
     // 用户身份（isFirstUrlSyncRef 守卫，与下方 isFirstIdentityRef 同构）。
-    if (isFirstUrlSyncRef.current && sessionParam && !botParam) {
+    const initialGroupUrl = initialGroupUrlRef.current;
+    if (isFirstUrlSyncRef.current && initialGroupUrl.session && !initialGroupUrl.bot) {
       isFirstUrlSyncRef.current = false;
       const store = useWorkspaceStore.getState();
       const me = store.identities.find((i) => i.kind === 'user');
       if (me && store.activeIdentityId !== me.id) store.setActiveIdentityId(me.id);
       const fresh = useWorkspaceStore.getState();
       fresh.setView('group');
-      if (membershipParam === 'session_only' || membershipParam === 'direct') {
-        useWorkspaceStore.getState().setMembership(membershipParam);
+      if (initialGroupUrl.membership === 'session_only' || initialGroupUrl.membership === 'direct') {
+        useWorkspaceStore.getState().setMembership(initialGroupUrl.membership);
       }
-      if (groupParam) {
-        fresh.selectGroup(groupParam);
-        ensureGroupExpanded(groupParam);
+      if (initialGroupUrl.group) {
+        fresh.selectGroup(initialGroupUrl.group);
+        ensureGroupExpanded(initialGroupUrl.group);
       } else {
         // 无 group 参数（邀请链接）：异步反查 groupId 后选中。
-        void sessionService.getSessionDetail(sessionParam).then((res) => {
+        void sessionService.getSessionDetail(initialGroupUrl.session).then((res) => {
           if (!res.ok) return;
           const s2 = useWorkspaceStore.getState();
           s2.selectGroup(res.data.groupId);
-          s2.selectSession(sessionParam);
+          s2.selectSession(initialGroupUrl.session);
           ensureGroupExpanded(res.data.groupId);
           s2.bumpHistoryRefresh();
         });
         return;
       }
-      fresh.selectSession(sessionParam);
+      fresh.selectSession(initialGroupUrl.session);
       fresh.bumpHistoryRefresh();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/frontend-nextgen/src/pages/Workspace/index.tsx
+++ b/src/frontend-nextgen/src/pages/Workspace/index.tsx
@@ -83,6 +83,7 @@ const WorkspacePage: React.FC = () => {
     submitPanelMessage: workspace.submitPanelMessage,
     appendAssistantMessage: workspace.appendAssistantMessage,
     streamAssistantMessage: workspace.streamAssistantMessage,
+    onOpenCollaborationPermissions: openCollaborationPermissions,
   });
   const taskComposerDisabledReason = !taskComposerContext && !workspace.isTestUser ? '请先选择一个 Bot 会话' : null;
   const handleSend = useComposerSend(taskExecution, {
@@ -184,9 +185,6 @@ const WorkspacePage: React.FC = () => {
           onMobileListClose={() => setMobileListOpen(false)}
           onOpenCreateGroup={() => setCreateGroupOpen(true)}
           onOpenAddFriend={() => setAddFriendOpen(true)}
-          onOpenPermissions={openCollaborationPermissions}
-          userAvatarUrl={workspace.currentUserAvatarUrl}
-          onManageBot={(bot) => navigate(`/bot-workshop/detail?type=view&id=${encodeURIComponent(bot.realBotId)}`)}
           onOpenBotWorkshop={() => navigate('/bot-workshop')}
         />
         {workspace.selectedAgentCodingBot ? (
@@ -250,10 +248,6 @@ const WorkspacePage: React.FC = () => {
             view={view}
             onViewChange={setView}
             availableViews={availableViews}
-            identities={workspace.identities}
-            activeIdentityId={workspace.activeIdentityId}
-            onChangeIdentity={workspace.setActiveIdentityId}
-            onOpenPermissions={openCollaborationPermissions}
             userAvatarUrl={workspace.currentUserAvatarUrl}
             userIdentityId={workspace.activeIdentityId}
             onAddFriend={() => setAddFriendOpen(true)}

--- a/src/frontend-nextgen/src/services/backendApi/collaboration/collaborationFriendConnectionController.ts
+++ b/src/frontend-nextgen/src/services/backendApi/collaboration/collaborationFriendConnectionController.ts
@@ -20,12 +20,10 @@ export interface FriendConnectionRequestDto {
   updated_at?: number | string;
 }
 
+/** 已建立好友连接列表项。接口返回连接另一端 actor，不返回 status/from_actor/to_actor。 */
 export interface FriendConnectionDto {
-  edge_id?: string;
-  from_actor: FriendConnectionActor;
-  to_actor: FriendConnectionActor;
-  status?: 'approved' | 'public_no_edge';
-  created_at?: number | string;
+  actor: FriendConnectionActor;
+  is_online?: boolean;
 }
 
 export interface FriendConnectionSummaryDto {

--- a/src/frontend-nextgen/src/services/backendApi/collaboration/taskGrantController.ts
+++ b/src/frontend-nextgen/src/services/backendApi/collaboration/taskGrantController.ts
@@ -1,4 +1,4 @@
-import { getCapabilities } from '@/capabilities';
+import { getCapabilities, type TaskClaimGrantStrategy } from '@/capabilities';
 import { backendRequest } from '../httpClient';
 import type { BackendApiEnvelope } from '../types';
 
@@ -27,8 +27,35 @@ export interface TaskClaimGrantResultDto {
   gmt_modified: string;
 }
 
+/** 任务认领授权策略解析;skip=开源直发短路,secbaas-relay=内部透传 secbaas。请求期读 capability(避免启动期未装填)。 */
+function resolveTaskClaimGrantStrategy(): TaskClaimGrantStrategy {
+  return getCapabilities().getTaskClaimGrantStrategy().value ?? 'skip';
+}
+
+/** 开源短路信封:api-key 直发无 secbaas,api_key_prefix/operator 留空;上层 enable/disable 仅检 data 真值即放行 PATCH。 */
+function syntheticTaskClaimResult(
+  body: { bcs_bot_id: string },
+  grantStatus: 'granted' | 'revoked',
+): BackendApiEnvelope<TaskClaimGrantResultDto> {
+  return {
+    success: true,
+    code: 200000,
+    message: 'OK',
+    data: {
+      bcs_bot_id: body.bcs_bot_id,
+      api_key_prefix: '',
+      grant_status: grantStatus,
+      operator: '',
+      gmt_modified: '',
+    },
+  };
+}
+
 /** 开启任务认领：grant 公共 api-key 给目标 Bot；幂等（已 granted 不报错）。 */
 export function grantTaskClaim(body: { bcs_bot_id: string }, signal?: AbortSignal) {
+  if (resolveTaskClaimGrantStrategy() === 'skip') {
+    return Promise.resolve(syntheticTaskClaimResult(body, 'granted'));
+  }
   return backendRequest<BackendApiEnvelope<TaskClaimGrantResultDto>>(`${taskApiBase()}/${TASK_GRANT_ENDPOINTS.grant}`, {
     method: 'POST',
     data: body,
@@ -39,6 +66,9 @@ export function grantTaskClaim(body: { bcs_bot_id: string }, signal?: AbortSigna
 
 /** 关闭任务认领：真 revoke（secbaas .../allowed-bots/revoke），置 task_bot_grant.revoked。 */
 export function revokeTaskClaim(body: { bcs_bot_id: string }, signal?: AbortSignal) {
+  if (resolveTaskClaimGrantStrategy() === 'skip') {
+    return Promise.resolve(syntheticTaskClaimResult(body, 'revoked'));
+  }
   return backendRequest<BackendApiEnvelope<TaskClaimGrantResultDto>>(
     `${taskApiBase()}/${TASK_GRANT_ENDPOINTS.revoke}`,
     {

--- a/src/frontend-nextgen/src/services/collaborationSquare/collaborationSquareService.ts
+++ b/src/frontend-nextgen/src/services/collaborationSquare/collaborationSquareService.ts
@@ -1,4 +1,5 @@
 import type {
+  BotCatalogViewer,
   FriendRequestActor,
   HumanBotActionContext,
   PublicBotDiscoveryQuery,
@@ -37,6 +38,39 @@ export class CollaborationSquareService {
   }
   listBotPage(query?: PublicBotSearchQuery, context?: HumanBotActionContext, signal?: AbortSignal) {
     return this.gateway.listBotPage(query, context, signal);
+  }
+  async resolveSharedBot(
+    targetId: string,
+    searchHint: string,
+    context?: HumanBotActionContext,
+    viewer?: BotCatalogViewer,
+    signal?: AbortSignal,
+  ) {
+    const id = targetId.trim();
+    const search = searchHint.trim();
+    if (!id || !search) return null;
+
+    const pageSize = 100;
+    let page = 1;
+    while (!signal?.aborted) {
+      const result = await this.gateway.listBotPage(
+        {
+          search,
+          page,
+          pageSize,
+          ...(viewer
+            ? { viewerActorType: viewer.viewerActorType, viewerActorId: viewer.viewerActorId }
+            : {}),
+        },
+        context,
+        signal,
+      );
+      const matched = result.items.find((bot) => bot.id === id);
+      if (matched) return matched;
+      if (page * pageSize >= result.total || result.items.length === 0) return null;
+      page += 1;
+    }
+    return null;
   }
   discoverBots(query: PublicBotDiscoveryQuery, context?: HumanBotActionContext, signal?: AbortSignal) {
     return this.gateway.discoverBots(query, context, signal);

--- a/src/frontend-nextgen/src/services/collaborationSquare/friendConnectionRelationships.ts
+++ b/src/frontend-nextgen/src/services/collaborationSquare/friendConnectionRelationships.ts
@@ -85,12 +85,11 @@ export async function listFriendBotRelationships(actor: FriendRequestActor, sign
   if (!Array.isArray(connections))
     throw new CollaborationSquareError('protocol_error', '好友连接接口返回了无法识别的数据');
   for (const connection of connections) {
-    if (!connection || (connection.status !== 'approved' && connection.status !== 'public_no_edge')) {
-      throw new CollaborationSquareError('protocol_error', '好友连接接口返回了无法识别的状态');
+    if (!connection?.actor || typeof connection.actor.id !== 'string' || !connection.actor.id.trim()) {
+      throw new CollaborationSquareError('protocol_error', '好友连接接口返回了无法识别的参与方');
     }
-    if (connection.status === 'approved') {
-      friendIds.add(getOtherActorId(connection.from_actor, connection.to_actor, actor.id));
-    }
+    // 已建立连接列表直接返回连接另一端 actor；仅回填 Bot，Human 关系不影响 Bot 卡片。
+    if (connection.actor.type === 'bot') friendIds.add(connection.actor.id.trim());
   }
 
   const applyingIds = await listPendingFriendBotRelationships(actor, signal);

--- a/src/frontend-nextgen/src/services/tasks/taskClaimQuery.ts
+++ b/src/frontend-nextgen/src/services/tasks/taskClaimQuery.ts
@@ -1,0 +1,31 @@
+import { listMyBots } from '@/services/backendApi/collaboration/collaborationBotController';
+import { isEnvelopeSuccessAnyDialect } from '@/services/backendApi/types';
+
+/**
+ * 查询当前会话所属 Bot 是否开启「任务认领」（task_claim_mode）。
+ *
+ * 供卡片「执行」前的门禁消费：只有明确读到 task_claim_mode===false 才阻断；
+ * 查询/鉴权异常或业务错误信封无法判定时放行（避免误伤演示主流程）。
+ *
+ * 数据源必须用 mine(`/collaboration/bots/mine`)：它回填各 Bot 的 task_claim_mode，
+ * 与协作权限页展示开关状态同源——用户在页面上看到开关已开启，门禁也读到开启。
+ * 详情(`detail`)接口的 task_claim_mode 不保证回填，不能作为门禁依据。
+ *
+ * 信封判成败必须用 `isEnvelopeSuccessAnyDialect`：mine 走 BCS 方言（5 位成功码 20000），
+ * `isEnvelopeSuccess` 仅认 6 位段（200000）会把成功误判为失败、导致开关已开启仍被阻断。
+ *
+ * 分层：Service（本文件）下沉 API Controller 编排，Hook 层不得直接调 Controller。
+ */
+export async function isBotTaskClaimEnabled(botId: string): Promise<boolean> {
+  try {
+    const env = await listMyBots({ kind: 'bot', limit: 100 });
+    if (!isEnvelopeSuccessAnyDialect(env)) return true; // 业务错误信封：无法判定，放行不阻断
+    const items = env?.data?.items;
+    if (!Array.isArray(items)) return true; // 非预期结构：放行
+    const bot = items.find((item) => item?.bot_id === botId);
+    if (!bot) return true; // 不在当前用户可管理 Bot 列表：认领不适用，放行
+    return Boolean(bot.task_claim_mode); // true→放行；false→阻断（与协作权限页映射一致）
+  } catch {
+    return true; // 网络/鉴权异常：放行
+  }
+}

--- a/src/frontend-nextgen/src/services/workspace/workspaceService.ts
+++ b/src/frontend-nextgen/src/services/workspace/workspaceService.ts
@@ -48,6 +48,11 @@ export const workspaceService = {
   persistIdentity(id: string) {
     identityService.persistLastIdentityId(id);
   },
+  /** 全局协作身份入口的切换用例：持久化选择并重置对应工作区状态。 */
+  switchIdentity(id: string) {
+    identityService.persistLastIdentityId(id);
+    useWorkspaceStore.getState().setActiveIdentity(id);
+  },
   getOverview() {
     return {
       module: 'workspace',

--- a/src/frontend-nextgen/src/shell/SidebarNavList.tsx
+++ b/src/frontend-nextgen/src/shell/SidebarNavList.tsx
@@ -3,6 +3,7 @@ import { Button, IconButton } from '@/components/ui';
 import { cn } from '@/utils/cn';
 import type { NavigationArea, NavigationItem } from './navigation';
 import { SpaceSwitcher } from './SpaceSwitcher';
+import { WorkspaceIdentitySwitcher } from './WorkspaceIdentitySwitcher';
 
 interface SidebarNavListProps {
   area: NavigationArea;
@@ -46,6 +47,11 @@ export function SidebarNavList({ area, activePath, items, onNavigate, collapsed 
         aria-label={area === 'work' ? '工作导航' : '管理导航'}
         className="app-scrollbar flex-1 overflow-y-auto px-3 py-3"
       >
+        {(area === 'work' || showSpaceSwitcher) && (
+          <div className="mb-3 border-b border-[var(--color-border)] pb-3">
+            {area === 'work' ? <WorkspaceIdentitySwitcher /> : <SpaceSwitcher />}
+          </div>
+        )}
         <p className="px-3 pb-2 text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--color-muted)]">
           {area === 'work' ? '工作' : '管理'}
         </p>
@@ -71,11 +77,6 @@ export function SidebarNavList({ area, activePath, items, onNavigate, collapsed 
           })}
         </div>
       </nav>
-      {showSpaceSwitcher && (
-        <div className="mt-auto border-t border-[var(--color-border)] px-3 pb-3 pt-2">
-          <SpaceSwitcher />
-        </div>
-      )}
     </>
   );
 }

--- a/src/frontend-nextgen/src/shell/SpaceSwitcher.tsx
+++ b/src/frontend-nextgen/src/shell/SpaceSwitcher.tsx
@@ -1,4 +1,4 @@
-// 侧边栏左下角空间切换器。是否展示由 AppSidebar 控制（仅管理页 area==='manage' 展示，工作页不展示，对齐 PRD demo）。
+// 管理一级导航顶部空间切换器。仅管理页 area==='manage' 展示。
 // 读 useSpaceContext：当前空间展示 + Popover 下拉（仅已加入）。
 // 选中即 switchSpaceContext(id) + 持久化。loading/error/empty 三态。
 // 视觉对齐 PRD（Teamclaw_PRD_new/src/components/Layout/Sidebar.tsx）：
@@ -16,6 +16,22 @@ function SpaceIcon({ type, className }: { type: Space['spaceType']; className?: 
   // 个人=紫 User(text-brand)，团队=蓝 Users(text-primary)，与 SpaceCard 图标配色一致
   if (type === 'PERSONAL') return <User className={cn('shrink-0 text-brand', className)} aria-hidden />;
   return <Users className={cn('shrink-0 text-[var(--color-primary)]', className)} aria-hidden />;
+}
+
+function SpaceAvatar({ type, loading }: { type: Space['spaceType']; loading: boolean }) {
+  return (
+    <span
+      role="img"
+      aria-label={loading ? '空间加载中' : `${type === 'PERSONAL' ? '个人空间' : '团队空间'}图标`}
+      className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-primary/10"
+    >
+      {loading ? (
+        <Loader2 className="h-3.5 w-3.5 animate-spin text-primary" aria-hidden />
+      ) : (
+        <SpaceIcon type={type} className="h-3.5 w-3.5" />
+      )}
+    </span>
+  );
 }
 
 function SpaceRow({ space, active, onSelect }: { space: Space; active: boolean; onSelect: (id: number) => void }) {
@@ -95,41 +111,40 @@ export function SpaceSwitcher() {
   const displayText = currentSpace?.spaceName ?? (loading ? '加载中…' : '选择空间');
 
   return (
-    <Popover open={open} onOpenChange={onOpenChange}>
-      <PopoverTrigger asChild>
-        <span className="inline-flex w-full">
-          {/* 触发器：浅色填充圆角卡片 + border（展开时转 primary）；左=空间类型图标，中=空间名，右=下拉箭头 */}
-          <Button
-            variant="ghost"
-            className={cn(
-              'h-auto w-full justify-between rounded-lg border bg-[var(--color-primary-soft)] px-3 py-2.5 text-[13px] text-[var(--color-fg)] hover:bg-[var(--color-primary-soft)] hover:text-[var(--color-fg)]',
-              open ? 'border-[var(--color-primary)]' : 'border-[var(--color-border)]',
-            )}
-            leftIcon={
-              loading ? (
-                <Loader2 className="h-4 w-4 shrink-0 animate-spin text-[var(--color-primary)]" aria-hidden />
-              ) : (
-                <SpaceIcon type={currentType} className="h-4 w-4" />
-              )
-            }
-            rightIcon={
+    <div className="space-y-1">
+      <div className="flex items-center px-1 pb-1 text-xs font-semibold text-foreground">
+        <span>管理空间</span>
+      </div>
+      <Popover open={open} onOpenChange={onOpenChange}>
+        <PopoverTrigger asChild>
+          <span className="inline-flex w-full">
+            <Button
+              variant="ghost"
+              className={cn(
+                'h-auto min-h-9 w-full justify-between gap-2 rounded-lg border border-border bg-muted/60 px-2.5 py-1.5 text-left text-foreground hover:bg-muted hover:text-foreground',
+                open && 'border-primary',
+              )}
+            >
+              <SpaceAvatar type={currentType} loading={loading} />
+              <span className="min-w-0 flex-1 truncate text-left text-xs font-medium text-foreground">{displayText}</span>
               <ChevronDown
-                className={cn('h-3 w-3 shrink-0 text-[var(--color-muted)] transition-transform', open && 'rotate-180')}
+                className={cn('h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform', open && 'rotate-180')}
                 aria-hidden
               />
-            }
-          >
-            <span className="min-w-0 flex-1 truncate text-left font-semibold text-[var(--color-fg)]">
-              {displayText}
-            </span>
-          </Button>
-        </span>
-      </PopoverTrigger>
-      <PopoverContent align="start" side="top" sideOffset={8} className="w-[var(--radix-popper-anchor-width)] p-0">
-        <div className="px-3 pb-2 pt-2 text-xs font-semibold text-[var(--color-muted)]">空间切换</div>
-        {listBody}
-      </PopoverContent>
-    </Popover>
+            </Button>
+          </span>
+        </PopoverTrigger>
+        <PopoverContent
+          align="start"
+          side="bottom"
+          sideOffset={8}
+          className="w-[var(--radix-popper-anchor-width)] p-0"
+        >
+          <div className="px-3 pb-2 pt-2 text-xs font-semibold text-[var(--color-muted)]">空间切换</div>
+          {listBody}
+        </PopoverContent>
+      </Popover>
+    </div>
   );
 }
 

--- a/src/frontend-nextgen/src/shell/WorkspaceIdentitySwitcher.tsx
+++ b/src/frontend-nextgen/src/shell/WorkspaceIdentitySwitcher.tsx
@@ -1,0 +1,36 @@
+import { WorkspaceIdentitySelector } from '@/components/Workspace/IdentitySelector';
+import { useHumanIdentity } from '@/hooks/useHumanIdentity';
+import { mapIdentityViewToIdentity } from '@/hooks/workspaceIdentityMapper';
+import { workspaceService } from '@/services/workspace/workspaceService';
+import { useWorkspaceStore } from '@/stores/workspaceStore';
+import { useCallback, useMemo } from 'react';
+
+function useWorkspaceIdentitySwitcherModel() {
+  const identityViews = useWorkspaceStore((state) => state.identities);
+  const activeIdentityId = useWorkspaceStore((state) => state.activeIdentityId);
+  const { identity: humanIdentity } = useHumanIdentity();
+  const identities = useMemo(() => identityViews.map(mapIdentityViewToIdentity), [identityViews]);
+  const switchIdentity = useCallback((identityId: string) => workspaceService.switchIdentity(identityId), []);
+
+  return {
+    identities,
+    activeIdentityId,
+    switchIdentity,
+    userAvatarUrl: humanIdentity?.avatarUrl,
+  };
+}
+
+/** 工作区一级导航顶部的协作身份入口。身份状态保持全局共享，不依赖对话页二级侧栏。 */
+export function WorkspaceIdentitySwitcher() {
+  const model = useWorkspaceIdentitySwitcherModel();
+
+  return (
+    <WorkspaceIdentitySelector
+      identities={model.identities}
+      activeId={model.activeIdentityId}
+      onChange={model.switchIdentity}
+      userAvatarUrl={model.userAvatarUrl}
+      layout="sidebar"
+    />
+  );
+}

--- a/src/frontend-nextgen/src/stores/collaborationSquareStore.ts
+++ b/src/frontend-nextgen/src/stores/collaborationSquareStore.ts
@@ -98,7 +98,10 @@ export const useCollaborationSquareStore = create<CollaborationSquareState>((set
   setDetailLoading: (detailLoading) => set({ detailLoading }),
   setError: (error) => set({ error }),
   setQuery: (resource, query) => set(resource === 'bot' ? { botQuery: query } : { groupQuery: query }),
-  setBotSearchMode: (botSearchMode) => set({ botSearchMode }),
+  setBotSearchMode: (botSearchMode) =>
+    set((state) =>
+      state.botSearchMode === botSearchMode ? { botSearchMode } : { botSearchMode, botQuery: '' },
+    ),
   setSelectedBotId: (selectedBotId) => set({ selectedBotId, botProfile: null }),
   setSelectedGroupId: (selectedGroupId) => set({ selectedGroupId, groupMembers: [] }),
   setBusy: (key, busy) =>

--- a/src/frontend-nextgen/src/utils/collaborationSquare.ts
+++ b/src/frontend-nextgen/src/utils/collaborationSquare.ts
@@ -19,12 +19,26 @@ export function getCollaborationGroupConversationUrl(groupId: string | null | un
   return `/workspace?${params.toString()}`;
 }
 
+export function getCollaborationSquareShareUrl(
+  origin: string,
+  resource: SquareResource,
+  id: string,
+  searchHint?: string,
+): string {
+  const pathname = resource === 'bot' ? '/collaboration-square/bots' : '/collaboration-square/groups';
+  const params = new URLSearchParams({ resource, id });
+  const normalizedSearchHint = searchHint?.trim();
+  if (resource === 'bot' && normalizedSearchHint) params.set('name', normalizedSearchHint);
+  return `${origin}${pathname}?${params.toString()}`;
+}
+
 export function clearCollaborationSquareTargetingSearch(resource: SquareResource, id: string): void {
   if (typeof window === 'undefined') return;
   const params = new URLSearchParams(window.location.search);
   if (params.get('resource') !== resource || params.get('id') !== id) return;
   params.delete('resource');
   params.delete('id');
+  params.delete('name');
   const search = params.toString();
   window.history.replaceState(
     window.history.state,

--- a/src/frontend-nextgen/test/capabilities/defaultCapabilities.test.ts
+++ b/src/frontend-nextgen/test/capabilities/defaultCapabilities.test.ts
@@ -154,4 +154,10 @@ describe('Open Core default capabilities', () => {
     expect(r.value).toBeNull();
     useExternalAuthStore.getState().reset();
   });
+
+  test('getTaskClaimGrantStrategy 默认 skip（Open Core api-key 直发,secbaas grant 短路 no-op）', () => {
+    const r = defaultCapabilities.getTaskClaimGrantStrategy();
+    expect(r.status).toBe('available');
+    expect(r.value).toBe('skip');
+  });
 });

--- a/src/frontend-nextgen/test/collaborationPrivacyPage.test.tsx
+++ b/src/frontend-nextgen/test/collaborationPrivacyPage.test.tsx
@@ -19,6 +19,8 @@ import { ConfirmDialog } from '../src/components/ui/ConfirmDialog';
 import { Switch } from '../src/components/ui/Switch';
 import type { CollaborationBot } from '../src/domain/collaborationPrivacy/types';
 
+jest.mock('@umijs/max', () => ({ history: { push: jest.fn() } }));
+
 Object.assign(globalThis, { TextDecoder, TextEncoder });
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 const { renderToStaticMarkup } = require('react-dom/server') as typeof import('react-dom/server');
@@ -145,9 +147,16 @@ describe('collaboration privacy accessible UI', () => {
     expect(html).not.toContain('border-b border-border pb-2');
     expect(html).toContain('divide-y divide-border');
 
-    const hookSource = readFileSync(path.join(process.cwd(), 'src/hooks/useCollaborationPrivacy.ts'), 'utf8');
-    expect(hookSource).toContain('开启后可加入新协作群，并在已加入的协作群会话中回复消息。好友单聊不受影响。');
-    expect(hookSource).toContain('关闭后无法加入新协作群，并停止在已加入的协作群会话中回复消息。好友单聊不受影响。');
+    const collaborationPrivacyHelpersSource = readFileSync(
+      path.join(process.cwd(), 'src/hooks/collaborationPrivacyHelpers.ts'),
+      'utf8',
+    );
+    expect(collaborationPrivacyHelpersSource).toContain(
+      '开启后可加入新协作群，并在已加入的协作群会话中回复消息。好友单聊不受影响。',
+    );
+    expect(collaborationPrivacyHelpersSource).toContain(
+      '关闭后无法加入新协作群，并停止在已加入的协作群会话中回复消息。好友单聊不受影响。',
+    );
   });
 
   test('身份卡展示 user_id 工号和原始 dept_name，部门同步入口保持紧凑', () => {
@@ -170,7 +179,7 @@ describe('collaboration privacy accessible UI', () => {
     expect(html).toContain('alt="示例管理员"');
     expect(html).not.toContain('UserRound');
     expect(html).not.toContain('title="同步用户部门信息"');
-    expect(html).toContain('h-7 w-7');
+    expect(html).toContain('h-5 w-5 shrink-0 rounded-md p-0');
     expect(html).toContain('text-base font-semibold text-foreground');
     expect(html).toContain('text-xs text-muted-foreground');
     expect(html).toContain('text-xs leading-5 text-muted-foreground');
@@ -321,7 +330,7 @@ describe('collaboration privacy accessible UI', () => {
     );
     expect(userHtml).toContain('其他用户无法发现当前 Bot');
     expect(userHtml).toContain('其他用户可发现并申请添加当前 Bot 为好友');
-    expect(userHtml).toContain('仅所选组织范围可发现并申请添加当前 Bot 为好友');
+    expect(userHtml).toContain('仅所选组织范围可申请添加当前 Bot 为好友');
     expect(userHtml).not.toContain('该受众');
     expect(userHtml).not.toContain('所有主体');
 
@@ -337,7 +346,7 @@ describe('collaboration privacy accessible UI', () => {
     );
     expect(botHtml).toContain('其他 Bot 无法发现当前 Bot');
     expect(botHtml).toContain('其他 Bot 可发现并申请添加当前 Bot 为好友');
-    expect(botHtml).toContain('仅所选组织范围内的 Bot 可发现并申请添加当前 Bot 为好友');
+    expect(botHtml).toContain('仅所选组织范围可申请添加当前 Bot 为好友');
   });
 
   test('公开范围编辑器阻止无变化提交并提供级联多选入口', () => {
@@ -352,7 +361,6 @@ describe('collaboration privacy accessible UI', () => {
       />,
     );
     expect(html).toContain('选择组织范围');
-    expect(html).toContain('可分别搜索集团、事业部、部门或团队，并连续添加多个范围。提交后将进入审批流程。');
     expect(html).toContain('已选组织范围（1）');
     expect(html).toContain('示例集团 / 事业部 / 部门 / 团队');
     expect(html).toContain('配置未发生变化，无需提交审批');

--- a/src/frontend-nextgen/test/collaborationSquareModel.test.ts
+++ b/src/frontend-nextgen/test/collaborationSquareModel.test.ts
@@ -217,7 +217,12 @@ describe('collaboration square model', () => {
     ).toBe('自定义协同');
   });
 
-  test('深链只接受当前资源类型和非空 id', () => {
+  test('深链只接受当前资源类型和非空 id，并解析 Bot 名称搜索提示', () => {
+    expect(parseSquareDeepLink('?resource=bot&id=b1&name=%E9%A1%B9%E7%9B%AE%E5%8A%A9%E6%89%8B', 'bot')).toEqual({
+      resource: 'bot',
+      id: 'b1',
+      searchHint: '项目助手',
+    });
     expect(parseSquareDeepLink('?resource=bot&id=b1', 'bot')).toEqual({ resource: 'bot', id: 'b1' });
     expect(parseSquareDeepLink('?resource=group&id=g1', 'bot')).toBeNull();
     expect(parseSquareDeepLink('?resource=bot&id=', 'bot')).toBeNull();

--- a/src/frontend-nextgen/test/collaborationSquareService.test.ts
+++ b/src/frontend-nextgen/test/collaborationSquareService.test.ts
@@ -1,4 +1,5 @@
 import type { CollaborationSquareGateway } from '../src/services/collaborationSquare/collaborationSquareGateway';
+import type { PublicBot } from '../src/domain/collaborationSquare/types';
 import {
   CollaborationSquareError,
   CollaborationSquareService,
@@ -6,6 +7,15 @@ import {
 import { MockCollaborationSquareAdapter } from '../src/services/collaborationSquare/mockCollaborationSquareAdapter';
 
 const humanContext = { actorId: 'human_327325', userId: '327325' };
+
+const publicBot = (id: string, name = '项目助手'): PublicBot => ({
+  id,
+  name,
+  ownerName: 'Owner',
+  description: '',
+  capabilities: [],
+  relationshipStatus: 'none',
+});
 
 function createGateway(overrides: Partial<CollaborationSquareGateway> = {}): CollaborationSquareGateway {
   return {
@@ -164,6 +174,62 @@ describe('collaboration square service', () => {
       total: 48,
     });
     await expect(service.listGroupPage({ offset: 0, limit: 24 })).resolves.toEqual({ items: [], total: 36 });
+  });
+
+  test('分享 Bot 用公开名称检索，并以 canonical ID 精确匹配同名结果', async () => {
+    const listBotPage = jest.fn(async () => ({
+      items: [publicBot('same-name-other'), publicBot('bot:target')],
+      total: 2,
+    }));
+    const service = new CollaborationSquareService(createGateway({ listBotPage }));
+    const signal = new AbortController().signal;
+
+    await expect(
+      service.resolveSharedBot(
+        'bot:target',
+        '  项目助手  ',
+        humanContext,
+        { viewerActorType: 'human', viewerActorId: '327325' },
+        signal,
+      ),
+    ).resolves.toEqual(expect.objectContaining({ id: 'bot:target' }));
+    expect(listBotPage).toHaveBeenCalledWith(
+      {
+        search: '项目助手',
+        page: 1,
+        pageSize: 100,
+        viewerActorType: 'human',
+        viewerActorId: '327325',
+      },
+      humanContext,
+      signal,
+    );
+  });
+
+  test('分享 Bot 首页未命中时继续搜索后续页，最终仍只接受 ID 精确匹配', async () => {
+    const listBotPage = jest
+      .fn()
+      .mockResolvedValueOnce({ items: [publicBot('same-name-other')], total: 101 })
+      .mockResolvedValueOnce({ items: [publicBot('bot:target')], total: 101 });
+    const service = new CollaborationSquareService(createGateway({ listBotPage }));
+
+    await expect(service.resolveSharedBot('bot:target', '项目助手', humanContext)).resolves.toEqual(
+      expect.objectContaining({ id: 'bot:target' }),
+    );
+    expect(listBotPage).toHaveBeenNthCalledWith(
+      2,
+      { search: '项目助手', page: 2, pageSize: 100 },
+      humanContext,
+      undefined,
+    );
+  });
+
+  test('分享 Bot 名称搜索只有同名不同 ID 时返回未命中', async () => {
+    const service = new CollaborationSquareService(
+      createGateway({ listBotPage: jest.fn(async () => ({ items: [publicBot('other')], total: 1 })) }),
+    );
+
+    await expect(service.resolveSharedBot('target', '项目助手', humanContext)).resolves.toBeNull();
   });
 
   test('Bot Discovery 与公开群查询原样交给 Gateway', async () => {

--- a/src/frontend-nextgen/test/components/CollaborationPrivacy/PermissionCard.test.tsx
+++ b/src/frontend-nextgen/test/components/CollaborationPrivacy/PermissionCard.test.tsx
@@ -48,11 +48,15 @@ describe('PermissionCard', () => {
 
     const capabilityHeading = screen.getByRole('heading', { level: 4, name: '协作能力' });
     const publicationHeading = screen.getByRole('heading', { level: 4, name: '公开范围' });
+    const cardColumns = capabilityHeading.closest('section')?.parentElement;
 
     expect(capabilityHeading).toHaveClass('text-xs', 'text-muted-foreground', 'tracking-wide');
     expect(publicationHeading).toHaveClass('text-xs', 'text-muted-foreground', 'tracking-wide');
+    expect(cardColumns).toHaveClass('grid', 'lg:grid-cols-2', 'gap-6');
+    expect(cardColumns?.lastElementChild).toHaveClass('lg:border-l', 'lg:pl-6');
     expect(capabilityHeading.parentElement).toHaveClass('mb-3');
     expect(publicationHeading.parentElement).toHaveClass('mb-3');
+    expect(screen.getByText('参与协作群聊').closest('div.flex.items-start')).toHaveClass('first:pt-0');
     expect(capabilityHeading.parentElement).not.toHaveClass('border-b');
     expect(publicationHeading.parentElement).not.toHaveClass('border-b');
     expect(screen.getByText('参与协作群聊')).toHaveClass('text-sm', 'text-foreground');

--- a/src/frontend-nextgen/test/components/CollaborationPrivacy/PublicationEditor.test.tsx
+++ b/src/frontend-nextgen/test/components/CollaborationPrivacy/PublicationEditor.test.tsx
@@ -1,9 +1,12 @@
 /** @jest-environment jsdom */
 import { PublicationEditor } from '@/components/CollaborationPrivacy/PublicationEditor';
 import type { OrganizationSearchEntry } from '@/domain/collaborationPrivacy/types';
-import { afterEach, describe, expect, it, jest } from '@jest/globals';
+import { afterEach, describe, expect, it } from '@jest/globals';
+import { history } from '@umijs/max';
 import '@testing-library/jest-dom';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+jest.mock('@umijs/max', () => ({ history: { push: jest.fn() } }));
 
 const existingEntry: OrganizationSearchEntry = {
   deptNo: 'TECH-001',
@@ -17,6 +20,44 @@ const addedEntry: OrganizationSearchEntry = {
 describe('PublicationEditor', () => {
   afterEach(() => {
     jest.useRealTimers();
+    (history.push as jest.Mock).mockClear();
+  });
+
+  it('describes collaboration square discovery for each audience', () => {
+    const props = {
+      open: true,
+      initialConfig: { scope: 'all' as const, organizationPaths: [] },
+      onSearch: jest.fn(async () => []),
+      onClose: jest.fn(),
+      onSubmit: jest.fn(),
+    };
+    const { rerender } = render(<PublicationEditor {...props} audience="user" />);
+
+    expect(screen.getByRole('heading', { name: '对其他用户公开' })).toBeInTheDocument();
+    const squareLink = screen.getByRole('link', { name: '[协作广场/公开Bot]' });
+    expect(squareLink).toHaveAttribute('href', '/collaboration-square/bots');
+    expect(squareLink).not.toHaveClass('underline');
+    expect(squareLink.parentElement).toHaveTextContent(
+      '公开后，其他用户可在 [协作广场/公开Bot] 中发现当前 Bot，并申请添加为好友。',
+    );
+    fireEvent.click(squareLink);
+    expect(history.push).toHaveBeenCalledWith('/collaboration-square/bots');
+    expect(screen.getByRole('radio', { name: /限制组织范围/ })).toHaveTextContent(
+      '仅所选组织范围可申请添加当前 Bot 为好友',
+    );
+    expect(
+      screen.queryByText('可分别搜索集团、事业部、部门或团队，并连续添加多个范围。提交后将进入审批流程。'),
+    ).not.toBeInTheDocument();
+
+    rerender(<PublicationEditor {...props} audience="bot" />);
+
+    expect(screen.getByRole('heading', { name: '对其他 Bot 公开' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '[协作广场/公开Bot]' }).parentElement).toHaveTextContent(
+      '公开后，其他 Bot 可在 [协作广场/公开Bot] 中发现当前 Bot，并申请添加为好友。',
+    );
+    expect(screen.getByRole('radio', { name: /限制组织范围/ })).toHaveTextContent(
+      '仅所选组织范围可申请添加当前 Bot 为好友',
+    );
   });
 
   it('restores configured departments and submits their codes with original department names', async () => {
@@ -39,7 +80,7 @@ describe('PublicationEditor', () => {
 
     expect(screen.getByRole('radiogroup', { name: '公开范围' })).toBeInTheDocument();
     expect(screen.getByRole('radio', { name: /全部公开/ })).toHaveAttribute('aria-checked', 'false');
-    expect(screen.getByRole('radio', { name: /指定组织/ })).toHaveAttribute('aria-checked', 'true');
+    expect(screen.getByRole('radio', { name: /限制组织范围/ })).toHaveAttribute('aria-checked', 'true');
     expect(screen.getByText('示例集团-技术事业部-平台团队')).toBeInTheDocument();
     fireEvent.change(screen.getByRole('textbox', { name: '搜索组织团队范围' }), {
       target: { value: '产品' },

--- a/src/frontend-nextgen/test/components/CollaborationSquare/PublicTaskCatalogPanel.test.tsx
+++ b/src/frontend-nextgen/test/components/CollaborationSquare/PublicTaskCatalogPanel.test.tsx
@@ -71,6 +71,13 @@ function buildVm(overrides: Partial<TaskCatalogViewModel> = {}): TaskCatalogView
 }
 
 describe('PublicTaskCatalogPanel', () => {
+  test('搜索工具栏保持统一最小高度，状态筛选不改变搜索区高度', () => {
+    const { container } = render(<PublicTaskCatalogPanel vm={buildVm()} />);
+    const toolbar = container.firstElementChild as HTMLElement;
+    expect(toolbar).toHaveClass('flex', 'min-h-8');
+    expect(screen.getByRole('group', { name: '任务状态筛选' })).toHaveClass('shrink-0');
+  });
+
   test('加载态渲染骨架占位网格', () => {
     render(<PublicTaskCatalogPanel vm={buildVm({ loading: true })} />);
     expect(screen.getByLabelText('正在加载任务广场')).toBeInTheDocument();

--- a/src/frontend-nextgen/test/components/CollaborationSquare/SquarePageShellDispatch.test.tsx
+++ b/src/frontend-nextgen/test/components/CollaborationSquare/SquarePageShellDispatch.test.tsx
@@ -1,13 +1,21 @@
 /** @jest-environment jsdom */
 import { SquarePageShell } from '@/components/CollaborationSquare/SquarePageShell';
 import { useCollaborationSquare } from '@/hooks/useCollaborationSquare';
-import '@testing-library/jest-dom';
-import { fireEvent, render, screen } from '@testing-library/react';
 import { history } from '@umijs/max';
+import '@testing-library/jest-dom';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
+import type { AnchorHTMLAttributes, ReactNode } from 'react';
 
-jest.mock('@umijs/max', () => ({ history: { push: jest.fn() } }));
+jest.mock('@umijs/max', () => ({
+  history: { push: jest.fn() },
+  Link: ({ to, children, ...props }: AnchorHTMLAttributes<HTMLAnchorElement> & { to: string; children: ReactNode }) => (
+    <a href={to} {...props}>
+      {children}
+    </a>
+  ),
+}));
 jest.mock('@/hooks/useCollaborationSquare', () => ({ useCollaborationSquare: jest.fn() }));
 jest.mock('@/components/CollaborationSquare/PublicBotCatalogPanel', () => ({
   PublicBotCatalogPanel: () => <div>bot panel</div>,
@@ -73,39 +81,73 @@ describe('SquarePageShell three-way dispatch', () => {
     expect(screen.getByText('task panel')).toBeInTheDocument();
     expect(screen.queryByText('bot panel')).not.toBeInTheDocument();
     expect(screen.queryByText('group section')).not.toBeInTheDocument();
-    const taskNav = screen.getByRole('button', { name: /任务广场/ });
+    const taskNav = screen.getByRole('link', { name: /任务广场/ });
     expect(taskNav).toBeInTheDocument();
-    expect(taskNav.className).toMatch(/bg-primary/);
-    expect(screen.getByText(/发现公开 BBS 求助任务/)).toBeInTheDocument();
+    expect(taskNav.className).toMatch(/text-foreground/);
+    expect(taskNav).toHaveAttribute('aria-current', 'page');
+    const description = screen.getByText(/发现公开 BBS 求助任务/);
+    const resourceRegion = screen.getByRole('region', { name: '任务广场内容' });
+    expect(screen.getByRole('banner')).toContainElement(description);
+    expect(resourceRegion).toContainElement(description);
+    expect(resourceRegion).toContainElement(screen.getByText('task panel'));
   });
 
-  test('resource=bot 渲染 Bot 面板且第一导航高亮、其它导航不高亮', () => {
+  test('路由 Tab 切换先播放下划线动效，再进入目标页面', () => {
+    jest.useFakeTimers();
+    render(<SquarePageShell resource="bot" />);
+
+    fireEvent.click(screen.getByRole('link', { name: /公开协作群/ }));
+
+    expect(history.push).not.toHaveBeenCalled();
+    expect(screen.getByRole('link', { name: /公开协作群/ }).className).toMatch(/text-foreground/);
+    expect(screen.getByRole('link', { name: /公开 Bot/ }).className).toMatch(/text-muted-foreground/);
+
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+    expect(history.push).toHaveBeenCalledWith('/collaboration-square/groups');
+    jest.useRealTimers();
+  });
+
+  test('resource=bot 渲染 Bot 面板且资源说明归属当前内容区', () => {
     render(<SquarePageShell resource="bot" />);
     expect(screen.getByText('bot panel')).toBeInTheDocument();
-    const botNav = screen.getByRole('button', { name: /公开 Bot/ });
-    expect(botNav.className).toMatch(/bg-primary/);
-    const taskNav = screen.getByRole('button', { name: /任务广场/ });
-    expect(taskNav.className).not.toMatch(/bg-primary/);
+    const description = screen.getByText(/可按 Bot 名称或 Owner 用户名称搜索公开 Bot/);
+    const resourceRegion = screen.getByRole('region', { name: '公开 Bot内容' });
+    expect(screen.getByRole('banner')).toContainElement(description);
+    expect(resourceRegion).toContainElement(description);
+    expect(resourceRegion).toContainElement(screen.getByText('bot panel'));
+    const botNav = screen.getByRole('link', { name: /公开 Bot/ });
+    expect(botNav.className).toMatch(/text-foreground/);
+    expect(botNav).toHaveAttribute('aria-current', 'page');
+    const taskNav = screen.getByRole('link', { name: /任务广场/ });
+    expect(taskNav.className).toMatch(/text-muted-foreground/);
+    expect(taskNav).not.toHaveAttribute('aria-current');
   });
 
-  test('resource=group 渲染群块且第二导航高亮', () => {
+  test('resource=group 渲染群块且资源说明归属当前内容区', () => {
     render(<SquarePageShell resource="group" />);
     expect(screen.getByText('group section')).toBeInTheDocument();
-    const groupNav = screen.getByRole('button', { name: /公开协作群/ });
-    expect(groupNav.className).toMatch(/bg-primary/);
+    const description = screen.getByText('发现协作群，支持基于公开协作群快速创建新会话。');
+    const resourceRegion = screen.getByRole('region', { name: '公开协作群内容' });
+    expect(screen.getByRole('banner')).toContainElement(description);
+    expect(resourceRegion).toContainElement(description);
+    expect(resourceRegion).toContainElement(screen.getByText('group section'));
+    const groupNav = screen.getByRole('link', { name: /公开协作群/ });
+    expect(groupNav.className).toMatch(/text-foreground/);
+    expect(groupNav).toHaveAttribute('aria-current', 'page');
   });
 
-  test('三个资源导航始终可见', () => {
+  test('三个资源导航始终以命名导航链接呈现', () => {
     render(<SquarePageShell resource="bot" />);
-    expect(screen.getByRole('button', { name: /公开 Bot/ })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /公开协作群/ })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /任务广场/ })).toBeInTheDocument();
-  });
-
-  test('点击任务广场导航 push /collaboration-square/tasks', () => {
-    render(<SquarePageShell resource="bot" />);
-    fireEvent.click(screen.getByRole('button', { name: /任务广场/ }));
-    expect(history.push).toHaveBeenCalledWith('/collaboration-square/tasks');
+    const navigation = screen.getByRole('navigation', { name: '协作广场资源导航' });
+    expect(screen.getByRole('link', { name: /公开 Bot/ })).toHaveAttribute('href', '/collaboration-square/bots');
+    expect(screen.getByRole('link', { name: /公开协作群/ })).toHaveAttribute(
+      'href',
+      '/collaboration-square/groups',
+    );
+    expect(screen.getByRole('link', { name: /任务广场/ })).toHaveAttribute('href', '/collaboration-square/tasks');
+    expect(navigation).toContainElement(screen.getByRole('link', { name: /公开 Bot/ }));
   });
 
   test('Shell 源码保持 UI 与分层约束且含任务描述', () => {

--- a/src/frontend-nextgen/test/components/CollaborationSquare/SquarePageShellPagination.test.tsx
+++ b/src/frontend-nextgen/test/components/CollaborationSquare/SquarePageShellPagination.test.tsx
@@ -2,8 +2,11 @@
 import { SquarePageShell } from '@/components/CollaborationSquare/SquarePageShell';
 import { useCollaborationSquare } from '@/hooks/useCollaborationSquare';
 import { fireEvent, render } from '@testing-library/react';
+import type { ReactNode } from 'react';
 
-jest.mock('@umijs/max', () => ({ history: { push: jest.fn() } }));
+jest.mock('@umijs/max', () => ({
+  Link: ({ to, children }: { to: string; children: ReactNode }) => <a href={to}>{children}</a>,
+}));
 jest.mock('@/hooks/useCollaborationSquare', () => ({ useCollaborationSquare: jest.fn() }));
 jest.mock('@/components/CollaborationSquare/BotCard', () => () => <div>Bot card</div>);
 jest.mock('@/components/CollaborationSquare/GroupCard', () => () => <div>Group card</div>);

--- a/src/frontend-nextgen/test/components/CollaborationSquare/SquareSearchBar.test.tsx
+++ b/src/frontend-nextgen/test/components/CollaborationSquare/SquareSearchBar.test.tsx
@@ -1,0 +1,90 @@
+/** @jest-environment jsdom */
+import SquareSearchBar from '@/components/CollaborationSquare/SquareSearchBar';
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+describe('SquareSearchBar', () => {
+  test('搜索工具栏不使用外层圆角卡片容器', () => {
+    const { container } = render(
+      <SquareSearchBar
+        resource="group"
+        query=""
+        onQueryChange={jest.fn()}
+      />,
+    );
+
+    const toolbar = container.firstElementChild as HTMLElement;
+    expect(toolbar).toHaveClass('flex', 'min-h-8', 'flex-col', 'gap-3');
+    expect(toolbar).not.toHaveClass('rounded-lg', 'border', 'bg-card', 'p-4');
+    expect(screen.getByRole('textbox').parentElement).toHaveClass('h-8');
+  });
+
+  test('Bot、群、任务搜索输入使用统一宽度基线', () => {
+    const { rerender } = render(
+      <SquareSearchBar resource="bot" query="" onQueryChange={jest.fn()} onModeChange={jest.fn()} />,
+    );
+    expect(screen.getByRole('textbox').parentElement).toHaveClass('w-full', 'max-w-md');
+
+    rerender(<SquareSearchBar resource="group" query="" onQueryChange={jest.fn()} />);
+    expect(screen.getByRole('textbox').parentElement).toHaveClass('w-full', 'max-w-md');
+
+    rerender(<SquareSearchBar resource="task" query="" onQueryChange={jest.fn()} />);
+    expect(screen.getByRole('textbox').parentElement).toHaveClass('w-full', 'max-w-md');
+  });
+
+  test('未选中的 Bot 搜索模式使用明确的弱化文字色', () => {
+    render(
+      <SquareSearchBar
+        resource="bot"
+        query=""
+        mode="name"
+        onQueryChange={jest.fn()}
+        onModeChange={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: '智能搜索' })).toHaveClass('text-muted-foreground');
+    expect(screen.getByRole('button', { name: '名称搜索' })).toHaveClass('text-primary');
+  });
+
+  test('切换 Bot 搜索模式时先清空已有输入', () => {
+    const onQueryChange = jest.fn();
+    const onModeChange = jest.fn();
+
+    render(
+      <SquareSearchBar
+        resource="bot"
+        query="已有关键词"
+        mode="name"
+        onQueryChange={onQueryChange}
+        onModeChange={onModeChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '智能搜索' }));
+
+    expect(onQueryChange).toHaveBeenCalledWith('');
+    expect(onModeChange).toHaveBeenCalledWith('smart');
+    expect(onQueryChange.mock.invocationCallOrder[0]).toBeLessThan(onModeChange.mock.invocationCallOrder[0]);
+  });
+
+  test('重复点击当前 Bot 搜索模式不清空输入', () => {
+    const onQueryChange = jest.fn();
+    const onModeChange = jest.fn();
+
+    render(
+      <SquareSearchBar
+        resource="bot"
+        query="已有关键词"
+        mode="name"
+        onQueryChange={onQueryChange}
+        onModeChange={onModeChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '名称搜索' }));
+
+    expect(onQueryChange).not.toHaveBeenCalled();
+    expect(onModeChange).toHaveBeenCalledWith('name');
+  });
+});

--- a/src/frontend-nextgen/test/components/Workspace/IdentitySelector.test.tsx
+++ b/src/frontend-nextgen/test/components/Workspace/IdentitySelector.test.tsx
@@ -64,16 +64,16 @@ describe('WorkspaceIdentitySelector', () => {
     expect(screen.getByText('个人 Bot')).toBeInTheDocument();
     expect(screen.getByText('个人 Bot')).toHaveClass('rounded-sm', 'px-1', 'py-0', 'text-[10px]');
     expect(screen.getByText('OpenClaw')).toBeInTheDocument();
-    expect(screen.getByText('运行状态：在线')).toBeInTheDocument();
+    expect(screen.getByText('在线')).toBeInTheDocument();
     expect(screen.queryByText('Bot ID：')).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: '当前协作身份：协作 Bot' }));
     expect(
-      screen.queryByText('当前协作身份决定在下方对话或群聊中，你以个人或指定 Bot 身份可查看的数据范围'),
+      screen.queryByText('当前协作身份决定在对话或群聊中，你以个人或指定 Bot 身份可查看的数据范围'),
     ).not.toBeInTheDocument();
     expect(await screen.findByText('隐藏 Bot')).toBeInTheDocument();
     expect(screen.getByText('ClaudeCode')).toBeInTheDocument();
-    expect(screen.getByText('运行状态：不在线')).toBeInTheDocument();
+    expect(screen.getByText('不在线')).toBeInTheDocument();
   });
 
   it('将 bots 接口的引擎枚举统一为可读标签', () => {
@@ -136,30 +136,49 @@ describe('WorkspaceIdentitySelector', () => {
     fireEvent.pointerMove(infoTrigger);
 
     expect(
-      await screen.findByText('当前协作身份决定在下方对话或群聊中，你以个人或指定 Bot 身份可查看的数据范围'),
+      await screen.findByText('当前协作身份决定在对话或群聊中，你以个人或指定 Bot 身份可查看的数据范围'),
     ).toBeInTheDocument();
     expect(screen.queryByText(/我参与的会话|当前身份可见/)).not.toBeInTheDocument();
   });
 
-  it('侧栏身份区不常显身份标签，说明收纳在下拉菜单的信息图标中', async () => {
+  it('侧栏身份区突出头像、名称和身份类型，并明确影响工作下全部页面', async () => {
     render(
       <WorkspaceIdentitySelector
         identities={identities}
-        activeId="human_447147"
+        activeId="bot-online"
         onChange={() => {}}
         layout="sidebar"
       />,
     );
 
-    expect(screen.queryByText('协作身份')).not.toBeInTheDocument();
-    expect(screen.queryByText('可切换身份')).not.toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole('button', { name: '当前协作身份：风太' }));
-    const infoTrigger = await screen.findByLabelText('协作身份说明');
-    fireEvent.pointerMove(infoTrigger);
+    expect(screen.getByText('工作身份')).toBeInTheDocument();
+    expect(screen.getByLabelText('工作身份说明')).toHaveClass('top-px', 'text-muted-foreground/70');
+    expect(screen.getByLabelText('工作身份说明').querySelector('svg')).toHaveClass('h-3', 'w-3');
     expect(
-      await screen.findByText('当前协作身份决定在下方对话或群聊中，你以个人或指定 Bot 身份可查看的数据范围'),
+      screen.queryByText('当前协作身份决定在对话或群聊中，你以个人或指定 Bot 身份可查看的数据范围'),
+    ).not.toBeInTheDocument();
+    fireEvent.pointerMove(screen.getByLabelText('工作身份说明'));
+    expect(
+      await screen.findByText('当前协作身份决定在对话或群聊中，你以个人或指定 Bot 身份可查看的数据范围'),
     ).toBeInTheDocument();
+    expect(screen.getByLabelText('协作 Bot')).toHaveStyle({ width: '24px', height: '24px' });
+    expect(screen.getByText('协作 Bot')).toHaveClass('text-xs');
+    expect(screen.queryByText('个人 Bot')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '当前协作身份：协作 Bot' })).toHaveClass(
+      'rounded-lg',
+      'border',
+      'bg-muted/60',
+      'min-h-9',
+      'px-2.5',
+      'py-1.5',
+    );
+    expect(screen.queryByText('OpenClaw')).not.toBeInTheDocument();
+    expect(screen.queryByText('在线')).not.toBeInTheDocument();
+    expect(screen.queryByText('切换身份')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: '当前协作身份：协作 Bot' }));
+    expect(await screen.findByText('个人 Bot')).toBeInTheDocument();
+    expect(screen.queryByLabelText('协作身份说明')).not.toBeInTheDocument();
   });
 
   it('只有一个协作身份时不显示切换提示', () => {
@@ -188,7 +207,7 @@ describe('WorkspaceIdentitySelector', () => {
       />,
     );
 
-    expect(screen.getByText('运行状态：在线')).toBeInTheDocument();
+    expect(screen.getByText('在线')).toBeInTheDocument();
     expect(screen.queryByText(/可参与群聊/)).not.toBeInTheDocument();
     expect(screen.getByText('桌面 Bot')).toBeInTheDocument();
   });
@@ -211,9 +230,9 @@ describe('WorkspaceIdentitySelector', () => {
       />,
     );
 
-    expect(screen.getByText('运行状态：不在线')).toBeInTheDocument();
+    expect(screen.getByText('不在线')).toBeInTheDocument();
     expect(screen.queryByText(/可参与群聊/)).not.toBeInTheDocument();
-    fireEvent.pointerMove(screen.getByLabelText('Bot 运行状态：不在线'));
+    fireEvent.pointerMove(screen.getByLabelText('Bot 不在线'));
     expect(await screen.findByText('请检查 Bot 实例状态')).toBeInTheDocument();
   });
 

--- a/src/frontend-nextgen/test/components/ui/Segmented.test.tsx
+++ b/src/frontend-nextgen/test/components/ui/Segmented.test.tsx
@@ -1,0 +1,50 @@
+/** @jest-environment jsdom */
+import { Segmented } from '@/components/ui/Segmented';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+describe('Segmented accessibility', () => {
+  test('exposes the current option through aria-pressed and an accessible group name', () => {
+    render(
+      <Segmented
+        aria-label="Bot 搜索模式"
+        value="name"
+        options={[
+          { value: 'name', label: '名称搜索' },
+          { value: 'smart', label: '智能搜索' },
+        ]}
+        onChange={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('group', { name: 'Bot 搜索模式' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '名称搜索' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: '智能搜索' })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  test('supports arrow-key selection and skips disabled options', async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    render(
+      <Segmented
+        aria-label="状态筛选"
+        value="all"
+        options={[
+          { value: 'all', label: '全部' },
+          { value: 'disabled', label: '不可用', disabledReason: '暂不可用' },
+          { value: 'completed', label: '已完成' },
+        ]}
+        onChange={onChange}
+      />,
+    );
+
+    const allOption = screen.getByRole('button', { name: '全部' });
+    const completedOption = screen.getByRole('button', { name: '已完成' });
+    allOption.focus();
+    await user.keyboard('{ArrowRight}');
+
+    expect(onChange).toHaveBeenCalledWith('completed');
+    expect(completedOption).toHaveFocus();
+  });
+});

--- a/src/frontend-nextgen/test/hooks/useCollaborationPrivacy.test.tsx
+++ b/src/frontend-nextgen/test/hooks/useCollaborationPrivacy.test.tsx
@@ -1,9 +1,10 @@
 /** @jest-environment jsdom */
-import type { CollaborationPrivacyOverview } from '@/domain/collaborationPrivacy/types';
+import type { CollaborationBot, CollaborationPrivacyOverview } from '@/domain/collaborationPrivacy/types';
 import { useCollaborationPrivacy } from '@/hooks/useCollaborationPrivacy';
 import * as identityModule from '@/hooks/useHumanIdentity';
 import { collaborationPrivacyService } from '@/services/collaborationPrivacy';
 import { useCollaborationPrivacyStore } from '@/stores/collaborationPrivacyStore';
+import { useWorkspaceStore } from '@/stores/workspaceStore';
 import { afterAll, afterEach, describe, expect, it, jest } from '@jest/globals';
 import { renderHook, waitFor } from '@testing-library/react';
 
@@ -15,9 +16,32 @@ const overview = {
   bots: [],
 } as CollaborationPrivacyOverview;
 
+const makeBot = (id: string, name: string): CollaborationBot => ({
+  id,
+  name,
+  engine: 'OpenClaw',
+  joinedBcn: true,
+  collaborationStatus: 'online',
+  profilePublic: true,
+  taskClaimingEnabled: false,
+  dreamModelEnabled: false,
+  publication: {
+    user: { scope: 'all', organizationPaths: [] },
+    bot: { scope: 'none', organizationPaths: [] },
+  },
+  pendingPublications: {},
+  friendApproval: { mode: 'all', exemptOrganizationPaths: [] },
+});
+
+const overviewWithBots: CollaborationPrivacyOverview = {
+  ...overview,
+  bots: [makeBot('bot-1', 'Bot A'), makeBot('bot-2', 'Bot B')],
+};
+
 afterEach(() => {
   jest.clearAllMocks();
   useCollaborationPrivacyStore.getState().reset();
+  useWorkspaceStore.getState().reset();
 });
 
 afterAll(() => {
@@ -44,5 +68,40 @@ describe('useCollaborationPrivacy identity wiring', () => {
 
     expect(collaborationPrivacyService.loadOverview).not.toHaveBeenCalled();
     expect(useCollaborationPrivacyStore.getState().loading).toBe(true);
+  });
+
+  it('用户身份只显示用户内容，不显示 Bot 管理卡片', async () => {
+    mockedUseHumanIdentity.mockReturnValue({
+      status: 'ready',
+      identity: { userId: '447147', displayName: '真实用户', online: true },
+    });
+    useWorkspaceStore.setState({
+      activeIdentityId: 'human-1',
+      identities: [{ id: 'human-1', kind: 'user', displayName: '真实用户', online: true }],
+    });
+    jest.spyOn(collaborationPrivacyService, 'loadOverview').mockResolvedValue(overviewWithBots);
+
+    const { result } = renderHook(() => useCollaborationPrivacy());
+
+    await waitFor(() => expect(result.current.showIdentityCard).toBe(true));
+    expect(result.current.visibleBots).toEqual([]);
+  });
+
+  it('Bot 身份只显示当前 Bot 的管理卡片', async () => {
+    mockedUseHumanIdentity.mockReturnValue({
+      status: 'ready',
+      identity: { userId: '447147', displayName: '真实用户', online: true },
+    });
+    useWorkspaceStore.setState({
+      activeIdentityId: 'bot-1:447147',
+      identities: [{ id: 'bot-1:447147', kind: 'bot', displayName: 'Bot A', online: true }],
+    });
+    jest.spyOn(collaborationPrivacyService, 'loadOverview').mockResolvedValue(overviewWithBots);
+
+    const { result } = renderHook(() => useCollaborationPrivacy());
+
+    await waitFor(() => expect(result.current.visibleBots).toHaveLength(1));
+    expect(result.current.showIdentityCard).toBe(false);
+    expect(result.current.visibleBots[0].id).toBe('bot-1');
   });
 });

--- a/src/frontend-nextgen/test/hooks/useCollaborationSquare.test.tsx
+++ b/src/frontend-nextgen/test/hooks/useCollaborationSquare.test.tsx
@@ -1,5 +1,6 @@
 /** @jest-environment jsdom */
 import type { PublicBot, PublicBotSearchQuery, PublicGroup, PublicTask } from '@/domain/collaborationSquare/types';
+import { notifyError, notifySuccess } from '@/components/ui/notify';
 import { useCollaborationSquare } from '@/hooks/useCollaborationSquare';
 import { useHumanIdentity } from '@/hooks/useHumanIdentity';
 import {
@@ -11,13 +12,16 @@ import {
 } from '@/services/collaborationSquare';
 import { useCollaborationSquareStore } from '@/stores/collaborationSquareStore';
 import { useWorkspaceStore } from '@/stores/workspaceStore';
-import { act, renderHook } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { history } from '@umijs/max';
 
 jest.mock('@umijs/max', () => ({ history: { push: jest.fn() } }));
 jest.mock('@/hooks/useHumanIdentity', () => ({ useHumanIdentity: jest.fn() }));
+jest.mock('@/components/ui/notify', () => ({ notifyError: jest.fn(), notifySuccess: jest.fn() }));
 
 const mockedUseHumanIdentity = useHumanIdentity as jest.MockedFunction<typeof useHumanIdentity>;
+const mockedNotifyError = notifyError as jest.MockedFunction<typeof notifyError>;
+const mockedNotifySuccess = notifySuccess as jest.MockedFunction<typeof notifySuccess>;
 const humanContext = { actorId: 'human_327325', userId: '327325' };
 const viewerFields = { viewerActorType: 'human', viewerActorId: '327325' };
 
@@ -76,6 +80,9 @@ describe('useCollaborationSquare Bot Search', () => {
       identity: { userId: '327325', displayName: '当前用户', online: true },
       status: 'ready',
     });
+    mockedNotifyError.mockClear();
+    mockedNotifySuccess.mockClear();
+    window.history.replaceState({}, '', '/collaboration-square/bots');
   });
 
   afterEach(() => {
@@ -127,6 +134,163 @@ describe('useCollaborationSquare Bot Search', () => {
     unmount();
   });
 
+  test('分享链接携带 Bot 名称提示，Clipboard 成功后只提示复制成功', async () => {
+    jest.spyOn(collaborationSquareBotService, 'listBotPage').mockResolvedValue(botPage([]));
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText } });
+    const { result, unmount } = renderHook(() => useCollaborationSquare('bot'));
+
+    await act(async () => {
+      jest.advanceTimersByTime(0);
+      await Promise.resolve();
+    });
+    await act(async () => {
+      result.current.share('bot', 'bot:target', '项目助手');
+      await Promise.resolve();
+    });
+
+    expect(writeText).toHaveBeenCalledWith(
+      `${window.location.origin}/collaboration-square/bots?resource=bot&id=bot%3Atarget&name=%E9%A1%B9%E7%9B%AE%E5%8A%A9%E6%89%8B`,
+    );
+    expect(mockedNotifySuccess).toHaveBeenCalledWith('分享链接已复制');
+    expect(mockedNotifyError).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  test('分享链接 Clipboard 失败时提示权限错误且不误报成功', async () => {
+    jest.spyOn(collaborationSquareBotService, 'listBotPage').mockResolvedValue(botPage([]));
+    const writeText = jest.fn().mockRejectedValue(new Error('clipboard denied'));
+    Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText } });
+    const { result, unmount } = renderHook(() => useCollaborationSquare('bot'));
+
+    await act(async () => {
+      jest.advanceTimersByTime(0);
+      await Promise.resolve();
+    });
+    await act(async () => {
+      result.current.share('bot', 'bot:target', '项目助手');
+      await Promise.resolve();
+    });
+
+    expect(mockedNotifyError).toHaveBeenCalledWith('复制失败，请检查浏览器剪贴板权限');
+    expect(mockedNotifySuccess).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  test('Bot 分享深链用名称调用真实 Search，并按 ID 精确命中后展示 Catalog 公开摘要', async () => {
+    const target = {
+      ...resultBot('bot:target'),
+      name: '项目助手',
+      description: '公开描述',
+      capabilities: ['任务拆解'],
+    };
+    jest.spyOn(collaborationSquareBotService, 'listBotPage').mockResolvedValue(botPage([]));
+    const resolveSharedBot = jest.spyOn(collaborationSquareBotService, 'resolveSharedBot').mockResolvedValue(target);
+    const legacyProfile = jest.spyOn(collaborationSquareService, 'getBotProfile');
+    window.history.replaceState(
+      {},
+      '',
+      '/collaboration-square/bots?resource=bot&id=bot%3Atarget&name=%E9%A1%B9%E7%9B%AE%E5%8A%A9%E6%89%8B',
+    );
+
+    const { unmount } = renderHook(() => useCollaborationSquare('bot'));
+    await act(async () => {
+      jest.advanceTimersByTime(0);
+      await Promise.resolve();
+    });
+    expect(useCollaborationSquareStore.getState().loading).toBe(false);
+
+    await waitFor(() =>
+      expect(resolveSharedBot).toHaveBeenCalledWith(
+        'bot:target',
+        '项目助手',
+        humanContext,
+        viewerFields,
+        expect.any(AbortSignal),
+      ),
+    );
+    await waitFor(() => expect(useCollaborationSquareStore.getState().selectedBotId).toBe('bot:target'));
+    expect(useCollaborationSquareStore.getState().botProfile).toEqual(
+      expect.objectContaining({
+        id: 'bot:target',
+        name: '项目助手',
+        description: '公开描述',
+        capabilities: [],
+      }),
+    );
+    expect(legacyProfile).not.toHaveBeenCalled();
+    expect(mockedNotifyError).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  test('Bot 分享深链已在当前页精确命中时不重复发起 Search', async () => {
+    const target = { ...resultBot('bot:loaded'), name: '当前页助手' };
+    jest.spyOn(collaborationSquareBotService, 'listBotPage').mockResolvedValue(botPage([target]));
+    const resolveSharedBot = jest.spyOn(collaborationSquareBotService, 'resolveSharedBot');
+    window.history.replaceState(
+      {},
+      '',
+      '/collaboration-square/bots?resource=bot&id=bot%3Aloaded&name=%E5%BD%93%E5%89%8D%E9%A1%B5%E5%8A%A9%E6%89%8B',
+    );
+
+    const { unmount } = renderHook(() => useCollaborationSquare('bot'));
+    await act(async () => {
+      jest.advanceTimersByTime(0);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(useCollaborationSquareStore.getState().selectedBotId).toBe('bot:loaded'));
+    expect(resolveSharedBot).not.toHaveBeenCalled();
+    expect(useCollaborationSquareStore.getState().botProfile).toEqual(
+      expect.objectContaining({ id: 'bot:loaded', name: '当前页助手' }),
+    );
+    unmount();
+  });
+
+  test('Bot 分享深链 Search 失败时展示真实错误，不误判为目标失效', async () => {
+    jest.spyOn(collaborationSquareBotService, 'listBotPage').mockResolvedValue(botPage([]));
+    jest
+      .spyOn(collaborationSquareBotService, 'resolveSharedBot')
+      .mockRejectedValue(new Error('Catalog Search 暂不可用'));
+    window.history.replaceState(
+      {},
+      '',
+      '/collaboration-square/bots?resource=bot&id=bot%3Atarget&name=%E9%A1%B9%E7%9B%AE%E5%8A%A9%E6%89%8B',
+    );
+
+    const { unmount } = renderHook(() => useCollaborationSquare('bot'));
+    await act(async () => {
+      jest.advanceTimersByTime(0);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(mockedNotifyError).toHaveBeenCalledWith('Catalog Search 暂不可用'));
+    expect(mockedNotifyError).not.toHaveBeenCalledWith('内容已取消公开或不可访问');
+    expect(window.location.search).toContain('id=bot%3Atarget');
+    unmount();
+  });
+
+  test('Bot 分享深链名称搜索无精确 ID 命中时才按目标失效处理', async () => {
+    jest.spyOn(collaborationSquareBotService, 'listBotPage').mockResolvedValue(botPage([]));
+    jest.spyOn(collaborationSquareBotService, 'resolveSharedBot').mockResolvedValue(null);
+    window.history.replaceState(
+      {},
+      '',
+      '/collaboration-square/bots?resource=bot&id=bot%3Atarget&name=%E9%A1%B9%E7%9B%AE%E5%8A%A9%E6%89%8B',
+    );
+
+    const { unmount } = renderHook(() => useCollaborationSquare('bot'));
+    await act(async () => {
+      jest.advanceTimersByTime(0);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(mockedNotifyError).toHaveBeenCalledWith('内容已取消公开或不可访问'));
+    expect(window.location.search).toBe('');
+    expect(useCollaborationSquareStore.getState().selectedBotId).toBeNull();
+    unmount();
+  });
+
   test('首屏使用 24 条并在加载更多时请求下一页且去重合并', async () => {
     const listBots = jest.spyOn(collaborationSquareBotService, 'listBotPage').mockImplementation(async (query) => {
       if (query?.page === 1)
@@ -161,6 +325,38 @@ describe('useCollaborationSquare Bot Search', () => {
     expect(useCollaborationSquareStore.getState().bots).toHaveLength(25);
     expect(useCollaborationSquareStore.getState().bots.map((bot) => bot.id)).toContain('page-2-0');
     expect(result.current.hasMore).toBe(false);
+
+    unmount();
+  });
+
+  test('名称搜索与智能搜索互相切换时清空已有输入', async () => {
+    jest.spyOn(collaborationSquareBotService, 'listBotPage').mockResolvedValue(botPage([]));
+    jest.spyOn(collaborationSquareBotService, 'discoverBots').mockResolvedValue([]);
+    const { result, unmount } = renderHook(() => useCollaborationSquare('bot'));
+
+    await act(async () => {
+      jest.advanceTimersByTime(0);
+    });
+
+    act(() => {
+      result.current.setQuery('bot', '旧名称');
+      result.current.setBotSearchMode('smart');
+    });
+    expect(result.current.botSearchMode).toBe('smart');
+    expect(result.current.botQuery).toBe('');
+
+    act(() => {
+      result.current.setQuery('bot', '能力描述');
+      result.current.setBotSearchMode('name');
+    });
+    expect(result.current.botSearchMode).toBe('name');
+    expect(result.current.botQuery).toBe('');
+
+    act(() => {
+      result.current.setQuery('bot', '保留当前模式输入');
+      result.current.setBotSearchMode('name');
+    });
+    expect(result.current.botQuery).toBe('保留当前模式输入');
 
     unmount();
   });

--- a/src/frontend-nextgen/test/hooks/usePublicBotCatalog.test.tsx
+++ b/src/frontend-nextgen/test/hooks/usePublicBotCatalog.test.tsx
@@ -1,5 +1,6 @@
 /** @jest-environment jsdom */
 import type { PublicBot } from '@/domain/collaborationSquare/types';
+import { notifyError, notifySuccess } from '@/components/ui/notify';
 import { useHumanIdentity } from '@/hooks/useHumanIdentity';
 import { usePublicBotCatalog } from '@/pages/Workspace/hooks/usePublicBotCatalog';
 import { collaborationSquareBotService } from '@/services/collaborationSquare';
@@ -9,8 +10,11 @@ import { history } from '@umijs/max';
 
 jest.mock('@umijs/max', () => ({ history: { push: jest.fn() } }));
 jest.mock('@/hooks/useHumanIdentity', () => ({ useHumanIdentity: jest.fn() }));
+jest.mock('@/components/ui/notify', () => ({ notifyError: jest.fn(), notifySuccess: jest.fn() }));
 
 const mockedUseHumanIdentity = useHumanIdentity as jest.MockedFunction<typeof useHumanIdentity>;
+const mockedNotifyError = notifyError as jest.MockedFunction<typeof notifyError>;
+const mockedNotifySuccess = notifySuccess as jest.MockedFunction<typeof notifySuccess>;
 
 const resultBot = (id: string): PublicBot => ({
   id,
@@ -33,6 +37,8 @@ describe('usePublicBotCatalog', () => {
       identity: { userId: '327325', displayName: '当前用户', online: true },
       status: 'ready',
     });
+    mockedNotifyError.mockClear();
+    mockedNotifySuccess.mockClear();
   });
 
   afterEach(() => {
@@ -124,6 +130,30 @@ describe('usePublicBotCatalog', () => {
       expect.any(AbortSignal),
     );
     expect(result.current.bots.map((bot) => bot.id)).toEqual(['smart']);
+    unmount();
+  });
+
+  test('对话协作 Bot 广场分享链接同样携带名称提示', async () => {
+    const bot = { ...resultBot('bot:shared'), name: '项目助手' };
+    jest.spyOn(collaborationSquareBotService, 'listBots').mockResolvedValue([bot]);
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText } });
+    const { result, unmount } = renderHook(() => usePublicBotCatalog({ enabled: true }));
+
+    await act(async () => {
+      jest.advanceTimersByTime(0);
+      await Promise.resolve();
+    });
+    await act(async () => {
+      result.current.share(bot);
+      await Promise.resolve();
+    });
+
+    expect(writeText).toHaveBeenCalledWith(
+      `${window.location.origin}/collaboration-square/bots?resource=bot&id=bot%3Ashared&name=%E9%A1%B9%E7%9B%AE%E5%8A%A9%E6%89%8B`,
+    );
+    expect(mockedNotifySuccess).toHaveBeenCalledWith('分享链接已复制');
+    expect(mockedNotifyError).not.toHaveBeenCalled();
     unmount();
   });
 

--- a/src/frontend-nextgen/test/hooks/useTaskExecuteFromCard.test.tsx
+++ b/src/frontend-nextgen/test/hooks/useTaskExecuteFromCard.test.tsx
@@ -1,0 +1,137 @@
+/** @jest-environment jsdom */
+import { useTaskExecuteFromCard } from '@/hooks/useTaskExecuteFromCard';
+import { isBotTaskClaimEnabled } from '@/services/tasks/taskClaimQuery';
+import type { TaskComposerContext } from '@/services/tasks/taskMapper';
+import { executeTaskService } from '@/services/tasks/taskService';
+import { setTaskExecuteHandler } from '@/services/workspace/chatBridge';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { toast } from 'sonner';
+
+jest.mock('@/services/workspace/chatBridge', () => ({
+  setTaskExecuteHandler: jest.fn(),
+}));
+jest.mock('@/services/tasks/taskClaimQuery', () => ({
+  isBotTaskClaimEnabled: jest.fn(),
+}));
+jest.mock('@/services/tasks/taskPreflightMock', () => ({
+  runTaskPreflightMock: jest.fn().mockResolvedValue({ matched: false, message: '' }),
+}));
+jest.mock('@/services/tasks/taskService', () => ({
+  executeTaskService: jest.fn(),
+}));
+jest.mock('@/services/tasks/taskPanelMessage', () => ({
+  buildTaskPanelAixUI: jest.fn().mockReturnValue('<AixUI-panel/>'),
+}));
+jest.mock('sonner', () => ({
+  toast: { warning: jest.fn(), info: jest.fn(), error: jest.fn() },
+}));
+
+const mockedSetHandler = setTaskExecuteHandler as unknown as jest.Mock;
+const mockedIsClaimEnabled = isBotTaskClaimEnabled as unknown as jest.Mock;
+const mockedExecute = executeTaskService as unknown as jest.Mock;
+const mockedToastWarning = toast.warning as unknown as jest.Mock;
+
+const context: TaskComposerContext = {
+  sourceType: 'bot',
+  ownerUserId: 'u1',
+  ownerBotId: 'b1',
+  mainSessionId: 's1',
+  mainSessionName: '会话',
+  parentTaskId: null,
+};
+const task = { goal: '修复 PR #1', deliverables: ['代码 PR'], task_type: 'dynamic' as const };
+
+describe('useTaskExecuteFromCard 执行前任务认领门禁', () => {
+  let registeredHandler: ((taskRaw: Record<string, unknown>) => void) | null = null;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    registeredHandler = null;
+    mockedSetHandler.mockImplementation((h: ((t: Record<string, unknown>) => void) | null) => {
+      registeredHandler = h;
+    });
+    mockedExecute.mockResolvedValue({ task_id: 't-1', create_time: 1, finish_time: 2 });
+  });
+
+  it('Bot 未开启任务认领 → 提示去任务协作页授权、阻断执行且不调 executeTaskService', async () => {
+    mockedIsClaimEnabled.mockResolvedValue(false);
+    const submitPanelMessage = jest.fn();
+
+    renderHook(() =>
+      useTaskExecuteFromCard({
+        panelRef: { current: null } as never,
+        context,
+        submitPanelMessage,
+        onOpenCollaborationPermissions: jest.fn(),
+      }),
+    );
+
+    await act(async () => {
+      registeredHandler?.(task);
+    });
+
+    expect(mockedToastWarning).toHaveBeenCalledWith(
+      '当前 Bot 未开启任务认领，请先去任务协作页对当前 Bot 授权开启后再执行',
+      expect.objectContaining({ action: expect.objectContaining({ label: '去开启' }) }),
+    );
+    expect(mockedExecute).not.toHaveBeenCalled();
+    expect(submitPanelMessage).not.toHaveBeenCalled();
+  });
+
+  it('Bot 已开启任务认领 → 放行，调 executeTaskService 后发副屏面板消息', async () => {
+    mockedIsClaimEnabled.mockResolvedValue(true);
+    const submitPanelMessage = jest.fn();
+
+    renderHook(() =>
+      useTaskExecuteFromCard({
+        panelRef: { current: null } as never,
+        context,
+        submitPanelMessage,
+      }),
+    );
+
+    await act(async () => {
+      registeredHandler?.(task);
+    });
+    await waitFor(() => expect(mockedExecute).toHaveBeenCalled());
+    expect(submitPanelMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('查询任务认领异常（开源无鉴权/网络抖动）→ 放行，不阻断执行', async () => {
+    mockedIsClaimEnabled.mockResolvedValue(true);
+    const submitPanelMessage = jest.fn();
+
+    renderHook(() =>
+      useTaskExecuteFromCard({
+        panelRef: { current: null } as never,
+        context,
+        submitPanelMessage,
+      }),
+    );
+
+    await act(async () => {
+      registeredHandler?.(task);
+    });
+    await waitFor(() => expect(mockedExecute).toHaveBeenCalled());
+    expect(mockedToastWarning).not.toHaveBeenCalled();
+  });
+
+  it('onOpenCollaborationPermissions 缺省 → 阻断 toast 不带跳转 action', async () => {
+    mockedIsClaimEnabled.mockResolvedValue(false);
+    const submitPanelMessage = jest.fn();
+
+    renderHook(() =>
+      useTaskExecuteFromCard({
+        panelRef: { current: null } as never,
+        context,
+        submitPanelMessage,
+      }),
+    );
+    await act(async () => {
+      registeredHandler?.(task);
+    });
+
+    expect(mockedToastWarning).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ action: undefined }));
+    expect(mockedExecute).not.toHaveBeenCalled();
+  });
+});

--- a/src/frontend-nextgen/test/pages/Workspace/GroupChatPane.test.tsx
+++ b/src/frontend-nextgen/test/pages/Workspace/GroupChatPane.test.tsx
@@ -10,6 +10,7 @@ import '@testing-library/jest-dom';
 import '@testing-library/jest-dom/jest-globals';
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
 
 // Stub SDK UI primitives: tests focus on GroupChatPane header/empty dispatch + Sender presence,
 // not on SDK bubble/markdown rendering. Stubs avoid pulling ESM @tc-chat/ui into jsdom.
@@ -136,26 +137,28 @@ function makeChat(overrides: Partial<Record<string, unknown>> = {}) {
 function renderPane(overrides: Partial<React.ComponentProps<typeof GroupChatPane>> = {}) {
   const { panelRef, ...rest } = overrides;
   return render(
-    <GroupChatPane
-      group={group}
-      session={session}
-      chat={makeChat()}
-      supportState={supportState}
-      connectionStatus="connected"
-      send={() => {}}
-      submitPanelMessage={() => {}}
-      stop={() => {}}
-      reconnect={() => {}}
-      reloadHistory={() => {}}
-      canManageGroup={{ allowed: false }}
-      activePanel="none"
-      onTogglePanel={() => {}}
-      onRequestDissolve={() => {}}
-      onRequestShareGroup={() => Promise.resolve({ ok: true, data: { invitationUrl: 'https://example.test/g' } })}
-      onRequestShareSession={() => Promise.resolve({ ok: true, data: { invitationUrl: 'https://example.test/s' } })}
-      panelRef={panelRef ?? React.createRef<PanelHandle>()}
-      {...rest}
-    />,
+    <MemoryRouter>
+      <GroupChatPane
+        group={group}
+        session={session}
+        chat={makeChat()}
+        supportState={supportState}
+        connectionStatus="connected"
+        send={() => {}}
+        submitPanelMessage={() => {}}
+        stop={() => {}}
+        reconnect={() => {}}
+        reloadHistory={() => {}}
+        canManageGroup={{ allowed: false }}
+        activePanel="none"
+        onTogglePanel={() => {}}
+        onRequestDissolve={() => {}}
+        onRequestShareGroup={() => Promise.resolve({ ok: true, data: { invitationUrl: 'https://example.test/g' } })}
+        onRequestShareSession={() => Promise.resolve({ ok: true, data: { invitationUrl: 'https://example.test/s' } })}
+        panelRef={panelRef ?? React.createRef<PanelHandle>()}
+        {...rest}
+      />
+    </MemoryRouter>,
   );
 }
 

--- a/src/frontend-nextgen/test/pages/Workspace/components/BotSessionSidebar/BotSessionSidebar.test.tsx
+++ b/src/frontend-nextgen/test/pages/Workspace/components/BotSessionSidebar/BotSessionSidebar.test.tsx
@@ -73,33 +73,106 @@ describe('BotSessionSidebar', () => {
       />,
     );
     expect(container.querySelector('.self-start')).not.toBeInTheDocument();
-    const activeTab = screen.getByRole('tab', { name: '对话' });
-    const inactiveTab = screen.getByRole('tab', { name: '协作群' });
+    const activeTab = screen.getByRole('button', { name: '对话' });
+    const inactiveTab = screen.getByRole('button', { name: '协作群' });
     const botTrigger = screen.getByRole('button', { name: '可聊Bot' });
-    expect(activeTab).toHaveClass('h-9', 'border-primary', 'text-primary');
-    expect(activeTab).toHaveClass('hover:bg-transparent', 'hover:text-primary');
-    expect(inactiveTab).toHaveClass('h-9', 'border-transparent', 'text-muted-foreground');
-    expect(inactiveTab).toHaveClass('hover:bg-transparent', 'hover:text-foreground');
-    expect(screen.getByRole('button', { name: '添加好友或发起协作' })).toHaveClass('h-9', 'w-9');
+    expect(activeTab).toHaveAttribute('aria-pressed', 'true');
+    expect(inactiveTab).toHaveAttribute('aria-pressed', 'false');
+    expect(activeTab).toHaveClass('bg-background', 'text-primary', 'shadow-sm');
+    expect(inactiveTab).toHaveClass('text-muted-foreground');
+    expect(screen.getByRole('button', { name: '添加好友或发起协作' })).toHaveClass('h-9', 'w-9', 'rounded-md');
     expect(screen.getByRole('button', { name: '添加好友或发起协作' })).toHaveClass(
-      'border-input',
-      'bg-background',
-      'text-muted-foreground',
+      'border-primary/20',
+      'bg-primary/5',
+      'text-primary',
     );
-    expect(screen.getByRole('button', { name: '添加好友或发起协作' })).not.toHaveClass(
-      'bg-primary',
-      'text-primary-foreground',
-    );
+    expect(screen.getByRole('button', { name: '添加好友或发起协作' })).not.toHaveClass('bg-primary', 'text-primary-foreground');
     expect(screen.getByRole('button', { name: '添加好友或发起协作' })).not.toHaveClass('lg:hidden');
-    expect(botTrigger.parentElement).toHaveClass('min-h-[72px]', 'px-[18px]', 'py-3');
-    expect(botTrigger).toHaveClass('gap-2.5', 'px-0', 'py-1');
-    expect(screen.getByText('可聊Bot')).toBeInTheDocument();
+    expect(botTrigger.parentElement).toHaveClass('min-h-16', 'bg-primary/5', 'px-4', 'py-2.5');
+    expect(botTrigger.querySelector('svg.lucide-chevron-down')).toBeInTheDocument();
+    expect(botTrigger).toHaveClass('gap-3', 'px-0', 'py-1');
+    expect(screen.getByText('可聊Bot')).toHaveClass('text-sm', 'font-semibold');
+    expect(screen.getByText('OpenClaw').parentElement).toHaveClass('text-xs', 'leading-4');
     expect(screen.getByText('不可聊Bot')).toBeInTheDocument();
     expect(screen.getByText('OpenClaw')).toBeInTheDocument();
     expect(screen.getByText('ClaudeCode')).toBeInTheDocument();
     expect(screen.getByText('会话1')).toBeInTheDocument();
-    expect(screen.getByText('08/30 12:00')).toBeInTheDocument();
+    expect(screen.getByText('08/30')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: '会话更多操作' })).toBeInTheDocument();
+  });
+
+  it('Bot 分组错误不伪装成空态，并提供重试入口', () => {
+    const onRetry = jest.fn();
+    render(
+      <BotSessionSidebar
+        view="chat"
+        availableViews={['chat', 'group']}
+        onViewChange={() => {}}
+        identities={[{ id: 'identity:me', name: '风太', kind: 'user', avatar: '风' }]}
+        activeIdentityId="identity:me"
+        chatBots={[]}
+        friendBots={[]}
+        isMyBotsLoading={false}
+        myBotsError="管理 Bot 加载失败"
+        onRetryMyBots={onRetry}
+        isFriendBotsLoading={false}
+        expandedBotSectionKey={{}}
+        expandedBotIds={{}}
+        sessionsByBotId={{}}
+        isSessionsLoading={false}
+        selectedBotSessionId={null}
+        onToggleBotExpanded={() => {}}
+        onSelectSession={() => {}}
+        onCreateSession={() => {}}
+        onDeleteSession={noopBool}
+        onRenameSession={noopBool}
+        onClearSessionContext={noopBool}
+        onToggleFavorite={noopBool}
+        onLoadFavorites={noopAsync}
+        onCreateGroup={noop}
+        onAddFriend={noop}
+      />,
+    );
+    expect(screen.getByRole('alert')).toHaveTextContent('管理 Bot 加载失败');
+    fireEvent.click(screen.getByRole('button', { name: '重试' }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('Bot 会话加载失败时保留会话范围并提供局部重试', () => {
+    const onReloadBot = jest.fn().mockResolvedValue(undefined);
+    render(
+      <BotSessionSidebar
+        view="chat"
+        availableViews={['chat', 'group']}
+        onViewChange={() => {}}
+        identities={[{ id: 'identity:me', name: '风太', kind: 'user', avatar: '风' }]}
+        activeIdentityId="identity:me"
+        chatBots={[bots[0]]}
+        friendBots={[]}
+        isMyBotsLoading={false}
+        isFriendBotsLoading={false}
+        expandedBotSectionKey={{ 'b:1': 'mine' }}
+        expandedBotIds={{ 'b:1': true }}
+        sessionsByBotId={{}}
+        sessionPageMetaByBotId={{ 'b:1': { total: 0, hasMore: false, nextPage: 1, isLoadingMore: false, error: '会话加载失败' } }}
+        isSessionsLoading={false}
+        selectedBotSessionId={null}
+        onToggleBotExpanded={() => {}}
+        onSelectSession={() => {}}
+        onCreateSession={() => {}}
+        onDeleteSession={noopBool}
+        onRenameSession={noopBool}
+        onClearSessionContext={noopBool}
+        onToggleFavorite={noopBool}
+        onLoadFavorites={noopAsync}
+        onReloadBot={onReloadBot}
+        onCreateGroup={noop}
+        onAddFriend={noop}
+      />,
+    );
+    expect(screen.getByRole('alert')).toHaveTextContent('会话加载失败');
+    fireEvent.click(screen.getByRole('button', { name: '重试' }));
+    expect(onReloadBot).toHaveBeenCalledWith('b:1');
   });
 
   it('对话列表向下滚动时一级 Tab 吸顶', () => {
@@ -130,9 +203,41 @@ describe('BotSessionSidebar', () => {
       />,
     );
 
-    const tabList = screen.getByRole('tablist', { name: '工作区类型' });
-    expect(tabList.parentElement).toHaveClass('sticky', 'top-0', 'z-20', 'bg-muted');
-    expect(tabList.parentElement?.parentElement).toHaveClass('bg-muted');
+    const tabGroup = screen.getByRole('group', { name: '工作区类型' });
+    expect(tabGroup.parentElement).toHaveClass('h-10', 'items-center');
+    expect(tabGroup.parentElement?.parentElement).toHaveClass('sticky', 'top-0', 'z-20', 'bg-muted/20');
+  });
+
+  it('对话筛选行与协作群搜索行使用统一上下留白', () => {
+    render(
+      <BotSessionSidebar
+        view="chat"
+        availableViews={['chat', 'group']}
+        onViewChange={() => {}}
+        chatBots={bots}
+        friendBots={[]}
+        isMyBotsLoading={false}
+        isFriendBotsLoading={false}
+        expandedBotSectionKey={{}}
+        expandedBotIds={{}}
+        sessionsByBotId={{}}
+        isSessionsLoading={false}
+        selectedBotSessionId={null}
+        onToggleBotExpanded={() => {}}
+        onSelectSession={() => {}}
+        onCreateSession={() => {}}
+        onDeleteSession={noopBool}
+        onRenameSession={noopBool}
+        onClearSessionContext={noopBool}
+        onToggleFavorite={noopBool}
+        onLoadFavorites={noopAsync}
+        onCreateGroup={noop}
+        onAddFriend={noop}
+      />,
+    );
+
+    const searchInput = screen.getByRole('textbox', { name: '搜索 Bot' });
+    expect(searchInput.parentElement?.parentElement).toHaveClass('my-2', 'px-[18px]');
   });
 
   it('Bot 行辅助信息使用 bots 接口 engine 字段的统一展示名', () => {
@@ -233,8 +338,9 @@ describe('BotSessionSidebar', () => {
       />,
     );
 
+    expect(screen.queryByRole('button', { name: '当前协作身份：风太' })).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: '风太管理的 Bot (2)' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: '风太管理的 Bot (2)' })).toHaveClass('min-h-10');
+    expect(screen.getByRole('button', { name: '风太管理的 Bot (2)' })).toHaveClass('min-h-9');
     expect(screen.getByRole('button', { name: '风太的好友 Bot (0)' })).toBeInTheDocument();
   });
 
@@ -275,12 +381,20 @@ describe('BotSessionSidebar', () => {
     expect(onToggle).toHaveBeenCalledWith('b:1', 'mine');
     const createSessionButton = screen.getByRole('button', { name: '新建会话' });
     expect(createSessionButton).toBeInTheDocument();
-    expect(createSessionButton).toHaveClass('h-7', 'w-7', 'rounded-md');
-    expect(screen.getByRole('group', { name: '会话范围筛选' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Bot操作' })).toHaveClass('rounded-md');
-    fireEvent.click(screen.getByRole('button', { name: 'Bot操作' }));
-    expect(screen.getByRole('button', { name: '管理 Bot' }).querySelector('svg')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: '已管理 Bot (2)' })).toHaveClass('rounded-none', 'min-h-10');
+    expect(createSessionButton).toHaveClass(
+      'h-7',
+      'w-7',
+      'rounded-md',
+      'text-muted-foreground',
+      'hover:bg-primary/10',
+      'hover:text-primary',
+    );
+    const scopeButton = screen.getByRole('button', { name: '会话范围：全部会话' });
+    expect(scopeButton).toHaveClass('h-7', 'w-7');
+    expect(scopeButton.querySelector('svg.lucide-list-filter')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Bot操作' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: '管理 Bot' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '已管理 Bot (2)' })).toHaveClass('rounded-none', 'min-h-9');
     fireEvent.click(screen.getByRole('button', { name: '新建会话' }));
     expect(onCreateSession).toHaveBeenCalledWith('b:1');
     expect(onToggle).toHaveBeenCalledTimes(1);
@@ -392,7 +506,105 @@ describe('BotSessionSidebar', () => {
     expect(onToggle).not.toHaveBeenCalled();
   });
 
-  it('展开 bot 显示 全部/已收藏 pill,切到已收藏过滤未收藏会话', () => {
+  it('Bot 展开与承载当前会话时使用一致选中指示', () => {
+    const { rerender } = render(
+      <BotSessionSidebar
+        view="chat"
+        availableViews={['chat', 'group']}
+        onViewChange={() => {}}
+        chatBots={[bots[0]]}
+        friendBots={[]}
+        isMyBotsLoading={false}
+        isFriendBotsLoading={false}
+        expandedBotSectionKey={{ 'b:1': 'mine' }}
+        expandedBotIds={{ 'b:1': true }}
+        sessionsByBotId={sessionsByBotId}
+        isSessionsLoading={false}
+        selectedBotSessionId={null}
+        onToggleBotExpanded={() => {}}
+        onSelectSession={() => {}}
+        onCreateSession={() => {}}
+        onDeleteSession={noopBool}
+        onRenameSession={noopBool}
+        onClearSessionContext={noopBool}
+        onToggleFavorite={noopBool}
+        onLoadFavorites={noopAsync}
+        onCreateGroup={noop}
+        onAddFriend={noop}
+      />,
+    );
+
+    let botRow = screen.getByRole('button', { name: '可聊Bot' }).parentElement;
+    expect(botRow).toHaveClass('bg-primary/5');
+    expect(botRow?.querySelector('[class~="w-[3px]"][class~="bg-primary"]')).toBeInTheDocument();
+
+    rerender(
+      <BotSessionSidebar
+        view="chat"
+        availableViews={['chat', 'group']}
+        onViewChange={() => {}}
+        chatBots={[bots[0]]}
+        friendBots={[]}
+        isMyBotsLoading={false}
+        isFriendBotsLoading={false}
+        expandedBotSectionKey={{}}
+        expandedBotIds={{}}
+        sessionsByBotId={sessionsByBotId}
+        isSessionsLoading={false}
+        selectedBotSessionId="s1"
+        onToggleBotExpanded={() => {}}
+        onSelectSession={() => {}}
+        onCreateSession={() => {}}
+        onDeleteSession={noopBool}
+        onRenameSession={noopBool}
+        onClearSessionContext={noopBool}
+        onToggleFavorite={noopBool}
+        onLoadFavorites={noopAsync}
+        onCreateGroup={noop}
+        onAddFriend={noop}
+      />,
+    );
+
+    botRow = screen.getByRole('button', { name: '可聊Bot' }).parentElement;
+    expect(botRow).toHaveClass('bg-primary/5');
+    expect(botRow?.querySelector('[class~="w-[3px]"][class~="bg-primary"]')).toBeInTheDocument();
+  });
+
+  it('Bot 会话背景铺满列表宽度，不保留整体缩进', () => {
+    render(
+      <BotSessionSidebar
+        view="chat"
+        availableViews={['chat', 'group']}
+        onViewChange={() => {}}
+        chatBots={[bots[0]]}
+        friendBots={[]}
+        isMyBotsLoading={false}
+        isFriendBotsLoading={false}
+        expandedBotSectionKey={{ 'b:1': 'mine' }}
+        expandedBotIds={{ 'b:1': true }}
+        sessionsByBotId={sessionsByBotId}
+        isSessionsLoading={false}
+        selectedBotSessionId={null}
+        onToggleBotExpanded={() => {}}
+        onSelectSession={() => {}}
+        onCreateSession={() => {}}
+        onDeleteSession={noopBool}
+        onRenameSession={noopBool}
+        onClearSessionContext={noopBool}
+        onToggleFavorite={noopBool}
+        onLoadFavorites={noopAsync}
+        onCreateGroup={noop}
+        onAddFriend={noop}
+      />,
+    );
+
+    const sessionList = screen.getByLabelText('Bot会话列表：可聊Bot');
+    expect(sessionList).toHaveClass('border-t');
+    expect(sessionList).not.toHaveClass('border-b', 'pl-2');
+    expect(sessionList.firstElementChild).not.toHaveClass('border-b', 'pl-2');
+  });
+
+  it('Bot 对象行通过纯 Icon 切换全部/已收藏会话', () => {
     render(
       <BotSessionSidebar
         view="chat"
@@ -421,17 +633,89 @@ describe('BotSessionSidebar', () => {
         onAddFriend={noop}
       />,
     );
-    const allTab = screen.getByRole('button', { name: '全部会话 1' });
-    expect(allTab).toBeInTheDocument();
-    expect(allTab).toHaveClass('border-0', 'rounded-none', 'text-primary');
-    const favoriteTab = screen.getByRole('button', { name: '已收藏会话 0' });
-    expect(favoriteTab).toHaveClass('text-muted-foreground');
-    fireEvent.click(favoriteTab);
-    // 切到已收藏 tab，无收藏会话时不显示会话1
+    const scopeButton = screen.getByRole('button', { name: '会话范围：全部会话' });
+    expect(scopeButton.textContent).toBe('');
+    fireEvent.click(scopeButton);
+    expect(screen.getByRole('radio', { name: '全部会话 1' })).toHaveAttribute('aria-checked', 'true');
+    fireEvent.click(screen.getByRole('radio', { name: '已收藏会话 0' }));
+    expect(screen.getByRole('button', { name: '会话范围：已收藏会话' })).toHaveAttribute('aria-pressed', 'true');
     expect(screen.queryByText('会话1')).not.toBeInTheDocument();
   });
 
-  it('接口返回 AgentCoding Bot 时展示 Bot 工坊入口卡片', () => {
+  it('收起 Bot 切换收藏范围后加载收藏并自动展开对象', () => {
+    const onLoadFavorites = jest.fn().mockResolvedValue(undefined);
+    const onToggleBotExpanded = jest.fn();
+    render(
+      <BotSessionSidebar
+        view="chat"
+        availableViews={['chat', 'group']}
+        onViewChange={() => {}}
+        chatBots={[bots[0]]}
+        friendBots={[]}
+        isMyBotsLoading={false}
+        isFriendBotsLoading={false}
+        expandedBotSectionKey={{}}
+        expandedBotIds={{}}
+        sessionsByBotId={sessionsByBotId}
+        isSessionsLoading={false}
+        selectedBotSessionId={null}
+        onToggleBotExpanded={onToggleBotExpanded}
+        onSelectSession={() => {}}
+        onCreateSession={() => {}}
+        onDeleteSession={noopBool}
+        onRenameSession={noopBool}
+        onClearSessionContext={noopBool}
+        onToggleFavorite={noopBool}
+        onLoadFavorites={onLoadFavorites}
+        onCreateGroup={noop}
+        onAddFriend={noop}
+      />,
+    );
+
+    const botTrigger = screen.getByRole('button', { name: '可聊Bot' });
+    expect(botTrigger).toHaveAttribute('aria-expanded', 'false');
+    expect(botTrigger.querySelector('svg.lucide-chevron-right')).toBeInTheDocument();
+    const scopeButton = screen.getByRole('button', { name: '会话范围：全部会话' });
+    expect(scopeButton.querySelector('svg.lucide-list-filter')).toBeInTheDocument();
+    fireEvent.click(scopeButton);
+    fireEvent.click(screen.getByRole('radio', { name: '已收藏会话 …' }));
+
+    expect(onLoadFavorites).toHaveBeenCalledWith('b:1');
+    expect(onToggleBotExpanded).toHaveBeenCalledWith('b:1', 'mine');
+  });
+
+  it('展开 Bot 会话区不再渲染旧会话范围工具栏', () => {
+    render(
+      <BotSessionSidebar
+        view="chat"
+        availableViews={['chat', 'group']}
+        onViewChange={() => {}}
+        chatBots={[bots[0]]}
+        friendBots={[]}
+        isMyBotsLoading={false}
+        isFriendBotsLoading={false}
+        expandedBotSectionKey={{ 'b:1': 'mine' }}
+        expandedBotIds={{ 'b:1': true }}
+        sessionsByBotId={sessionsByBotId}
+        isSessionsLoading={false}
+        selectedBotSessionId={null}
+        onToggleBotExpanded={() => {}}
+        onSelectSession={() => {}}
+        onCreateSession={() => {}}
+        onDeleteSession={noopBool}
+        onRenameSession={noopBool}
+        onClearSessionContext={noopBool}
+        onToggleFavorite={noopBool}
+        onLoadFavorites={noopAsync}
+        onCreateGroup={noop}
+        onAddFriend={noop}
+      />,
+    );
+
+    expect(screen.queryByRole('group', { name: '会话范围筛选' })).not.toBeInTheDocument();
+  });
+
+  it('接口返回 AgentCoding Bot 时在管理 Bot 分组展示 Bot 工坊提示链接', async () => {
     const onOpenBotWorkshop = jest.fn();
     render(
       <BotSessionSidebar
@@ -464,12 +748,17 @@ describe('BotSessionSidebar', () => {
       />,
     );
 
-    const workshopCard = screen.getByRole('button', { name: 'AgentCoding Bot 请前往 Bot 工坊使用' });
-    expect(workshopCard).toHaveClass('bg-primary/5', 'border-primary/20');
-    fireEvent.click(workshopCard);
+    const hintButton = screen.getByRole('button', { name: 'AgentCoding Bot 使用提示' });
+    expect(hintButton).toHaveClass('h-7', 'w-7');
+    expect(hintButton.closest('.flex.min-h-9')).toContainElement(
+      screen.getByRole('button', { name: '风太管理的 Bot (2)' }),
+    );
+    await userEvent.setup().hover(hintButton);
+    const workshopLink = await screen.findByRole('link', { name: 'Bot 工坊' });
+    expect(workshopLink).toHaveAttribute('href', '/bot-workshop');
+    expect(workshopLink.parentElement).toHaveTextContent('AgentCoding Bot 请前往 Bot 工坊 使用');
+    fireEvent.click(workshopLink);
     expect(onOpenBotWorkshop).toHaveBeenCalledTimes(1);
-
-    expect(screen.queryByRole('img', { name: 'AgentCoding Bot 使用说明' })).not.toBeInTheDocument();
-    expect(workshopCard).toHaveClass('cursor-pointer');
+    expect(screen.queryByRole('button', { name: 'AgentCoding Bot 请前往 Bot 工坊使用' })).not.toBeInTheDocument();
   });
 });

--- a/src/frontend-nextgen/test/pages/Workspace/components/GroupSidebar/GroupSidebar.test.tsx
+++ b/src/frontend-nextgen/test/pages/Workspace/components/GroupSidebar/GroupSidebar.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it, jest } from '@jest/globals';
 import '@testing-library/jest-dom';
 import '@testing-library/jest-dom/jest-globals';
 import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 const baseGroup = {
@@ -94,6 +95,32 @@ describe('GroupSidebar', () => {
     expect(onCreateGroup).toHaveBeenCalled();
   });
 
+  it('群列表错误不伪装成空态，并提供重试入口', () => {
+    const onRetryGroups = jest.fn().mockResolvedValue(undefined);
+    render(<GroupSidebar {...makeProps({ groups: [], groupsError: '协作群加载失败', onRetryGroups })} />);
+    expect(screen.getByRole('alert')).toHaveTextContent('协作群加载失败');
+    expect(screen.queryByText('暂无协作群')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: '重试' }));
+    expect(onRetryGroups).toHaveBeenCalledTimes(1);
+  });
+
+  it('群会话错误保留父对象并提供局部重试', () => {
+    const onReloadSession = jest.fn().mockResolvedValue(undefined);
+    render(
+      <GroupSidebar
+        {...makeProps({
+          sessionsByGroupId: {},
+          errorByGroupId: { g1: '群会话加载失败' },
+          onReloadSession,
+        })}
+      />,
+    );
+    expect(screen.getByText('主站群')).toBeInTheDocument();
+    expect(screen.getByRole('alert')).toHaveTextContent('群会话加载失败');
+    fireEvent.click(screen.getByRole('button', { name: '重试' }));
+    expect(onReloadSession).toHaveBeenCalledWith('g1');
+  });
+
   it('顶部蓝色 + 触发发起协作', () => {
     const onCreateGroup = jest.fn();
     render(<GroupSidebar {...makeProps({ onCreateGroup })} />);
@@ -137,6 +164,21 @@ describe('GroupSidebar', () => {
     expect(groupTrigger.textContent).toMatch(/主站群.*公开.*任务协作.*固定群成员/);
     expect(groupTrigger.textContent).not.toContain('6 个成员');
     expect(screen.queryByLabelText('6 个成员')).not.toBeInTheDocument();
+  });
+
+  it('协作群标签截断时可通过 hover 查看完整内容', async () => {
+    render(
+      <GroupSidebar
+        {...makeProps({
+          groups: [{ ...baseGroup, isPublic: true, kind: 'task_dag' as const, membership: 'session_only' as const }],
+        })}
+      />,
+    );
+
+    const metadata = screen.getByLabelText('协作群标签：公开 · 自定义协同 · 仅参与临时会话');
+    expect(metadata).toHaveClass('truncate');
+    await userEvent.setup().hover(metadata);
+    expect(await screen.findByRole('tooltip')).toHaveTextContent('公开 · 自定义协同 · 仅参与临时会话');
   });
 
   it('does not render session member count', () => {
@@ -193,7 +235,11 @@ describe('GroupSidebar', () => {
     const onManageGroup = jest.fn();
     const onToggleGroupExpanded = jest.fn();
     render(<GroupSidebar {...makeProps({ onCreateSession, onManageGroup, onToggleGroupExpanded })} />);
-    expect(screen.getByRole('button', { name: '协作群操作' })).toHaveClass('rounded-md');
+    expect(screen.getByRole('button', { name: '协作群操作' })).toHaveClass(
+      'rounded-md',
+      'hover:bg-primary/10',
+      'hover:text-primary',
+    );
     expect(
       screen.getByRole('button', { name: '主站群' }).querySelector('svg.lucide-chevron-right'),
     ).not.toBeInTheDocument();
@@ -202,8 +248,17 @@ describe('GroupSidebar', () => {
     expect(onManageGroup).toHaveBeenCalledWith('g1');
     expect(onToggleGroupExpanded).not.toHaveBeenCalled();
     const createSessionButton = screen.getByRole('button', { name: '新建会话' });
-    expect(createSessionButton).toHaveClass('h-7', 'w-7', 'rounded-md');
-    expect(screen.getByRole('group', { name: '会话范围筛选' })).toBeInTheDocument();
+    expect(createSessionButton).toHaveClass(
+      'h-7',
+      'w-7',
+      'rounded-md',
+      'text-muted-foreground',
+      'hover:bg-primary/10',
+      'hover:text-primary',
+    );
+    const scopeButton = screen.getByRole('button', { name: '会话范围：全部会话' });
+    expect(scopeButton).toHaveClass('h-7', 'w-7');
+    expect(scopeButton.querySelector('svg.lucide-list-filter')).toBeInTheDocument();
     fireEvent.click(createSessionButton);
     expect(onCreateSession).toHaveBeenCalledWith('g1');
     expect(onToggleGroupExpanded).not.toHaveBeenCalled();
@@ -221,10 +276,12 @@ describe('GroupSidebar', () => {
     const secondGroup = { ...baseGroup, groupId: 'g2', name: '新品发布协作组', sessions: [] };
     render(<GroupSidebar {...makeProps({ groups: [baseGroup, secondGroup] })} />);
 
-    const groupList = screen.getByText('协作群', { selector: 'span.font-medium' }).parentElement?.nextElementSibling;
+    const groupList = screen.getByText(/^协作群 \(\d+\)$/).nextElementSibling;
     expect(groupList).toHaveClass('divide-y', 'divide-border/70');
     const sessionList = screen.getByLabelText('协作群会话列表：主站群');
-    expect(sessionList).not.toHaveClass('ml-[60px]', 'border-l');
+    expect(sessionList).toHaveClass('border-t');
+    expect(sessionList).not.toHaveClass('border-b', 'ml-[60px]', 'border-l', 'pl-2');
+    expect(sessionList.firstElementChild).not.toHaveClass('border-b');
   });
 
   it('clicking a session does not collapse its group (no bubble to card)', () => {
@@ -248,31 +305,26 @@ describe('GroupSidebar', () => {
       '协作群参与方式',
     ]);
     const filterPanel = screen.getByRole('radiogroup', { name: '协作群参与方式' }).parentElement;
-    expect(filterPanel).toHaveClass('bg-muted', 'border-y', 'px-[18px]', 'py-3');
-    expect(screen.getByRole('radiogroup', { name: '协作群类型' })).toHaveClass(
-      'grid',
-      'min-w-0',
-      'grid-cols-[4rem_minmax(0,1fr)]',
-      'gap-1',
-    );
+    expect(filterPanel).toHaveClass('mx-[18px]', 'rounded-lg', 'border', 'bg-muted/50', 'px-3', 'py-3', 'shadow-sm');
+    expect(screen.getByRole('radiogroup', { name: '协作群类型' })).toHaveClass('min-w-0');
     expect(screen.getByRole('radiogroup', { name: '协作群类型' }).querySelector('.flex')).toHaveClass(
+      'app-scrollbar',
       'min-w-0',
       'flex-nowrap',
       'overflow-x-auto',
-      'scrollbar-hide',
-      'gap-x-2',
+      'gap-x-1',
+      'pb-1',
+      'touch-pan-x',
     );
-    expect(screen.getByRole('radiogroup', { name: '协作群参与方式' })).toHaveClass(
-      'min-w-0',
-      'grid-cols-[4rem_minmax(0,1fr)]',
-      'gap-1',
-    );
+    expect(screen.getByRole('radiogroup', { name: '协作群参与方式' })).toHaveClass('min-w-0', 'border-t', 'pt-3');
     expect(screen.getByRole('radiogroup', { name: '协作群参与方式' }).querySelector('.flex')).toHaveClass(
+      'app-scrollbar',
       'min-w-0',
       'flex-nowrap',
       'overflow-x-auto',
-      'scrollbar-hide',
-      'gap-x-2',
+      'gap-x-1',
+      'pb-1',
+      'touch-pan-x',
     );
     expect(screen.getByRole('radio', { name: '全部' }).querySelector('svg')).toBeInTheDocument();
   });
@@ -285,15 +337,15 @@ describe('GroupSidebar', () => {
 
   it('顶部视图切换与新增按钮等高，未选中 Tab 保持清晰对比', () => {
     render(<GroupSidebar {...makeProps()} />);
-    const inactiveTab = screen.getByRole('tab', { name: '对话' });
-    const activeTab = screen.getByRole('tab', { name: '协作群' });
+    const inactiveTab = screen.getByRole('button', { name: '对话' });
+    const activeTab = screen.getByRole('button', { name: '协作群' });
     const actionButton = screen.getByRole('button', { name: '添加好友或发起协作' });
-    expect(inactiveTab).toHaveClass('h-9', 'border-transparent', 'text-muted-foreground');
-    expect(inactiveTab).toHaveClass('hover:bg-transparent', 'hover:text-foreground');
-    expect(activeTab).toHaveClass('h-9', 'border-primary', 'text-primary');
-    expect(activeTab).toHaveClass('hover:bg-transparent', 'hover:text-primary');
-    expect(actionButton).toHaveClass('h-9', 'w-9');
-    expect(actionButton).toHaveClass('border-input', 'bg-background', 'text-muted-foreground');
+    expect(inactiveTab).toHaveAttribute('aria-pressed', 'false');
+    expect(activeTab).toHaveAttribute('aria-pressed', 'true');
+    expect(activeTab).toHaveClass('bg-background', 'text-primary', 'shadow-sm');
+    expect(inactiveTab).toHaveClass('text-muted-foreground');
+    expect(actionButton).toHaveClass('h-9', 'w-9', 'rounded-md');
+    expect(actionButton).toHaveClass('border-primary/20', 'bg-primary/5', 'text-primary');
     expect(actionButton).not.toHaveClass('bg-primary', 'text-primary-foreground');
     expect(actionButton).not.toHaveClass('lg:hidden');
   });
@@ -304,21 +356,30 @@ describe('GroupSidebar', () => {
     expect(screen.getByRole('button', { name: '筛选' })).toHaveClass('h-9');
   });
 
-  it('协作身份保持紧凑，群卡片保留可读间距并降低标题字重', () => {
+  it('协作身份移出二级侧栏，群卡片保留可读间距并降低标题字重', () => {
+    render(
+      <GroupSidebar {...makeProps()} />,
+    );
+    expect(screen.queryByRole('button', { name: '当前协作身份：风太' })).not.toBeInTheDocument();
+    const groupTrigger = screen.getByRole('button', { name: /主站群/ });
+    expect(groupTrigger.parentElement).toHaveClass('min-h-16', 'bg-primary/5', 'px-4', 'py-2.5');
+    expect(groupTrigger).toHaveClass('px-0', 'py-1');
+    expect(screen.getByText('主站群')).toHaveClass('text-sm', 'font-semibold');
+    expect(screen.getByText('自由聊天').parentElement).toHaveClass('text-xs', 'leading-4');
+  });
+
+  it('选中协作群暂无会话时展示明确空态', () => {
     render(
       <GroupSidebar
         {...makeProps({
-          identities: [{ id: 'me', name: '风太', kind: 'user', avatar: '风' }],
-          activeIdentityId: 'me',
+          selectedGroupId: 'g1',
+          sessionsByGroupId: { g1: [] },
         })}
       />,
     );
-    expect(screen.getByRole('button', { name: '当前协作身份：风太' })).toHaveClass('min-h-10');
-    const groupTrigger = screen.getByRole('button', { name: /主站群/ });
-    expect(groupTrigger.parentElement).toHaveClass('min-h-[72px]', 'px-[18px]', 'py-3');
-    expect(groupTrigger).toHaveClass('px-0', 'py-1');
-    expect(screen.getByText('主站群')).toHaveClass('font-medium');
-    expect(screen.getByText('主站群')).not.toHaveClass('font-semibold');
+
+    expect(screen.getByText('当前协作群暂无会话')).toBeInTheDocument();
+    expect(screen.queryByText('暂无协作群临时会话')).not.toBeInTheDocument();
   });
 
   it('group collapse toggle hides sessions', () => {
@@ -338,7 +399,7 @@ describe('GroupSidebar', () => {
     expect(onMembershipChange).toHaveBeenCalledWith('session_only');
   });
 
-  it('per-group favorite tab shows only favorite sessions and fires onSessionTabForGroup', () => {
+  it('对象行会话范围 Icon 按群过滤收藏会话', () => {
     const onSessionTabForGroup = jest.fn();
     render(
       <GroupSidebar
@@ -349,25 +410,26 @@ describe('GroupSidebar', () => {
         })}
       />,
     );
-    // 收藏 tab 下仅 s1 可见，s2 被隐藏
     expect(screen.getByText('会话一')).toBeInTheDocument();
     expect(screen.queryByText('会话二')).not.toBeInTheDocument();
-    // 切回全部触发 onSessionTabForGroup('g1', 'all')；群会话 Tab 不重复显示数量
-    const favoriteTab = screen.getByRole('button', { name: /已收藏会话/ });
-    const allTab = screen.getByRole('button', { name: /全部会话/ });
-    expect(favoriteTab).toHaveClass('text-primary');
-    expect(allTab).toHaveClass('text-muted-foreground');
-    fireEvent.click(allTab);
+    const scopeButton = screen.getByRole('button', { name: '会话范围：已收藏会话' });
+    expect(scopeButton).toHaveAttribute('aria-pressed', 'true');
+    expect(scopeButton.textContent).toBe('');
+    fireEvent.click(scopeButton);
+    expect(screen.getByRole('radio', { name: /已收藏会话/ })).toHaveAttribute('aria-checked', 'true');
+    fireEvent.click(screen.getByRole('radio', { name: /全部会话/ }));
     expect(onSessionTabForGroup).toHaveBeenCalledWith('g1', 'all');
   });
 
-  it('会话范围筛选使用弱化的行内文字样式并保留水平内边距', () => {
+  it('会话范围使用对象行纯 Icon，选项在 Popover 中展示', () => {
     render(<GroupSidebar {...makeProps({ totalSessionsByGroupId: { g1: 12 } })} />);
 
-    const allTab = screen.getByRole('button', { name: '全部会话 12' });
-    const favoriteTab = screen.getByRole('button', { name: '已收藏会话 0' });
-    expect(allTab).toHaveClass('px-2.5', 'border-0', 'rounded-none', 'text-primary');
-    expect(favoriteTab).toHaveClass('px-2.5', 'border-0', 'rounded-none', 'text-muted-foreground');
+    const scopeButton = screen.getByRole('button', { name: '会话范围：全部会话' });
+    expect(scopeButton.textContent).toBe('');
+    fireEvent.click(scopeButton);
+    expect(screen.getByRole('radiogroup', { name: '会话范围' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: '全部会话 12' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: '已收藏会话 0' })).toBeInTheDocument();
   });
 
   it('renders all and favorite session counts beside collaboration session tabs', () => {
@@ -379,15 +441,17 @@ describe('GroupSidebar', () => {
         })}
       />,
     );
-    expect(screen.getByRole('button', { name: '全部会话 12' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: '已收藏会话 1' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: '会话范围：全部会话' }));
+    expect(screen.getByRole('radio', { name: '全部会话 12' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: '已收藏会话 1' })).toBeInTheDocument();
   });
 
   it('群会话总数未知时使用占位符，不用当前已加载条数冒充总数', () => {
     render(<GroupSidebar {...makeProps({ favoriteSessionIds: ['s1'] })} />);
 
-    expect(screen.getByRole('button', { name: '全部会话 …' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: '已收藏会话 1' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: '会话范围：全部会话' }));
+    expect(screen.getByRole('radio', { name: '全部会话 …' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: '已收藏会话 1' })).toBeInTheDocument();
   });
 
   it('does not present the loaded-page favorite count as a total while more group sessions remain', () => {
@@ -400,25 +464,72 @@ describe('GroupSidebar', () => {
       />,
     );
 
-    expect(screen.getByRole('button', { name: '全部会话 …' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: '已收藏会话 …' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: '会话范围：全部会话' }));
+    expect(screen.getByRole('radio', { name: '全部会话 …' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: '已收藏会话 …' })).toBeInTheDocument();
+  });
+
+  it('收起协作群切换会话范围后自动展开对象', () => {
+    const onSessionTabForGroup = jest.fn();
+    const onToggleGroupExpanded = jest.fn();
+    render(
+      <GroupSidebar
+        {...makeProps({
+          expandedGroupIds: {},
+          onSessionTabForGroup,
+          onToggleGroupExpanded,
+        })}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '会话范围：全部会话' }));
+    fireEvent.click(screen.getByRole('radio', { name: '已收藏会话 0' }));
+
+    expect(onSessionTabForGroup).toHaveBeenCalledWith('g1', 'favorite');
+    expect(onToggleGroupExpanded).toHaveBeenCalledWith('g1');
+  });
+
+  it('收藏范围仅检查已加载分页时展示明确空态', () => {
+    render(
+      <GroupSidebar
+        {...makeProps({
+          sessionTabsByGroup: { g1: 'favorite' },
+          favoriteSessionIds: [],
+          hasMoreSessionsByGroupId: { g1: true },
+        })}
+      />,
+    );
+
+    expect(screen.getByText('当前已加载会话中暂无收藏')).toBeInTheDocument();
+  });
+
+  it('展开会话区不再渲染旧会话范围工具栏', () => {
+    render(<GroupSidebar {...makeProps()} />);
+
+    expect(screen.queryByRole('group', { name: '会话范围筛选' })).not.toBeInTheDocument();
+  });
+
+  it('协作群会话与 Bot 会话统一使用消息 Icon', () => {
+    const { container } = render(<GroupSidebar {...makeProps()} />);
+
+    expect(container.querySelectorAll('svg.lucide-message-square')).toHaveLength(2);
+    expect(container.querySelector('[data-session-indicator].rounded-full')).not.toBeInTheDocument();
   });
 
   it('群会话没有次行内容时使用紧凑行高', () => {
     render(<GroupSidebar {...makeProps()} />);
 
     const sessionTrigger = screen.getByRole('button', { name: /会话一/ });
-    expect(sessionTrigger).toHaveClass('min-h-[56px]', 'py-2');
-    expect(sessionTrigger.parentElement).toHaveClass('min-h-[56px]');
+    expect(sessionTrigger).toHaveClass('min-h-12', 'py-2');
+    expect(sessionTrigger.parentElement).toHaveClass('min-h-12');
     expect(sessionTrigger.textContent).not.toContain('个成员');
   });
 
   it('协作群列表向下滚动时一级 Tab 吸顶', () => {
     render(<GroupSidebar {...makeProps()} />);
 
-    const tabList = screen.getByRole('tablist', { name: '工作区类型' });
-    expect(tabList.parentElement).toHaveClass('sticky', 'top-0', 'z-20', 'bg-muted');
-    expect(tabList.parentElement?.parentElement).toHaveClass('bg-muted');
+    const tabGroup = screen.getByRole('group', { name: '工作区类型' });
+    expect(tabGroup.parentElement?.parentElement).toHaveClass('sticky', 'top-0', 'z-20', 'bg-muted/20');
   });
 
   it('closes the filter panel after selecting a filter', () => {
@@ -474,7 +585,7 @@ describe('GroupSidebar', () => {
         })}
       />,
     );
-    fireEvent.click(screen.getByRole('button', { name: '加载更多' }));
+    fireEvent.click(screen.getByRole('button', { name: '加载更多会话' }));
     expect(onLoadMoreSessions).toHaveBeenCalledWith('g1');
     expect(onToggleGroupExpanded).not.toHaveBeenCalled();
   });

--- a/src/frontend-nextgen/test/pages/Workspace/components/Modals/CreateGroupModal.test.tsx
+++ b/src/frontend-nextgen/test/pages/Workspace/components/Modals/CreateGroupModal.test.tsx
@@ -141,6 +141,22 @@ it('task_master_slave uses the selected manager as driver_bot_uuid', async () =>
   );
 });
 
+it('falls back to participant names when the bot identity creates a group without a name', async () => {
+  gs.createGroup.mockResolvedValue({ ok: true, data: { groupId: 'g9' } });
+  renderModal({ activeIdentity: botIdentity });
+
+  fireEvent.click(await screen.findByRole('button', { name: /Alpha/ }));
+  fireEvent.click(screen.getByRole('button', { name: '确认创建' }));
+
+  await waitFor(() =>
+    expect(gs.createGroup).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Alpha、我 Bot',
+      }),
+    ),
+  );
+});
+
 it('leader options only contain the currently selected bots', async () => {
   renderModal({ activeIdentity: botIdentity });
   await screen.findByRole('button', { name: /Alpha/ });

--- a/src/frontend-nextgen/test/pages/Workspace/components/Modals/groupNaming.test.ts
+++ b/src/frontend-nextgen/test/pages/Workspace/components/Modals/groupNaming.test.ts
@@ -1,0 +1,22 @@
+import { formatAutoGroupName } from '@/pages/Workspace/components/Modals/groupNaming';
+
+const nameById = new Map([
+  ['b1', 'Alpha'],
+  ['b2', 'Beta'],
+  ['b3', 'Gamma'],
+  ['b4', 'Delta'],
+  ['b5', 'Epsilon'],
+  ['b6', 'Zeta'],
+]);
+
+it('joins five or fewer participant names', () => {
+  expect(formatAutoGroupName(['b1', 'b2', 'b3'], 'b3', false, (id) => nameById.get(id) ?? id)).toBe(
+    'Alpha、Beta、Gamma',
+  );
+});
+
+it('truncates auto group names after five participants', () => {
+  expect(formatAutoGroupName(['b1', 'b2', 'b3', 'b4', 'b5', 'b6'], 'b6', false, (id) => nameById.get(id) ?? id)).toBe(
+    'Alpha、Beta、Gamma、Delta、Epsilon等',
+  );
+});

--- a/src/frontend-nextgen/test/pages/Workspace/components/ResizableWorkspaceSidebar.test.tsx
+++ b/src/frontend-nextgen/test/pages/Workspace/components/ResizableWorkspaceSidebar.test.tsx
@@ -1,0 +1,146 @@
+/** @jest-environment jsdom */
+import {
+  ResizableWorkspaceSidebar,
+  WORKSPACE_SIDEBAR_DEFAULT_WIDTH,
+  WORKSPACE_SIDEBAR_MAX_WIDTH,
+  WORKSPACE_SIDEBAR_MIN_WIDTH,
+  WORKSPACE_SIDEBAR_STORAGE_KEY,
+} from '@/pages/Workspace/components/ResizableWorkspaceSidebar';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/jest-globals';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+let containerWidth = 1200;
+
+function rect(width: number): DOMRect {
+  return {
+    width,
+    height: 600,
+    top: 0,
+    right: width,
+    bottom: 600,
+    left: 0,
+    x: 0,
+    y: 0,
+    toJSON: () => ({}),
+  };
+}
+
+// jsdom 无 PointerEvent 构造函数，RTL 的 fireEvent.pointerDown 会回退为普通 Event，
+// 丢失 button/clientX，导致组件的左键守卫与拖动数学失效。这里用预构造的 MouseEvent 交给
+// fireEvent 派发：既保留 button/clientX，又经由 act 同步提交状态（确保拖拽监听在移动前挂载）。
+// 真实浏览器中 PointerEvent 同样携带这些属性，组件行为一致。
+function dispatchPointer(
+  target: Element | Document,
+  type: string,
+  init: { button?: number; clientX?: number; bubbles?: boolean },
+) {
+  fireEvent(target, new MouseEvent(type, {
+    bubbles: init.bubbles ?? true,
+    cancelable: true,
+    button: init.button ?? 0,
+    clientX: init.clientX ?? 0,
+  }));
+}
+
+function renderSidebar() {
+  return render(
+    <div>
+      <ResizableWorkspaceSidebar ariaLabel="测试会话侧栏">
+        <div>列表内容</div>
+      </ResizableWorkspaceSidebar>
+      <main>消息区</main>
+    </div>,
+  );
+}
+
+describe('ResizableWorkspaceSidebar', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    containerWidth = 1200;
+    jest.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(() => rect(containerWidth));
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('默认使用 320px，并输出可访问宽度阈值', () => {
+    renderSidebar();
+
+    expect(screen.getByLabelText('测试会话侧栏')).toHaveStyle({ width: `${WORKSPACE_SIDEBAR_DEFAULT_WIDTH}px` });
+    expect(screen.getByRole('separator', { name: '调整对话协作左栏宽度' })).toHaveAttribute(
+      'aria-valuemin',
+      String(WORKSPACE_SIDEBAR_MIN_WIDTH),
+    );
+    expect(screen.getByRole('separator', { name: '调整对话协作左栏宽度' })).toHaveAttribute(
+      'aria-valuemax',
+      String(WORKSPACE_SIDEBAR_MAX_WIDTH),
+    );
+  });
+
+  it('常驻拖拽提示胶囊可见，不再提供快速收窄按钮', () => {
+    renderSidebar();
+    expect(screen.getByTestId('workspace-sidebar-grip')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: '收窄对话协作左栏' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: '展开对话协作左栏' })).not.toBeInTheDocument();
+  });
+
+  it('拖动时钳制宽度，松开后持久化', () => {
+    renderSidebar();
+    const sidebar = screen.getByLabelText('测试会话侧栏');
+    const separator = screen.getByRole('separator', { name: '调整对话协作左栏宽度' });
+
+    dispatchPointer(separator, 'pointerdown', { button: 0, clientX: 320 });
+    dispatchPointer(document, 'pointermove', { clientX: 800 });
+    expect(sidebar).toHaveStyle({ width: `${WORKSPACE_SIDEBAR_MAX_WIDTH}px` });
+    dispatchPointer(document, 'pointerup', { clientX: 800 });
+    expect(window.localStorage.getItem(WORKSPACE_SIDEBAR_STORAGE_KEY)).toBe(String(WORKSPACE_SIDEBAR_MAX_WIDTH));
+
+    dispatchPointer(separator, 'pointerdown', { button: 0, clientX: 480 });
+    dispatchPointer(document, 'pointermove', { clientX: 0 });
+    expect(sidebar).toHaveStyle({ width: `${WORKSPACE_SIDEBAR_MIN_WIDTH}px` });
+    dispatchPointer(document, 'pointerup', { clientX: 0 });
+    expect(window.localStorage.getItem(WORKSPACE_SIDEBAR_STORAGE_KEY)).toBe(String(WORKSPACE_SIDEBAR_MIN_WIDTH));
+  });
+
+  it('仅响应左键，右键不启动拖动', () => {
+    renderSidebar();
+    const sidebar = screen.getByLabelText('测试会话侧栏');
+    const separator = screen.getByRole('separator', { name: '调整对话协作左栏宽度' });
+
+    dispatchPointer(separator, 'pointerdown', { button: 2, clientX: 320 });
+    dispatchPointer(document, 'pointermove', { clientX: 800 });
+    expect(sidebar).toHaveStyle({ width: `${WORKSPACE_SIDEBAR_DEFAULT_WIDTH}px` });
+  });
+
+  it('支持键盘步进、阈值跳转和双击复位', () => {
+    renderSidebar();
+    const sidebar = screen.getByLabelText('测试会话侧栏');
+    const separator = screen.getByRole('separator', { name: '调整对话协作左栏宽度' });
+
+    fireEvent.keyDown(separator, { key: 'ArrowRight' });
+    expect(sidebar).toHaveStyle({ width: '328px' });
+    fireEvent.keyDown(separator, { key: 'ArrowRight', shiftKey: true });
+    expect(sidebar).toHaveStyle({ width: '352px' });
+    fireEvent.keyDown(separator, { key: 'Home' });
+    expect(sidebar).toHaveStyle({ width: `${WORKSPACE_SIDEBAR_MIN_WIDTH}px` });
+    fireEvent.keyDown(separator, { key: 'End' });
+    expect(sidebar).toHaveStyle({ width: `${WORKSPACE_SIDEBAR_MAX_WIDTH}px` });
+    fireEvent.doubleClick(separator);
+    expect(sidebar).toHaveStyle({ width: `${WORKSPACE_SIDEBAR_DEFAULT_WIDTH}px` });
+    expect(window.localStorage.getItem(WORKSPACE_SIDEBAR_STORAGE_KEY)).toBe(String(WORKSPACE_SIDEBAR_DEFAULT_WIDTH));
+  });
+
+  it('读取浏览器偏好，并按工作区宽度 45% 动态钳制', () => {
+    window.localStorage.setItem(WORKSPACE_SIDEBAR_STORAGE_KEY, '460');
+    containerWidth = 800;
+
+    renderSidebar();
+
+    expect(screen.getByLabelText('测试会话侧栏')).toHaveStyle({ width: '360px' });
+    expect(screen.getByRole('separator', { name: '调整对话协作左栏宽度' })).toHaveAttribute('aria-valuemax', '360');
+    expect(window.localStorage.getItem(WORKSPACE_SIDEBAR_STORAGE_KEY)).toBe('460');
+  });
+});

--- a/src/frontend-nextgen/test/pages/Workspace/components/SessionCard.test.tsx
+++ b/src/frontend-nextgen/test/pages/Workspace/components/SessionCard.test.tsx
@@ -1,6 +1,6 @@
 /** @jest-environment jsdom */
 import { Button } from '@/components/ui';
-import { SessionCard } from '@/pages/Workspace/components/SessionCard';
+import { formatSessionTime, SessionCard } from '@/pages/Workspace/components/SessionCard';
 import { describe, expect, it, jest } from '@jest/globals';
 import '@testing-library/jest-dom';
 import '@testing-library/jest-dom/jest-globals';
@@ -8,6 +8,16 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 describe('SessionCard', () => {
+  it('按固定时间分层展示相对时间', () => {
+    const now = new Date(2026, 8, 4, 15, 30);
+    expect(formatSessionTime('2026-09-04T09:05:00', now)).toBe('09:05');
+    expect(formatSessionTime('2026-09-03T23:05:00', now)).toBe('昨天');
+    expect(formatSessionTime('2026-09-01T12:00:00', now)).toBe('周二');
+    expect(formatSessionTime('2026-08-30T12:00:00', now)).toBe('08/30');
+    expect(formatSessionTime('2025-12-31T12:00:00', now)).toBe('2025/12/31');
+    expect(formatSessionTime('not-a-date', now)).toBe('');
+  });
+
   it('会话主触发区支持键盘选择,右侧操作不触发选择', async () => {
     const onSelect = jest.fn();
     const onAction = jest.fn();
@@ -24,7 +34,13 @@ describe('SessionCard', () => {
 
     const trigger = screen.getByRole('button', { name: /项目会话/ });
     expect(trigger).toHaveAttribute('aria-pressed', 'false');
-    expect(trigger.parentElement).toHaveClass('min-h-[70px]', 'border-t', 'bg-background');
+    expect(trigger.parentElement).toHaveClass(
+      'min-h-[60px]',
+      'border-b',
+      'last:border-b-0',
+      'bg-background',
+      'hover:bg-primary/5',
+    );
     trigger.focus();
     await userEvent.setup().keyboard('{Enter}');
     expect(onSelect).toHaveBeenCalledTimes(1);
@@ -32,6 +48,53 @@ describe('SessionCard', () => {
     fireEvent.click(screen.getByRole('button', { name: '会话操作' }));
     expect(onAction).toHaveBeenCalledTimes(1);
     expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+
+  it('使用圆点强化会话识别，选中态同步品牌色', () => {
+    const { container, rerender } = render(
+      <SessionCard title="普通会话" subtitle="暂无消息" selected={false} onSelect={jest.fn()} />,
+    );
+
+    const indicator = container.querySelector('[data-session-indicator]');
+    expect(indicator).toHaveClass(
+      'h-1.5',
+      'w-1.5',
+      'rounded-full',
+      'bg-muted-foreground/50',
+      'group-hover:bg-primary/60',
+    );
+    expect(container.querySelector('svg.lucide-message-square')).not.toBeInTheDocument();
+
+    rerender(<SessionCard title="当前会话" subtitle="3 条消息" selected onSelect={jest.fn()} />);
+
+    expect(container.querySelector('[data-session-indicator]')).toHaveClass('bg-primary');
+    expect(screen.getByText('当前会话')).toHaveClass('font-medium', 'text-primary');
+    expect(screen.getByText('3 条消息')).toHaveClass('text-primary/80');
+  });
+
+  it('Bot 与协作群会话都支持垂直居中的消息 Icon', () => {
+    const { container, rerender } = render(
+      <SessionCard title="Bot 会话" subtitle="暂无消息" indicator="message" selected={false} onSelect={jest.fn()} />,
+    );
+
+    const botMessageIcon = container.querySelector('svg.lucide-message-square');
+    expect(botMessageIcon).toBeInTheDocument();
+    expect(botMessageIcon?.parentElement).toHaveClass('self-center');
+
+    rerender(
+      <SessionCard title="协作群会话" subtitle="" indicator="message" selected={false} onSelect={jest.fn()} compact />,
+    );
+    const groupMessageIcon = container.querySelector('svg.lucide-message-square');
+    expect(groupMessageIcon).toBeInTheDocument();
+    expect(groupMessageIcon?.parentElement).toHaveClass('self-center');
+  });
+
+  it('选中会话输出当前态，但不复用对象行左侧指示线', () => {
+    const { container } = render(
+      <SessionCard title="当前会话" selected onSelect={jest.fn()} />,
+    );
+    expect(screen.getByRole('button', { name: /当前会话/ })).toHaveAttribute('aria-current', 'page');
+    expect(container.querySelector('[class~="w-0.5"][class~="bg-primary"]')).not.toBeInTheDocument();
   });
 
   it('无副行内容时使用紧凑行高，保留标准会话的双行高度', () => {
@@ -47,8 +110,8 @@ describe('SessionCard', () => {
     );
 
     const compactTrigger = screen.getByRole('button', { name: '协作群会话' });
-    expect(compactTrigger).toHaveClass('min-h-[56px]', 'items-center', 'py-2');
-    expect(compactTrigger.parentElement).toHaveClass('min-h-[56px]');
+    expect(compactTrigger).toHaveClass('min-h-12', 'items-center', 'py-2');
+    expect(compactTrigger.parentElement).toHaveClass('min-h-12');
     expect(compactTrigger.parentElement?.lastElementChild).toHaveClass('items-center');
 
     rerender(
@@ -56,7 +119,9 @@ describe('SessionCard', () => {
     );
 
     const standardTrigger = screen.getByRole('button', { name: /Bot 会话/ });
-    expect(standardTrigger).toHaveClass('min-h-[70px]', 'py-3');
-    expect(standardTrigger.parentElement).toHaveClass('min-h-[70px]');
+    expect(standardTrigger).toHaveClass('min-h-[60px]', 'py-2.5');
+    expect(standardTrigger.parentElement).toHaveClass('min-h-[60px]');
+    expect(standardTrigger.parentElement?.lastElementChild).toHaveClass('items-center', 'pt-2');
+    expect(standardTrigger.parentElement?.lastElementChild).not.toHaveClass('items-start', 'pt-3');
   });
 });

--- a/src/frontend-nextgen/test/pages/Workspace/hooks/useBotSessions.test.ts
+++ b/src/frontend-nextgen/test/pages/Workspace/hooks/useBotSessions.test.ts
@@ -53,6 +53,14 @@ it('展开 bot 时懒加载会话并缓存', async () => {
   await waitFor(() => expect(result.current.sessionsByBotId['b:1']).toHaveLength(2));
 });
 
+it('展开 bot 并加载会话后自动选中首条', async () => {
+  const { result } = renderHook(() => useBotSessions([bot], ['b:1'], 'human-1'));
+
+  await waitFor(() => expect(result.current.sessionsByBotId['b:1']).toHaveLength(2));
+  await waitFor(() => expect(result.current.selectedBotSessionId).toBe('s2'));
+  expect(result.current.selectedSession?.sessionId).toBe('s2');
+});
+
 it('createSession 选中新建会话并前置', async () => {
   const { result } = renderHook(() => useBotSessions([bot], ['b:1'], 'human-1'));
   await waitFor(() => expect(result.current.sessionsByBotId['b:1']).toBeDefined());

--- a/src/frontend-nextgen/test/pages/Workspace/hooks/useConnectionStatusSmoothing.test.ts
+++ b/src/frontend-nextgen/test/pages/Workspace/hooks/useConnectionStatusSmoothing.test.ts
@@ -1,0 +1,105 @@
+/** @jest-environment jsdom */
+import type { ProviderConnectionStatus } from '@tc-chat/adapters';
+import { DEFAULT_GRACE_MS, useConnectionStatusSmoothing } from '@/pages/Workspace/hooks/useConnectionStatusSmoothing';
+import { afterEach, beforeEach, expect, it, jest } from '@jest/globals';
+import { act, renderHook } from '@testing-library/react';
+
+beforeEach(() => { jest.useFakeTimers(); });
+afterEach(() => { jest.useRealTimers(); });
+
+const render = (initial: ProviderConnectionStatus) =>
+  renderHook((props: { v: ProviderConnectionStatus }) => useConnectionStatusSmoothing(props.v), {
+    initialProps: { v: initial },
+  });
+
+it('冷启动首连：初始 disconnected 即展示 connecting，不闪离线；成功后在线', () => {
+  const { result, rerender } = render('disconnected');
+  expect(result.current).toBe('connecting'); // 不显离线
+  rerender({ v: 'connecting' });
+  expect(result.current).toBe('connecting');
+  rerender({ v: 'connected' });
+  expect(result.current).toBe('connected');
+});
+
+it('会话切换：connected→disconnected→connecting→connected 全程连接中优先，不显离线', () => {
+  const { result, rerender } = render('connected');
+  expect(result.current).toBe('connected');
+  rerender({ v: 'disconnected' }); // 新 provider 初态
+  expect(result.current).toBe('connecting'); // 切换即先显连接中，不再闪离线
+  rerender({ v: 'connecting' });
+  expect(result.current).toBe('connecting');
+  rerender({ v: 'connected' });
+  expect(result.current).toBe('connected');
+});
+
+it('真实连不上：disconnected 持续超过宽限期才降级为离线', () => {
+  const { result, rerender } = render('disconnected');
+  expect(result.current).toBe('connecting'); // 宽限期内仍连接中
+  act(() => { jest.advanceTimersByTime(DEFAULT_GRACE_MS + 100); });
+  expect(result.current).toBe('disconnected'); // 超宽限仍未连上 → 离线
+  // 之后恢复 connected 立即展示在线
+  rerender({ v: 'connected' });
+  expect(result.current).toBe('connected');
+});
+
+it('会话切换中连不上超过宽限，也降级离线后再恢复', () => {
+  const { result, rerender } = render('connected');
+  rerender({ v: 'disconnected' });
+  expect(result.current).toBe('connecting');
+  act(() => { jest.advanceTimersByTime(DEFAULT_GRACE_MS + 100); });
+  expect(result.current).toBe('disconnected');
+  rerender({ v: 'connecting' });
+  expect(result.current).toBe('connecting');
+  rerender({ v: 'connected' });
+  expect(result.current).toBe('connected');
+});
+
+it('reconnecting / error 立即展示，不走宽限', () => {
+  const { result, rerender } = render('connected');
+  rerender({ v: 'reconnecting' });
+  expect(result.current).toBe('reconnecting');
+  rerender({ v: 'error' });
+  expect(result.current).toBe('error');
+  rerender({ v: 'connected' });
+  expect(result.current).toBe('connected');
+});
+
+it('连接中→离线→连接中→在线：中间瞬态 disconnected 不显离线', () => {
+  // 真实 emit 序列 connecting→disconnected→connecting→connected
+  const { result, rerender } = render('connecting');
+  expect(result.current).toBe('connecting');
+  rerender({ v: 'disconnected' }); // 中间瞬态
+  expect(result.current).toBe('connecting'); // 不显离线
+  rerender({ v: 'connecting' });
+  expect(result.current).toBe('connecting');
+  rerender({ v: 'connected' });
+  expect(result.current).toBe('connected');
+});
+
+it('连接中瞬态 disconnected 超宽限期才降级离线', () => {
+  const { result, rerender } = render('connecting');
+  rerender({ v: 'disconnected' });
+  expect(result.current).toBe('connecting'); // 宽限期内仍连接中
+  act(() => { jest.advanceTimersByTime(DEFAULT_GRACE_MS + 100); });
+  expect(result.current).toBe('disconnected'); // 超宽限无后续 connecting -> 离线
+  rerender({ v: 'connecting' });
+  expect(result.current).toBe('connecting');
+  rerender({ v: 'connected' });
+  expect(result.current).toBe('connected');
+});
+
+it('中间断连 ~4s（覆盖 SDK reconnectDelay=3s 重连等待）不显离线', () => {
+  const { result, rerender } = render('connecting');
+  rerender({ v: 'disconnected' });
+  expect(result.current).toBe('connecting');
+  act(() => { jest.advanceTimersByTime(4000); }); // 仍 < 5000ms 宽限
+  expect(result.current).toBe('connecting'); // 不闪离线
+  rerender({ v: 'reconnecting' });
+  expect(result.current).toBe('reconnecting');
+  rerender({ v: 'connected' });
+  expect(result.current).toBe('connected');
+});
+
+it('DEFAULT_GRACE_MS 默认宽限值为 5000ms', () => {
+  expect(DEFAULT_GRACE_MS).toBe(5000);
+});

--- a/src/frontend-nextgen/test/pages/Workspace/hooks/useWorkspacePage.botOnly.test.tsx
+++ b/src/frontend-nextgen/test/pages/Workspace/hooks/useWorkspacePage.botOnly.test.tsx
@@ -45,3 +45,99 @@ it('bot-only 单聊 URL 恢复用户身份并展开对应 Bot', async () => {
   expect(state.selectedBotSessionId).toBeNull();
   expect(sessionService.getSessionDetail).not.toHaveBeenCalled();
 });
+
+it('协作群外链 session= 仍会把身份切回用户并选中群/会话（保留邀请/外链直达行为）', async () => {
+  mockedUseSearchParams.mockReturnValue([
+    new URLSearchParams('tab=group&group=g1&session=s1'),
+    jest.fn(),
+  ] as unknown as ReturnType<typeof useSearchParams>);
+  useWorkspaceStore.setState({
+    identities: [
+      { id: 'human_2088', kind: 'user', displayName: '我', online: true },
+      { id: 'bot_old:2088', kind: 'bot', displayName: '旧 Bot', online: true },
+    ],
+    activeIdentityId: 'bot_old:2088',
+    view: 'group',
+    selectedBotSessionId: null,
+    selectedGroupId: null,
+    selectedSessionId: null,
+  });
+
+  renderHook(() => useWorkspacePage());
+  await act(async () => Promise.resolve());
+
+  const state = useWorkspaceStore.getState();
+  expect(state.activeIdentityId).toBe('human_2088');
+  expect(state.view).toBe('group');
+  expect(state.selectedGroupId).toBe('g1');
+  expect(state.selectedSessionId).toBe('s1');
+});
+
+it('挂载无 session= 时，Bot 身份不因协作群视图被切回用户', async () => {
+  mockedUseSearchParams.mockReturnValue([new URLSearchParams('tab=group'), jest.fn()] as unknown as ReturnType<
+    typeof useSearchParams
+  >);
+  useWorkspaceStore.setState({
+    identities: [
+      { id: 'human_2088', kind: 'user', displayName: '我', online: true },
+      { id: 'bot_old:2088', kind: 'bot', displayName: '旧 Bot', online: true },
+    ],
+    activeIdentityId: 'bot_old:2088',
+    view: 'group',
+    selectedBotSessionId: null,
+    selectedGroupId: null,
+    selectedSessionId: null,
+  });
+
+  renderHook(() => useWorkspacePage());
+  await act(async () => Promise.resolve());
+
+  const state = useWorkspaceStore.getState();
+  // 挂载时无外链 session=，不应触发身份切回用户；Bot 身份保持。
+  expect(state.activeIdentityId).toBe('bot_old:2088');
+  expect(sessionService.getSessionDetail).not.toHaveBeenCalled();
+});
+
+it('用户先选 Bot 身份再点击协作群（内部产生 session=）不应把身份切回用户', async () => {
+  // 用 live URLSearchParams + 透传 setter 模拟 store→URL 往返：点击协作群后由 Store→URL effect 写回 group=/session=。
+  const liveParams = new URLSearchParams('tab=group');
+  const setParams = jest.fn((next: unknown) => {
+    const np = typeof next === 'string' ? new URLSearchParams(next) : new URLSearchParams(String(next));
+    ['tab', 'group', 'session', 'bot'].forEach((k) => liveParams.delete(k));
+    np.forEach((v, k) => liveParams.set(k, v));
+  });
+  mockedUseSearchParams.mockReturnValue([
+    liveParams,
+    setParams as unknown as ReturnType<typeof useSearchParams>[1],
+  ] as unknown as ReturnType<typeof useSearchParams>);
+  useWorkspaceStore.setState({
+    identities: [
+      { id: 'human_2088', kind: 'user', displayName: '我', online: true },
+      { id: 'bot_old:2088', kind: 'bot', displayName: '旧 Bot', online: true },
+    ],
+    activeIdentityId: 'bot_old:2088',
+    view: 'group',
+    selectedBotSessionId: null,
+    selectedGroupId: null,
+    selectedSessionId: null,
+  });
+
+  const { rerender } = renderHook(() => useWorkspacePage());
+  await act(async () => Promise.resolve());
+  // 挂载时无外链 session=，身份保持 Bot。
+  expect(useWorkspaceStore.getState().activeIdentityId).toBe('bot_old:2088');
+
+  // 模拟在 Bot 身份下点击协作群：选中群 + 自动首个会话（内部选中，非外链）。
+  await act(async () => {
+    useWorkspaceStore.getState().selectGroup('g1');
+    useWorkspaceStore.getState().selectSession('s1');
+  });
+  // Store→URL effect 已把 group=/session= 写回 liveParams；触发一次重渲染让 URL→Store effect 读取新 URL。
+  rerender();
+  await act(async () => Promise.resolve());
+
+  const state = useWorkspaceStore.getState();
+  expect(state.activeIdentityId).toBe('bot_old:2088');
+  expect(state.selectedGroupId).toBe('g1');
+  expect(state.selectedSessionId).toBe('s1');
+});

--- a/src/frontend-nextgen/test/services/backendApi/collaboration/taskGrantController.test.ts
+++ b/src/frontend-nextgen/test/services/backendApi/collaboration/taskGrantController.test.ts
@@ -1,0 +1,66 @@
+import type { TaskClaimGrantStrategy } from '@/capabilities';
+import { grantTaskClaim, revokeTaskClaim } from '@/services/backendApi/collaboration/taskGrantController';
+import { backendRequest } from '@/services/backendApi/httpClient';
+import { isEnvelopeSuccess } from '@/services/backendApi/types';
+
+jest.mock('@/capabilities', () => ({
+  getCapabilities: jest.fn(),
+}));
+jest.mock('@/services/backendApi/httpClient', () => ({
+  backendRequest: jest.fn(),
+}));
+
+// getCapabilities 由 jest.mock 占位为 jest.fn；按用例注入返回的 capability 集合。
+import { getCapabilities } from '@/capabilities';
+const cap = getCapabilities as jest.Mock;
+const setStrategy = (strategy: TaskClaimGrantStrategy, apiBase = '/openapi/v1/collaboration/tasks') =>
+  cap.mockReturnValue({
+    getTaskClaimGrantStrategy: () => ({ status: 'available', value: strategy }),
+    getTaskApiBase: () => ({ status: 'available', value: apiBase }),
+  });
+
+describe('taskGrantController 任务认领授权策略', () => {
+  const be = backendRequest as jest.Mock;
+
+  beforeEach(() => {
+    be.mockReset();
+  });
+
+  test('skip 策略:grant 短路返回 granted 合成信封,不调后端', async () => {
+    setStrategy('skip');
+    const resp = await grantTaskClaim({ bcs_bot_id: 'bot:owner1' });
+    expect(be).not.toHaveBeenCalled();
+    expect(isEnvelopeSuccess(resp)).toBe(true);
+    expect(resp.data?.grant_status).toBe('granted');
+    expect(resp.data?.bcs_bot_id).toBe('bot:owner1');
+    expect(resp.data?.api_key_prefix).toBe('');
+  });
+
+  test('skip 策略:revoke 短路返回 revoked 合成信封,不调后端', async () => {
+    setStrategy('skip');
+    const resp = await revokeTaskClaim({ bcs_bot_id: 'bot:owner1' });
+    expect(be).not.toHaveBeenCalled();
+    expect(isEnvelopeSuccess(resp)).toBe(true);
+    expect(resp.data?.grant_status).toBe('revoked');
+  });
+
+  test('secbaas-relay 策略:grant 真调后端 /grant(透传 secbaas,不走短路)', async () => {
+    setStrategy('secbaas-relay', '/api/v1/collaboration/tasks');
+    be.mockResolvedValueOnce({ code: 200000, message: 'OK', data: {} });
+    await grantTaskClaim({ bcs_bot_id: 'bot:owner1' });
+    expect(be).toHaveBeenCalledTimes(1);
+    const [url, opts] = be.mock.calls[0];
+    expect(url).toBe('/api/v1/collaboration/tasks/grant');
+    expect(opts.method).toBe('POST');
+    expect(opts.data).toEqual({ bcs_bot_id: 'bot:owner1' });
+    expect(opts.injectUserId).toBe(false);
+  });
+
+  test('secbaas-relay 策略:revoke 真调后端 /revoke', async () => {
+    setStrategy('secbaas-relay', '/api/v1/collaboration/tasks');
+    be.mockResolvedValueOnce({ code: 200000, message: 'OK', data: {} });
+    await revokeTaskClaim({ bcs_bot_id: 'bot:owner1' });
+    expect(be).toHaveBeenCalledTimes(1);
+    expect(be.mock.calls[0][0]).toBe('/api/v1/collaboration/tasks/revoke');
+  });
+});

--- a/src/frontend-nextgen/test/services/backendApi/collaborationFriendConnectionController.test.ts
+++ b/src/frontend-nextgen/test/services/backendApi/collaborationFriendConnectionController.test.ts
@@ -71,7 +71,10 @@ describe('collaboration friend connection controller', () => {
   });
 
   it('lists current Human friend connections without injecting user_id', async () => {
-    backendRequest.mockResolvedValue({ code: 20000, data: { items: [], total: 0 } });
+    backendRequest.mockResolvedValue({
+      code: 20000,
+      data: { items: [{ actor: { type: 'bot', id: 'bot-1' }, is_online: false }], total: 1 },
+    });
 
     await listFriendConnections({ actor_type: 'human', actor_id: '327325' });
 

--- a/src/frontend-nextgen/test/services/collaborationSquare/collaborationSquareApiAdapter.test.ts
+++ b/src/frontend-nextgen/test/services/collaborationSquare/collaborationSquareApiAdapter.test.ts
@@ -513,7 +513,7 @@ describe('CollaborationSquareApiAdapter', () => {
     expect(result.map((bot) => bot.friendRequestBotId)).toEqual([undefined, undefined]);
   });
 
-  it('still enriches Discovery results with approved and pending Friend Connections', async () => {
+  it('enriches Discovery results with connected actors and pending Friend Connection requests', async () => {
     mockedDiscoverPublicBots.mockResolvedValue({
       code: 200000,
       data: {
@@ -563,9 +563,8 @@ describe('CollaborationSquareApiAdapter', () => {
       data: {
         items: [
           {
-            from_actor: { type: 'human', id: '327325' },
-            to_actor: { type: 'bot', id: 'bot-friend:e1' },
-            status: 'approved',
+            actor: { type: 'bot', id: 'bot-friend:e1' },
+            is_online: false,
           },
         ],
         total: 1,

--- a/src/frontend-nextgen/test/services/tasks/taskClaimQuery.test.ts
+++ b/src/frontend-nextgen/test/services/tasks/taskClaimQuery.test.ts
@@ -1,0 +1,92 @@
+import { listMyBots } from '@/services/backendApi/collaboration/collaborationBotController';
+import { isBotTaskClaimEnabled } from '@/services/tasks/taskClaimQuery';
+
+jest.mock('@/services/backendApi/collaboration/collaborationBotController', () => ({
+  listMyBots: jest.fn(),
+}));
+
+// 注意：不 mock `@/services/backendApi/types`，使用真实 isEnvelopeSuccessAnyDialect，
+// 验证 service 确实按「双方言并集」判成败（正是根因 bug 的复现点）。
+
+const mockedListMyBots = listMyBots as unknown as jest.Mock;
+
+const page = (items: Array<{ bot_id?: string; task_claim_mode?: boolean }>) => ({
+  items,
+  total: items.length,
+  offset: 0,
+  limit: 100,
+});
+
+describe('isBotTaskClaimEnabled —— mine 数据源 + 信封方言判定（执行前任务认领门禁）', () => {
+  beforeEach(() => mockedListMyBots.mockClear());
+
+  it('请求 mine 限 limit<=100（后端上限 100,>100 会 40000）', async () => {
+    mockedListMyBots.mockResolvedValue({
+      code: 20000,
+      message: 'OK',
+      data: page([{ bot_id: 'b1', task_claim_mode: true }]),
+    });
+    await isBotTaskClaimEnabled('b1');
+    expect(mockedListMyBots).toHaveBeenCalledWith(expect.objectContaining({ kind: 'bot', limit: 100 }));
+  });
+
+  it('mine 返回 BCS 5 位成功码(20000)+目标 Bot 已开启 → 放行(true)【根因回归点:旧 detail 实现误判】', async () => {
+    mockedListMyBots.mockResolvedValue({
+      code: 20000,
+      message: 'OK',
+      data: page([{ bot_id: 'b1', task_claim_mode: true }]),
+    });
+    await expect(isBotTaskClaimEnabled('b1')).resolves.toBe(true);
+  });
+
+  it('mine 返回 BCS 5 位成功码(20000)+目标 Bot 未开启 → 阻断(false)', async () => {
+    mockedListMyBots.mockResolvedValue({
+      code: 20000,
+      message: 'OK',
+      data: page([{ bot_id: 'b1', task_claim_mode: false }]),
+    });
+    await expect(isBotTaskClaimEnabled('b1')).resolves.toBe(false);
+  });
+
+  it('mine 返回 Python 6 位成功码(200000)+已开启 → 放行', async () => {
+    mockedListMyBots.mockResolvedValue({
+      code: 200000,
+      message: 'OK',
+      data: page([{ bot_id: 'b1', task_claim_mode: true }]),
+    });
+    await expect(isBotTaskClaimEnabled('b1')).resolves.toBe(true);
+  });
+
+  it('mine 返回 Python 6 位成功码(200000)+未开启 → 阻断', async () => {
+    mockedListMyBots.mockResolvedValue({
+      code: 200000,
+      message: 'OK',
+      data: page([{ bot_id: 'b1', task_claim_mode: false }]),
+    });
+    await expect(isBotTaskClaimEnabled('b1')).resolves.toBe(false);
+  });
+
+  it('目标 Bot 不在 mine（非当前用户可管理 Bot）→ 认领不适用,放行(true)', async () => {
+    mockedListMyBots.mockResolvedValue({
+      code: 20000,
+      message: 'OK',
+      data: page([{ bot_id: 'other', task_claim_mode: true }]),
+    });
+    await expect(isBotTaskClaimEnabled('b1')).resolves.toBe(true);
+  });
+
+  it('mine 列表为空 → 放行(true)', async () => {
+    mockedListMyBots.mockResolvedValue({ code: 20000, message: 'OK', data: page([]) });
+    await expect(isBotTaskClaimEnabled('b1')).resolves.toBe(true);
+  });
+
+  it('mine 业务错误码(40400,2xx HTTP 回包)→ 无法判定,放行(true)避免误伤', async () => {
+    mockedListMyBots.mockResolvedValue({ code: 40400, message: 'error', data: null });
+    await expect(isBotTaskClaimEnabled('b1')).resolves.toBe(true);
+  });
+
+  it('mine 请求抛异常(网络/鉴权)→ 放行(true)', async () => {
+    mockedListMyBots.mockRejectedValue(new Error('network'));
+    await expect(isBotTaskClaimEnabled('b1')).resolves.toBe(true);
+  });
+});

--- a/src/frontend-nextgen/test/shell/AppShellResponsive.test.tsx
+++ b/src/frontend-nextgen/test/shell/AppShellResponsive.test.tsx
@@ -39,6 +39,9 @@ jest.mock('@/shell/HelpMenu', () => ({ HelpMenu: () => <div data-testid="help" /
 // 内流一级侧栏桩化（避免 <lg 时内流与抽屉重复渲染同名导航项）；抽屉内容用的是真实 SidebarNavList。
 jest.mock('@/shell/AppSidebar', () => ({ AppSidebar: () => <aside data-testid="app-sidebar" /> }));
 jest.mock('@/shell/SpaceSwitcher', () => ({ SpaceSwitcher: () => <div data-testid="space-switcher" /> }));
+jest.mock('@/shell/WorkspaceIdentitySwitcher', () => ({
+  WorkspaceIdentitySwitcher: () => <div data-testid="identity-switcher" />,
+}));
 
 // Drawer 原语桩化为受控组件：open=true 渲染 children，open=false 渲染 null。
 // 规避 Radix Dialog 在 jsdom 下退出动画不触发导致内容不卸载的问题。

--- a/src/frontend-nextgen/test/shell/AppSidebar.test.tsx
+++ b/src/frontend-nextgen/test/shell/AppSidebar.test.tsx
@@ -10,24 +10,29 @@ import { render, screen } from '@testing-library/react';
 jest.mock('@/shell/SpaceSwitcher', () => ({
   SpaceSwitcher: () => <div data-testid="space-switcher">选择空间</div>,
 }));
+jest.mock('@/shell/WorkspaceIdentitySwitcher', () => ({
+  WorkspaceIdentitySwitcher: () => <div data-testid="identity-switcher">协作身份</div>,
+}));
 
 const renderSidebar = (area: NavigationArea) =>
   render(<AppSidebar area={area} activePath="/workspace" collapsed={false} items={[]} onNavigate={jest.fn()} />);
 
-// Open Core 默认 capabilities（spaceSwitcher=false）下的新语义：
-// 空间切换器为形态级入口（getShellVisibility），默认不渲染；空间数据链路不受影响（initSpaceContext 由 AppShell 触发）。
-it('Open 默认:工作区域不展示空间切换器', () => {
+it('工作区域在导航顶部展示协作身份入口，不展示空间切换器', () => {
   renderSidebar('work');
+  const nav = screen.getByRole('navigation', { name: '工作导航' });
+  expect(screen.getByTestId('identity-switcher')).toBeInTheDocument();
   expect(screen.queryByTestId('space-switcher')).not.toBeInTheDocument();
+  expect(nav.textContent?.indexOf('协作身份')).toBeLessThan(nav.textContent?.indexOf('工作') ?? -1);
 });
 
-it('Open 默认:管理区域也不展示空间切换器(spaceSwitcher=false)', () => {
+it('Open 默认:管理区域不展示空间切换器或协作身份入口', () => {
   renderSidebar('manage');
   expect(screen.queryByTestId('space-switcher')).not.toBeInTheDocument();
+  expect(screen.queryByTestId('identity-switcher')).not.toBeInTheDocument();
 });
 
 // extendCapabilities 合并后无法恢复，capability override 用例置于文件末尾。
-it('internal overlay:管理区域展示空间切换器(spaceSwitcher=true)', () => {
+it('internal overlay:管理区域在导航顶部展示空间切换器', () => {
   extendCapabilities({
     getShellVisibility: () => ({
       status: 'available',
@@ -35,5 +40,8 @@ it('internal overlay:管理区域展示空间切换器(spaceSwitcher=true)', () 
     }),
   });
   renderSidebar('manage');
+  const nav = screen.getByRole('navigation', { name: '管理导航' });
   expect(screen.getByTestId('space-switcher')).toBeInTheDocument();
+  expect(screen.queryByTestId('identity-switcher')).not.toBeInTheDocument();
+  expect(nav.textContent?.indexOf('选择空间')).toBeLessThan(nav.textContent?.indexOf('管理') ?? -1);
 });

--- a/src/frontend-nextgen/test/shell/SpaceSwitcher.test.tsx
+++ b/src/frontend-nextgen/test/shell/SpaceSwitcher.test.tsx
@@ -1,0 +1,43 @@
+/** @jest-environment jsdom */
+import { describe, expect, it, jest } from '@jest/globals';
+import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/jest-globals';
+import { render, screen } from '@testing-library/react';
+
+const space = {
+  spaceId: 10000,
+  spaceCode: 'personal',
+  spaceName: '个人空间',
+  spaceType: 'PERSONAL' as const,
+  joinStatus: 'JOINED' as const,
+  currentUserRole: 'ADMIN' as const,
+};
+
+jest.mock('@/hooks/useSpaceContext', () => ({
+  useSpaceContext: (selector: (state: unknown) => unknown) =>
+    selector({ currentSpace: space, currentSpaceId: space.spaceId, spaces: [space], loading: false, error: null }),
+  refreshSpaceContext: jest.fn(async () => undefined),
+  switchSpaceContext: jest.fn(),
+}));
+
+const { SpaceSwitcher } = require('@/shell/SpaceSwitcher') as typeof import('@/shell/SpaceSwitcher');
+
+describe('SpaceSwitcher', () => {
+  it('展示管理空间标题和切换卡片样式', () => {
+    render(<SpaceSwitcher />);
+
+    expect(screen.getByText('管理空间')).toBeInTheDocument();
+    expect(screen.queryByLabelText('管理空间说明')).not.toBeInTheDocument();
+    expect(screen.queryByText('“管理”下所有页面数据均按此空间展示')).not.toBeInTheDocument();
+    expect(screen.getByRole('img', { name: '个人空间图标' })).toHaveClass('h-6', 'w-6');
+    expect(screen.getByText('个人空间', { selector: 'span.truncate' })).toHaveClass('text-xs');
+    expect(screen.getByRole('button', { name: /个人空间/ })).toHaveClass(
+      'rounded-lg',
+      'border',
+      'bg-muted/60',
+      'min-h-9',
+      'px-2.5',
+      'py-1.5',
+    );
+  });
+});

--- a/src/frontend-nextgen/test/shell/WorkspaceIdentitySwitcher.test.tsx
+++ b/src/frontend-nextgen/test/shell/WorkspaceIdentitySwitcher.test.tsx
@@ -1,0 +1,44 @@
+/** @jest-environment jsdom */
+import { useWorkspaceStore } from '@/stores/workspaceStore';
+import { describe, expect, it, jest } from '@jest/globals';
+import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/jest-globals';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+const mockSwitchIdentity = jest.fn();
+
+jest.mock('@/hooks/useHumanIdentity', () => ({
+  useHumanIdentity: () => ({ identity: { avatarUrl: 'https://example.test/user.png' } }),
+}));
+jest.mock('@/services/workspace/workspaceService', () => ({
+  workspaceService: { switchIdentity: (...args: unknown[]) => mockSwitchIdentity(...args) },
+}));
+
+const { WorkspaceIdentitySwitcher } =
+  require('@/shell/WorkspaceIdentitySwitcher') as typeof import('@/shell/WorkspaceIdentitySwitcher');
+
+describe('WorkspaceIdentitySwitcher', () => {
+  it('从全局身份状态切换身份，不在弹层重复展示协作权限入口', async () => {
+    useWorkspaceStore.setState({
+      identities: [
+        { id: 'human-1', kind: 'user', displayName: '验收用户', online: true },
+        { id: 'bot-1', kind: 'bot', displayName: '协作 Bot', online: true },
+      ],
+      activeIdentityId: 'human-1',
+    });
+    render(<WorkspaceIdentitySwitcher />);
+
+    expect(screen.getByText('工作身份')).toBeInTheDocument();
+    expect(
+      screen.queryByText('当前协作身份决定在对话或群聊中，你以个人或指定 Bot 身份可查看的数据范围'),
+    ).not.toBeInTheDocument();
+    const trigger = screen.getByRole('button', { name: '当前协作身份：验收用户' });
+    expect(trigger).toHaveClass('rounded-lg', 'border', 'bg-muted/60', 'min-h-9', 'px-2.5', 'py-1.5');
+    expect(screen.queryByText('用户')).not.toBeInTheDocument();
+    fireEvent.click(trigger);
+    expect(screen.queryByRole('button', { name: '进入协作权限设置' })).not.toBeInTheDocument();
+    expect(await screen.findByText('用户')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /协作 Bot/ }));
+    expect(mockSwitchIdentity).toHaveBeenCalledWith('bot-1');
+  });
+});


### PR DESCRIPTION
## 问题

`src/frontend-nextgen` Open Core 前端落后于 TeamClaw 源码基线。最新的 TeamClaw Workspace 重构、Collaboration Square/Privacy 改进、组件更新以及缺失的 `openCollaborationPermissions` 修复尚未同步至 Avernet。

## 解决方案

通过仓库标准的 `export:avernet` 流水线，将最新的 TeamClaw Open Core 镜像导出至 `src/frontend-nextgen`。该流水线在独立环境中组装纯净的 Open Core 子集，运行全面验证，并仅在所有检查通过后同步至目标目录。

**源提交:** `33b21bc85961bfc5f448e2d12455f3b71c7d0100` (TeamClaw 分支 `sprint_teamclaw_S090011826218_20260806`)

本次导出包含 124 个变更文件：
- **Workspace 重构:** BotSessionSidebar, GroupSidebar, GroupChatPane, ChatSessionSidebarSlot, SessionCard/Toolbar, WorkspacePrimaryTabs
- **Collaboration Square:** BotCard, GroupCard, 搜索栏、目录面板、页面框架增强
- **Collaboration Privacy:** IdentityCard, PermissionCard, PublicationEditor, 隐私页面
- **Capabilities & domain:** collaboration square mapper/types 更新
- **UI 组件:** Segmented, PageHeader, TaskCardControls 优化
- **Bug 修复:** 恢复 PR 320 中缺失的 `openCollaborationPermissions` 函数定义（此前导致 TS2304 错误，阻塞了内部和 Open Core 的类型检查）

原有 `src/frontend` 应用未作修改。Open Core 泄漏扫描确认无内部路径、域名、token 或 `@alipay` 导入泄露至公共镜像中。

## 验证

所有检查均在隔离的导出镜像中通过，确认无误后才进行同步：

| 检查项 | 结果 |
| --- | --- |
| Open Core 泄漏检查 (`check:open-core`) | ✅ 已通过 |
| 类型检查 (`tsc --noEmit`) | ✅ 已通过 |
| 代码检查 (`max lint`) | ✅ 已通过 |
| 测试 (`jest --runInBand`) | ✅ 267 个测试套件，1890 个测试 — 全部通过 |
| 构建 (`max build`) | ✅ 编译耗时 13.08s |
| 包清单 (`npm pack --dry-run`) | ✅ 已通过 |

同步后验证：
- `OPEN_CORE_MANIFEST.json` sourceCommit 与 TeamClaw HEAD 一致：`33b21bc85961bfc5f448e2d12455f3b71c7d0100`
- `git diff --check`: 清洁（无空白字符错误或冲突标记）
- 124 个文件已变更，全部位于 `src/frontend-nextgen`
- `src/frontend` (原有): 0 个文件变更

## 兼容性与风险

- 源同步的 Open Core 导出；公共依赖集和 lockfile 与之前的导出保持不变。
- 保留了 `antd@6.6.1` 仅 SDK 使用的例外（作为 `@tc-chat/ui` / `@ant-design/x` 的 peer 依赖）；应用代码不直接导入 `antd`。
- 本次导出不涉及 Dockerfile、Nginx 模板或部署配置的变更。
- 变更处于未暂存状态 —— 审查后请按需暂存并提交。