### PR TITLE
feat(engine): add user-scoped session source filtering

### DIFF
--- a/src/engine/src/engine/community/claude_code_gateway/src/cron/store.ts
+++ b/src/engine/src/engine/community/claude_code_gateway/src/cron/store.ts
@@ -41,7 +41,8 @@ export class CronStore {
   private runsDirty = false;
   private jobsTimer: NodeJS.Timeout | null = null;
   private runsTimer: NodeJS.Timeout | null = null;
-  private writeInFlight: Promise<void> | null = null;
+  private jobsWriteInFlight: Promise<void> | null = null;
+  private runsWriteInFlight: Promise<void> | null = null;
 
   constructor(jobsPath: string, options: CronStoreOptions = {}) {
     this.jobsPath = jobsPath;
@@ -129,11 +130,7 @@ export class CronStore {
   async flush(): Promise<void> {
     if (this.jobsTimer) { clearTimeout(this.jobsTimer); this.jobsTimer = null; }
     if (this.runsTimer) { clearTimeout(this.runsTimer); this.runsTimer = null; }
-    await Promise.all([
-      this.jobsDirty ? this.writeJobs() : Promise.resolve(),
-      this.runsDirty ? this.writeRuns() : Promise.resolve(),
-    ]);
-    if (this.writeInFlight) await this.writeInFlight;
+    await Promise.all([ this.writeJobs(), this.writeRuns() ]);
   }
 
   // ---- Internals ----
@@ -165,25 +162,47 @@ export class CronStore {
   }
 
   private async writeJobs(): Promise<void> {
+    if (this.jobsWriteInFlight) {
+      await this.jobsWriteInFlight;
+      if (this.jobsDirty) await this.writeJobs();
+      return;
+    }
     if (!this.jobsDirty) return;
+
     this.jobsDirty = false;
     const snapshot = JSON.stringify([ ...this.jobs.values() ], null, 2);
-    this.writeInFlight = this.writeAtomic(this.jobsPath, snapshot)
-      .catch(err => { this.jobsDirty = true; throw err; })
-      .finally(() => { this.writeInFlight = null; });
-    await this.writeInFlight;
+    const write = this.writeAtomic(this.jobsPath, snapshot)
+      .catch(err => { this.jobsDirty = true; throw err; });
+    this.jobsWriteInFlight = write;
+    try {
+      await write;
+    } finally {
+      if (this.jobsWriteInFlight === write) this.jobsWriteInFlight = null;
+    }
+    if (this.jobsDirty) await this.writeJobs();
   }
 
   private async writeRuns(): Promise<void> {
+    if (this.runsWriteInFlight) {
+      await this.runsWriteInFlight;
+      if (this.runsDirty) await this.writeRuns();
+      return;
+    }
     if (!this.runsDirty) return;
+
     this.runsDirty = false;
     const obj: Record<string, CronRunRecord[]> = {};
     for (const [ id, list ] of this.runs.entries()) obj[id] = list;
     const snapshot = JSON.stringify(obj, null, 2);
-    this.writeInFlight = this.writeAtomic(this.runsPath, snapshot)
-      .catch(err => { this.runsDirty = true; throw err; })
-      .finally(() => { this.writeInFlight = null; });
-    await this.writeInFlight;
+    const write = this.writeAtomic(this.runsPath, snapshot)
+      .catch(err => { this.runsDirty = true; throw err; });
+    this.runsWriteInFlight = write;
+    try {
+      await write;
+    } finally {
+      if (this.runsWriteInFlight === write) this.runsWriteInFlight = null;
+    }
+    if (this.runsDirty) await this.writeRuns();
   }
 
   private async writeAtomic(filePath: string, contents: string): Promise<void> {

--- a/src/engine/src/engine/community/claude_code_gateway/src/gateway/handlers/sessions.ts
+++ b/src/engine/src/engine/community/claude_code_gateway/src/gateway/handlers/sessions.ts
@@ -313,8 +313,43 @@ export const handleSessionNew: SessionsHandler = async (ctx, frame, deps) => {
 };
 
 export const handleSessionsList: SessionsHandler = async (ctx, frame, deps) => {
-  const sessions = deps.store.list().map(mapSessionSummary);
-  ctx.response(frame.id, true, { sessions });
+  const params = (frame.params ?? {}) as Record<string, unknown>;
+  const source = params.source;
+  const allSessions = deps.store.list();
+  let sessions = allSessions;
+
+  if (source !== undefined) {
+    if (source !== 'all_but_others') {
+      log.warn('sessions.list: invalid request', { reason: 'unsupported-source' });
+      ctx.response(frame.id, false, undefined, {
+        message: 'unsupported source',
+        code: 'INVALID_REQUEST',
+      });
+      return;
+    }
+
+    const userId = typeof params.userId === 'string' ? params.userId.trim() : '';
+    if (!userId) {
+      log.warn('sessions.list: invalid request', { reason: 'missing-user-id' });
+      ctx.response(frame.id, false, undefined, {
+        message: 'userId required for source all_but_others',
+        code: 'INVALID_REQUEST',
+      });
+      return;
+    }
+
+    sessions = allSessions.filter(binding => {
+      const match = binding.gatewaySessionKey.match(/:user:([^:]+)$/);
+      return !match || match[1] === userId;
+    });
+  }
+
+  log.debug('sessions.list: complete', {
+    source: source ?? 'all',
+    total: allSessions.length,
+    returned: sessions.length,
+  });
+  ctx.response(frame.id, true, { sessions: sessions.map(mapSessionSummary) });
 };
 
 export const handleSessionsPatch: SessionsHandler = async (ctx, frame, deps) => {

--- a/src/engine/src/engine/community/claude_code_gateway/test/cron.test.ts
+++ b/src/engine/src/engine/community/claude_code_gateway/test/cron.test.ts
@@ -132,6 +132,45 @@ describe('CronStore', () => {
     assert.deepEqual(store.getRuns('j', 10), []);
   });
 
+  it('flush waits for concurrent jobs and runs writes', async () => {
+    const runsPath = path.join(path.dirname(storePath), `cron-runs-gated-${Date.now()}-${Math.random().toString(36).slice(2, 6)}.json`);
+    const persistent = new CronStore(storePath, { writeDebounceMs: 0, runsPath, maxRunsPerJob: 3 });
+    const writable = persistent as unknown as {
+      writeAtomic: (filePath: string, contents: string) => Promise<void>;
+    };
+    const originalWriteAtomic = writable.writeAtomic.bind(persistent);
+    let releaseJobsWrite!: () => void;
+    const jobsWriteGate = new Promise<void>(resolve => { releaseJobsWrite = resolve; });
+    writable.writeAtomic = async (filePath, contents) => {
+      if (filePath === storePath) await jobsWriteGate;
+      await originalWriteAtomic(filePath, contents);
+    };
+
+    try {
+      persistent.put(makeJob({ id: 'persist' }));
+      persistent.appendRun({ jobId: 'persist', runId: 'r1', runAtMs: 0, ts: 1, status: 'ok', durationMs: 1 });
+
+      let flushSettled = false;
+      const flushPromise = persistent.flush().then(() => { flushSettled = true; });
+      await new Promise<void>(resolve => setImmediate(resolve));
+      assert.equal(flushSettled, false, 'flush returned before the blocked jobs write completed');
+
+      releaseJobsWrite();
+      await flushPromise;
+
+      const reopened = new CronStore(storePath, { writeDebounceMs: 0, runsPath, maxRunsPerJob: 3 });
+      assert.equal(reopened.get('persist')?.id, 'persist');
+      assert.equal(reopened.getRuns('persist', 10).length, 1);
+      await reopened.flush();
+    } finally {
+      releaseJobsWrite();
+      await persistent.flush();
+      if (fs.existsSync(runsPath)) {
+        try { fs.unlinkSync(runsPath); } catch { /* ignore */ }
+      }
+    }
+  });
+
   it('flush persists and a new store reloads state', async () => {
     const runsPath = path.join(path.dirname(storePath), `cron-runs-${Date.now()}-${Math.random().toString(36).slice(2, 6)}.json`);
     const persistent = new CronStore(storePath, { writeDebounceMs: 0, runsPath, maxRunsPerJob: 3 });

--- a/src/engine/src/engine/community/claude_code_gateway/test/server.test.ts
+++ b/src/engine/src/engine/community/claude_code_gateway/test/server.test.ts
@@ -264,6 +264,75 @@ describe('Gateway server (E2E)', () => {
     }
   });
 
+  it('sessions.list filters only other user-scoped keys without pagination', async () => {
+    const { server, store, storePath } = await bootServer([{ kind: 'done' }]);
+
+    try {
+      const client = await connectedClient(server.port);
+      for (const sessionKey of [
+        'session:mine:user:u1',
+        'agent:bot:session:mine-agent:user:u1',
+        'session:other:user:u2',
+        'agent:bot:session:other-agent:user:u2',
+        'session:legacy',
+        'custom:format:userless',
+      ]) {
+        await client.request('session.new', { sessionKey });
+      }
+
+      const list = await client.request('sessions.list', {
+        source: 'all_but_others',
+        userId: 'u1',
+        offset: 1,
+        limit: 1,
+      });
+      const keys = (list.payload as { sessions: Array<{ key: string }> }).sessions
+        .map(session => session.key);
+
+      assert(keys.includes('session:mine:user:u1'));
+      assert(keys.includes('agent:bot:session:mine-agent:user:u1'));
+      assert(!keys.includes('session:other:user:u2'));
+      assert(!keys.includes('agent:bot:session:other-agent:user:u2'));
+      assert(keys.includes('session:legacy'));
+      assert(keys.includes('custom:format:userless'));
+      assert.equal(keys.length, 4, 'gateway must not apply offset/limit pagination');
+
+      await client.close();
+    } finally {
+      await teardown(server, store, storePath);
+    }
+  });
+
+  it('sessions.list rejects an unknown source', async () => {
+    const { server, store, storePath } = await bootServer([{ kind: 'done' }]);
+
+    try {
+      const client = await connectedClient(server.port);
+      const res = await client.request('sessions.list', { source: 'unknown', userId: 'u1' });
+
+      assert.equal(res.ok, false);
+      assert.equal(res.error?.code, 'INVALID_REQUEST');
+      await client.close();
+    } finally {
+      await teardown(server, store, storePath);
+    }
+  });
+
+  it('sessions.list requires userId for all_but_others', async () => {
+    const { server, store, storePath } = await bootServer([{ kind: 'done' }]);
+
+    try {
+      const client = await connectedClient(server.port);
+      const res = await client.request('sessions.list', { source: 'all_but_others' });
+
+      assert.equal(res.ok, false);
+      assert.equal(res.error?.code, 'INVALID_REQUEST');
+      await client.close();
+    } finally {
+      await teardown(server, store, storePath);
+    }
+  });
+
   it('sessions.list exposes cwd and model from binding', async () => {
     // 让 OCB engine adaptor 能在 sessions.list 直接拿到 cwd / model，
     // 不必再读 binding 内部状态。

--- a/src/engine/src/engine/community/core/adapters/claude_code/session.py
+++ b/src/engine/src/engine/community/core/adapters/claude_code/session.py
@@ -55,8 +55,9 @@ log = logging.getLogger("claude-code-session-adapter")
 def _parse_session_key(key: str) -> tuple[str | None, str | None]:
     """Extract (user_id, agent_id) from a canonical claude_code session key.
 
-    Recognises two long forms:
+    Recognises three user-scoped forms:
       * new  ``agent:<a>:session:<s>:user:<u>``
+      * no-agent ``session:<s>:user:<u>``
       * legacy ``user:<u>:session:<s>:agent:<a>``
 
     Returns ``(None, None)`` for the legacy short form ``session:<uuid>`` and
@@ -72,6 +73,17 @@ def _parse_session_key(key: str) -> tuple[str | None, str | None]:
         if not user_part or not agent_part:
             return None, None
         return user_part, agent_part
+
+    if key.startswith("session:") and ":user:" in key:
+        try:
+            session_part, user_part = key.removeprefix("session:").split(
+                ":user:", 1
+            )
+        except ValueError:
+            return None, None
+        if not session_part or not user_part:
+            return None, None
+        return user_part, None
 
     if key.startswith("user:") and ":session:" in key and ":agent:" in key:
         try:
@@ -281,12 +293,17 @@ class ClaudeCodeSessionAdapter(SessionService):
             has_session_key,
         )
 
+        source_params = (
+            {"source": request.source, "user_id": request.user_id}
+            if request.source is not None else {}
+        )
         raw_sessions = await self._port.sessions_list(
             token=token,
             offset=request.offset,
             limit=request.limit,
             agent_id=request.agent_id,
             session_key=request.session_key,
+            **source_params,
         )
 
         sessions: list[Session] = []
@@ -318,10 +335,10 @@ class ClaudeCodeSessionAdapter(SessionService):
 
         user_id = request.user_id or "default"
         session_uuid = request.uuid or str(uuid.uuid4())
-        if request.agent_id and request.user_id:
+        if request.agent_id:
             session_key = f"agent:{request.agent_id}:session:{session_uuid}:user:{user_id}"
         else:
-            session_key = f"session:{session_uuid}"
+            session_key = f"session:{session_uuid}:user:{user_id}"
 
         label = request.title or None
 

--- a/src/engine/src/engine/community/core/adapters/claude_code/tests/test_adapters.py
+++ b/src/engine/src/engine/community/core/adapters/claude_code/tests/test_adapters.py
@@ -84,10 +84,12 @@ class _FakeSessionPort:
 
     async def sessions_list(
         self, token=None, offset=0, limit=50, agent_id=None, session_key=None,
+        source=None, user_id=None,
     ) -> list[dict]:
         self.calls.append({
             "method": "sessions_list", "token": token, "offset": offset,
             "limit": limit, "agent_id": agent_id, "session_key": session_key,
+            "source": source, "user_id": user_id,
         })
         return self._sessions
 
@@ -159,6 +161,9 @@ class TestSessionAdapter:
         assert user == "u2"
         assert agent == "bot2"
 
+    def test_parse_session_key_user_form(self):
+        assert _parse_session_key("session:uuid-only:user:u3") == ("u3", None)
+
     def test_parse_session_key_short_form_returns_none(self):
         assert _parse_session_key("session:uuid-only") == (None, None)
 
@@ -204,7 +209,9 @@ class TestSessionAdapter:
         adapter = ClaudeCodeSessionAdapter(port)
 
         sessions = await adapter.list(
-            SessionListRequest(user_id="u1", agent_id="b1", limit=10),
+            SessionListRequest(
+                user_id="u1", agent_id="b1", source="all_but_others", limit=10,
+            ),
             auth=_auth("tok-1"),
         )
 
@@ -212,6 +219,8 @@ class TestSessionAdapter:
         assert sessions[0].id == "agent:b1:session:s1:user:u1"
         assert port.calls[0]["token"] == "tok-1"
         assert port.calls[0]["agent_id"] == "b1"
+        assert port.calls[0]["source"] == "all_but_others"
+        assert port.calls[0]["user_id"] == "u1"
         assert port.calls[0]["limit"] == 10
 
     async def test_list_forwards_session_key_to_port(self):
@@ -254,16 +263,26 @@ class TestSessionAdapter:
         session = await adapter.create(
             SessionCreateRequest(
                 title="T", user_id="u1", agent_id="b1", model="m1",
+                uuid="session-uuid",
             ),
             auth=_auth("tok-2"),
         )
-        # The key form is agent:b1:session:<uuid>:user:u1
-        assert session.id.startswith("agent:b1:session:")
-        assert session.id.endswith(":user:u1")
+        assert session.id == "agent:b1:session:session-uuid:user:u1"
         assert session.model == "m1"
         assert port.calls[0]["method"] == "session_create"
         assert port.calls[0]["token"] == "tok-2"
         assert port.calls[0]["model"] == "m1"
+
+    async def test_create_without_agent_builds_user_scoped_key(self):
+        port = _FakeSessionPort()
+        adapter = ClaudeCodeSessionAdapter(port)
+
+        session = await adapter.create(
+            SessionCreateRequest(uuid="session-uuid", user_id="u2"),
+        )
+
+        assert session.key == "session:session-uuid:user:u2"
+        assert port.calls[0]["key"] == "session:session-uuid:user:u2"
 
     async def test_delete_delegates(self):
         port = _FakeSessionPort()

--- a/src/engine/src/engine/community/local/claude_code/plugin_impl.py
+++ b/src/engine/src/engine/community/local/claude_code/plugin_impl.py
@@ -14,6 +14,7 @@ dict so round-trip assertions work.
 from __future__ import annotations
 
 import logging
+import re
 from collections.abc import AsyncGenerator
 from typing import Any
 
@@ -159,7 +160,15 @@ class LocalClaudeCodePluginImpl(ClaudeCodePlugin):
         limit: int = 50,
         agent_id: str | None = None,
         session_key: str | None = None,
+        source: str | None = None,
+        user_id: str | None = None,
     ) -> list[dict]:
+        if source not in (None, "all_but_others"):
+            return []
+        actor_user_id = user_id.strip() if isinstance(user_id, str) else ""
+        if source == "all_but_others" and not actor_user_id:
+            return []
+
         items = list(self._sessions.values())
         if agent_id is not None:
             before_count = len(items)
@@ -181,6 +190,13 @@ class LocalClaudeCodePluginImpl(ClaudeCodePlugin):
                 before_count,
                 len(items),
             )
+        if source == "all_but_others":
+            items = [
+                item for item in items
+                if not isinstance(item.get("key"), str)
+                or not (match := re.search(r":user:([^:]+)$", item["key"]))
+                or match.group(1) == actor_user_id
+            ]
         return items[offset: offset + limit]
 
     async def session_create(

--- a/src/engine/src/engine/community/plugin_api/claude_code/session.py
+++ b/src/engine/src/engine/community/plugin_api/claude_code/session.py
@@ -38,6 +38,8 @@ class ClaudeCodeSessionPort(Protocol):
         limit: int = 50,
         agent_id: str | None = None,
         session_key: str | None = None,
+        source: str | None = None,
+        user_id: str | None = None,
     ) -> list[dict]:
         """Call ``sessions.list`` and return raw session dicts.
 
@@ -50,6 +52,8 @@ class ClaudeCodeSessionPort(Protocol):
             limit: Page size (default 50).
             agent_id: Optional agent filter.
             session_key: Optional exact session-key filter; blank values are ignored.
+            source: Optional gateway source filter.
+            user_id: User id forwarded with a source filter.
 
         Returns:
             List of raw session dicts after local filtering and pagination.

--- a/src/engine/src/engine/community/plugins/claude_code/_session.py
+++ b/src/engine/src/engine/community/plugins/claude_code/_session.py
@@ -43,10 +43,13 @@ class _SessionPortMixin:
         limit: int = 50,
         agent_id: str | None = None,
         session_key: str | None = None,
+        source: str | None = None,
+        user_id: str | None = None,
     ) -> list[dict]:
         client = await self._relay()
+        params = {"source": source, "userId": user_id} if source is not None else {}
         try:
-            resp = await client.send_request("sessions.list", {})
+            resp = await client.send_request("sessions.list", params)
         except Exception as e:  # noqa: BLE001
             log.error("[sessions_list] RPC failed: %s", e)
             return []

--- a/src/engine/src/engine/community/plugins/claude_code/tests/test_mixins_coverage.py
+++ b/src/engine/src/engine/community/plugins/claude_code/tests/test_mixins_coverage.py
@@ -1061,12 +1061,30 @@ class TestSessionMixin:
         assert await impl.sessions_list(session_key="tar") == []
         assert await impl.sessions_list(session_key="get") == []
 
+    async def test_list_forwards_source_and_user_id_before_local_pagination(self):
+        c = _FakeRelayClient()
+        c.set_response("sessions.list", _ok({"sessions": [
+            {"key": "first"}, {"key": "second"}, {"key": "third"},
+        ]}))
+        impl, _ = _impl(c)
+
+        out = await impl.sessions_list(
+            source="all_but_others", user_id="u1", offset=1, limit=1,
+        )
+
+        assert out == [{"key": "second"}]
+        _, args, kw = _last_call(c)
+        assert args[0] == "sessions.list"
+        assert kw["params"] == {"source": "all_but_others", "userId": "u1"}
+
     async def test_list_offset_limit(self):
         c = _FakeRelayClient()
         c.set_response("sessions.list", _ok({"sessions": [{"key": str(i)} for i in range(10)]}))
         impl, _ = _impl(c)
         out = await impl.sessions_list(offset=2, limit=3)
         assert [s["key"] for s in out] == ["2", "3", "4"]
+        _, _, kw = _last_call(c)
+        assert kw["params"] == {}
 
     async def test_create_success_full_params(self):
         c = _FakeRelayClient()

--- a/src/engine/src/engine/community/tests/contracts/test_claude_code_local_plugin.py
+++ b/src/engine/src/engine/community/tests/contracts/test_claude_code_local_plugin.py
@@ -8,6 +8,8 @@ local plugin, no ``world`` fixture.
 """
 from __future__ import annotations
 
+from engine.community.core.adapters.claude_code.session import ClaudeCodeSessionAdapter
+from engine.community.core.session.models import SessionListRequest
 from engine.community.kernel.frames import EventFrame
 from engine.community.plugin_api.claude_code.plugin import ClaudeCodePlugin
 from engine.community.local.claude_code import LocalClaudeCodePluginImpl
@@ -84,6 +86,34 @@ async def test_local_claude_code_session_key_lookup_is_exact_and_pre_paginated()
     assert await plugin.sessions_list(session_key="get") == []
     assert await plugin.sessions_list(session_key="missing", offset=0, limit=1) == []
     assert await plugin.sessions_list(session_key="  ", offset=0, limit=1) == [first]
+
+
+async def test_local_claude_code_source_filter_via_adapter_before_pagination():
+    plugin = LocalClaudeCodePluginImpl()
+    await plugin.session_create("session:other:user:u2")
+    current = await plugin.session_create("session:current:user:u1")
+    userless = await plugin.session_create("session:legacy")
+    adapter = ClaudeCodeSessionAdapter(plugin)
+
+    sessions = await adapter.list(SessionListRequest(
+        source="all_but_others", user_id="u1", limit=10,
+    ))
+    assert [session.key for session in sessions] == [current["key"], userless["key"]]
+
+    padded = await adapter.list(SessionListRequest(
+        source="all_but_others", user_id=" u1 ", limit=10,
+    ))
+    assert [session.key for session in padded] == [current["key"], userless["key"]]
+
+    blank = await adapter.list(SessionListRequest(
+        source="all_but_others", user_id="   ", limit=10,
+    ))
+    assert blank == []
+
+    page = await adapter.list(SessionListRequest(
+        source="all_but_others", user_id="u1", offset=1, limit=1,
+    ))
+    assert [session.key for session in page] == [userless["key"]]
 
 
 async def test_local_claude_code_agent_lookup_uses_canonical_key_without_agent_id():


### PR DESCRIPTION
## Problem

Claude Code sessions created without an agent identifier were emitted as `session:<uuid>` and did not preserve the creating user in the session key. The existing Engine session-list API already accepts `source`, but the Claude Code gateway did not implement `source=all_but_others`.

The Gateway `CronStore` also used one shared in-flight Promise for independent jobs and runs files. Concurrent zero-debounce writes could overwrite that Promise, allowing `flush()` to return before the jobs file was persisted.

## Solution

- Generate `session:<uuid>:user:<user_id>` for Claude Code sessions without an agent identifier, while preserving `agent:<agent_id>:session:<uuid>:user:<user_id>` when an agent is present.
- Forward the existing `source` and `user_id` values through the Claude Code Adapter and Port as the gateway `source` and `userId` parameters.
- Implement `all_but_others` in `claude_code_gateway`: exclude only session keys whose trailing `:user:<id>` belongs to another user, while retaining legacy keys and other formats.
- Keep pagination in the Python Port after the gateway returns the complete filtered list.
- Keep the Local Claude Code Plugin compatible with the updated Port signature and filtering semantics.
- Track jobs and runs persistence independently in `CronStore`, serialize follow-up writes for each file, and make `flush()` await both write streams.

## Validation

- Cron persistence race reproduced in an isolated loop on iteration 9 before the fix.
- Deterministic concurrent jobs/runs write regression: passed after the fix.
- Cron persistence stress: 100/100 iterations passed after the fix.
- Gateway test suite: `327 passing`.
- Gateway build: `npm run prepublishOnly` passed.
- Engine community suite: `2472 passed, 5 skipped, 17 warnings`.
- Focused Adapter/Port/Local Plugin tests: `255 passed`.
- Ruff `F401/F841`, Python compilation, and `git diff --check`: passed.

## Compatibility and risk

- Omitting `source` preserves the existing `sessions.list` request shape and behavior.
- The gateway performs source filtering only; existing Port-side `agent_id`, exact session-key filtering, and pagination remain unchanged.
- Session keys without a trailing `:user:<id>` remain visible under `all_but_others`, as required by the product contract.
- Cron jobs and run history remain in separate files; the fix changes only in-flight write coordination and flush guarantees.
