### PR TITLE
fix(bot-config-manifest): align DDL with OceanBase, add ac_task_queue schema

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/sql/2026_08_31_bot_config_manifest.sql
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/sql/2026_08_31_bot_config_manifest.sql
@@ -43,6 +43,29 @@
 --
 -- entity_id is a storage key only: it is resolved server-side from the bot
 -- record and is never a request parameter or a response field on the public API.
+-- DIALECT: OCEANBASE, MYSQL MODE. What this file writes follows the deployed
+-- tables there rather than portable MySQL -- compare ``SHOW CREATE TABLE
+-- ac_bots``, and the sibling DDL in core/caller_identity/sql/.
+--
+--   * EVERY INDEX IS DECLARED ``GLOBAL``. On a partitioned table an index
+--     without it is partition-local, and a partition-local UNIQUE enforces
+--     uniqueness only *within* a partition. These tables are not
+--     partitioned today, so it is a no-op now and cheap insurance later: what
+--     it prevents surfaces as duplicate rows, silently, never as an error.
+--     SQLAlchemy cannot render the modifier, so this file is the only place it
+--     can live.
+--   * ``TIMESTAMP``, NOT ``DATETIME``, for gmt_* and the business timestamps,
+--     matching ac_bots and every table added since. Mixing the two is what
+--     skill_center/sql/2026_09_03_align_space_skill_timestamps_with_gmt.sql
+--     had to repair: TIMESTAMP converts by session time zone and DATETIME does
+--     not, so a session outside Asia/Shanghai reads the two as disagreeing by
+--     the offset. The ORM keeps ``DateTime`` either way -- ac_skill_version's
+--     published_at is the precedent for that pairing.
+--   * NO ``ENGINE`` CLAUSE, and no BLOCK_SIZE / REPLICA_NUM / COMPRESSION /
+--     TABLET_SIZE / PCTFREE / ROW_FORMAT. OceanBase applies its own defaults
+--     and echoes them back from SHOW CREATE TABLE; writing them here would be
+--     copying its own output back at it.
+
 CREATE TABLE `ac_bot_config_manifest` (
   `id`             bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT '主键ID',
   `env`            varchar(20)   NOT NULL COMMENT '环境标识: prod/pre/dev',
@@ -65,11 +88,12 @@ CREATE TABLE `ac_bot_config_manifest` (
   `schema_version` int(11)       NOT NULL COMMENT 'schema 版本（当前仅 1）',
   `modifier`       varchar(1024) NOT NULL COMMENT '审计：最后写入者',
   `avernet_tenant` varchar(64)   NOT NULL DEFAULT 'teamclaw' COMMENT '数据隔离租户',
-  `gmt_create`     datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
-  `gmt_modified`   datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '修改时间',
+  `gmt_create`     timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `gmt_modified`   timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '修改时间',
   PRIMARY KEY (`id`),
   -- The only index, and every read uses it: the repository filters on env,
   -- entity_id and bot_id, which are exactly this key's columns after the tenant
   -- the guard supplies. No second lookup key to drift out of step with it.
-  UNIQUE KEY `uk_tenant_env_entity_bot` (`avernet_tenant`, `env`, `entity_id`, `bot_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='Bot 配置清单';
+  UNIQUE KEY `uk_tenant_env_entity_bot`
+    (`avernet_tenant`, `env`, `entity_id`, `bot_id`) GLOBAL
+) DEFAULT CHARSET = utf8mb4 COMMENT = 'Bot 配置清单';

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/sql/2026_08_31_bot_config_manifest.sql
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/sql/2026_08_31_bot_config_manifest.sql
@@ -54,13 +54,25 @@
 --     it prevents surfaces as duplicate rows, silently, never as an error.
 --     SQLAlchemy cannot render the modifier, so this file is the only place it
 --     can live.
---   * ``TIMESTAMP``, NOT ``DATETIME``, for gmt_* and the business timestamps,
---     matching ac_bots and every table added since. Mixing the two is what
---     skill_center/sql/2026_09_03_align_space_skill_timestamps_with_gmt.sql
---     had to repair: TIMESTAMP converts by session time zone and DATETIME does
---     not, so a session outside Asia/Shanghai reads the two as disagreeing by
---     the offset. The ORM keeps ``DateTime`` either way -- ac_skill_version's
---     published_at is the precedent for that pairing.
+--   * ``TIMESTAMP`` FOR THE DB-CLOCK COLUMNS, ``DATETIME`` FOR THE REST, and
+--     which one a column gets is decided by who fills it, not by taste.
+--     gmt_create and gmt_modified are written by the database itself
+--     (``DEFAULT CURRENT_TIMESTAMP``, and ``func.now()`` from the ORM), so
+--     TIMESTAMP's session-time-zone conversion is a no-op round trip and they
+--     match ac_bots and every table added since --
+--     skill_center/sql/2026_09_03_align_space_skill_timestamps_with_gmt.sql is
+--     the repair that convention exists to avoid repeating.
+--
+--     A column the APPLICATION fills stays DATETIME. TIMESTAMP reads the naive
+--     value being bound as session-local wall time and converts it to UTC for
+--     storage, so a Python-supplied instant is stored shifted by the session
+--     offset -- eight hours under the Asia/Shanghai session assumed here. This
+--     was got wrong in the first draft of this change and caught in review; this table has no
+--     application-supplied time column today, so the rule only matters to
+--     whoever adds one.
+--
+--     The ORM keeps ``DateTime`` for both kinds -- ac_skill_version's
+--     published_at is the precedent for ``DateTime`` over a TIMESTAMP column.
 --   * NO ``ENGINE`` CLAUSE, and no BLOCK_SIZE / REPLICA_NUM / COMPRESSION /
 --     TABLET_SIZE / PCTFREE / ROW_FORMAT. OceanBase applies its own defaults
 --     and echoes them back from SHOW CREATE TABLE; writing them here would be

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/sql/2026_08_31_bot_config_manifest_apply.sql
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/sql/2026_08_31_bot_config_manifest_apply.sql
@@ -34,6 +34,38 @@
 -- apply lock — so one tenant's apply could block or unblock another's — and
 -- read each other's apply reports.
 
+-- DIALECT: OCEANBASE, MYSQL MODE. What this file writes follows the deployed
+-- tables there rather than portable MySQL -- compare ``SHOW CREATE TABLE
+-- ac_bots``, and the sibling DDL in core/caller_identity/sql/.
+--
+--   * EVERY INDEX IS DECLARED ``GLOBAL``. On a partitioned table an index
+--     without it is partition-local, and a partition-local UNIQUE enforces
+--     uniqueness only *within* a partition. For ``uk_manifest_apply_lock``
+--     that is the whole mechanism -- the UNIQUE constraint *is* the lock,
+--     so a partition-local one lets two applies hold it at once. These tables are not
+--     partitioned today, so it is a no-op now and cheap insurance later: what
+--     it prevents surfaces as duplicate rows, silently, never as an error.
+--     SQLAlchemy cannot render the modifier, so this file is the only place it
+--     can live.
+--   * ``TIMESTAMP``, NOT ``DATETIME``, for gmt_* and the business timestamps,
+--     matching ac_bots and every table added since. Mixing the two is what
+--     skill_center/sql/2026_09_03_align_space_skill_timestamps_with_gmt.sql
+--     had to repair: TIMESTAMP converts by session time zone and DATETIME does
+--     not, so a session outside Asia/Shanghai reads the two as disagreeing by
+--     the offset. The ORM keeps ``DateTime`` either way -- ac_skill_version's
+--     published_at is the precedent for that pairing.
+--   * NO ``ENGINE`` CLAUSE, and no BLOCK_SIZE / REPLICA_NUM / COMPRESSION /
+--     TABLET_SIZE / PCTFREE / ROW_FORMAT. OceanBase applies its own defaults
+--     and echoes them back from SHOW CREATE TABLE; writing them here would be
+--     copying its own output back at it.
+--   * ``AUTO_INCREMENT_MODE = 'ORDER'``, pinned rather than inherited from the
+--     tenant default, because this table's read order rests on it:
+--     ``config_manifest_apply.py`` answers GET .../last-apply with
+--     ``ORDER BY id DESC``. Under NOORDER each observer caches its own
+--     auto-increment range, so ids stop being monotonic in insertion order and
+--     "max id" stops meaning "newest" -- last-apply would serve a stale report
+--     while the newer one sat behind a smaller id.
+
 CREATE TABLE `ac_bot_config_manifest_apply` (
   `id`             bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT 'Primary key',
   -- The report's public identity: returned by the 202 from POST .../apply and
@@ -68,20 +100,23 @@ CREATE TABLE `ac_bot_config_manifest_apply` (
   -- ("app:7:on-behalf-of:<...>"), so the composed value can legitimately be
   -- long without anything being malformed.
   `actor`          varchar(1024) NOT NULL COMMENT 'Audit: who started it',
-  `started_at`     datetime      NOT NULL COMMENT 'When the apply began',
+  `started_at`     timestamp      NOT NULL COMMENT 'When the apply began',
   -- NULL exactly while status is RUNNING. The two move together.
-  `finished_at`    datetime      NULL     COMMENT 'When it ended; NULL while RUNNING',
+  `finished_at`    timestamp      NULL     COMMENT 'When it ended; NULL while RUNNING',
   `avernet_tenant` varchar(64)   NOT NULL DEFAULT 'teamclaw' COMMENT 'Tenant, for data isolation',
-  `gmt_create`     datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'Row created',
-  `gmt_modified`   datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Row last modified',
+  `gmt_create`     timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'Row created',
+  `gmt_modified`   timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Row last modified',
   PRIMARY KEY (`id`),
   -- Two indexes, one per read. There are exactly two reads on this table.
   --
   -- GET .../last-apply — the newest row for this bot.
-  KEY `idx_manifest_apply_latest` (`avernet_tenant`, `env`, `entity_id`, `bot_id`, `id`),
+  KEY `idx_manifest_apply_latest`
+    (`avernet_tenant`, `env`, `entity_id`, `bot_id`, `id`) GLOBAL,
   -- GET .../applies/{apply_id} — the poll by id, scoped to the bot.
-  KEY `idx_manifest_apply_by_id` (`avernet_tenant`, `env`, `entity_id`, `bot_id`, `apply_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='Bot config manifest apply record';
+  KEY `idx_manifest_apply_by_id`
+    (`avernet_tenant`, `env`, `entity_id`, `bot_id`, `apply_id`) GLOBAL
+) AUTO_INCREMENT_MODE = 'ORDER' DEFAULT CHARSET = utf8mb4
+  COMMENT = 'Bot config manifest apply record';
 
 -- NO dry_run COLUMN, deliberately. A dry run mints no apply_id and writes no
 -- row at all, so there is nothing here to mark. A flag would invite a future
@@ -98,8 +133,8 @@ CREATE TABLE `ac_bot_config_manifest_apply_lock` (
   -- reaped as stale could delete the lock a *later* apply legitimately took.
   `lock_token`     varchar(256)  NOT NULL COMMENT 'Fencing token, compared on release',
   `avernet_tenant` varchar(64)   NOT NULL DEFAULT 'teamclaw' COMMENT 'Tenant, for data isolation',
-  `gmt_create`     datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'Row created',
-  `gmt_modified`   datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Row last modified',
+  `gmt_create`     timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'Row created',
+  `gmt_modified`   timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Row last modified',
   PRIMARY KEY (`id`),
   -- THE UNIQUE CONSTRAINT IS THE LOCK. One row per bot; concurrent INSERTs are
   -- arbitrated by the database, exactly one wins, and the losers see the
@@ -107,5 +142,7 @@ CREATE TABLE `ac_bot_config_manifest_apply_lock` (
   --
   -- gmt_create is what get_if_stale measures against, on the DB clock, so a
   -- process killed mid-apply cannot hold this forever.
-  UNIQUE KEY `uk_manifest_apply_lock` (`avernet_tenant`, `env`, `entity_id`, `bot_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='Bot config manifest apply serialization lock';
+  UNIQUE KEY `uk_manifest_apply_lock`
+    (`avernet_tenant`, `env`, `entity_id`, `bot_id`) GLOBAL
+) DEFAULT CHARSET = utf8mb4
+  COMMENT = 'Bot config manifest apply serialization lock';

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/sql/2026_08_31_bot_config_manifest_apply.sql
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/sql/2026_08_31_bot_config_manifest_apply.sql
@@ -47,13 +47,24 @@
 --     it prevents surfaces as duplicate rows, silently, never as an error.
 --     SQLAlchemy cannot render the modifier, so this file is the only place it
 --     can live.
---   * ``TIMESTAMP``, NOT ``DATETIME``, for gmt_* and the business timestamps,
---     matching ac_bots and every table added since. Mixing the two is what
---     skill_center/sql/2026_09_03_align_space_skill_timestamps_with_gmt.sql
---     had to repair: TIMESTAMP converts by session time zone and DATETIME does
---     not, so a session outside Asia/Shanghai reads the two as disagreeing by
---     the offset. The ORM keeps ``DateTime`` either way -- ac_skill_version's
---     published_at is the precedent for that pairing.
+--   * ``TIMESTAMP`` FOR THE DB-CLOCK COLUMNS, ``DATETIME`` FOR THE REST, and
+--     which one a column gets is decided by who fills it, not by taste.
+--     gmt_create and gmt_modified are written by the database itself
+--     (``DEFAULT CURRENT_TIMESTAMP``, and ``func.now()`` from the ORM), so
+--     TIMESTAMP's session-time-zone conversion is a no-op round trip and they
+--     match ac_bots and every table added since --
+--     skill_center/sql/2026_09_03_align_space_skill_timestamps_with_gmt.sql is
+--     the repair that convention exists to avoid repeating.
+--
+--     A column the APPLICATION fills stays DATETIME. TIMESTAMP reads the naive
+--     value being bound as session-local wall time and converts it to UTC for
+--     storage, so a Python-supplied instant is stored shifted by the session
+--     offset -- eight hours under the Asia/Shanghai session assumed here. This
+--     was got wrong in the first draft of this change and caught in review; started_at and
+--     finished_at are the columns in question here, per their comment below.
+--
+--     The ORM keeps ``DateTime`` for both kinds -- ac_skill_version's
+--     published_at is the precedent for ``DateTime`` over a TIMESTAMP column.
 --   * NO ``ENGINE`` CLAUSE, and no BLOCK_SIZE / REPLICA_NUM / COMPRESSION /
 --     TABLET_SIZE / PCTFREE / ROW_FORMAT. OceanBase applies its own defaults
 --     and echoes them back from SHOW CREATE TABLE; writing them here would be
@@ -100,9 +111,16 @@ CREATE TABLE `ac_bot_config_manifest_apply` (
   -- ("app:7:on-behalf-of:<...>"), so the composed value can legitimately be
   -- long without anything being malformed.
   `actor`          varchar(1024) NOT NULL COMMENT 'Audit: who started it',
-  `started_at`     timestamp      NOT NULL COMMENT 'When the apply began',
+  -- DATETIME, not TIMESTAMP, for both of these: they are filled by the
+  -- application from datetime.now() (process-local, naive), never by the
+  -- database. TIMESTAMP binds a naive value as session-local, so these would
+  -- be stored correctly only where the process time zone happens to equal the
+  -- database session's -- and a container on UTC against an Asia/Shanghai
+  -- session is exactly where that stops being true. gmt_* below are a
+  -- different case: the database fills those itself.
+  `started_at`     datetime      NOT NULL COMMENT 'When the apply began',
   -- NULL exactly while status is RUNNING. The two move together.
-  `finished_at`    timestamp      NULL     COMMENT 'When it ended; NULL while RUNNING',
+  `finished_at`    datetime      NULL     COMMENT 'When it ended; NULL while RUNNING',
   `avernet_tenant` varchar(64)   NOT NULL DEFAULT 'teamclaw' COMMENT 'Tenant, for data isolation',
   `gmt_create`     timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'Row created',
   `gmt_modified`   timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Row last modified',

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/sql/2026_08_31_manifest_content.sql
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/sql/2026_08_31_manifest_content.sql
@@ -68,6 +68,33 @@
 -- ``.tmp-*`` staging files from crashed writes are not audit facts and are
 -- age-swept at store time (see content/service.py); they are the only thing
 -- a sweeper may ever touch.
+-- DIALECT: OCEANBASE, MYSQL MODE. What this file writes follows the deployed
+-- tables there rather than portable MySQL -- compare ``SHOW CREATE TABLE
+-- ac_bots``, and the sibling DDL in core/caller_identity/sql/.
+--
+--   * EVERY INDEX IS DECLARED ``GLOBAL``. On a partitioned table an index
+--     without it is partition-local, and a partition-local UNIQUE enforces
+--     uniqueness only *within* a partition. These tables are not
+--     partitioned today, so it is a no-op now and cheap insurance later: what
+--     it prevents surfaces as duplicate rows, silently, never as an error.
+--     SQLAlchemy cannot render the modifier, so this file is the only place it
+--     can live.
+--   * ``TIMESTAMP``, NOT ``DATETIME``, for gmt_* and the business timestamps,
+--     matching ac_bots and every table added since. Mixing the two is what
+--     skill_center/sql/2026_09_03_align_space_skill_timestamps_with_gmt.sql
+--     had to repair: TIMESTAMP converts by session time zone and DATETIME does
+--     not, so a session outside Asia/Shanghai reads the two as disagreeing by
+--     the offset. The ORM keeps ``DateTime`` either way -- ac_skill_version's
+--     published_at is the precedent for that pairing.
+--   * NO ``ENGINE`` CLAUSE, and no BLOCK_SIZE / REPLICA_NUM / COMPRESSION /
+--     TABLET_SIZE / PCTFREE / ROW_FORMAT. OceanBase applies its own defaults
+--     and echoes them back from SHOW CREATE TABLE; writing them here would be
+--     copying its own output back at it.
+--   * ``AUTO_INCREMENT_MODE = 'ORDER'``, pinned rather than inherited, because
+--     id is the tie-break keep_last resolves on: reads order by
+--     ``gmt_create DESC, id DESC``, so within one second the newest receipt is
+--     the largest id -- true only while ids are allocated in order.
+
 CREATE TABLE `ac_manifest_content` (
   `id`            bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT '主键ID',
   `avernet_tenant` varchar(64)  NOT NULL DEFAULT 'teamclaw' COMMENT '数据隔离租户',
@@ -89,7 +116,7 @@ CREATE TABLE `ac_manifest_content` (
   -- reconciliation anchor, not this).
   `content_type`  varchar(256)  DEFAULT NULL COMMENT '响应 Content-Type（advisory；超宽存 NULL）',
   `size_bytes`    bigint(20) unsigned NOT NULL COMMENT '字节数（与 digest 同为对账锚）',
-  `fetched_at`    datetime      NOT NULL COMMENT '拉取时间（FetchedObject.fetched_at）',
+  `fetched_at`    timestamp      NOT NULL COMMENT '拉取时间（FetchedObject.fetched_at）',
   -- The join back to the apply record (ac_bot_config_manifest_apply), and
   -- the per-entry identity a fetch served: apply_id is what that table's
   -- own comment ("also what a per-entry table would join on") points at
@@ -106,13 +133,15 @@ CREATE TABLE `ac_manifest_content` (
   `category`      varchar(32)   DEFAULT NULL COMMENT '条目类目（skills/identity/…；条目维度之一）',
   `entry_identity` varchar(256) DEFAULT NULL COMMENT '条目标识（对账锚外的维度：skill name / identity type / …）',
   `modifier`      varchar(1024) NOT NULL DEFAULT '' COMMENT '审计：触发拉取的身份',
-  `gmt_create`    datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
-  `gmt_modified`  datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '修改时间',
+  `gmt_create`    timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `gmt_modified`  timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '修改时间',
   PRIMARY KEY (`id`),
   -- The audit query shape: one bot's receipts, newest first. Leading column
   -- tenant keeps it aligned with the guard's filter.
-  KEY `idx_tenant_env_entity_bot` (`avernet_tenant`, `env`, `entity_id`, `bot_id`, `gmt_create`),
+  KEY `idx_tenant_env_entity_bot`
+    (`avernet_tenant`, `env`, `entity_id`, `bot_id`, `gmt_create`) GLOBAL,
   -- "What did apply X fetch" — the join the apply record's own comment
   -- anticipated this table providing.
-  KEY `idx_apply` (`apply_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='manifest 拉取内容平台副本的溯源日志（行 append-only，字节在内容寻址 blob 目录）';
+  KEY `idx_apply` (`apply_id`) GLOBAL
+) AUTO_INCREMENT_MODE = 'ORDER' DEFAULT CHARSET = utf8mb4
+  COMMENT = 'manifest 拉取内容平台副本的溯源日志（行 append-only，字节在内容寻址 blob 目录）';

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/sql/2026_08_31_manifest_content.sql
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/sql/2026_08_31_manifest_content.sql
@@ -79,13 +79,24 @@
 --     it prevents surfaces as duplicate rows, silently, never as an error.
 --     SQLAlchemy cannot render the modifier, so this file is the only place it
 --     can live.
---   * ``TIMESTAMP``, NOT ``DATETIME``, for gmt_* and the business timestamps,
---     matching ac_bots and every table added since. Mixing the two is what
---     skill_center/sql/2026_09_03_align_space_skill_timestamps_with_gmt.sql
---     had to repair: TIMESTAMP converts by session time zone and DATETIME does
---     not, so a session outside Asia/Shanghai reads the two as disagreeing by
---     the offset. The ORM keeps ``DateTime`` either way -- ac_skill_version's
---     published_at is the precedent for that pairing.
+--   * ``TIMESTAMP`` FOR THE DB-CLOCK COLUMNS, ``DATETIME`` FOR THE REST, and
+--     which one a column gets is decided by who fills it, not by taste.
+--     gmt_create and gmt_modified are written by the database itself
+--     (``DEFAULT CURRENT_TIMESTAMP``, and ``func.now()`` from the ORM), so
+--     TIMESTAMP's session-time-zone conversion is a no-op round trip and they
+--     match ac_bots and every table added since --
+--     skill_center/sql/2026_09_03_align_space_skill_timestamps_with_gmt.sql is
+--     the repair that convention exists to avoid repeating.
+--
+--     A column the APPLICATION fills stays DATETIME. TIMESTAMP reads the naive
+--     value being bound as session-local wall time and converts it to UTC for
+--     storage, so a Python-supplied instant is stored shifted by the session
+--     offset -- eight hours under the Asia/Shanghai session assumed here. This
+--     was got wrong in the first draft of this change and caught in review; fetched_at
+--     is the column in question here, and its own comment below says why.
+--
+--     The ORM keeps ``DateTime`` for both kinds -- ac_skill_version's
+--     published_at is the precedent for ``DateTime`` over a TIMESTAMP column.
 --   * NO ``ENGINE`` CLAUSE, and no BLOCK_SIZE / REPLICA_NUM / COMPRESSION /
 --     TABLET_SIZE / PCTFREE / ROW_FORMAT. OceanBase applies its own defaults
 --     and echoes them back from SHOW CREATE TABLE; writing them here would be
@@ -116,7 +127,15 @@ CREATE TABLE `ac_manifest_content` (
   -- reconciliation anchor, not this).
   `content_type`  varchar(256)  DEFAULT NULL COMMENT '响应 Content-Type（advisory；超宽存 NULL）',
   `size_bytes`    bigint(20) unsigned NOT NULL COMMENT '字节数（与 digest 同为对账锚）',
-  `fetched_at`    timestamp      NOT NULL COMMENT '拉取时间（FetchedObject.fetched_at）',
+  -- DATETIME, not TIMESTAMP, and deliberately out of step with the gmt_*
+  -- columns below: content/service.py normalises FetchedObject.fetched_at to
+  -- UTC and strips tzinfo before binding it. TIMESTAMP would read that
+  -- already-UTC value as session-local wall time and store it shifted by the
+  -- session offset -- eight hours, under the Asia/Shanghai session the gmt_*
+  -- columns assume. The audit question this table exists to answer is *when*
+  -- a bot received something, so a silently shifted instant is the one defect
+  -- it cannot carry.
+  `fetched_at`    datetime      NOT NULL COMMENT '拉取时间（FetchedObject.fetched_at；应用侧已归一到 UTC）',
   -- The join back to the apply record (ac_bot_config_manifest_apply), and
   -- the per-entry identity a fetch served: apply_id is what that table's
   -- own comment ("also what a per-entry table would join on") points at

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/sql/2026_08_31_source_credential.sql
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/sql/2026_08_31_source_credential.sql
@@ -36,13 +36,25 @@
 --     it prevents surfaces as duplicate rows, silently, never as an error.
 --     SQLAlchemy cannot render the modifier, so this file is the only place it
 --     can live.
---   * ``TIMESTAMP``, NOT ``DATETIME``, for gmt_* and the business timestamps,
---     matching ac_bots and every table added since. Mixing the two is what
---     skill_center/sql/2026_09_03_align_space_skill_timestamps_with_gmt.sql
---     had to repair: TIMESTAMP converts by session time zone and DATETIME does
---     not, so a session outside Asia/Shanghai reads the two as disagreeing by
---     the offset. The ORM keeps ``DateTime`` either way -- ac_skill_version's
---     published_at is the precedent for that pairing.
+--   * ``TIMESTAMP`` FOR THE DB-CLOCK COLUMNS, ``DATETIME`` FOR THE REST, and
+--     which one a column gets is decided by who fills it, not by taste.
+--     gmt_create and gmt_modified are written by the database itself
+--     (``DEFAULT CURRENT_TIMESTAMP``, and ``func.now()`` from the ORM), so
+--     TIMESTAMP's session-time-zone conversion is a no-op round trip and they
+--     match ac_bots and every table added since --
+--     skill_center/sql/2026_09_03_align_space_skill_timestamps_with_gmt.sql is
+--     the repair that convention exists to avoid repeating.
+--
+--     A column the APPLICATION fills stays DATETIME. TIMESTAMP reads the naive
+--     value being bound as session-local wall time and converts it to UTC for
+--     storage, so a Python-supplied instant is stored shifted by the session
+--     offset -- eight hours under the Asia/Shanghai session assumed here. This
+--     was got wrong in the first draft of this change and caught in review; this table has no
+--     application-supplied time column today, so the rule only matters to
+--     whoever adds one.
+--
+--     The ORM keeps ``DateTime`` for both kinds -- ac_skill_version's
+--     published_at is the precedent for ``DateTime`` over a TIMESTAMP column.
 --   * NO ``ENGINE`` CLAUSE, and no BLOCK_SIZE / REPLICA_NUM / COMPRESSION /
 --     TABLET_SIZE / PCTFREE / ROW_FORMAT. OceanBase applies its own defaults
 --     and echoes them back from SHOW CREATE TABLE; writing them here would be

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/sql/2026_08_31_source_credential.sql
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/sql/2026_08_31_source_credential.sql
@@ -25,6 +25,29 @@
 -- application's alone (owner_app_id, stamped at insert, never re-stamped).
 -- Every application of the tenant may read the masked inventory: the name
 -- is the shared reference namespace manifests cite.
+-- DIALECT: OCEANBASE, MYSQL MODE. What this file writes follows the deployed
+-- tables there rather than portable MySQL -- compare ``SHOW CREATE TABLE
+-- ac_bots``, and the sibling DDL in core/caller_identity/sql/.
+--
+--   * EVERY INDEX IS DECLARED ``GLOBAL``. On a partitioned table an index
+--     without it is partition-local, and a partition-local UNIQUE enforces
+--     uniqueness only *within* a partition. These tables are not
+--     partitioned today, so it is a no-op now and cheap insurance later: what
+--     it prevents surfaces as duplicate rows, silently, never as an error.
+--     SQLAlchemy cannot render the modifier, so this file is the only place it
+--     can live.
+--   * ``TIMESTAMP``, NOT ``DATETIME``, for gmt_* and the business timestamps,
+--     matching ac_bots and every table added since. Mixing the two is what
+--     skill_center/sql/2026_09_03_align_space_skill_timestamps_with_gmt.sql
+--     had to repair: TIMESTAMP converts by session time zone and DATETIME does
+--     not, so a session outside Asia/Shanghai reads the two as disagreeing by
+--     the offset. The ORM keeps ``DateTime`` either way -- ac_skill_version's
+--     published_at is the precedent for that pairing.
+--   * NO ``ENGINE`` CLAUSE, and no BLOCK_SIZE / REPLICA_NUM / COMPRESSION /
+--     TABLET_SIZE / PCTFREE / ROW_FORMAT. OceanBase applies its own defaults
+--     and echoes them back from SHOW CREATE TABLE; writing them here would be
+--     copying its own output back at it.
+
 CREATE TABLE `ac_source_credential` (
   `id`            bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT '主键ID',
   `avernet_tenant` varchar(64)  NOT NULL DEFAULT 'teamclaw' COMMENT '数据隔离租户',
@@ -35,8 +58,9 @@ CREATE TABLE `ac_source_credential` (
   `secret_ciphertext` text     NOT NULL COMMENT 'enc:v1:<AES-GCM 密文>（fail-closed profile 下明文写入被拒绝）',
   `owner_app_id`  bigint(20) NOT NULL COMMENT '归属应用（创建者 app id）：轮换与删除仅限它；插入时钉死，不再改写',
   `modifier`      varchar(1024) NOT NULL DEFAULT '' COMMENT '审计：最后写入者（app:<id> / app:<id>:on-behalf-of:<user>）',
-  `gmt_create`    datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
-  `gmt_modified`  datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '修改时间',
+  `gmt_create`    timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `gmt_modified`  timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '修改时间',
   PRIMARY KEY (`id`),
-  UNIQUE KEY `uk_tenant_source_credential_name` (`avernet_tenant`, `name`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='租户级源凭证';
+  UNIQUE KEY `uk_tenant_source_credential_name`
+    (`avernet_tenant`, `name`) GLOBAL
+) DEFAULT CHARSET = utf8mb4 COMMENT = '租户级源凭证';

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/sql/2026_09_03_bot_cli_tool.sql
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/sql/2026_09_03_bot_cli_tool.sql
@@ -36,13 +36,25 @@
 --     it prevents surfaces as duplicate rows, silently, never as an error.
 --     SQLAlchemy cannot render the modifier, so this file is the only place it
 --     can live.
---   * ``TIMESTAMP``, NOT ``DATETIME``, for gmt_* and the business timestamps,
---     matching ac_bots and every table added since. Mixing the two is what
---     skill_center/sql/2026_09_03_align_space_skill_timestamps_with_gmt.sql
---     had to repair: TIMESTAMP converts by session time zone and DATETIME does
---     not, so a session outside Asia/Shanghai reads the two as disagreeing by
---     the offset. The ORM keeps ``DateTime`` either way -- ac_skill_version's
---     published_at is the precedent for that pairing.
+--   * ``TIMESTAMP`` FOR THE DB-CLOCK COLUMNS, ``DATETIME`` FOR THE REST, and
+--     which one a column gets is decided by who fills it, not by taste.
+--     gmt_create and gmt_modified are written by the database itself
+--     (``DEFAULT CURRENT_TIMESTAMP``, and ``func.now()`` from the ORM), so
+--     TIMESTAMP's session-time-zone conversion is a no-op round trip and they
+--     match ac_bots and every table added since --
+--     skill_center/sql/2026_09_03_align_space_skill_timestamps_with_gmt.sql is
+--     the repair that convention exists to avoid repeating.
+--
+--     A column the APPLICATION fills stays DATETIME. TIMESTAMP reads the naive
+--     value being bound as session-local wall time and converts it to UTC for
+--     storage, so a Python-supplied instant is stored shifted by the session
+--     offset -- eight hours under the Asia/Shanghai session assumed here. This
+--     was got wrong in the first draft of this change and caught in review; this table has no
+--     application-supplied time column today, so the rule only matters to
+--     whoever adds one.
+--
+--     The ORM keeps ``DateTime`` for both kinds -- ac_skill_version's
+--     published_at is the precedent for ``DateTime`` over a TIMESTAMP column.
 --   * NO ``ENGINE`` CLAUSE, and no BLOCK_SIZE / REPLICA_NUM / COMPRESSION /
 --     TABLET_SIZE / PCTFREE / ROW_FORMAT. OceanBase applies its own defaults
 --     and echoes them back from SHOW CREATE TABLE; writing them here would be

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/sql/2026_09_03_bot_cli_tool.sql
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/sql/2026_09_03_bot_cli_tool.sql
@@ -25,6 +25,29 @@
 --
 -- entity_id is a storage key only: it is resolved server-side from the bot
 -- record and is never a request parameter or a response field on the public API.
+-- DIALECT: OCEANBASE, MYSQL MODE. What this file writes follows the deployed
+-- tables there rather than portable MySQL -- compare ``SHOW CREATE TABLE
+-- ac_bots``, and the sibling DDL in core/caller_identity/sql/.
+--
+--   * EVERY INDEX IS DECLARED ``GLOBAL``. On a partitioned table an index
+--     without it is partition-local, and a partition-local UNIQUE enforces
+--     uniqueness only *within* a partition. These tables are not
+--     partitioned today, so it is a no-op now and cheap insurance later: what
+--     it prevents surfaces as duplicate rows, silently, never as an error.
+--     SQLAlchemy cannot render the modifier, so this file is the only place it
+--     can live.
+--   * ``TIMESTAMP``, NOT ``DATETIME``, for gmt_* and the business timestamps,
+--     matching ac_bots and every table added since. Mixing the two is what
+--     skill_center/sql/2026_09_03_align_space_skill_timestamps_with_gmt.sql
+--     had to repair: TIMESTAMP converts by session time zone and DATETIME does
+--     not, so a session outside Asia/Shanghai reads the two as disagreeing by
+--     the offset. The ORM keeps ``DateTime`` either way -- ac_skill_version's
+--     published_at is the precedent for that pairing.
+--   * NO ``ENGINE`` CLAUSE, and no BLOCK_SIZE / REPLICA_NUM / COMPRESSION /
+--     TABLET_SIZE / PCTFREE / ROW_FORMAT. OceanBase applies its own defaults
+--     and echoes them back from SHOW CREATE TABLE; writing them here would be
+--     copying its own output back at it.
+
 CREATE TABLE `ac_bot_cli_tool` (
   `id`            bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT '主键ID',
   `env`           varchar(20)   NOT NULL COMMENT '环境标识: prod/pre/dev',
@@ -57,12 +80,12 @@ CREATE TABLE `ac_bot_cli_tool` (
   `modifier`      varchar(1024) NOT NULL COMMENT '审计：最后写入者',
   `avernet_tenant` varchar(64)  NOT NULL DEFAULT 'teamclaw' COMMENT '数据隔离租户',
   `tool_key`      char(64)      NOT NULL COMMENT '唯一键代理：sha256(env|entity_id|bot_id|name)',
-  `gmt_create`    datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
-  `gmt_modified`  datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '修改时间',
+  `gmt_create`    timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `gmt_modified`  timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '修改时间',
   PRIMARY KEY (`id`),
   -- A command name is unwritable twice for one bot: two concurrent installs of
   -- the same name cannot both land, whichever order they arrive in.
-  UNIQUE KEY `uk_tenant_cli_tool_key` (`avernet_tenant`, `tool_key`),
+  UNIQUE KEY `uk_tenant_cli_tool_key` (`avernet_tenant`, `tool_key`) GLOBAL,
   -- Listing a bot's tools is the hot read (every apply, every compose). The
   -- tenant leads because the guard appends `avernet_tenant = ?` to every SELECT
   -- on this model, so a tenant-trailing index would make it a residual filter —
@@ -77,5 +100,5 @@ CREATE TABLE `ac_bot_cli_tool` (
   -- bot_id) already narrows to the handful of tools one bot has, and entity_id
   -- is functionally determined by bot_id within a tenant. It stays a residual
   -- filter, and the index stays narrow.
-  KEY `idx_tenant_env_bot` (`avernet_tenant`, `env`, `bot_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='Bot CLI 工具';
+  KEY `idx_tenant_env_bot` (`avernet_tenant`, `env`, `bot_id`) GLOBAL
+) DEFAULT CHARSET = utf8mb4 COMMENT = 'Bot CLI 工具';

--- a/src/backend/src/agentclaw/community/core/task_queue/README.md
+++ b/src/backend/src/agentclaw/community/core/task_queue/README.md
@@ -260,11 +260,20 @@ inconsistent row, not a repair — see its docstring.
 
 ## Provisioning
 
-**`repository/models.py` is the source of truth for the schema.** No DDL is
-checked in: the deployed tables are provisioned out of band, so a copy in the
-repo would be a second definition to keep in step rather than an authority. Read
-the ORM model — column types, nullability, collations, and the index are all
-declared there with the reasoning inline.
+**`repository/models.py` is the source of truth for the schema.** Read the ORM
+model — column types, nullability, collations, and the indexes are all declared
+there with the reasoning inline.
+
+`sql/2026_09_06_task_queue.sql` is a **provisioning reference derived from that
+model, not a second authority.** It exists because two things cannot be read off
+the ORM: `GLOBAL` on the unique indexes, which SQLAlchemy has no way to render
+and which a partitioned table needs or dedup degrades to once-per-partition, and
+`AUTO_INCREMENT_MODE = 'ORDER'`, which `_find_by_key`'s `ORDER BY id DESC`
+depends on. It declares the same two unique indexes the model does, legacy one
+included, so a freshly provisioned database behaves the way the test suite
+asserts. Where the two disagree the ORM wins and the file is what gets fixed; on
+a deployment that already has the table, `SHOW CREATE TABLE ac_task_queue`
+outranks both.
 
 **The schema change must be applied before deploying the release that contains
 it** — for `app` as much as for the key columns, and not merely before the first

--- a/src/backend/src/agentclaw/community/core/task_queue/sql/2026_09_06_task_queue.sql
+++ b/src/backend/src/agentclaw/community/core/task_queue/sql/2026_09_06_task_queue.sql
@@ -1,0 +1,101 @@
+-- The generic background task queue (``core/task_queue``).
+--
+-- WHY THIS FILE EXISTS AT ALL. The table had no DDL in the repository: README's
+-- "Status" section says the production table "must be provisioned before
+-- enabling the worker", local and test runs build it from the shared ORM
+-- metadata, and the OceanBase-only ``GLOBAL`` modifier lived in prose alone.
+-- Every manifest apply path now goes through this queue (PR #1791), and W13
+-- (#1696) creates bots on it, so a deployment that provisions the six
+-- bot_config_manifest tables and not this one has an API that accepts work and
+-- never performs it.
+--
+-- WHAT THIS FILE IS NOT. It is reconstructed from ``repository/models.py`` and
+-- README, not dumped from a live table. On a deployment that already HAS
+-- ac_task_queue, ``SHOW CREATE TABLE ac_task_queue`` is the truth and this file
+-- is not -- reconcile against it before running anything here. Two known ways
+-- an existing table differs:
+--
+--   * THE LEGACY DEDUP INDEX. ``uk_env_task_type_active_idempotency_key``
+--     (no ``app``) is still present on the deployed table, and dropping it is
+--     the last step of the app-scoping migration -- README "Provisioning" owns
+--     that sequence. It is omitted below because a NEW table should never gain
+--     it: it enforces a scope wider than the code's, so it can reject a keyed
+--     enqueue whose key is free in the caller's own (env, app, task_type).
+--   * TIMESTAMP COLUMNS. The manifest DDL in core/bot_config_manifest/sql/ uses
+--     TIMESTAMP to match ac_bots. This file deliberately keeps DATETIME,
+--     mirroring the ORM's ``DateTime`` and the table as it was provisioned.
+--     Do not "align" it as a consistency edit: every claim, reclaim and
+--     deadline comparison here is a DB-clock comparison, and changing the type
+--     under a running fleet changes what those comparisons mean.
+--
+-- DIALECT: OCEANBASE, MYSQL MODE. No ENGINE clause and no BLOCK_SIZE /
+-- REPLICA_NUM / COMPRESSION / TABLET_SIZE / PCTFREE / ROW_FORMAT -- OceanBase
+-- applies its own defaults and echoes them back from SHOW CREATE TABLE.
+--
+-- ``AUTO_INCREMENT_MODE = 'ORDER'`` is pinned rather than inherited from the
+-- tenant default, because the code states the assumption outright:
+-- ``_find_by_key``'s audit lookup orders by ``id DESC``, and its comment reads
+-- "ids are monotonic per row and need no tie-break, while two rows enqueued in
+-- the same second share a gmt_create". Under NOORDER each observer caches its
+-- own auto-increment range, so ids stop being monotonic in insertion order
+-- across observers and the query answering "which task handled key X?" returns
+-- an older row -- with no timestamp precise enough to fall back to.
+
+CREATE TABLE `ac_task_queue` (
+  `id`            bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT '主键ID',
+  -- utf8mb4_bin, and it is not decoration: task_type is the third column of the
+  -- dedup unique index, and an index is only as precise as its least precise
+  -- column. Under the default ci collation 'Job' and 'job' are two handlers but
+  -- one index entry, so a keyed enqueue for one joins the other's live task.
+  -- HandlerRegistry.register also refuses types that fold together, but that
+  -- check is process-local: it cannot see a row written by another version
+  -- during a rolling deploy, which is why the scope is enforced here too.
+  `task_type`     varchar(100) COLLATE utf8mb4_bin NOT NULL COMMENT 'handler registry key',
+  `payload`       text          NOT NULL COMMENT 'JSON string; deserialised in to_record()',
+  `status`        varchar(20)   NOT NULL COMMENT 'PENDING/RUNNING/SUCCEEDED/FAILED/TIMED_OUT',
+  `run_at`        datetime      NOT NULL COMMENT 'next-eligible time (DB clock); claim requires run_at <= now()',
+  `claimed_by`    varchar(128)  DEFAULT NULL COMMENT 'worker id of the current holder; NULL when not RUNNING',
+  `lease_expires_at` datetime   DEFAULT NULL COMMENT 'claim lease deadline (DB clock); expired => reclaimable',
+  `attempts`      int(11)       NOT NULL DEFAULT 0 COMMENT 'incremented on each claim; diagnostic only, not the give-up rule',
+  `last_error`    text          DEFAULT NULL COMMENT 'last failure / timeout message',
+  `deadline_at`   datetime      NOT NULL COMMENT 'give-up time from first enqueue (DB clock); a task always has one',
+  -- Two columns on purpose. idempotency_key is the durable audit value, written
+  -- once at enqueue and never cleared, so "which task handled key X?" stays
+  -- answerable after the task finishes. active_idempotency_key is the
+  -- enforcement value: equal to it while the task is live, NULLed on every
+  -- terminal transition to release the key. MySQL/OceanBase have no partial
+  -- indexes, so nulling a plain column is the portable way to express "unique
+  -- among live rows only" -- both engines treat NULLs as distinct in a unique
+  -- index, so un-keyed enqueues never collide. That is relied upon, not
+  -- incidental.
+  `idempotency_key` varchar(190) COLLATE utf8mb4_bin DEFAULT NULL COMMENT 'caller-supplied enqueue dedup key; NULL = opted out. Audit only',
+  `active_idempotency_key` varchar(190) COLLATE utf8mb4_bin DEFAULT NULL COMMENT 'enforcement copy; NULLed on terminal transitions',
+  `env`           varchar(20)   NOT NULL COMMENT '环境标识: prod/pre/dev; all queries filter by env',
+  -- Which application owns the row. A second, independently deployed backend
+  -- shares this table; without this column both fleets claim each other's
+  -- tasks, each running a task_type its registry never heard of. The value
+  -- comes from deployment config (TaskQueueConfig.app), never from a per-call
+  -- argument, exactly like env.
+  `app`           varchar(32)   NOT NULL DEFAULT 'agentclaw' COMMENT 'app who owns the task; every query that selects work filters by app',
+  `gmt_create`    datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'first-enqueue audit time',
+  `gmt_modified`  datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'audit; set DB-side on every CAS UPDATE',
+  PRIMARY KEY (`id`),
+  -- Claim and reclaim scans. The app-scoped pair leads with app because every
+  -- claim/reclaim query now carries an app term; without it the busiest
+  -- statement the component runs degrades to a full partition read.
+  KEY `idx_env_status_run_at` (`env`, `status`, `run_at`) GLOBAL,
+  KEY `idx_env_lease_expires_at` (`env`, `lease_expires_at`) GLOBAL,
+  KEY `idx_env_app_status_run_at` (`env`, `app`, `status`, `run_at`) GLOBAL,
+  KEY `idx_env_app_lease_expires_at` (`env`, `app`, `lease_expires_at`) GLOBAL,
+  -- Active-only enqueue dedup: at most one LIVE task per key within an
+  -- (env, app, task_type). Terminal rows null their active key and drop out.
+  --
+  -- GLOBAL IS LOAD-BEARING HERE, and it is the requirement README says the ORM
+  -- cannot express: a partition-local index would allow the same active key
+  -- once per partition and defeat dedup entirely. For W13 that means one
+  -- create-with-manifest request running twice -- two Passport applications,
+  -- two containers -- which is exactly what the key exists to prevent.
+  UNIQUE KEY `uk_env_app_task_type_active_idempotency_key`
+    (`env`, `app`, `task_type`, `active_idempotency_key`) GLOBAL
+) AUTO_INCREMENT_MODE = 'ORDER' DEFAULT CHARSET = utf8mb4
+  COMMENT = '通用后台任务队列';

--- a/src/backend/src/agentclaw/community/core/task_queue/sql/2026_09_06_task_queue.sql
+++ b/src/backend/src/agentclaw/community/core/task_queue/sql/2026_09_06_task_queue.sql
@@ -15,12 +15,20 @@
 -- is not -- reconcile against it before running anything here. Two known ways
 -- an existing table differs:
 --
---   * THE LEGACY DEDUP INDEX. ``uk_env_task_type_active_idempotency_key``
---     (no ``app``) is still present on the deployed table, and dropping it is
---     the last step of the app-scoping migration -- README "Provisioning" owns
---     that sequence. It is omitted below because a NEW table should never gain
---     it: it enforces a scope wider than the code's, so it can reject a keyed
---     enqueue whose key is free in the caller's own (env, app, task_type).
+--   * THE LEGACY DEDUP INDEX IS DECLARED HERE, not omitted. An earlier draft
+--     of this file left it out on the reasoning that a NEW table should never
+--     gain an index scoped wider than the code's -- true in isolation, and
+--     wrong as a schema decision, because ``repository/models.py`` still
+--     declares it and
+--     tests/community/repository/platform/test_task_queue_repository.py
+--     asserts the behaviour it produces
+--     (test_same_key_under_different_app_is_rejected_while_the_legacy_index_lives).
+--     Omitting it here would mean a freshly provisioned OceanBase database
+--     accepts an enqueue that every local SQLite test run rejects -- the two
+--     schemas disagreeing while both claim to be this component's. The ORM's
+--     own comment sets the order: dropping it is the last step of the
+--     app-scoping migration, "drop it there and here in the same change"
+--     (README "Provisioning"). This file is the "here".
 --   * TIMESTAMP COLUMNS. The manifest DDL in core/bot_config_manifest/sql/ uses
 --     TIMESTAMP to match ac_bots. This file deliberately keeps DATETIME,
 --     mirroring the ORM's ``DateTime`` and the table as it was provisioned.
@@ -96,6 +104,21 @@ CREATE TABLE `ac_task_queue` (
   -- create-with-manifest request running twice -- two Passport applications,
   -- two containers -- which is exactly what the key exists to prevent.
   UNIQUE KEY `uk_env_app_task_type_active_idempotency_key`
-    (`env`, `app`, `task_type`, `active_idempotency_key`) GLOBAL
+    (`env`, `app`, `task_type`, `active_idempotency_key`) GLOBAL,
+  -- The pre-``app`` dedup index. Redundant once every app writes its own
+  -- ``app``, and scheduled for removal -- but present because the ORM still
+  -- declares it, so leaving it out would make a fresh database behave
+  -- differently from every test run. It is unique on (env, task_type, key)
+  -- regardless of app, so while it exists two deployments cannot use the same
+  -- key for the same task_type in one env: the second app's INSERT is rejected
+  -- even though the key is free in its own scope. ``enqueue`` never joins that
+  -- row -- it belongs to another app and this deployment could not claim it --
+  -- so the enqueue fails loudly once its retries are spent, which is the
+  -- documented intermediate state rather than a defect in this file.
+  --
+  -- Drop it from this file, from models.py and from the deployed tables in one
+  -- change; dropping it here alone re-opens the divergence described above.
+  UNIQUE KEY `uk_env_task_type_active_idempotency_key`
+    (`env`, `task_type`, `active_idempotency_key`) GLOBAL
 ) AUTO_INCREMENT_MODE = 'ORDER' DEFAULT CHARSET = utf8mb4
   COMMENT = '通用后台任务队列';

--- a/src/backend/tests/community/core/bot_config_manifest/test_manifest_ddl_contract.py
+++ b/src/backend/tests/community/core/bot_config_manifest/test_manifest_ddl_contract.py
@@ -42,21 +42,55 @@ _APPLICATION_SUPPLIED = {
 _DB_FILLED = ("gmt_create", "gmt_modified")
 
 
-def _declarations(path: Path) -> dict[str, str]:
-    """Map column name -> the rest of its declaration, comments stripped.
+def _tables(path: Path) -> dict[str, dict[str, str]]:
+    """Map table name -> {column name: rest of its declaration}.
 
-    Comments have to go first: ``DEFAULT CURRENT_TIMESTAMP`` appears throughout
-    the prose in these files, and the type token is only meaningful in the
-    position directly after the backticked column name.
+    SCOPED PER TABLE, NOT PER FILE, and that is the whole point. An earlier
+    version of this helper returned one dict per file; a file declaring two
+    tables that share a column name — which
+    2026_08_31_bot_config_manifest_apply.sql does, with the apply table and its
+    lock both carrying gmt_create/gmt_modified — kept only the last match, so
+    the apply table's audit columns went unchecked by every test here. That is
+    the same table the implicit-ON-UPDATE hazard lived in, so the hole sat
+    exactly where the coverage was supposed to be.
+
+    Comments are stripped first: ``DEFAULT CURRENT_TIMESTAMP`` appears
+    throughout the prose in these files, and the type token is only meaningful
+    in the position directly after the backticked column name.
     """
     body = "\n".join(
         line
         for line in path.read_text(encoding="utf-8").splitlines()
         if line.strip() and not line.lstrip().startswith("--")
     )
+    starts = [
+        (match.group(1), match.start())
+        for match in re.finditer(r"CREATE TABLE\s+`(\w+)`", body)
+    ]
+    assert starts, f"{path.name}: no CREATE TABLE found"
+
+    bounds = [start for _, start in starts] + [len(body)]
     return {
-        name: rest.strip()
-        for name, rest in re.findall(r"^\s*`(\w+)`\s+(.+?),?$", body, flags=re.M)
+        name: {
+            column: rest.strip()
+            for column, rest in re.findall(
+                r"^\s*`(\w+)`\s+(.+?),?$", body[bounds[i] : bounds[i + 1]], flags=re.M
+            )
+        }
+        for i, (name, _) in enumerate(starts)
+    }
+
+
+def _declarations(path: Path) -> dict[str, str]:
+    """Every column in the file as ``table.column`` -> declaration.
+
+    Flat, but with table-qualified keys, so same-named columns in sibling
+    tables can no longer shadow each other.
+    """
+    return {
+        f"{table}.{column}": rest
+        for table, columns in _tables(path).items()
+        for column, rest in columns.items()
     }
 
 
@@ -69,27 +103,60 @@ def _sql_files() -> list[Path]:
 def test_application_supplied_times_are_datetime() -> None:
     """The regression fixed in acb6c1c5: these must not become TIMESTAMP."""
     for filename, columns in _APPLICATION_SUPPLIED.items():
-        declarations = _declarations(_SQL_DIR / filename)
+        tables = _tables(_SQL_DIR / filename)
         for column in columns:
-            assert column in declarations, f"{filename}: {column} is gone"
-            declared_type = declarations[column].split()[0].lower()
-            assert declared_type == "datetime", (
-                f"{filename}: `{column}` is declared {declared_type}, not datetime. "
-                "It is filled by the application, so TIMESTAMP would reinterpret "
-                "the bound value as session-local and store it shifted."
-            )
+            found = {
+                table: declarations[column]
+                for table, declarations in tables.items()
+                if column in declarations
+            }
+            assert found, f"{filename}: `{column}` is gone from every table"
+            for table, declaration in found.items():
+                declared_type = declaration.split()[0].lower()
+                assert declared_type == "datetime", (
+                    f"{table}.{column} is declared {declared_type}, not datetime. "
+                    "It is filled by the application, so TIMESTAMP would "
+                    "reinterpret the bound value as session-local and store it "
+                    "shifted."
+                )
 
 
 def test_database_filled_times_are_timestamp() -> None:
-    """The other half of the rule, so the split is asserted in both directions."""
+    """The other half of the rule, so the split is asserted in both directions.
+
+    Every table is checked independently — including both tables in the apply
+    file, which is what the per-file version of this silently skipped.
+    """
     for path in _sql_files():
-        declarations = _declarations(path)
-        for column in _DB_FILLED:
-            assert column in declarations, f"{path.name}: {column} is missing"
-            declared_type = declarations[column].split()[0].lower()
-            assert declared_type == "timestamp", (
-                f"{path.name}: `{column}` is declared {declared_type}, not timestamp"
-            )
+        for table, declarations in _tables(path).items():
+            for column in _DB_FILLED:
+                assert column in declarations, f"{table}: {column} is missing"
+                declared_type = declarations[column].split()[0].lower()
+                assert declared_type == "timestamp", (
+                    f"{table}.{column} is declared {declared_type}, not timestamp"
+                )
+
+
+def test_every_table_in_every_file_is_parsed() -> None:
+    """Guards the parser itself, not the DDL.
+
+    Both tests above are only as complete as ``_tables`` is. If it silently
+    returned one table for a two-table file again, they would go quiet rather
+    than fail, which is precisely how the shadowing bug survived review round 2.
+    """
+    tables = {
+        table
+        for path in _sql_files()
+        for table in _tables(path)
+    }
+    assert tables == {
+        "ac_bot_config_manifest",
+        "ac_bot_config_manifest_apply",
+        "ac_bot_config_manifest_apply_lock",
+        "ac_manifest_content",
+        "ac_source_credential",
+        "ac_bot_cli_tool",
+    }
 
 
 def test_no_bare_timestamp_column_can_attach_an_implicit_on_update() -> None:
@@ -102,7 +169,7 @@ def test_no_bare_timestamp_column_can_attach_an_implicit_on_update() -> None:
     caught that way is overwritten with the finish time on every apply.
     """
     for path in _sql_files():
-        for column, rest in _declarations(path).items():
+        for column, rest in _declarations(path).items():  # table-qualified keys
             tokens = rest.lower()
             if tokens.split()[0] != "timestamp":
                 continue
@@ -111,6 +178,6 @@ def test_no_bare_timestamp_column_can_attach_an_implicit_on_update() -> None:
             # pass exactly the declaration this test exists to reject.
             explicitly_nullable = re.search(r"(?<!not )\bnull\b", tokens) is not None
             assert "default" in tokens or explicitly_nullable, (
-                f"{path.name}: `{column}` is a bare TIMESTAMP NOT NULL with no "
+                f"{path.name}: {column} is a bare TIMESTAMP NOT NULL with no "
                 "DEFAULT; the server may attach ON UPDATE CURRENT_TIMESTAMP to it"
             )

--- a/src/backend/tests/community/core/bot_config_manifest/test_manifest_ddl_contract.py
+++ b/src/backend/tests/community/core/bot_config_manifest/test_manifest_ddl_contract.py
@@ -1,0 +1,116 @@
+"""Contract checks on the column-type choices in this module's DDL.
+
+Both rules asserted here were violated once, in the first draft of the
+OceanBase alignment change, and neither violation was caught by anything in CI —
+they were found by review. The prose in each file explains the reasoning; these
+tests are what make a future "tidy this up for consistency" edit fail loudly
+instead of silently corrupting an audit column.
+
+WHY TEXT RATHER THAN A LIVE SCHEMA. The suite runs on SQLite, which has no
+TIMESTAMP/DATETIME distinction, no implicit-default rule, and does not parse the
+OceanBase modifiers these files carry. The distinction being guarded therefore
+cannot be observed by creating the tables — only by reading what is declared.
+The sibling ``core/task_queue/test_task_queue_schema_contract.py`` guards its
+file the same way and for the same reason.
+"""
+
+from pathlib import Path
+import re
+
+
+_SQL_DIR = (
+    Path(__file__).parents[4]
+    / "src"
+    / "agentclaw"
+    / "community"
+    / "core"
+    / "bot_config_manifest"
+    / "sql"
+)
+
+#: Columns filled by the application, which must stay DATETIME. TIMESTAMP reads
+#: the bound naive value as session-local and converts it, so an instant the
+#: application already normalised to UTC (``fetched_at``) or took from
+#: ``datetime.now()`` (the apply times) is stored shifted by the session offset.
+_APPLICATION_SUPPLIED = {
+    "2026_08_31_bot_config_manifest_apply.sql": ("started_at", "finished_at"),
+    "2026_08_31_manifest_content.sql": ("fetched_at",),
+}
+
+#: Filled by the database itself, so TIMESTAMP's conversion is a no-op round
+#: trip and matches ac_bots. Every table here has both.
+_DB_FILLED = ("gmt_create", "gmt_modified")
+
+
+def _declarations(path: Path) -> dict[str, str]:
+    """Map column name -> the rest of its declaration, comments stripped.
+
+    Comments have to go first: ``DEFAULT CURRENT_TIMESTAMP`` appears throughout
+    the prose in these files, and the type token is only meaningful in the
+    position directly after the backticked column name.
+    """
+    body = "\n".join(
+        line
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("--")
+    )
+    return {
+        name: rest.strip()
+        for name, rest in re.findall(r"^\s*`(\w+)`\s+(.+?),?$", body, flags=re.M)
+    }
+
+
+def _sql_files() -> list[Path]:
+    files = sorted(_SQL_DIR.glob("*.sql"))
+    assert files, f"no DDL found under {_SQL_DIR}"
+    return files
+
+
+def test_application_supplied_times_are_datetime() -> None:
+    """The regression fixed in acb6c1c5: these must not become TIMESTAMP."""
+    for filename, columns in _APPLICATION_SUPPLIED.items():
+        declarations = _declarations(_SQL_DIR / filename)
+        for column in columns:
+            assert column in declarations, f"{filename}: {column} is gone"
+            declared_type = declarations[column].split()[0].lower()
+            assert declared_type == "datetime", (
+                f"{filename}: `{column}` is declared {declared_type}, not datetime. "
+                "It is filled by the application, so TIMESTAMP would reinterpret "
+                "the bound value as session-local and store it shifted."
+            )
+
+
+def test_database_filled_times_are_timestamp() -> None:
+    """The other half of the rule, so the split is asserted in both directions."""
+    for path in _sql_files():
+        declarations = _declarations(path)
+        for column in _DB_FILLED:
+            assert column in declarations, f"{path.name}: {column} is missing"
+            declared_type = declarations[column].split()[0].lower()
+            assert declared_type == "timestamp", (
+                f"{path.name}: `{column}` is declared {declared_type}, not timestamp"
+            )
+
+
+def test_no_bare_timestamp_column_can_attach_an_implicit_on_update() -> None:
+    """Guards the blocking finding from round 1 of review.
+
+    Under ``explicit_defaults_for_timestamp=OFF`` the server attaches
+    ``DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP`` to a table's first
+    TIMESTAMP column that is NOT NULL and declares no DEFAULT — and ON UPDATE
+    fires on any change to the row, not only to that column. A ``started_at``
+    caught that way is overwritten with the finish time on every apply.
+    """
+    for path in _sql_files():
+        for column, rest in _declarations(path).items():
+            tokens = rest.lower()
+            if tokens.split()[0] != "timestamp":
+                continue
+            # An explicit NULL exempts the column; NOT NULL does not. Matching a
+            # bare "null" substring would treat "NOT NULL" as the exemption and
+            # pass exactly the declaration this test exists to reject.
+            explicitly_nullable = re.search(r"(?<!not )\bnull\b", tokens) is not None
+            assert "default" in tokens or explicitly_nullable, (
+                f"{path.name}: `{column}` is a bare TIMESTAMP NOT NULL with no "
+                "DEFAULT; the server may attach ON UPDATE CURRENT_TIMESTAMP to it"
+            )

--- a/src/backend/tests/community/core/task_queue/test_task_queue_schema_contract.py
+++ b/src/backend/tests/community/core/task_queue/test_task_queue_schema_contract.py
@@ -1,0 +1,97 @@
+"""Contract checks keeping the provisioning DDL aligned with the ORM model.
+
+``repository/models.py`` is the source of truth for this table's schema and
+``sql/2026_09_06_task_queue.sql`` is a reference derived from it, so the failure
+mode worth guarding is the two drifting apart — specifically an index the ORM
+declares going missing from the DDL. That is not hypothetical: the first draft
+of the DDL deliberately omitted the legacy dedup index on the reasoning that a
+new table should not gain a scope wider than the code's, which would have left a
+freshly provisioned OceanBase database accepting an enqueue that
+``test_same_key_under_different_app_is_rejected_while_the_legacy_index_lives``
+asserts is rejected. Nothing caught it; this does.
+
+The DDL is read as text rather than executed because its OceanBase-only
+modifiers (``GLOBAL``, ``AUTO_INCREMENT_MODE``) are not parseable by the SQLite
+engine the suite runs on — which is the same reason they cannot be expressed in
+the ORM and have to live in the file at all.
+"""
+
+from pathlib import Path
+import re
+
+from sqlalchemy import Index
+
+from agentclaw.community.core.task_queue.repository.models import TaskQueueModel
+
+
+_DDL_PATH = (
+    Path(__file__).parents[4]
+    / "src"
+    / "agentclaw"
+    / "community"
+    / "core"
+    / "task_queue"
+    / "sql"
+    / "2026_09_06_task_queue.sql"
+)
+
+
+def _ddl_without_comments() -> str:
+    return "\n".join(
+        line
+        for line in _DDL_PATH.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("--")
+    )
+
+
+def _orm_unique_indexes() -> dict[str, tuple[str, ...]]:
+    return {
+        item.name: tuple(column.name for column in item.columns)
+        for item in TaskQueueModel.__table__.indexes
+        if isinstance(item, Index) and item.unique
+    }
+
+
+def _ddl_unique_indexes(ddl: str) -> dict[str, tuple[str, ...]]:
+    found = {}
+    for name, columns in re.findall(
+        r"UNIQUE KEY\s+`([^`]+)`\s*\(([^)]*)\)", ddl, flags=re.DOTALL
+    ):
+        found[name] = tuple(re.findall(r"`([^`]+)`", columns))
+    return found
+
+
+def test_ddl_declares_every_unique_index_the_orm_does() -> None:
+    """Both dedup indexes, with the same columns in the same order.
+
+    Column order is part of the assertion because a unique index is a different
+    constraint under a different order, and the dedup scope is exactly what
+    these two indexes disagree about.
+    """
+    assert _ddl_unique_indexes(_ddl_without_comments()) == _orm_unique_indexes()
+
+
+def test_unique_indexes_are_global() -> None:
+    """``GLOBAL`` is the one property the ORM cannot express.
+
+    Without it a partitioned table allows the same active idempotency key once
+    per partition, which defeats enqueue dedup silently rather than loudly.
+    """
+    ddl = _ddl_without_comments()
+    for name in _orm_unique_indexes():
+        clause = re.search(
+            rf"UNIQUE KEY\s+`{re.escape(name)}`\s*\([^)]*\)\s*(\w+)",
+            ddl,
+            flags=re.DOTALL,
+        )
+        assert clause is not None, f"{name} missing from the DDL"
+        assert clause.group(1) == "GLOBAL", f"{name} is not declared GLOBAL"
+
+
+def test_auto_increment_mode_is_pinned_to_order() -> None:
+    """``_find_by_key`` reads the audit row with ``ORDER BY id DESC``.
+
+    Under NOORDER each observer caches its own auto-increment range, so ids stop
+    being monotonic in insertion order and that query answers with an older row.
+    """
+    assert "AUTO_INCREMENT_MODE = 'ORDER'" in _ddl_without_comments()


### PR DESCRIPTION
## Problem

The hand-written DDL for the six `bot-config-manifest` tables was authored in portable MySQL form, but production is OceanBase. Measured against a real deployed table (`SHOW CREATE TABLE ac_bots`) it diverged in three ways that are not cosmetic:

1. **No index carried `GLOBAL`.** On a partitioned table an index without it is partition-local, and a partition-local `UNIQUE` enforces uniqueness only *within* a partition. For `uk_manifest_apply_lock` that is the entire mechanism — the `UNIQUE` constraint **is** the apply lock (work-items §2.7), so a partition-local one lets two applies run against one bot simultaneously. The same applies to the manifest key, the credential name and the CLI tool key, where the failure surfaces as duplicate rows appearing silently rather than as an error.
2. **`gmt_*` columns were `DATETIME` where the platform uses `TIMESTAMP`.** `ac_bots` and every table added since (`ac_bot_cli_call_config`, `ac_bot_app_grant`) use `TIMESTAMP` for the audit columns, and `skill_center/sql/2026_09_03_align_space_skill_timestamps_with_gmt.sql` is the repair that convention exists to avoid repeating.
3. **`AUTO_INCREMENT_MODE` left to the tenant default on tables whose reads depend on it.** `config_manifest_apply.py` answers `GET .../config-manifest/last-apply` with `ORDER BY id DESC`. Under `NOORDER` each observer caches its own auto-increment range, so ids stop being monotonic in insertion order and "max id" stops meaning "newest" — last-apply would serve a stale report while the newer one sat behind a smaller id. `ac_manifest_content` uses id as the within-second tie-break `keep_last` resolves on, and `ac_task_queue`'s `_find_by_key` states the same assumption in a code comment.

Separately, **`ac_task_queue` had no DDL in the repository at all.** Local and test runs build it from ORM metadata, and the OceanBase-only `GLOBAL` requirement lived in README prose. Since #1791 every manifest apply path goes through the queue, and W13 (#1696) creates bots on it, so a deployment that provisions the six manifest tables and not this one exposes an API that accepts work and never performs it.

## Solution

None of the six manifest tables are provisioned yet, so this corrects the `CREATE TABLE` files in place rather than shipping `ALTER`s — no migration, no index drop against a live apply lock.

- **`GLOBAL` on every index**, in all seven tables.
- **Timestamp type is decided by who fills the column**, which is the rule rather than a list of names:
  - `gmt_create` / `gmt_modified` → `TIMESTAMP`. The database fills these (`DEFAULT CURRENT_TIMESTAMP`, `func.now()` from the ORM), so the session-time-zone conversion is a no-op round trip and they match `ac_bots`.
  - `started_at`, `finished_at`, `fetched_at` → **`DATETIME`**. These are filled by the application, and `TIMESTAMP` reads a bound naive value as session-local before converting it — so an instant already normalised to UTC (`fetched_at`, per `content/service.py:271-276`) or taken from `datetime.now()` is stored shifted by the session offset.
- **`AUTO_INCREMENT_MODE = 'ORDER'`** on `ac_bot_config_manifest_apply`, `ac_manifest_content` and `ac_task_queue`.
- `ENGINE=InnoDB` dropped — OceanBase neither needs nor echoes it — and the table options now match the sibling DDL in `core/caller_identity/sql/`.
- The storage options `ac_bots` echoes back (`BLOCK_SIZE`, `REPLICA_NUM`, `COMPRESSION`, `TABLET_SIZE`, `PCTFREE`, `ROW_FORMAT`) are deliberately **not** written: they are `SHOW CREATE TABLE` output, not input, and no other `.sql` in this repo writes them.
- Each file carries a dialect note recording the reasoning, so the modifiers are not later "tidied" away as noise.
- New `core/task_queue/sql/2026_09_06_task_queue.sql`, plus two contract test files (below).

Column widths, the surrogate-vs-logical key choices, and the tenant-leading index order are unchanged. The ORM keeps `DateTime` against both column kinds — `ac_skill_version.published_at` is the existing precedent for `DateTime` over a `TIMESTAMP` column — so no model change is needed.

### Two contract tests, because prose already failed once

Both rules below were violated during this PR and caught by review, not CI. They are now asserted, and **each assertion was verified by injecting the regression it names and watching it fail**:

- `tests/community/core/task_queue/test_task_queue_schema_contract.py` — the DDL declares every unique index the ORM declares (both, legacy included), both are `GLOBAL`, and `AUTO_INCREMENT_MODE` stays pinned.
- `tests/community/core/bot_config_manifest/test_manifest_ddl_contract.py` — app-supplied columns stay `DATETIME`, DB-filled columns stay `TIMESTAMP`, no bare `TIMESTAMP NOT NULL` without a `DEFAULT` exists in any file (such a column can pick up an implicit `ON UPDATE CURRENT_TIMESTAMP`, which the apply record's terminal write would fire on every apply), and every table in every file is actually parsed.

## Validation

- On the current head `96d255e6`: `pytest tests/community/core/bot_config_manifest tests/community/core/task_queue` — **880 passed**. On `ddeba211`, the wider `bot_config_manifest` + `task_queue` + `repository` run — **1900 passed, 5 skipped**. CI's `Backend unit tests` covers the full backend suite on every commit and is green on `96d255e6`.
- Each DDL file re-parsed after editing to confirm it still contains only complete, paren-balanced `CREATE TABLE` statements.
- Both contract tests verified against injected regressions, not just observed green. **Two assertions were fixed by that exercise before landing**: one exempted any declaration containing `null`, which also matched `NOT NULL`, so it passed the exact declaration it exists to reject; another parsed per file rather than per table, so in the one file declaring two tables the apply table's `gmt_*` columns were masked by the lock table's.
- **Not run:** the DDL has never been executed against an OceanBase instance — none is reachable from this environment. Every claim about `GLOBAL`, `AUTO_INCREMENT_MODE` and the implicit-default rule is reasoned from the deployed `ac_bots` schema and documented engine behaviour, not observed. **Apply it to a non-production tenant before trusting it.**

## Compatibility and risk

Low for the six manifest tables: they do not exist in any environment yet, so there is no data to migrate and no rollback beyond reverting.

`ac_task_queue` is the one to read carefully. The file is **reconstructed from the ORM and README, not dumped from a live table**, and its header says so. It keeps `DATETIME` throughout — mirroring the ORM and what was provisioned, rather than adopting this PR's `TIMESTAMP` convention — because every claim, reclaim and deadline comparison in that component is a DB-clock comparison. It **declares both unique indexes the ORM declares, including the legacy pre-`app` one**, so a freshly provisioned database behaves the way the test suite asserts; dropping that index is a single future change touching `models.py`, this file and the deployed tables together. For any deployment that already has the table, `SHOW CREATE TABLE ac_task_queue` outranks both this file and the ORM.

## Review history

Four rounds of automated review (Codex and Claude Code) across `06df08d6` → `acb6c1c5` → `ddeba211` → `96d255e6` produced **six findings. All were verified against the source, all were real, none were disputed.**

Three were defects in the DDL — two of them the same root cause, converting *every* datetime column to `TIMESTAMP` when only the database-filled ones should have moved. Three were gaps in the tests guarding it, two of those in tests written during the review itself. Both reviewers are clear on `96d255e6`.

## Related issues

Touches the DDL from #1469 (W1), #1471 (W3), #1472 (W4), #1477 (W9), #1510 (W11), and the queue W13 (#1696) runs on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015bEPXsL1QHUYjS7PzQGjTk