### PR TITLE
fix(baas): raise openapi message-run default_timeout to avoid premature 30s timeout

### DIFF
--- a/src/baas/configs/application.yaml
+++ b/src/baas/configs/application.yaml
@@ -71,7 +71,7 @@ user_config:
     queue_max: 0                     # 全局最大排队等待数（0=不限）
     acquire_timeout: 0               # acquire 等待槽位超时秒数（0=不限）
     task_timeout: 660.0              # 单任务最大执行秒数（0=不限，默认660=10分钟+1分钟缓冲）
-    default_timeout: 30.0            # 请求默认超时秒数（metadata 未指定 timeout 时使用）
+    default_timeout: 1800.0            # 请求默认超时秒数（metadata 未指定 timeout 时使用）
     origin: "https://teamclaw.example.com"
 
   # BotRun 队列 Worker 配置


### PR DESCRIPTION
## Problem
  `user_config.runtime.default_timeout` was 30s. The task framework's
  `send_message` (POST /openapi/v1/messages) does not pass a per-request timeout in
  metadata, so BaaS fell back to this 30s default and marked the run
  `TIME_OUT` / `error="Task execution timeout"` / `result=null` at 30s — even though
  the bot actually completed and the reply existed in the session history. The 30s
  cut happened before the (slower, multi-step) bot reply could be collected into the
  run record, so callers polling `GET /openapi/v1/messages/{id}` only saw a terminal
  `TIME_OUT` with null result, while the correct reply remained only in the bot
  session.

  ## Solution
  Raise `default_timeout` from 30.0 to 1800.0 so the message-run waits long enough
  for the bot reply to be collected into the run record. Effective execution is
  still capped by `task_timeout` (660s), so this only removes the premature 30s cut;
  it does not lengthen the real task ceiling.

  ## Validation
  - Config-only change (single line); no code/test change.
  - Verified the branch diff vs `origin/dev` is exactly this one line.
  - Pending: message-run round-trip verification in the target deployment —
    `GET /openapi/v1/messages/{id}` no longer early-times-out when the bot reply
    arrives after 30s.

  ## Compatibility and risk
  - Behavior: openapi message-run no longer terminates at 30s for runs without an
    explicit metadata timeout; the real execution ceiling (`task_timeout=660s`) is
    unchanged.
  - Rollback: revert this single commit; no schema/data migration.