### PR TITLE
fix(skill-center): gate installation reader reconciliation

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -422,6 +422,16 @@ class BotService(BotServiceProtocol):
         self._runtime_reconciler = runtime_reconciler
         self._runtime_reconciler_provider = runtime_reconciler_provider
         self._bot_quota_service = bot_quota_service
+    def _initialize_capability_installations(
+        self, *, bot_id: str, owner_id: str, bot: "Dict[str, Any] | None" = None
+    ) -> None:
+        """Persist a new Bot's DB-only capability projection before returning.
+
+        No Runtime projection or device readiness check is involved here.
+        """
+        self._skill_set_factory.initialize_installations(
+            bot_id=bot_id, owner_id=owner_id, bot=bot
+        )
 
     def _service_bot_image_policy_enabled(self) -> bool:
         """Whether draft create/restart should opt into image policy."""
@@ -1342,7 +1352,12 @@ class BotService(BotServiceProtocol):
         if bot_id is not None:
             existing_bot = self._repository.get_by_id_and_owner(bot_id, user_id)
             if existing_bot:
-                # Bot 已存在，直接返回（幂等）
+                # A prior create can have persisted the Bot and failed before
+                # capability initialization.  Retrying must converge that
+                # recoverable state instead of reporting a false success.
+                self._initialize_capability_installations(
+                    bot_id=bot_id, owner_id=user_id, bot=existing_bot
+                )
                 logger.info(f"[bot_service.create_bot] Bot {bot_id} already exists for user {user_id}, returning existing bot")
                 return existing_bot
             # 不存在，继续创建流程，使用传入的 bot_id
@@ -1524,6 +1539,13 @@ class BotService(BotServiceProtocol):
                         ) from e
                     # Keep the historical best-effort behavior for non-coding
                     # template creation.
+
+            # This is deliberately DB-only and precedes both early returns.
+            # New Bots must not depend on a later effective read or Runtime
+            # projector to materialize their initial Default/SkillSet state.
+            self._initialize_capability_installations(
+                bot_id=bot_id, owner_id=user_id
+            )
 
             # 桌面 bot 的设备分配走 BaaS 流程（DesktopBotService._execute_creation），
             # 不应走 DeviceService.apply_device()（会生成 staff_xxx 格式 device_id）。

--- a/src/backend/src/agentclaw/community/core/desktop_bot/services/desktop_bot_service.py
+++ b/src/backend/src/agentclaw/community/core/desktop_bot/services/desktop_bot_service.py
@@ -699,6 +699,14 @@ class DesktopBotService(DesktopBotServiceProtocol):
                 "ext": ext,
             })
 
+            # The desktop flow has its own Bot insert and must establish the
+            # same DB-only Installation facts before it starts publish polling.
+            # This intentionally neither waits for the container nor projects
+            # Runtime state.
+            self._skill_set_factory.initialize_installations(
+                bot_id=bot_id, owner_id=user_id
+            )
+
             logger.info(
                 "[DesktopBotService._execute_creation] bot_id=%s binding_id=%s bot_uuid=%s",
                 bot_id, binding_id, bot_uuid,
@@ -760,6 +768,30 @@ class DesktopBotService(DesktopBotServiceProtocol):
         bot_id = bot.get("bot_id", "")
         if not bot_id:
             raise DesktopBotServiceError("bot_id is required for create_after_authorization")
+
+        existing = self._bot_repo.get_by_id_and_owner(bot_id=bot_id, owner_id=user_id)
+        if isinstance(existing, dict):
+            # A previous attempt can have committed the local Bot/Binding and
+            # then failed at Installation initialization. Repair that DB-only
+            # step before returning the same create result; never issue a
+            # second BaaS create or overwrite the persisted Bot.
+            self._skill_set_factory.initialize_installations(
+                bot_id=bot_id, owner_id=user_id, bot=existing
+            )
+            ext = existing.get("ext") or {}
+            if isinstance(ext, str):
+                try:
+                    ext = json.loads(ext)
+                except json.JSONDecodeError:
+                    ext = {}
+            passport = ext.get("passport") if isinstance(ext, dict) else {}
+            agent_code = passport.get("agent_code", "") if isinstance(passport, dict) else ""
+            return {
+                "bot_uuid": existing.get("device_id", ""),
+                "binding_id": existing.get("binding_id"),
+                "bot_id": bot_id,
+                "agent_code": agent_code,
+            }
 
         passport_info = self._passport.query_agent_passport(
             bot_id=bot_id,

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/bot_skillset_installations.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/bot_skillset_installations.py
@@ -6,6 +6,8 @@ range over every Set a Bot has and answer what its Installation table should say
 
 from __future__ import annotations
 
+from collections.abc import Callable
+
 from sqlalchemy import and_, func, or_
 
 from agentclaw.community.core.models.mcp import SkillSetMCPServer
@@ -145,10 +147,83 @@ class BotSkillSetInstallations:
         Skills and MCPs, one algorithm. Returns the plan it applied, so the
         caller need not resolve twice.
         """
-        # Resolve unlocked first: a Bot that already agrees — the common case —
-        # answers here without a row lock or a write transaction.
+        return self._reconcile_installations(
+            bot_id=bot_id,
+            owner_id=owner_id,
+            env=env,
+            engine_type=engine_type,
+            default_engine_types=default_engine_types,
+            plan_resolver=self._resolve_flush_plan,
+            allow_uninstall=True,
+        )
+
+    def sync_default_installations(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+        env: str,
+        engine_type: str | None = None,
+        default_engine_types: tuple[str, ...] | None = None,
+    ) -> InstallationFlushPlan:
+        """Materialize the current Default Set without repairing ordinary Sets.
+
+        The mode is safe only after the operator has backfilled ordinary
+        SkillSet history.  A Default membership removal is deliberately not
+        inferred from an Installation row: that row may be Direct, and Default
+        removal is an explicit operational cleanup.  Per-Bot exclusions are
+        the one supported Default removal signal.  An active ordinary claim
+        still wins over that signal for malformed historical overlap.
+        """
+        return self._reconcile_installations(
+            bot_id=bot_id,
+            owner_id=owner_id,
+            env=env,
+            engine_type=engine_type,
+            default_engine_types=default_engine_types,
+            plan_resolver=self._resolve_default_sync_plan,
+            allow_uninstall=True,
+        )
+
+    def initialize_installations(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+        env: str,
+        engine_type: str | None = None,
+        default_engine_types: tuple[str, ...] | None = None,
+    ) -> InstallationFlushPlan:
+        """Insert missing active Set facts without deleting existing capabilities.
+
+        This is the new-Bot and retry boundary.  A partially persisted Bot can
+        be retried safely, while a full backfill remains the explicit repair
+        operation allowed to remove stale Set-derived rows.
+        """
+        return self._reconcile_installations(
+            bot_id=bot_id,
+            owner_id=owner_id,
+            env=env,
+            engine_type=engine_type,
+            default_engine_types=default_engine_types,
+            plan_resolver=self._resolve_flush_plan,
+            allow_uninstall=False,
+        )
+
+    def _reconcile_installations(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+        env: str,
+        engine_type: str | None,
+        default_engine_types: tuple[str, ...] | None,
+        plan_resolver: Callable[..., InstallationFlushPlan],
+        allow_uninstall: bool,
+    ) -> InstallationFlushPlan:
+        """Apply one resolver's plan with the shared lock and write protocol."""
         with self._db.orm_session() as session:
-            plan = self._resolve_flush_plan(
+            plan = plan_resolver(
                 session,
                 bot_id=bot_id,
                 owner_id=owner_id,
@@ -163,16 +238,17 @@ class BotSkillSetInstallations:
             )
         if (
             not (plan.skills_to_install - installed)
-            and not (plan.skills_to_uninstall & installed)
+            and (not allow_uninstall or not (plan.skills_to_uninstall & installed))
             and not (plan.mcps_to_install - installed_mcps)
-            and not (plan.mcps_to_uninstall & installed_mcps)
+            and (
+                not allow_uninstall
+                or not (plan.mcps_to_uninstall & installed_mcps)
+            )
         ):
             return plan
 
-        # There is something to write, so resolve again holding the Set rows —
-        # the same locks every SkillSet mutation takes.
         with self._db.transactional_orm_session() as session:
-            plan = self._resolve_flush_plan(
+            plan = plan_resolver(
                 session,
                 bot_id=bot_id,
                 owner_id=owner_id,
@@ -188,10 +264,11 @@ class BotSkillSetInstallations:
                     session, bot_id=bot_id, owner_id=owner_id, env=env,
                     skill_id=skill_id,
                 )
-            skill_installations.uninstall(
-                session, bot_id=bot_id, owner_id=owner_id, env=env,
-                skill_ids=plan.skills_to_uninstall & installed,
-            )
+            if allow_uninstall:
+                skill_installations.uninstall(
+                    session, bot_id=bot_id, owner_id=owner_id, env=env,
+                    skill_ids=plan.skills_to_uninstall & installed,
+                )
             installed_mcps = mcp_installations.installed_codes(
                 session, bot_id=bot_id, owner_id=owner_id, env=env, locked=True
             )
@@ -200,11 +277,102 @@ class BotSkillSetInstallations:
                     session, bot_id=bot_id, owner_id=owner_id, env=env,
                     server_code=server_code,
                 )
-            mcp_installations.uninstall(
-                session, bot_id=bot_id, owner_id=owner_id, env=env,
-                server_codes=plan.mcps_to_uninstall & installed_mcps,
-            )
+            if allow_uninstall:
+                mcp_installations.uninstall(
+                    session, bot_id=bot_id, owner_id=owner_id, env=env,
+                    server_codes=plan.mcps_to_uninstall & installed_mcps,
+                )
             return plan
+
+    def list_member_skill_ids(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+        engine_type: str | None = None,
+        default_engine_types: tuple[str, ...] | None = None,
+    ) -> frozenset[int]:
+        """Read Set reachability for list/manifest consumers without a flush."""
+        with self._db.orm_session() as session:
+            members: set[int] = set()
+            for row in self._bot_sets(
+                session,
+                bot_id=bot_id,
+                owner_id=owner_id,
+                engine_type=engine_type,
+                default_engine_types=default_engine_types,
+            ):
+                ids = set_member_skill_ids(self._scope, session, skill_set_id=int(row.id))
+                if row.is_default:
+                    ids -= set(
+                        default_exclusions.excluded_skill_ids(
+                            session,
+                            bot_id=bot_id,
+                            owner_id=owner_id,
+                            set_id=int(row.id),
+                        )
+                    )
+                members |= ids
+            return frozenset(members)
+
+    def _resolve_default_sync_plan(
+        self,
+        session,
+        *,
+        bot_id: str,
+        owner_id: str,
+        engine_type: str | None,
+        default_engine_types: tuple[str, ...] | None,
+        locked: bool = False,
+    ) -> InstallationFlushPlan:
+        """Resolve only Default materialization plus targeted active claims."""
+        bot_sets = self._bot_sets(
+            session,
+            bot_id=bot_id,
+            owner_id=owner_id,
+            engine_type=engine_type,
+            default_engine_types=default_engine_types,
+            locked=locked,
+        )
+        default_skills: set[int] = set()
+        excluded_skills: set[int] = set()
+        default_mcps: set[str] = set()
+        excluded_mcps: set[str] = set()
+        ordinary_active_skills: set[int] = set()
+        ordinary_active_mcps: set[str] = set()
+        for row in bot_sets:
+            skill_ids = set_member_skill_ids(
+                self._scope, session, skill_set_id=int(row.id)
+            )
+            mcp_codes = set_member_mcp_codes(
+                self._scope, session, skill_set_id=int(row.id)
+            )
+            if not row.is_default:
+                if row.is_active:
+                    ordinary_active_skills |= skill_ids
+                    ordinary_active_mcps |= mcp_codes
+                continue
+            excluded_skill_ids = set(
+                default_exclusions.excluded_skill_ids(
+                    session, bot_id=bot_id, owner_id=owner_id, set_id=int(row.id)
+                )
+            )
+            excluded_mcp_codes = set(
+                default_exclusions.excluded_mcp_codes(
+                    session, bot_id=bot_id, owner_id=owner_id, set_id=int(row.id)
+                )
+            )
+            default_skills |= skill_ids - excluded_skill_ids
+            excluded_skills |= skill_ids & excluded_skill_ids
+            default_mcps |= mcp_codes - excluded_mcp_codes
+            excluded_mcps |= mcp_codes & excluded_mcp_codes
+        return InstallationFlushPlan(
+            member_skill_ids=frozenset(default_skills),
+            skills_to_install=frozenset(default_skills),
+            skills_to_uninstall=frozenset(excluded_skills - ordinary_active_skills),
+            mcps_to_install=frozenset(default_mcps),
+            mcps_to_uninstall=frozenset(excluded_mcps - ordinary_active_mcps),
+        )
 
     def _resolve_flush_plan(
         self,

--- a/src/backend/src/agentclaw/community/core/repository/protocols/capability_desired_state.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/capability_desired_state.py
@@ -48,6 +48,46 @@ class CapabilityDesiredStateRepositoryProtocol(Protocol):
         """
         ...
     @abstractmethod
+    def sync_default_installations(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+        env: str,
+        engine_type: str | None = None,
+        default_engine_types: tuple[str, ...] | None = None,
+    ) -> InstallationFlushPlan:
+        """Materialize only the applicable Default Set and its exclusions.
+
+        This is the post-backfill reader migration path.  It intentionally
+        does not repair ordinary SkillSet history or infer provenance for a
+        removed Default membership.
+        """
+        ...
+    @abstractmethod
+    def initialize_installations(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+        env: str,
+        engine_type: str | None = None,
+        default_engine_types: tuple[str, ...] | None = None,
+    ) -> InstallationFlushPlan:
+        """Insert missing active Set facts without deleting existing rows."""
+        ...
+    @abstractmethod
+    def list_member_skill_ids(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+        engine_type: str | None = None,
+        default_engine_types: tuple[str, ...] | None = None,
+    ) -> frozenset[int]:
+        """Read the Bot's Set reachability without materializing Installation."""
+        ...
+    @abstractmethod
     def resolve_legacy_set_scope(
         self, *, set_id: str
     ) -> LegacySkillSetScope | None:

--- a/src/backend/src/agentclaw/community/core/skill_center/README.md
+++ b/src/backend/src/agentclaw/community/core/skill_center/README.md
@@ -271,7 +271,7 @@ observes the loss at the next item boundary, stops subsequent items, and reports
 the stable coordinator error. A later periodic/manual pass converges the
 materialized-only set again.
 
-### One writer, one flush, one reader, one rule book
+### One writer, migration-gated synchronization, one reader, one rule book
 
 Installation (`ac_bot_skill_installation` / `ac_bot_mcp_installation`) is the
 single source of truth for a Bot's active capabilities, and four seams keep it
@@ -283,11 +283,18 @@ that way:
   `CapabilityDesiredStateRepository` unit of work composes them. An
   architecture test (`test_installation_table_write_ownership.py`) fails any
   other module that writes the models.
-- **One flush.** `flush_installations` is the only reconciliation from Set
-  configuration into Installation, and every read-side consumer runs it first
-  (details below).
+- **Staged synchronization.** Before an environment's Installation backfill is
+  accepted, `flush_installations` is the complete reconciliation from Set
+  configuration into Installation. The default-off
+  `SC_INSTALLATION_DEFAULT_SYNC_ONLY` switch is enabled only after that
+  acceptance; it retains Default membership + per-Bot exclusion materialization
+  but does not repair ordinary Set history. The internal backfill endpoint
+  always invokes the complete resolver, independent of this switch.
 - **One reader.** `BotCapabilityStateReader` answers every "what is active on
-  this Bot" question — it flushes, then reads Installation alone.
+  this Bot" question — it synchronizes the configured migration scope, then
+  reads Installation alone. It has an explicit DB-only new-Bot initializer, so
+  a create retry, `provision=False`, and desktop creation do not depend on a
+  later effective read or Runtime projection.
   `SkillQueryService` (listing/detail/content/parameters) and
   `DirectActivationService.list_installed_mcps` answer through it.
 - **One rule book.** `policies/capability_ownership.py` owns the ownership
@@ -323,7 +330,15 @@ reads such as `GET /openapi/v1/bots/{bot_id}/skills` (see
 difference, in one transaction, after the caller's Bot access has been checked,
 and never touches runtime.
 
-`InstallationBackfillService` runs that same flush deliberately for one named
+After the documented backfill acceptance, the explicit operator switch may
+select `sync_default_installations`: it materializes only the currently
+applicable Default and exclusions, still reads effective identity solely from
+Installation, preserves active ordinary claims on malformed historical overlap,
+and never infers a deletion from removed Default membership. Removing a global
+Default member remains an operations cleanup that must protect Direct
+Installation rows.
+
+`InstallationBackfillService` runs the complete flush deliberately for one named
 Bot, behind the Bearer-token
 `POST /api/internal/skill-center/installations/backfill/bot` endpoint. The lazy
 flush converges a Bot only when something reads it, which is enough for per-Bot

--- a/src/backend/src/agentclaw/community/core/skill_center/capability_state_contract.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/capability_state_contract.py
@@ -16,19 +16,38 @@ if TYPE_CHECKING:
 class BotCapabilityStateReaderProtocol(Protocol):
     """The one read model for a Bot's active capabilities.
 
-    Installation is the active-identity source of truth; the tables are not
-    backfilled, so every read first flushes SkillSet configuration into
-    Installation, then answers from Installation alone. Center identities are
-    resolved to an exact PUBLISHED Version before they leave this seam. The
-    reader never triggers a runtime projection.
+    Installation is the active-identity source of truth.  The configured
+    migration mode materializes either full legacy SkillSet state or only the
+    applicable Default+exclusion state before effective reads.  The reader
+    never triggers a runtime projection.
     """
 
     def member_skill_ids(self, *, bot: Mapping[str, Any]) -> frozenset[int]:
-        """Flush, then answer which Skills the Bot's Sets bring to it.
+        """Read which Skills the Bot's Sets bring to it, without a flush.
 
         The listing filter needs this half of the flush plan: a bridged
         Skill belongs on the page even though only a Set ties it to the Bot.
         """
+        ...
+
+    def initialize_installations(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+        bot: Mapping[str, Any] | None = None,
+    ) -> None:
+        """Initialize a newly persisted Bot's Installation rows without Runtime I/O."""
+        ...
+
+    def synchronize_installations(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+        bot: Mapping[str, Any] | None = None,
+    ) -> None:
+        """Materialize the configured reader scope before an effective read."""
         ...
 
     def active_skill_assets(

--- a/src/backend/src/agentclaw/community/core/skill_center/factories.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/factories.py
@@ -633,6 +633,25 @@ class SkillSetServiceFactory(SkillSetServiceFactoryProtocol):
         self._ext_info_provider = ext_info_provider
         self._reader = reader
 
+    def initialize_installations(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+        bot: Mapping[str, Any] | None = None,
+    ) -> None:
+        """Initialize one persisted Bot's DB-only Installation facts.
+
+        This keeps Bot lifecycle services on the existing Skill Center factory
+        seam. A missing reader is a construction error, never a successful
+        no-op that leaves a created Bot without its capability projection.
+        """
+        if self._reader is None:
+            raise RuntimeError("SkillSetServiceFactory requires a capability reader")
+        self._reader.initialize_installations(
+            bot_id=bot_id, owner_id=owner_id, bot=bot
+        )
+
     def create(
         self,
         skills_dir: Optional[Path] = None,

--- a/src/backend/src/agentclaw/community/core/skill_center/feature_flags.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/feature_flags.py
@@ -15,6 +15,9 @@ class SkillCenterFlags:
     symlink_verify_auto_fix: bool
     write_skill_uuid: bool  # 双写控制，不关
     space_skill_enabled: bool = False
+    # Migration gate for Installation backfill.  It remains false until the
+    # operator has completed and accepted the environment backfill.
+    installation_default_sync_only: bool = False
 
     @classmethod
     def from_env(cls) -> "SkillCenterFlags":
@@ -26,6 +29,10 @@ class SkillCenterFlags:
             symlink_verify_auto_fix=os.environ.get("SC_SYMLINK_AUTO_FIX", "false").lower() == "true",
             write_skill_uuid=os.environ.get("SC_WRITE_SKILL_UUID", "true").lower() == "true",
             space_skill_enabled=os.environ.get("SC_SPACE_SKILL_ENABLED", "false").lower() == "true",
+            installation_default_sync_only=(
+                os.environ.get("SC_INSTALLATION_DEFAULT_SYNC_ONLY", "false").lower()
+                == "true"
+            ),
         )
 
     def any_blocking_enabled(self) -> bool:

--- a/src/backend/src/agentclaw/community/core/skill_center/services/bot_capability_state_reader.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/bot_capability_state_reader.py
@@ -1,4 +1,4 @@
-"""Flush-then-read access to a Bot's active capability state."""
+"""Installation-backed access to a Bot's active capability state."""
 
 from __future__ import annotations
 
@@ -21,6 +21,7 @@ from agentclaw.community.core.skill_center.bot_engine_scope import (
     bot_default_engine_types,
     bot_engine_type,
 )
+from agentclaw.community.core.skill_center.feature_flags import get_skill_center_flags
 from agentclaw.community.core.skill_center.errors import LocalSkillNotFoundError
 from agentclaw.community.core.skill_center.version_resolution_contract import (
     SkillVersionResolverProtocol,
@@ -32,12 +33,11 @@ from agentclaw.community.core.skill_center.bot_capability_state_reader_protocol 
 class BotCapabilityStateReader(BotCapabilityStateReaderProtocol):
     """The one read model for a Bot's active capabilities.
 
-    Installation is the active-identity source of truth; the tables are not
-    backfilled, so every read first flushes SkillSet configuration into
-    Installation, then answers from Installation alone. Center identities are
-    resolved to an exact PUBLISHED Version before they leave this seam. The
-    flush and Version resolution are DB-side only — this reader never triggers
-    a runtime projection.
+    Installation is the active-identity source of truth.  Before the historical
+    backfill is accepted, every effective read fully repairs SkillSet state.
+    Afterwards a guarded migration mode retains only Default+exclusion
+    materialization and still answers from Installation alone. Center identities
+    are resolved to an exact PUBLISHED Version before they leave this seam.
     """
 
     @inject
@@ -54,12 +54,50 @@ class BotCapabilityStateReader(BotCapabilityStateReaderProtocol):
         self._version_resolver = version_resolver
 
     def member_skill_ids(self, *, bot: Mapping[str, Any]) -> frozenset[int]:
-        plan = self._flush(
-            bot=bot,
+        return self._repository.list_member_skill_ids(
             bot_id=str(bot["bot_id"]),
             owner_id=str(bot["owner_id"]),
+            engine_type=bot_engine_type(bot),
+            default_engine_types=bot_default_engine_types(bot),
         )
-        return plan.member_skill_ids
+
+    def initialize_installations(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+        bot: Mapping[str, Any] | None = None,
+    ) -> None:
+        """Explicitly initialize a newly persisted Bot without Runtime I/O.
+
+        Creation always uses the complete resolver, independent of the reader
+        migration gate.  This makes retries converge new rows and ensures a
+        newly created Bot does not rely on a later read or projector to gain its
+        initial Installation facts.
+        """
+        resolved_bot = self._bot(bot_id=bot_id, owner_id=owner_id, bot=bot)
+        self._repository.initialize_installations(
+            bot_id=bot_id,
+            owner_id=owner_id,
+            env=str(resolved_bot["env"]),
+            engine_type=bot_engine_type(resolved_bot),
+            default_engine_types=bot_default_engine_types(resolved_bot),
+        )
+
+    def synchronize_installations(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+        bot: Mapping[str, Any] | None = None,
+    ) -> None:
+        """Apply the configured reader migration scope without Runtime I/O."""
+        resolved_bot = self._bot(bot_id=bot_id, owner_id=owner_id, bot=bot)
+        self._flush(
+            bot=resolved_bot,
+            bot_id=bot_id,
+            owner_id=owner_id,
+        )
 
     def active_skill_assets(
         self,
@@ -69,7 +107,9 @@ class BotCapabilityStateReader(BotCapabilityStateReaderProtocol):
         bot: Mapping[str, Any] | None = None,
     ) -> tuple[RegisteredSkillAsset, ...]:
         bot = self._bot(bot_id=bot_id, owner_id=owner_id, bot=bot)
-        self._flush(bot=bot, bot_id=bot_id, owner_id=owner_id)
+        self.synchronize_installations(
+            bot_id=bot_id, owner_id=owner_id, bot=bot
+        )
         assets = tuple(
             self._pool_skills.list_bot_installed_assets(
                 env=str(bot["env"]),
@@ -89,7 +129,9 @@ class BotCapabilityStateReader(BotCapabilityStateReaderProtocol):
         bot: Mapping[str, Any] | None = None,
     ) -> frozenset[str]:
         bot = self._bot(bot_id=bot_id, owner_id=owner_id, bot=bot)
-        self._flush(bot=bot, bot_id=bot_id, owner_id=owner_id)
+        self.synchronize_installations(
+            bot_id=bot_id, owner_id=owner_id, bot=bot
+        )
         return frozenset(
             self._repository.list_installed_mcps(bot_id=bot_id, owner_id=owner_id)
         )
@@ -108,7 +150,12 @@ class BotCapabilityStateReader(BotCapabilityStateReaderProtocol):
     def _flush(
         self, *, bot: Mapping[str, Any], bot_id: str, owner_id: str
     ) -> InstallationFlushPlan:
-        return self._repository.flush_installations(
+        sync = (
+            self._repository.sync_default_installations
+            if get_skill_center_flags().installation_default_sync_only
+            else self._repository.flush_installations
+        )
+        return sync(
             bot_id=bot_id,
             owner_id=owner_id,
             env=str(bot["env"]),

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_query_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_query_service.py
@@ -165,8 +165,12 @@ class SkillQueryService(SkillQueryServiceProtocol):
         bot = self._require_view_access(
             bot_id=bot_id, owner_id=owner_id, actor_id=actor_id
         )
-        # The reader flushes before answering, so the page need not resolve
-        # Set membership again.
+        # Synchronize effective Installation state first, then read the
+        # independent Set-reachability relation used to include bridged and
+        # inactive members on the page.
+        self._reader.synchronize_installations(
+            bot_id=bot_id, owner_id=owner_id, bot=bot
+        )
         member_ids = self._reader.member_skill_ids(bot=bot)
         return self._skill_repo.list_bot_skills(
             bot_id=bot_id,

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_desktop_guard.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_desktop_guard.py
@@ -219,6 +219,40 @@ class TestCreateBotDesktopGuard:
         assert result is not None
         assert result["bot_type"] == "desktop"
 
+    def test_desktop_bot_create_initializes_installations_before_returning(self):
+        svc = _make_service()
+        svc._repository.get_by_id_and_owner.return_value = None
+        svc._repository.exists_by_bot_name.return_value = False
+        svc._repository.insert.return_value = _make_bot(
+            bot_id="desktop_new", bot_type="desktop", status="PENDING"
+        )
+
+        with patch(
+            "agentclaw.community.core.bot_management.services.bot_service.generate_bot_id",
+            return_value="desktop_new",
+        ):
+            svc.create_bot(
+                user_id="user001", nick_name="TestUser", bot_type="desktop"
+            )
+
+        svc._skill_set_factory.initialize_installations.assert_called_once_with(
+            bot_id="desktop_new", owner_id="user001", bot=None
+        )
+
+    def test_existing_create_retry_initializes_installations_before_returning(self):
+        svc = _make_service()
+        existing = _make_bot(bot_id="retry", bot_type="desktop", status="PENDING")
+        existing["env"] = "dev"
+        svc._repository.get_by_id_and_owner.return_value = existing
+
+        assert svc.create_bot(
+            user_id="user001", nick_name="TestUser", bot_id="retry"
+        ) == existing
+
+        svc._skill_set_factory.initialize_installations.assert_called_once_with(
+            bot_id="retry", owner_id="user001", bot=existing
+        )
+
     def test_personal_bot_create_calls_apply_device(self):
         """create_bot with default bot_type should call apply_device."""
         svc = _make_service()

--- a/src/backend/tests/community/core/desktop_bot/services/test_desktop_bot_service.py
+++ b/src/backend/tests/community/core/desktop_bot/services/test_desktop_bot_service.py
@@ -350,6 +350,51 @@ class TestCreate:
         )
         assert bot_insert_call["ext"]["desktop_template_uuid"] == "desk-tpl-001"
 
+    def test_desktop_create_initializes_installations_after_the_local_insert(self):
+        service, mocks = _make_service_with_mocks()
+        mocks["passport"].query_agent_passport.return_value = {"agent_code": "ac-1"}
+        mocks["baas"].post_bots_api.return_value = {"bot_uuid": "bu-1"}
+        mocks["binding_repo"].insert_binding.return_value = 20
+
+        service.create_after_authorization(
+            bot={"bot_id": "desktop_bot_003", "bot_name": "Desktop"},
+            user_id="u001",
+            machine_id="m-002",
+        )
+
+        mocks["skill_set_factory"].initialize_installations.assert_called_once_with(
+            bot_id="desktop_bot_003", owner_id="u001"
+        )
+
+    def test_desktop_create_retry_repairs_installations_without_a_second_baas_create(self):
+        service, mocks = _make_service_with_mocks()
+        existing = {
+            "bot_id": "desktop_bot_retry",
+            "owner_id": "u001",
+            "device_id": "bu-existing",
+            "binding_id": 20,
+            "ext": {"passport": {"agent_code": "ac-existing"}},
+        }
+        mocks["bot_repo"].get_by_id_and_owner.return_value = existing
+
+        result = service.create_after_authorization(
+            bot={"bot_id": "desktop_bot_retry", "bot_name": "Desktop"},
+            user_id="u001",
+            machine_id="m-002",
+        )
+
+        assert result == {
+            "bot_uuid": "bu-existing",
+            "binding_id": 20,
+            "bot_id": "desktop_bot_retry",
+            "agent_code": "ac-existing",
+        }
+        mocks["skill_set_factory"].initialize_installations.assert_called_once_with(
+            bot_id="desktop_bot_retry", owner_id="u001", bot=existing
+        )
+        mocks["baas"].post_bots_api.assert_not_called()
+        mocks["passport"].query_agent_passport.assert_not_called()
+
     def test_create_continue_with_custom_mount_path(self):
         service, mocks = _make_service_with_mocks()
         mocks["passport"].query_agent_passport.return_value = {

--- a/src/backend/tests/community/core/skill_center/test_bot_capability_state_reader.py
+++ b/src/backend/tests/community/core/skill_center/test_bot_capability_state_reader.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pytest
+from types import SimpleNamespace
 
 from agentclaw.community.api.bot_capability_state_reader import (
     BotCapabilityStateReaderProtocol,
@@ -38,10 +39,29 @@ class _Bots:
 class _Repository:
     def __init__(self) -> None:
         self.flush_calls: list[dict] = []
+        self.default_sync_calls: list[dict] = []
+        self.initialization_calls: list[dict] = []
         self.mcp_reads: list[dict] = []
+        self.member_reads: list[dict] = []
 
     def flush_installations(self, **kwargs) -> InstallationFlushPlan:
         self.flush_calls.append(kwargs)
+        return InstallationFlushPlan(
+            member_skill_ids=frozenset({1}),
+            skills_to_install=frozenset({1}),
+            skills_to_uninstall=frozenset(),
+        )
+
+    def sync_default_installations(self, **kwargs) -> InstallationFlushPlan:
+        self.default_sync_calls.append(kwargs)
+        return InstallationFlushPlan(
+            member_skill_ids=frozenset(),
+            skills_to_install=frozenset(),
+            skills_to_uninstall=frozenset(),
+        )
+
+    def initialize_installations(self, **kwargs) -> InstallationFlushPlan:
+        self.initialization_calls.append(kwargs)
         return InstallationFlushPlan(
             member_skill_ids=frozenset({1}),
             skills_to_install=frozenset({1}),
@@ -54,6 +74,10 @@ class _Repository:
         self.mcp_reads.append(kwargs)
         return {"mcp.weather"}
 
+    def list_member_skill_ids(self, **kwargs) -> frozenset[int]:
+        self.member_reads.append(kwargs)
+        return frozenset({1})
+
 
 class _PoolSkills:
     def __init__(self) -> None:
@@ -65,7 +89,9 @@ class _PoolSkills:
         return self
 
     def list_bot_installed_assets(self, **kwargs) -> list[RegisteredSkillAsset]:
-        assert self._repository.flush_calls, (
+        assert (
+            self._repository.flush_calls or self._repository.default_sync_calls
+        ), (
             "read reached Installation before the flush"
         )
         self.reads.append(kwargs)
@@ -173,11 +199,49 @@ def test_a_missing_bot_raises_before_any_flush():
     assert repository.flush_calls == []
 
 
-def test_member_skill_ids_flushes_and_answers_the_set_membership_half():
+def test_member_skill_ids_reads_the_set_membership_without_materializing():
     reader, repository, _pool, bots, _versions = _reader()
 
     ids = reader.member_skill_ids(bot=_BOT)
 
     assert bots.lookups == []
-    assert repository.flush_calls == [_EXPECTED_FLUSH]
+    assert repository.flush_calls == []
+    assert repository.member_reads == [{
+        "bot_id": "bot-1",
+        "owner_id": "owner",
+        "engine_type": "openclaw",
+        "default_engine_types": ("openclaw",),
+    }]
     assert ids == frozenset({1})
+
+
+def test_reader_uses_default_only_sync_after_the_explicit_migration_switch(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    reader, repository, pool_skills, _bots, _versions = _reader()
+    monkeypatch.setattr(
+        "agentclaw.community.core.skill_center.services.bot_capability_state_reader.get_skill_center_flags",
+        lambda: SimpleNamespace(installation_default_sync_only=True),
+    )
+
+    reader.active_skill_assets(bot_id="bot-1", owner_id="owner")
+
+    assert repository.flush_calls == []
+    assert repository.default_sync_calls == [_EXPECTED_FLUSH]
+    assert pool_skills.reads
+
+
+def test_new_bot_initialization_always_uses_the_complete_resolver(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    reader, repository, _pool, _bots, _versions = _reader()
+    monkeypatch.setattr(
+        "agentclaw.community.core.skill_center.services.bot_capability_state_reader.get_skill_center_flags",
+        lambda: SimpleNamespace(installation_default_sync_only=True),
+    )
+
+    reader.initialize_installations(bot_id="bot-1", owner_id="owner")
+
+    assert repository.initialization_calls == [_EXPECTED_FLUSH]
+    assert repository.flush_calls == []
+    assert repository.default_sync_calls == []

--- a/src/backend/tests/community/core/skill_center/test_feature_flags.py
+++ b/src/backend/tests/community/core/skill_center/test_feature_flags.py
@@ -19,15 +19,18 @@ class TestSkillCenterFlags:
     def test_from_env_reads_env_vars(self):
         os.environ["SC_NAS_SYNC_ENABLED"] = "true"
         os.environ["SC_PROPAGATION_ENABLED"] = "true"
+        os.environ["SC_INSTALLATION_DEFAULT_SYNC_ONLY"] = "true"
         try:
             flags = SkillCenterFlags.from_env()
             assert flags.nas_sync_enabled is True
             assert flags.propagation_enabled is True
             assert flags.center_uri_enabled is False
             assert flags.space_skill_enabled is False
+            assert flags.installation_default_sync_only is True
         finally:
             del os.environ["SC_NAS_SYNC_ENABLED"]
             del os.environ["SC_PROPAGATION_ENABLED"]
+            del os.environ["SC_INSTALLATION_DEFAULT_SYNC_ONLY"]
 
     def test_any_blocking_enabled_true_when_any_flag_on(self):
         flags = SkillCenterFlags(

--- a/src/backend/tests/community/core/skill_center/test_skill_query_service.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_query_service.py
@@ -79,15 +79,20 @@ class _Bots:
 
 
 class _SkillSets:
-    """Stands in for the repository seam that owns resolution *and* repair."""
+    """Stands in for the repository seam that owns resolution and membership."""
 
     def __init__(self, bridge: InstallationFlushPlan) -> None:
         self._bridge = bridge
         self.calls: list[dict] = []
+        self.member_calls: list[dict] = []
 
     def flush_installations(self, **kwargs) -> InstallationFlushPlan:
         self.calls.append(kwargs)
         return self._bridge
+
+    def list_member_skill_ids(self, **kwargs) -> frozenset[int]:
+        self.member_calls.append(kwargs)
+        return self._bridge.member_skill_ids
 
 
 class _Skills:
@@ -142,11 +147,11 @@ def _list(service, *, actor_id: str = "owner", source: str | None = None):
     )
 
 
-# ── Listing: flush-first, engine scoping, refusal-before-write ──────
+# ── Listing: membership-first, engine scoping, refusal-before-write ─
 
 
-def test_the_repair_runs_before_the_page_is_cut():
-    """`active` is a filter, so the repair cannot happen after the query."""
+def test_effective_sync_then_membership_read_runs_before_the_page_is_cut():
+    """Listing synchronizes effective state but reads reachability separately."""
     service, skills, sets, _bots = _listing_service(
         bridge=InstallationFlushPlan(
             member_skill_ids=frozenset({1, 2}),
@@ -158,18 +163,19 @@ def test_the_repair_runs_before_the_page_is_cut():
     _list(service)
 
     assert len(sets.calls) == 1
+    assert len(sets.member_calls) == 1
     assert skills.calls[0]["skill_set_member_ids"] == frozenset({1, 2})
     assert skills.calls[0]["bot_id"] == "bot"
     assert skills.calls[0]["user_id"] == "owner"
     assert skills.calls[0]["source"] is None
 
 
-def test_local_source_filter_is_forwarded_after_the_standard_flush():
+def test_local_source_filter_is_forwarded_after_the_membership_read():
     service, skills, sets, _bots = _listing_service(bridge=_EMPTY)
 
     _list(service, source="LOCAL")
 
-    assert len(sets.calls) == 1
+    assert len(sets.member_calls) == 1
     assert skills.calls[0]["source"] == "LOCAL"
 
 
@@ -182,9 +188,8 @@ def test_the_skillset_scope_uses_the_bots_engine_and_layout_precedence():
 
     _list(service)
 
-    assert sets.calls[0]["env"] == "dev"
-    assert sets.calls[0]["engine_type"] == "claude_code"
-    assert sets.calls[0]["default_engine_types"] == ("aicoding", "claude_code")
+    assert sets.member_calls[0]["engine_type"] == "claude_code"
+    assert sets.member_calls[0]["default_engine_types"] == ("aicoding", "claude_code")
     # One Bot read for the whole listing: the engine comes off it.
     assert bots.reads == 1
 
@@ -202,8 +207,8 @@ def test_a_bot_with_no_recorded_engine_does_not_scope_to_a_literal_none():
 
     _list(service)
 
-    assert sets.calls[0]["engine_type"] is None
-    assert sets.calls[0]["default_engine_types"] == ()
+    assert sets.member_calls[0]["engine_type"] is None
+    assert sets.member_calls[0]["default_engine_types"] == ()
 
 
 def test_an_invisible_bot_is_refused_before_anything_is_written():

--- a/src/backend/tests/community/repository/skill_center/test_capability_desired_state_uow.py
+++ b/src/backend/tests/community/repository/skill_center/test_capability_desired_state_uow.py
@@ -211,6 +211,126 @@ def test_global_default_reads_apply_owner_bot_exclusions_without_hiding_membersh
         bot_id="default", owner_id="owner-b", set_id=str(default.id), engine_type="openclaw"
     )] == ["included", "excluded"]
 
+
+def test_default_only_sync_materializes_defaults_without_repairing_ordinary_history():
+    """The post-backfill path has one writer: Default membership/exclusion."""
+    db = _Database()
+    with db.transactional_orm_session() as session:
+        default = SkillSet(
+            name="platform-default", bolt_id="", user_id="", engine_type="openclaw",
+            is_default=True, env="dev",
+        )
+        ordinary = SkillSet(
+            name="ordinary", bolt_id="bot", user_id="owner", engine_type="openclaw",
+            is_active=True, env="dev",
+        )
+        default_skill = Skill(name="default", git_path="git://default", env="dev")
+        excluded_skill = Skill(name="excluded", git_path="git://excluded", env="dev")
+        shared_skill = Skill(name="shared", git_path="git://shared", env="dev")
+        direct_skill = Skill(name="direct", git_path="local://direct", env="dev")
+        former_default_skill = Skill(
+            name="former-default", git_path="git://former-default", env="dev"
+        )
+        session.add_all([
+            default, ordinary, default_skill, excluded_skill, shared_skill,
+            direct_skill, former_default_skill,
+        ])
+        session.flush()
+        session.add_all([
+            SkillSetSkill(skill_set_id=default.id, skill_id=default_skill.id, env="dev"),
+            SkillSetSkill(skill_set_id=default.id, skill_id=excluded_skill.id, env="dev"),
+            SkillSetSkill(skill_set_id=default.id, skill_id=shared_skill.id, env="dev"),
+            SkillSetSkill(skill_set_id=ordinary.id, skill_id=shared_skill.id, env="dev"),
+            SkillSetMCPServer(skill_set_id=default.id, server_code="mcp.default", name="default", env="dev"),
+            SkillSetMCPServer(skill_set_id=default.id, server_code="mcp.excluded", name="excluded", env="dev"),
+            SkillSetMCPServer(skill_set_id=default.id, server_code="mcp.shared", name="shared", env="dev"),
+            SkillSetMCPServer(skill_set_id=ordinary.id, server_code="mcp.shared", name="shared", env="dev"),
+            DefaultSkillsetSkillExclusion(
+                user_id="owner", bot_id="bot", skill_set_id=default.id,
+                skill_id=excluded_skill.id,
+            ),
+            DefaultSkillsetSkillExclusion(
+                user_id="owner", bot_id="bot", skill_set_id=default.id,
+                skill_id=shared_skill.id,
+            ),
+            DefaultSkillsetMcpExclusion(
+                user_id="owner", bot_id="bot", skill_set_id=default.id,
+                server_code="mcp.excluded",
+            ),
+            BotSkillInstallation(bot_id="bot", owner_id="owner", skill_id=excluded_skill.id, env="dev"),
+            # Historical malformed overlap: Default exclusion must not remove
+            # the active ordinary Set's claim.
+            BotSkillInstallation(bot_id="bot", owner_id="owner", skill_id=shared_skill.id, env="dev"),
+            BotSkillInstallation(bot_id="bot", owner_id="owner", skill_id=direct_skill.id, env="dev"),
+            # Default membership removal is an explicit operations cleanup;
+            # the reader cannot infer that this is not a Direct installation.
+            BotSkillInstallation(bot_id="bot", owner_id="owner", skill_id=former_default_skill.id, env="dev"),
+            BotMCPInstallation(bot_id="bot", owner_id="owner", server_code="mcp.excluded", env="dev"),
+        ])
+
+    repository = CapabilityDesiredStateRepository(db)
+    plan = repository.sync_default_installations(
+        bot_id="bot", owner_id="owner", env="dev", engine_type="openclaw"
+    )
+
+    assert plan.skills_to_install == frozenset({default_skill.id})
+    assert plan.skills_to_uninstall == frozenset({excluded_skill.id})
+    assert plan.mcps_to_install == frozenset({"mcp.default", "mcp.shared"})
+    assert plan.mcps_to_uninstall == frozenset({"mcp.excluded"})
+    with db.orm_session() as session:
+        assert {row.skill_id for row in session.query(BotSkillInstallation).all()} == {
+            default_skill.id, shared_skill.id, direct_skill.id, former_default_skill.id,
+        }
+        assert {row.server_code for row in session.query(BotMCPInstallation).all()} == {
+            "mcp.default", "mcp.shared",
+        }
+
+    assert repository.sync_default_installations(
+        bot_id="bot", owner_id="owner", env="dev", engine_type="openclaw"
+    ) == plan
+
+
+def test_new_bot_initialization_inserts_missing_rows_without_deleting_existing_rows():
+    """Creation/retry initializes DB state without Reader or Runtime projection."""
+    db = _Database()
+    with db.transactional_orm_session() as session:
+        active = SkillSet(
+            name="active", bolt_id="bot", user_id="owner", engine_type="openclaw",
+            is_active=True, env="dev",
+        )
+        inactive = SkillSet(
+            name="inactive", bolt_id="bot", user_id="owner", engine_type="openclaw",
+            is_active=False, env="dev",
+        )
+        active_skill = Skill(name="active", git_path="git://active", env="dev")
+        stale_skill = Skill(name="stale", git_path="git://stale", env="dev")
+        direct_skill = Skill(name="direct", git_path="local://direct", env="dev")
+        session.add_all([active, inactive, active_skill, stale_skill, direct_skill])
+        session.flush()
+        session.add_all([
+            SkillSetSkill(skill_set_id=active.id, skill_id=active_skill.id, env="dev"),
+            SkillSetSkill(skill_set_id=inactive.id, skill_id=stale_skill.id, env="dev"),
+            SkillSetMCPServer(skill_set_id=active.id, server_code="mcp.active", name="active", env="dev"),
+            SkillSetMCPServer(skill_set_id=inactive.id, server_code="mcp.stale", name="stale", env="dev"),
+            BotSkillInstallation(bot_id="bot", owner_id="owner", skill_id=stale_skill.id, env="dev"),
+            BotSkillInstallation(bot_id="bot", owner_id="owner", skill_id=direct_skill.id, env="dev"),
+            BotMCPInstallation(bot_id="bot", owner_id="owner", server_code="mcp.stale", env="dev"),
+            BotMCPInstallation(bot_id="bot", owner_id="owner", server_code="mcp.direct", env="dev"),
+        ])
+
+    CapabilityDesiredStateRepository(db).initialize_installations(
+        bot_id="bot", owner_id="owner", env="dev", engine_type="openclaw"
+    )
+
+    with db.orm_session() as session:
+        assert {row.skill_id for row in session.query(BotSkillInstallation).all()} == {
+            active_skill.id, stale_skill.id, direct_skill.id,
+        }
+        assert {row.server_code for row in session.query(BotMCPInstallation).all()} == {
+            "mcp.active", "mcp.stale", "mcp.direct",
+        }
+
+
 def test_flush_does_not_resurrect_a_deactivated_sets_member():
     """A later flush cannot re-add a member after its Set is deactivated."""
     db = _Database()


### PR DESCRIPTION
## Problem
Installation is the active-capability SSOT, but new Bot creation relied on a later Reader/Projector write and ordinary SkillSet reconciliation cannot be removed before historical backfill is accepted.

## Solution
- Initialize missing Skill/MCP Installation rows DB-only during normal and desktop Bot creation, with append-only retry repair.
- Keep full reconciliation as the default and backfill path; add an explicit default-off switch that reduces post-backfill effective reads to Default membership plus exclusions.
- Separate pure SkillSet membership reads from effective-state synchronization, retaining Installation as the only effective source.

## Validation
- `uv run pytest -q` — 17643 passed, 60 skipped.
- Targeted Installation, Reader, creation, OpenAPI, manifest, DI, architecture and contract tests passed.
- Standards/Spec review completed; high-priority findings were fixed.

## Compatibility and risk
No public HTTP contract or schema change. `SC_INSTALLATION_DEFAULT_SYNC_ONLY` defaults to `false`; do not enable it until the environment backfill and its acceptance checks complete. The internal backfill endpoint always runs the complete resolver. Global Default membership removal remains controlled operations cleanup and is not inferred from Installation rows.