### PR TITLE
fix(engine): reduce skill mapping source scans

### DIFF
--- a/src/backend/src/agentclaw/community/core/skill_center/bot_runtime_projector_protocol.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/bot_runtime_projector_protocol.py
@@ -6,15 +6,14 @@ from typing import Protocol, runtime_checkable
 from agentclaw.community.core.skill_center.runtime_projection_contract import (
     BotRuntimeProjectorProtocol as CoreBotRuntimeProjectorProtocol,
     ProjectionScope,
+    ResolvedSkillPlan,
     RuntimeProjectionResult,
 )
 from agentclaw.community.core.skills_pool.models import PoolSkillMapping
 
 
 @runtime_checkable
-class BotRuntimeProjectorProtocol(
-    CoreBotRuntimeProjectorProtocol, Protocol
-):
+class BotRuntimeProjectorProtocol(CoreBotRuntimeProjectorProtocol, Protocol):
     """Transport-facing contract; Core depends only on its sibling contract."""
 
     async def snapshot_skill_mappings(
@@ -29,6 +28,23 @@ class BotRuntimeProjectorProtocol(
         *,
         bot_id: str,
         owner_id: str,
+        retired_mappings: Sequence[PoolSkillMapping] = (),
+        scope: ProjectionScope,
+    ) -> RuntimeProjectionResult: ...
+
+    def resolve_plan(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+        retired_mappings: Sequence[PoolSkillMapping] = (),
+        scope: ProjectionScope,
+    ) -> ResolvedSkillPlan: ...
+
+    async def apply_plan(
+        self,
+        *,
+        plan: ResolvedSkillPlan,
         retired_mappings: Sequence[PoolSkillMapping] = (),
         scope: ProjectionScope,
     ) -> RuntimeProjectionResult: ...

--- a/src/backend/src/agentclaw/community/core/skill_center/runtime_projection_contract.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/runtime_projection_contract.py
@@ -152,7 +152,6 @@ class RuntimeProjectionResult:
             data["reason"] = self.reason
         return data
 
-
 @runtime_checkable
 class CapabilityRuntimeBoundary(Protocol):
     """The runtime writes a capability projection is allowed to make.
@@ -419,6 +418,7 @@ class ProjectionScope:
             released_mcp=self.claimed_mcp,
         )
 
+
 @runtime_checkable
 class BotRuntimeProjectorProtocol(Protocol):
     """Apply database desired state through the selected runtime authority."""
@@ -447,6 +447,27 @@ class BotRuntimeProjectorProtocol(Protocol):
         never the one a mutation wants. Callers with genuinely nothing to
         declare say so with ``ProjectionScope.everything()``.
         """
+        ...
+
+    def resolve_plan(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+        retired_mappings: Sequence[PoolSkillMapping] = (),
+        scope: ProjectionScope,
+    ) -> ResolvedSkillPlan:
+        """Resolve one immutable post-mutation plan without applying it."""
+        ...
+
+    async def apply_plan(
+        self,
+        *,
+        plan: ResolvedSkillPlan,
+        retired_mappings: Sequence[PoolSkillMapping] = (),
+        scope: ProjectionScope,
+    ) -> RuntimeProjectionResult:
+        """Apply the exact plan returned by ``resolve_plan``."""
         ...
 
     async def project_mcp_and_cli(

--- a/src/backend/src/agentclaw/community/core/skill_center/services/_mutation_flow.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/_mutation_flow.py
@@ -238,10 +238,12 @@ class MutationProjectionFlow:
             )
         try:
             snapshot_started_at = time.perf_counter()
-            current_mappings = await self._runtime.snapshot_skill_mappings(
+            plan = self._runtime.resolve_plan(
                 bot_id=bot_id,
                 owner_id=owner_id,
+                scope=scope,
             )
+            current_mappings = plan.projection.skill_mappings
         except Exception:
             return RuntimeProjectionResult.pending(
                 code="RUNTIME_SNAPSHOT_UNAVAILABLE",
@@ -257,13 +259,13 @@ class MutationProjectionFlow:
             scope=scope,
         )
         try:
-            projected = await self._runtime.project(
-                bot_id=bot_id,
-                owner_id=owner_id,
-                retired_mappings=retired_logical_skill_mappings(
-                    list(previous_mappings),
-                    list(current_mappings),
-                ),
+            retired_mappings = retired_logical_skill_mappings(
+                list(previous_mappings),
+                list(current_mappings),
+            )
+            projected = await self._runtime.apply_plan(
+                plan=plan,
+                retired_mappings=retired_mappings,
                 scope=scope,
             )
             # Existing in-process fakes and pre-change Runtime adapters return

--- a/src/backend/src/agentclaw/community/core/skill_center/services/bot_runtime_projector.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/bot_runtime_projector.py
@@ -130,11 +130,45 @@ class BotRuntimeProjector(BotRuntimeProjectorProtocol):
         retired_mappings: Sequence[PoolSkillMapping] = (),
         scope: ProjectionScope,
     ) -> RuntimeProjectionResult:
-        plan = self._resolve_plan(
+        plan = self.resolve_plan(
             bot_id=bot_id,
             owner_id=owner_id,
             retired_mappings=retired_mappings,
             scope=scope,
+        )
+        return await self.apply_plan(
+            plan=plan,
+            retired_mappings=retired_mappings,
+            scope=scope,
+        )
+
+    def resolve_plan(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+        retired_mappings: Sequence[PoolSkillMapping] = (),
+        scope: ProjectionScope,
+    ) -> ResolvedSkillPlan:
+        """Build the sole Reader-backed plan consumed by one projection."""
+        return self._resolve_plan(
+            bot_id=bot_id,
+            owner_id=owner_id,
+            retired_mappings=retired_mappings,
+            scope=scope,
+        )
+
+    async def apply_plan(
+        self,
+        *,
+        plan: ResolvedSkillPlan,
+        retired_mappings: Sequence[PoolSkillMapping] = (),
+        scope: ProjectionScope,
+    ) -> RuntimeProjectionResult:
+        """Apply one already-resolved plan without reading desired state again."""
+        self._registry.for_engine(plan.engine).validate_plan(
+            skill_assets=plan.projection.skill_assets,
+            retired_mappings=retired_mappings,
         )
         if scope.mcp and not isinstance(plan, ResolvedCapabilityPlan):
             # Contract guard before any engine write: an MCP scope must never

--- a/src/backend/tests/community/contracts/test_bot_runtime_projector.py
+++ b/src/backend/tests/community/contracts/test_bot_runtime_projector.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 from injector import inject, singleton
 
@@ -10,6 +12,7 @@ from agentclaw.community.api.bot_runtime_projector import (
 )
 from agentclaw.community.core.skill_center.runtime_projection_contract import (
     BotRuntimeProjectorProtocol as CoreBotRuntimeProjectorProtocol,
+    ProjectionScope,
 )
 from agentclaw.community.core.skill_center.services.bot_runtime_projector import (
     BotRuntimeProjector,
@@ -32,6 +35,17 @@ class _RecordingReconciler:
         if self.error is not None:
             raise self.error
 
+    def resolve_plan(self, **kwargs):
+        self.calls.append({"operation": "resolve_plan", **kwargs})
+        if self.error is not None:
+            raise self.error
+        return SimpleNamespace(projection=SimpleNamespace(skill_mappings=()))
+
+    async def apply_plan(self, **kwargs) -> None:
+        self.calls.append({"operation": "apply_plan", **kwargs})
+        if self.error is not None:
+            raise self.error
+
     async def project_mcp_and_cli(self, **kwargs) -> None:
         self.calls.append({"operation": "non_skill", **kwargs})
         if self.error is not None:
@@ -48,6 +62,15 @@ class _Consumer:
 
     async def snapshot_skill_mappings(self) -> None:
         await self._runtime.snapshot_skill_mappings(bot_id="bot-1", owner_id="owner-1")
+
+    async def resolve_and_apply(self) -> None:
+        scope = ProjectionScope(skills=True)
+        plan = self._runtime.resolve_plan(
+            bot_id="bot-1",
+            owner_id="owner-1",
+            scope=scope,
+        )
+        await self._runtime.apply_plan(plan=plan, scope=scope)
 
     async def refresh_non_skill(self) -> None:
         await self._runtime.project_mcp_and_cli(
@@ -98,6 +121,18 @@ async def test_snapshot_service_api_reads_without_reconciliation(world) -> None:
     assert runtime.calls == [
         {"operation": "snapshot", "bot_id": "bot-1", "owner_id": "owner-1"}
     ]
+
+
+@pytest.mark.asyncio
+async def test_resolved_plan_service_api_applies_the_same_plan(world) -> None:
+    runtime = _RecordingReconciler()
+    consumer = _consumer(world, runtime)
+
+    await consumer.resolve_and_apply()
+
+    assert runtime.calls[0]["operation"] == "resolve_plan"
+    assert runtime.calls[1]["operation"] == "apply_plan"
+    assert runtime.calls[1]["plan"].projection.skill_mappings == ()
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/community/core/skill_center/test_direct_activation_service.py
+++ b/src/backend/tests/community/core/skill_center/test_direct_activation_service.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
 from dataclasses import replace
@@ -144,6 +146,20 @@ class _SuccessfulRuntime:
 
     async def project(self, **_kwargs) -> None:
         return None
+
+    def resolve_plan(self, *, bot_id: str, owner_id: str, **_kwargs):
+        return SimpleNamespace(
+            bot_id=bot_id,
+            owner_id=owner_id,
+            projection=SimpleNamespace(skill_mappings=()),
+        )
+
+    async def apply_plan(self, *, plan, **kwargs) -> None:
+        await self.project(
+            bot_id=plan.bot_id,
+            owner_id=plan.owner_id,
+            **kwargs,
+        )
 
 
 class _ScopeRecordingRuntime(_SuccessfulRuntime):
@@ -646,6 +662,9 @@ class _NeverProjects(_SuccessfulRuntime):
 
     async def project(self, **_kwargs) -> None:
         raise AssertionError("record-only activation must not project")
+
+    def resolve_plan(self, **_kwargs):
+        raise AssertionError("record-only activation must not resolve a plan")
 
 
 class _PendingBotsForRecordOnly(_Bots):

--- a/src/backend/tests/community/core/skill_center/test_mutation_flow_timing.py
+++ b/src/backend/tests/community/core/skill_center/test_mutation_flow_timing.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from types import SimpleNamespace
 
 import pytest
 
@@ -10,9 +11,14 @@ from agentclaw.community.core.repository.capability_desired_state_types import (
 )
 from agentclaw.community.core.skill_center.runtime_projection_contract import (
     ProjectionScope,
+    RuntimeProjectionResult,
 )
+from agentclaw.community.core.skills_pool.models import PoolSkillMapping
 from agentclaw.community.core.skill_center.services._mutation_flow import (
     MutationProjectionFlow,
+)
+from agentclaw.community.core.skill_center.services.bot_runtime_projector import (
+    BotRuntimeProjector,
 )
 
 
@@ -22,11 +28,59 @@ class _Repository:
 
 
 class _Runtime:
+    def __init__(self) -> None:
+        self.plan = SimpleNamespace(
+            projection=SimpleNamespace(skill_mappings=())
+        )
+
     async def snapshot_skill_mappings(self, **_kwargs):
         return ()
 
     async def project(self, **_kwargs) -> None:
         return None
+
+    def resolve_plan(self, **_kwargs):
+        return self.plan
+
+    async def apply_plan(self, **_kwargs) -> None:
+        return None
+
+
+class _PlanRuntime:
+    def __init__(self) -> None:
+        self.before = (
+            PoolSkillMapping(corpus="local", relative_path="old", link_name="old"),
+        )
+        self.after = (
+            PoolSkillMapping(corpus="repo", relative_path="new", link_name="new"),
+        )
+        self.plan = SimpleNamespace(
+            projection=SimpleNamespace(skill_mappings=self.after)
+        )
+        self.snapshot_calls = 0
+        self.resolve_calls = 0
+        self.applied_plan = None
+        self.retired_mappings = ()
+        self.fail_resolve = False
+        self.fail_apply_once = False
+
+    async def snapshot_skill_mappings(self, **_kwargs):
+        self.snapshot_calls += 1
+        return self.before
+
+    def resolve_plan(self, **_kwargs):
+        self.resolve_calls += 1
+        if self.fail_resolve:
+            raise RuntimeError("plan unavailable")
+        return self.plan
+
+    async def apply_plan(self, *, plan, retired_mappings, **_kwargs):
+        self.applied_plan = plan
+        self.retired_mappings = tuple(retired_mappings)
+        if self.fail_apply_once:
+            self.fail_apply_once = False
+            raise RuntimeError("runtime unavailable")
+        return RuntimeProjectionResult.converged()
 
 
 @pytest.mark.asyncio
@@ -75,3 +129,111 @@ async def test_mutation_flow_logs_control_plane_timing_stages(caplog) -> None:
             and "duration_ms=" in message
             for message in messages
         )
+
+
+@pytest.mark.asyncio
+async def test_mutation_flow_applies_the_single_post_mutation_plan() -> None:
+    runtime = _PlanRuntime()
+    flow = MutationProjectionFlow(repository=_Repository(), runtime=runtime)
+
+    await flow.apply(
+        bot={"owner_id": "owner-1", "status": "ACTIVE"},
+        bot_id="bot-1",
+        engine_type="openclaw",
+        scope=ProjectionScope(skills=True),
+        mutation=lambda: DesiredStateMutation(
+            item={"id": "set-1"},
+            changed=True,
+            previous_state=CapabilityDesiredState(
+                installations=set(),
+                set_active={},
+                memberships={},
+            ),
+        ),
+    )
+
+    assert runtime.snapshot_calls == 1
+    assert runtime.resolve_calls == 1
+    assert runtime.applied_plan is runtime.plan
+    assert runtime.retired_mappings == runtime.before
+
+
+@pytest.mark.asyncio
+async def test_mutation_flow_preserves_plan_failure_and_retry_outcomes() -> None:
+    runtime = _PlanRuntime()
+    flow = MutationProjectionFlow(repository=_Repository(), runtime=runtime)
+    mutation = lambda: DesiredStateMutation(
+        item={"id": "set-1"},
+        changed=True,
+        previous_state=CapabilityDesiredState(
+            installations=set(), set_active={}, memberships={}
+        ),
+    )
+
+    runtime.fail_resolve = True
+    unresolved = await flow.apply(
+        bot={"owner_id": "owner-1", "status": "ACTIVE"},
+        bot_id="bot-1",
+        engine_type="openclaw",
+        scope=ProjectionScope(skills=True),
+        mutation=mutation,
+    )
+    runtime.fail_resolve = False
+    runtime.fail_apply_once = True
+    unavailable = await flow.apply(
+        bot={"owner_id": "owner-1", "status": "ACTIVE"},
+        bot_id="bot-1",
+        engine_type="openclaw",
+        scope=ProjectionScope(skills=True),
+        mutation=mutation,
+    )
+    retried = await flow.apply(
+        bot={"owner_id": "owner-1", "status": "ACTIVE"},
+        bot_id="bot-1",
+        engine_type="openclaw",
+        scope=ProjectionScope(skills=True),
+        mutation=mutation,
+    )
+
+    assert unresolved["runtime_projection"]["issues"][0]["code"] == "RUNTIME_SNAPSHOT_UNAVAILABLE"
+    assert unavailable["runtime_projection"]["issues"][0]["code"] == "RUNTIME_PROJECTION_UNAVAILABLE"
+    assert retried["runtime_projection"]["status"] == "CONVERGED"
+    assert runtime.resolve_calls == 3
+
+
+@pytest.mark.asyncio
+async def test_apply_plan_validates_retired_mappings_before_runtime_write() -> None:
+    class _Engine:
+        def __init__(self) -> None:
+            self.validated_retired = ()
+
+        def validate_plan(self, *, retired_mappings=(), **_kwargs) -> None:
+            self.validated_retired = tuple(retired_mappings)
+
+        async def apply(self, **_kwargs):
+            return RuntimeProjectionResult.converged()
+
+    class _Registry:
+        def __init__(self, engine) -> None:
+            self.engine = engine
+
+        def for_engine(self, _name):
+            return self.engine
+
+    engine = _Engine()
+    projector = object.__new__(BotRuntimeProjector)
+    projector._registry = _Registry(engine)
+    plan = SimpleNamespace(
+        engine="openclaw",
+        bot_id="bot-1",
+        projection=SimpleNamespace(skill_assets=()),
+    )
+    retired = (PoolSkillMapping(corpus="local", relative_path="old", link_name="old"),)
+
+    await projector.apply_plan(
+        plan=plan,
+        retired_mappings=retired,
+        scope=ProjectionScope(skills=True),
+    )
+
+    assert engine.validated_retired == retired

--- a/src/backend/tests/community/core/skill_center/test_skill_set_management_service.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_set_management_service.py
@@ -283,6 +283,23 @@ class _Runtime:
         self.snapshot_calls.append({"bot_id": bot_id, "owner_id": owner_id})
         return self._snapshots[len(self.snapshot_calls) - 1]
 
+    def resolve_plan(self, *, bot_id: str, owner_id: str, **_kwargs):
+        assert bot_id == "bot-1"
+        self.snapshot_calls.append({"bot_id": bot_id, "owner_id": owner_id})
+        mappings = self._snapshots[len(self.snapshot_calls) - 1]
+        return SimpleNamespace(
+            bot_id=bot_id,
+            owner_id=owner_id,
+            projection=SimpleNamespace(skill_mappings=mappings),
+        )
+
+    async def apply_plan(self, *, plan, **kwargs) -> None:
+        await self.project(
+            bot_id=plan.bot_id,
+            owner_id=plan.owner_id,
+            **kwargs,
+        )
+
     async def project(
         self,
         *,
@@ -337,6 +354,20 @@ class _SuccessfulRuntime:
 
     async def project(self, **_kwargs) -> None:
         return None
+
+    def resolve_plan(self, *, bot_id: str, owner_id: str, **_kwargs):
+        return SimpleNamespace(
+            bot_id=bot_id,
+            owner_id=owner_id,
+            projection=SimpleNamespace(skill_mappings=()),
+        )
+
+    async def apply_plan(self, *, plan, **kwargs) -> None:
+        await self.project(
+            bot_id=plan.bot_id,
+            owner_id=plan.owner_id,
+            **kwargs,
+        )
 
 
 

--- a/src/backend/tests/community/endpoints/test_openapi_skill_sets.py
+++ b/src/backend/tests/community/endpoints/test_openapi_skill_sets.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 import time
+from types import SimpleNamespace
 
 import jwt
 
@@ -91,6 +92,20 @@ class _Runtime:
 
     async def project(self, *, bot_id: str, owner_id: str, **_kwargs) -> None:
         self.calls.append((bot_id, owner_id))
+
+    def resolve_plan(self, *, bot_id: str, owner_id: str, **_kwargs):
+        return SimpleNamespace(
+            bot_id=bot_id,
+            owner_id=owner_id,
+            projection=SimpleNamespace(skill_mappings=()),
+        )
+
+    async def apply_plan(self, *, plan, **kwargs) -> None:
+        await self.project(
+            bot_id=plan.bot_id,
+            owner_id=plan.owner_id,
+            **kwargs,
+        )
 
 
 def _principal() -> str:

--- a/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import re
+import stat
+import time
 from collections.abc import Callable, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from enum import StrEnum
 from pathlib import Path
@@ -39,6 +42,9 @@ from engine.community.plugins.skills_pool.layout_sync import (
     mirror_local_tree,
     write_baseline_manifest,
 )
+
+logger = logging.getLogger(__name__)
+_SLOW_SOURCE_LIMIT = 3
 
 
 class PoolActivationStatus(StrEnum):
@@ -739,6 +745,99 @@ def _managed_source_failure(
     return None
 
 
+@dataclass(slots=True)
+class _BestEffortSourceInspection:
+    """Request-local, bounded source checks for ordinary runtime projection."""
+
+    layout: _Layout
+    source_layout: MappingSourceLayout
+    results: dict[Path, str | None] = field(default_factory=dict)
+    resolved_roots: dict[Path, Path | None] = field(default_factory=dict)
+    durations_ms: dict[Path, float] = field(default_factory=dict)
+    checks: int = 0
+    cache_hits: int = 0
+
+    def failure(self, source: Path) -> str | None:
+        normalized = Path(os.path.abspath(source))
+        if normalized in self.results:
+            self.cache_hits += 1
+            return self.results[normalized]
+        started_at = time.perf_counter()
+        result = self._inspect(normalized)
+        self.checks += 1
+        self.results[normalized] = result
+        self.durations_ms[normalized] = (time.perf_counter() - started_at) * 1000
+        return result
+
+    def _inspect(self, source: Path) -> str | None:
+        roots, outside_reason = self._roots()
+        containing_root: Path | None = None
+        for root in roots:
+            normalized_root = Path(os.path.abspath(root))
+            if source.is_relative_to(normalized_root):
+                containing_root = normalized_root
+                break
+        if containing_root is None:
+            return outside_reason
+        try:
+            source_stat = source.stat()
+        except FileNotFoundError:
+            return "source_missing"
+        except OSError:
+            return "source_unreadable"
+        if not stat.S_ISDIR(source_stat.st_mode):
+            return "source_not_directory"
+        resolved_root = self._resolved_root(containing_root)
+        if resolved_root is None:
+            return "source_unreadable"
+        try:
+            if not source.resolve(strict=True).is_relative_to(resolved_root):
+                return "source_escapes_pool"
+        except OSError:
+            return "source_unreadable"
+        if not os.access(source, os.R_OK | os.X_OK):
+            return "source_unreadable"
+        return None
+
+    def _resolved_root(self, root: Path) -> Path | None:
+        if root not in self.resolved_roots:
+            try:
+                self.resolved_roots[root] = root.resolve(strict=True)
+            except OSError:
+                self.resolved_roots[root] = None
+        return self.resolved_roots[root]
+
+    def _roots(self) -> tuple[tuple[Path, ...], str]:
+        if self.source_layout is MappingSourceLayout.LEGACY:
+            roots = [
+                self.layout.legacy_local,
+                self.layout.legacy_repo,
+                self.layout.pool_center,
+            ]
+            if self.layout.engine_type == "claude_code":
+                roots.append(self.layout.repo_bridge)
+            return tuple(roots), "source_outside_legacy"
+        return (
+            self.layout.pool_local,
+            self.layout.pool_repo,
+            self.layout.pool_center,
+        ), "source_outside_pool"
+
+    def evidence(self) -> dict[str, object]:
+        slowest = sorted(
+            self.durations_ms.items(), key=lambda item: item[1], reverse=True
+        )[:_SLOW_SOURCE_LIMIT]
+        return {
+            "source_checks": self.checks,
+            "source_check_cache_hits": self.cache_hits,
+            "unique_sources": len(self.results),
+            "slow_sources": [
+                {"name": source.name, "duration_ms": round(duration_ms, 3)}
+                for source, duration_ms in slowest
+            ],
+        }
+
+
 def _source_failure(
     layout: _Layout,
     source: Path,
@@ -1028,6 +1127,7 @@ def _best_effort_desired(
     layout: _Layout,
     mappings: Sequence[SkillMapping],
     source_layout: MappingSourceLayout,
+    inspection: _BestEffortSourceInspection,
 ) -> tuple[dict[Path, Path], list[MappingItemResult]]:
     """Classify requested mappings without treating source availability as unsafe.
 
@@ -1068,11 +1168,7 @@ def _best_effort_desired(
                 )
             )
             continue
-        source_reason = _source_failure(
-            layout,
-            source,
-            source_layout=source_layout,
-        )
+        source_reason = inspection.failure(source)
         if source_reason not in {None, "source_missing", "source_unreadable"}:
             outcomes.append(
                 MappingItemResult(
@@ -1157,13 +1253,27 @@ def _best_effort_retire(
                 )
             )
             continue
-        if not target.exists() and not target.is_symlink():
+        try:
+            target.lstat()
+        except FileNotFoundError:
             absent.append(str(target))
             outcomes.append(
                 MappingItemResult(
                     target=str(target),
                     source=str(source),
                     status=MappingProjectionStatus.CONVERGED,
+                    action="RETIRE",
+                )
+            )
+            continue
+        except OSError:
+            outcomes.append(
+                MappingItemResult(
+                    target=str(target),
+                    source=str(source),
+                    status=MappingProjectionStatus.PENDING,
+                    code="MAPPING_PUBLISH_IO_ERROR",
+                    retryable=True,
                     action="RETIRE",
                 )
             )
@@ -1211,7 +1321,7 @@ def _best_effort_retire(
                 )
                 continue
             removed.append(str(target))
-        elif target.exists() or target.is_symlink():
+        else:
             outcomes.append(
                 MappingItemResult(
                     target=str(target),
@@ -1244,11 +1354,20 @@ def _best_effort_mapping_results(
 ) -> tuple[tuple[MappingItemResult, ...], dict[str, object]]:
     """Apply or inspect one full desired mapping set without touching unknown data."""
 
+    started_at = time.perf_counter()
+    inspection = _BestEffortSourceInspection(
+        layout=layout,
+        source_layout=source_layout,
+    )
+    classify_started_at = time.perf_counter()
     desired, outcomes = _best_effort_desired(
         layout=layout,
         mappings=mappings,
         source_layout=source_layout,
+        inspection=inspection,
     )
+    classify_ms = (time.perf_counter() - classify_started_at) * 1000
+    retire_started_at = time.perf_counter()
     retired, removed, absent = _best_effort_retire(
         layout=layout,
         retired_mappings=retired_mappings,
@@ -1257,14 +1376,18 @@ def _best_effort_mapping_results(
         additional_retirement_roots=additional_retirement_roots,
         apply=apply,
     )
+    retire_ms = (time.perf_counter() - retire_started_at) * 1000
     outcomes.extend(retired)
 
+    inventory_started_at = time.perf_counter()
     discovered, external, occupied = _active_entry_inventory(layout)
+    inventory_ms = (time.perf_counter() - inventory_started_at) * 1000
     external_targets = set(external)
     occupied_targets = set(occupied)
     created: list[str] = []
     updated: list[str] = []
     kept: list[str] = []
+    reconcile_started_at = time.perf_counter()
     for target, source in desired.items():
         if target in external_targets:
             outcomes.append(
@@ -1286,11 +1409,7 @@ def _best_effort_mapping_results(
                 )
             )
             continue
-        source_reason = _source_failure(
-            layout,
-            source,
-            source_layout=source_layout,
-        )
+        source_reason = inspection.failure(source)
         pending = source_reason in {"source_missing", "source_unreadable"}
         if not apply:
             if not target.is_symlink() or _lexical_target(target) != source:
@@ -1352,19 +1471,21 @@ def _best_effort_mapping_results(
                 retryable=pending,
             )
         )
+    reconcile_ms = (time.perf_counter() - reconcile_started_at) * 1000
 
     # A previously published managed link is preserved by the full-snapshot
     # contract.  Report its missing source as pending so unrelated product
     # mutations do not hide existing runtime drift.
+    retired_targets = {Path(item.target) for item in retired_mappings}
     for target, pool_source in discovered.items():
-        if target in desired or target in {Path(item.target) for item in retired_mappings}:
+        if target in desired or target in retired_targets:
             continue
         source = _source_for_layout(
             layout,
             pool_source,
             source_layout=source_layout,
         )
-        reason = _source_failure(layout, source, source_layout=source_layout)
+        reason = inspection.failure(source)
         if reason in {"source_missing", "source_unreadable"}:
             outcomes.append(
                 MappingItemResult(
@@ -1376,7 +1497,7 @@ def _best_effort_mapping_results(
                 )
             )
 
-    return tuple(outcomes), {
+    evidence = {
         "total": len(desired),
         "created": created,
         "updated": updated,
@@ -1384,7 +1505,36 @@ def _best_effort_mapping_results(
         "removed": removed,
         "retired_absent": absent,
         "external_ignored": [str(path) for path in external],
+        **inspection.evidence(),
+        "source_check_ms": round(sum(inspection.durations_ms.values()), 3),
+        "classify_ms": round(classify_ms, 3),
+        "retire_ms": round(retire_ms, 3),
+        "inventory_ms": round(inventory_ms, 3),
+        "reconcile_ms": round(reconcile_ms, 3),
+        "duration_ms": round((time.perf_counter() - started_at) * 1000, 3),
     }
+    logger.info(
+        "[SkillsPoolMapping] best_effort apply=%s duration_ms=%s desired=%s "
+        "retired=%s inventory=%s source_checks=%s source_cache_hits=%s "
+        "source_check_ms=%s classify_ms=%s retire_ms=%s inventory_ms=%s "
+        "reconcile_ms=%s "
+        "slow_sources=%s status=%s",
+        apply,
+        evidence["duration_ms"],
+        len(desired),
+        len(retired_mappings),
+        len(discovered) + len(external) + len(occupied),
+        evidence["source_checks"],
+        evidence["source_check_cache_hits"],
+        evidence["source_check_ms"],
+        evidence["classify_ms"],
+        evidence["retire_ms"],
+        evidence["inventory_ms"],
+        evidence["reconcile_ms"],
+        evidence["slow_sources"],
+        _mapping_status(outcomes).value,
+    )
+    return tuple(outcomes), evidence
 
 
 def _retirement_plan(

--- a/src/engine/src/engine/community/plugins/skills_pool/tests/test_mapping_retirement.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/tests/test_mapping_retirement.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
+from unittest.mock import Mock
 
 import pytest
 
@@ -80,6 +82,129 @@ def test_best_effort_mapping_keeps_unmanaged_entry_and_publishes_safe_entries(
     assert verified.to_data()["items"] == [
         item.to_data() for item in verified.items
     ]
+
+
+@pytest.mark.parametrize(
+    ("engine", "source_layout", "source_root"),
+    [
+        ("openclaw", MappingSourceLayout.POOL, "pool_local"),
+        ("claude_code", MappingSourceLayout.LEGACY, "legacy_repo"),
+        ("hermes", MappingSourceLayout.POOL, "pool_center"),
+    ],
+)
+def test_best_effort_uses_one_bounded_source_check_per_request(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    engine: str,
+    source_layout: MappingSourceLayout,
+    source_root: str,
+) -> None:
+    home = tmp_path / "home/admin"
+    layout = _Layout.for_engine(engine, home)
+    layout.active_root.mkdir(parents=True)
+    source = getattr(layout, source_root) / "nested" / "sample"
+    source.mkdir(parents=True)
+    for index in range(500):
+        (source / f"asset-{index}.txt").write_text("payload")
+    (source / "unreadable-child").write_text("still not inspected")
+    target = layout.active_root / "sample"
+
+    monkeypatch.setattr(
+        os,
+        "walk",
+        Mock(side_effect=AssertionError("BEST_EFFORT must not recurse")),
+    )
+    published = publish_pool_mappings(
+        mappings=[SkillMapping(str(source), str(target))],
+        home=home,
+        engine=engine,
+        source_layout=source_layout,
+        apply_mode=MappingApplyMode.BEST_EFFORT,
+    )
+    verified = verify_skill_mappings(
+        mappings=[SkillMapping(str(source), str(target))],
+        home=home,
+        engine=engine,
+        source_layout=source_layout,
+        apply_mode=MappingApplyMode.BEST_EFFORT,
+    )
+
+    assert published.status == "CONVERGED"
+    assert verified.status == "CONVERGED"
+    assert published.evidence["source_checks"] == 1
+    assert published.evidence["source_check_cache_hits"] == 1
+    assert verified.evidence["source_checks"] == 1
+    assert verified.evidence["source_check_cache_hits"] == 1
+
+
+def test_best_effort_retirement_does_not_follow_dangling_source(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home/admin"
+    layout = _Layout.for_engine("openclaw", home)
+    layout.active_root.mkdir(parents=True)
+    retired_source = layout.pool_repo / "removed" / "skill"
+    target = layout.active_root / "skill"
+    target.symlink_to(retired_source, target_is_directory=True)
+    monkeypatch.setattr(
+        Path,
+        "exists",
+        Mock(side_effect=AssertionError("retirement must use lstat")),
+    )
+    published = publish_pool_mappings(
+        mappings=[],
+        retired_mappings=[SkillMapping(str(retired_source), str(target))],
+        home=home,
+        engine="openclaw",
+        apply_mode=MappingApplyMode.BEST_EFFORT,
+    )
+
+    assert published.status == "CONVERGED"
+    assert not target.is_symlink()
+
+
+def test_best_effort_preserves_bounded_source_safety_and_availability(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home/admin"
+    layout = _Layout.for_engine("openclaw", home)
+    layout.active_root.mkdir(parents=True)
+    unreadable = layout.pool_local / "unreadable"
+    unreadable.mkdir(parents=True)
+    ordinary_file = layout.pool_local / "ordinary-file"
+    ordinary_file.write_text("not a directory")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    escaping = layout.pool_repo / "escaping"
+    escaping.parent.mkdir(parents=True)
+    escaping.symlink_to(outside, target_is_directory=True)
+    monkeypatch.setattr(os, "access", lambda path, _mode: Path(path) != unreadable)
+    result = publish_pool_mappings(
+        mappings=[
+            SkillMapping(str(unreadable), str(layout.active_root / "unreadable")),
+            SkillMapping(str(ordinary_file), str(layout.active_root / "ordinary-file")),
+            SkillMapping(str(escaping), str(layout.active_root / "escaping")),
+        ],
+        home=home,
+        engine="openclaw",
+        apply_mode=MappingApplyMode.BEST_EFFORT,
+    )
+
+    assert result.item_for(target=layout.active_root / "unreadable").status == "PENDING"
+    assert (
+        result.item_for(target=layout.active_root / "unreadable").code
+        == "MANAGED_SOURCE_MISSING"
+    )
+    assert (
+        result.item_for(target=layout.active_root / "ordinary-file").code
+        == "SOURCE_NOT_DIRECTORY"
+    )
+    assert (
+        result.item_for(target=layout.active_root / "escaping").code
+        == "SOURCE_ESCAPES_POOL"
+    )
 
 
 def test_best_effort_reports_invalid_requested_mappings_without_touching_safe_ones(


### PR DESCRIPTION
## Problem
SkillSet runtime projection recursively walked every file below each Local, Repo, and Center source during ordinary BEST_EFFORT publish and verify. On production read-only OSSFS, two observed requests spent 36.57s and 23.05s waiting on publish+verify; a read-only scan of 11 Repo sources took 14.69s for one recursive pass. Backend also resolved the post-mutation Skill state twice: once for the after snapshot and again while building the applied plan.

## Solution
- Replace recursive content walks only in ordinary BEST_EFFORT mapping projection with a bounded source-root check that retains managed-root, escape, directory, and root read/execute validation. STRICT and Pool cutover validation remain unchanged.
- Cache source and managed-root inspection only within one publish or verify request. Publish and verify still observe independently, and verify still checks the actual target and retired entries.
- Classify retirement entries with lstat/readlink so a dangling or unavailable retired source is not followed; remove only an exact managed symlink identity.
- Add bounded aggregate timing/count evidence, including the three slowest source checks. Public payload/status fields are unchanged.
- Resolve one Reader-backed post-mutation Plan in Backend, calculate retired mappings from that Plan, and apply the exact same Plan. The before snapshot and Reader flush behavior remain unchanged.

## Validation
- Engine community: 2468 passed, 5 skipped.
- Backend community: 17627 passed, 60 skipped; the first full run exposed 8 endpoint fake contract failures, all fixed, then the exact 8 cases passed.
- Backend Plan/service/contract/architecture focused run: 289 passed; post-fix contract set: 147 passed.
- Engine focused mapping/router/contract run: 156 passed; final mapping retirement file: 34 passed.
- Local SAST block scans passed for changed Engine and Backend files. Standards/Spec parallel review was rerun after fixes with no remaining findings.
- Read-only real asset measurement: copied 3 Skills from /Users/freddie/aiworkbench into a temporary sandbox. The same public publish+verify entry points changed from 12 recursive checks / 10.115ms to 6 bounded checks / 1.413ms on local disk. A synthetic 10,000-file Skill completed publish+verify in 0.863ms with one check per request. These are local-disk complexity measurements, not production OSSFS or end-to-end claims.

## Compatibility and risk
CONVERGED now means the requested entry is aligned and its source directory passes the bounded root check; it no longer proves every descendant is readable. Upload, publication, materialization, STRICT mapping, Pool cutover/rollback, Center probe/ensure, v2/v3 negotiation, active-root layout, and response status/item fields are unchanged. Backend retains before snapshot, Reader flush, failure classification, and per-request retry resolution.

Production benefit requires the new Engine to be built, deployed, and actually loaded by the Bot. Existing production Bot `168944/default` was observed on an older strict Engine, so merging this PR alone cannot improve that runtime. No pre-release/production mutation, restart, merge, or deployment was performed. The 3-5s end-to-end target remains to be verified on upgraded pre-release OSSFS.