### PR TITLE
feat(baas): best-effort engine chat.abort on session-run abort

### DIFF
--- a/src/baas/src/secbaas/community/bootstrap/_core_services.py
+++ b/src/baas/src/secbaas/community/bootstrap/_core_services.py
@@ -87,7 +87,52 @@ from secbaas.community.core.service.sse import (
 )
 from secbaas.community.core.service.template_manage import DefaultDeviceTemplateService
 from secbaas.community.core.service.tenant_manage import DefaultTenantManageService
+from secbaas.community.logger import get_logger
 from secbaas.community.spi.sandbox import PaasSandboxPlugins
+
+logger = get_logger("bootstrap-core-services")
+
+
+class _EngineAbortNotifier:
+    """Best-effort ``chat.abort`` 通知器，供 ``BotRequestWorker`` 在
+    ``abort_runs_by_session`` 命中归属机 run 时调用。
+
+    ``bot_runner`` 通过 DI 注入（容器在解析 ``engine_abort_notifier`` 时经
+    ``providers.Singleton`` 解析 bot_runner，与 ``bcn_downlink_service`` 共享同一
+    BotRunner 实例），经 ``BotRunner.deliver_chat_abort`` →
+    ``BaasBotService.send_chat_abort`` → ``AsyncChatClient.chat_abort`` 转发
+    chat.abort 控制帧到 engine。失败仅记日志（与 worker 侧 best-effort 语义一致，
+    双重兜底），不阻断 abort 主流程（FAILED + force_done + 本机 cancel）。
+
+    之所以用一个 ``__call__`` 类而非 class body 内 ``async def`` 闭包：class 作用域
+    变量不对方法内部可见，且 class body 内 ``async def`` 会被当作需要 ``self`` 的方法；
+    更重要的是，只有作为 DI provider 的依赖（而非捕获 class-level provider 对象），
+    容器实例 ``container.bot_runner.override(...)`` 才能在测试中对通知器生效。
+    """
+
+    def __init__(self, bot_runner: BotRunner) -> None:
+        self._bot_runner = bot_runner
+
+    async def __call__(
+        self,
+        session_id: str,
+        bot_id: str,
+        run_id: str | None,
+    ) -> None:
+        try:
+            await self._bot_runner.deliver_chat_abort(
+                bot_id=bot_id, session_id=session_id, run_id=run_id
+            )
+        except Exception as e:
+            logger.warning(
+                "[bootstrap] engine_abort_notifier failed: session_id=%s "
+                "bot_id=%s run_id=%s: %s",
+                session_id,
+                bot_id,
+                run_id,
+                e,
+                exc_info=True,
+            )
 
 
 def _real_bot_service_plugin(base_url: str = "", timeout: float = 10.0):
@@ -684,12 +729,25 @@ class CoreServiceContainer(containers.DeclarativeContainer):
         count=config.bot_run_queue.machine_count,
     )
 
+    # engine_abort_notifier: bootstrap 装配的 chat.abort 通知器，DI 注入 bot_runner
+    # Singleton（与 bcn_downlink_service 共享同一 BotRunner 实例）。BotRequestWorker
+    # .abort_runs_by_session 命中归属机 run 时 best-effort 调用，经
+    # BotRunner.deliver_chat_abort → BaasBotService.send_chat_abort →
+    # AsyncChatClient.chat_abort 转发 chat.abort 到 engine。失败仅记日志（双重兜底），
+    # 不阻断 abort 主流程（FAILED + force_done + 本机 cancel）。作为 provider 依赖
+    # 注入 bot_runner（而非捕获 class-level provider 对象），使容器实例 override 能在
+    # 测试中对通知器生效。
+    engine_abort_notifier = providers.Singleton(
+        _EngineAbortNotifier, bot_runner=bot_runner
+    )
+
     bot_request_worker = providers.Singleton(
         BotRequestWorker,
         queue_repository=bot_run_queue_repository,
         qpm_manager=bot_qpm_manager,
         executor=result_guard_executor,
         run_repository=bot_run_repository,
+        engine_abort_notifier=engine_abort_notifier,
         post_run_callback_factories=providers.Dict(
             {
                 "bcn_uplink": bcn_uplink_callback,

--- a/src/baas/src/secbaas/community/bootstrap/_core_services.py
+++ b/src/baas/src/secbaas/community/bootstrap/_core_services.py
@@ -118,10 +118,14 @@ class _EngineAbortNotifier:
         session_id: str,
         bot_id: str,
         run_id: str | None,
+        tenant: str = "",
     ) -> None:
         try:
-            await self._bot_runner.deliver_chat_abort(
-                bot_id=bot_id, session_id=session_id, run_id=run_id
+            result = await self._bot_runner.deliver_chat_abort(
+                bot_id=bot_id,
+                session_id=session_id,
+                run_id=run_id,
+                tenant=tenant,
             )
         except Exception as e:
             logger.warning(
@@ -132,6 +136,32 @@ class _EngineAbortNotifier:
                 run_id,
                 e,
                 exc_info=True,
+            )
+            return
+
+        # best-effort 可观测性：deliver_chat_abort 返回底层 chat.abort 响应语义，
+        # 区分“engine 实际已取消”与“engine 拒绝/未命中 active run”。不抛异常、不阻断
+        # BaaS 侧 abort 主流程（FAILED + force_done + 本机 cancel 仍已执行）。
+        if not isinstance(result, dict):
+            return
+        payload = result.get("payload")
+        aborted = payload.get("aborted") if isinstance(payload, dict) else None
+        if result.get("ok") is False:
+            logger.warning(
+                "[bootstrap] engine_abort_notifier rejected by engine: "
+                "session_id=%s bot_id=%s run_id=%s result=%s",
+                session_id,
+                bot_id,
+                run_id,
+                result,
+            )
+        elif aborted is False:
+            logger.info(
+                "[bootstrap] engine_abort_notifier returned aborted=false "
+                "(no active run matched): session_id=%s bot_id=%s run_id=%s",
+                session_id,
+                bot_id,
+                run_id,
             )
 
 

--- a/src/baas/src/secbaas/community/bootstrap/_core_services.py
+++ b/src/baas/src/secbaas/community/bootstrap/_core_services.py
@@ -90,7 +90,7 @@ from secbaas.community.core.service.tenant_manage import DefaultTenantManageServ
 from secbaas.community.logger import get_logger
 from secbaas.community.spi.sandbox import PaasSandboxPlugins
 
-logger = get_logger("bootstrap-core-services")
+logger = get_logger("bootstrap")
 
 
 class _EngineAbortNotifier:

--- a/src/baas/src/secbaas/community/core/service/bot_run/_async_chat_client.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_async_chat_client.py
@@ -630,17 +630,24 @@ class AsyncChatClient:
         self,
         session_key: str,
         run_id: str | None = None,
-    ) -> None:
+    ) -> dict[str, Any] | None:
         """发送 ``chat.abort`` 控制帧，best-effort 通知 engine 取消 session/run。
 
         与 ``send_message`` 不同，``chat.abort`` 是带外控制帧：不获取 sessionKey 并发
         发送锁，直接经底层 ``BotWebSocketClient`` 发送。与在跑 ``chat.send`` 帧的交错
         由 engine 的 abort 优先级语义处理。底层 ``_client`` 未建立（未连接）时记日志
-        并返回，不抛异常——避免 abort 链路因连接瞬时不可用而中断。
+        并返回 ``None``，不抛异常——避免 abort 链路因连接瞬时不可用而中断。
+
+        返回底层 ``chat.abort`` 的完整响应（``dict``，含 ``ok`` / ``payload.aborted``
+        等语义），供上层（``_EngineAbortNotifier``）区分“engine 实际已取消”与
+        “engine 拒绝/未命中 active run”，避免把 ``aborted:false`` 静默当作成功。
 
         Args:
             session_key: 会话 key（即 session_id）。
             run_id: 本次取消的 run id，None 时仅按 sessionKey 取消。
+
+        Returns:
+            底层响应 dict；未连接时为 ``None``。
         """
         client = self._client
         if client is None:
@@ -649,8 +656,8 @@ class AsyncChatClient:
                 session_key,
                 run_id,
             )
-            return
-        await client.chat_abort(session_key=session_key, run_id=run_id)
+            return None
+        return await client.chat_abort(session_key=session_key, run_id=run_id)
 
     async def close(self) -> None:
         """关闭连接并清理所有 session state。"""

--- a/src/baas/src/secbaas/community/core/service/bot_run/_async_chat_client.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_async_chat_client.py
@@ -626,6 +626,32 @@ class AsyncChatClient:
             if self._concurrency_sem is not None:
                 self._concurrency_sem.release()
 
+    async def chat_abort(
+        self,
+        session_key: str,
+        run_id: str | None = None,
+    ) -> None:
+        """发送 ``chat.abort`` 控制帧，best-effort 通知 engine 取消 session/run。
+
+        与 ``send_message`` 不同，``chat.abort`` 是带外控制帧：不获取 sessionKey 并发
+        发送锁，直接经底层 ``BotWebSocketClient`` 发送。与在跑 ``chat.send`` 帧的交错
+        由 engine 的 abort 优先级语义处理。底层 ``_client`` 未建立（未连接）时记日志
+        并返回，不抛异常——避免 abort 链路因连接瞬时不可用而中断。
+
+        Args:
+            session_key: 会话 key（即 session_id）。
+            run_id: 本次取消的 run id，None 时仅按 sessionKey 取消。
+        """
+        client = self._client
+        if client is None:
+            logger.warning(
+                "[chat_abort] client not connected, skip: session_key=%s, run_id=%s",
+                session_key,
+                run_id,
+            )
+            return
+        await client.chat_abort(session_key=session_key, run_id=run_id)
+
     async def close(self) -> None:
         """关闭连接并清理所有 session state。"""
         self._closed_intentionally = True

--- a/src/baas/src/secbaas/community/core/service/bot_run/_baas_service.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_baas_service.py
@@ -476,7 +476,8 @@ class BaasBotService(BotService):
         binding_info: BotBindingInfo,
         session_id: str,
         run_id: str | None = None,
-    ) -> None:
+        context: BotChatContext | None = None,
+    ) -> dict[str, Any] | None:
         """向 engine 发送 ``chat.abort`` 控制帧（best-effort）。
 
         复用既有 ``_resolve_ws_connection_for_binding`` + ``_client_pool.get`` 解析归属
@@ -486,17 +487,29 @@ class BaasBotService(BotService):
         写入）。与 ``send_message`` 共享同一连接解析与 pool 取连接路径，保证 abort 帧落到
         与 chat.send 相同的归属连接。
 
+        ``context`` 仅用于解析归属 WS 连接时透传 ``tenant``：abort 路径无原始请求上下文，
+        由 ``BotRequestWorker`` 从 ``baas_bot_run.metadata["tenant"]`` 恢复后传入。
+        缺失 tenant 时 ``_resolve_ws_connection_for_binding`` 会以空串查询 bot，对
+        tenant 非空的多租户记录会 miss——因此上层必须尽力恢复 tenant。
+
         Args:
             binding_info: bot binding（含 device_id/tenant/engine_type）。
             session_id: 会话 id（即 sessionKey）。
             run_id: 本次取消的 run id，None 时仅按 sessionKey 取消。
+            context: 可选请求上下文，仅取 ``tenant`` 用于 WS 连接解析。
+
+        Returns:
+            底层 ``chat.abort`` 响应 dict（含 ``ok``/``payload.aborted`` 语义），
+            未送达时为 ``None``。
         """
         conn_info = await self._resolve_ws_connection_for_binding(
-            binding_info, session_id, context=None
+            binding_info, session_id, context=context
         )
         headers = {"x-proxypass-token": conn_info.token}
-        client = await self._client_pool.get(conn_info.target, conn_info.ws_url, headers)
-        await client.chat_abort(session_id, run_id)
+        client = await self._client_pool.get(
+            conn_info.target, conn_info.ws_url, headers
+        )
+        return await client.chat_abort(session_id, run_id)
 
     async def send_message_stream(
         self,

--- a/src/baas/src/secbaas/community/core/service/bot_run/_baas_service.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_baas_service.py
@@ -470,6 +470,34 @@ class BaasBotService(BotService):
                 f"Failed to send message: {_safe_client_msg(e)}"
             ) from e
 
+    async def send_chat_abort(
+        self,
+        *,
+        binding_info: BotBindingInfo,
+        session_id: str,
+        run_id: str | None = None,
+    ) -> None:
+        """向 engine 发送 ``chat.abort`` 控制帧（best-effort）。
+
+        复用既有 ``_resolve_ws_connection_for_binding`` + ``_client_pool.get`` 解析归属
+        WS 连接，经 ``AsyncChatClient.chat_abort`` 转发到底层 ``BotWebSocketClient.chat_abort``。
+        异常向上抛由调用方 best-effort 捕获记日志；本方法不做任何 session 状态标记
+        （abort 不改写会话终态，BaaS 侧终态由 ``BotRequestWorker.abort_runs_by_session``
+        写入）。与 ``send_message`` 共享同一连接解析与 pool 取连接路径，保证 abort 帧落到
+        与 chat.send 相同的归属连接。
+
+        Args:
+            binding_info: bot binding（含 device_id/tenant/engine_type）。
+            session_id: 会话 id（即 sessionKey）。
+            run_id: 本次取消的 run id，None 时仅按 sessionKey 取消。
+        """
+        conn_info = await self._resolve_ws_connection_for_binding(
+            binding_info, session_id, context=None
+        )
+        headers = {"x-proxypass-token": conn_info.token}
+        client = await self._client_pool.get(conn_info.target, conn_info.ws_url, headers)
+        await client.chat_abort(session_id, run_id)
+
     async def send_message_stream(
         self,
         *,

--- a/src/baas/src/secbaas/community/core/service/bot_run/_runner.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_runner.py
@@ -365,8 +365,9 @@ class BotRunner:
         bot_id: str,
         session_id: str,
         run_id: str | None = None,
+        tenant: str = "",
         lifecycle_stage: str = "online",
-    ) -> None:
+    ) -> dict[str, Any] | None:
         """向 engine 转发 ``chat.abort`` 控制帧（best-effort）。
 
         解析 bot 的 binding → 选择 ``BotService`` → 调用 ``service.send_chat_abort``；
@@ -374,6 +375,10 @@ class BotRunner:
         ``send_chat_abort``）时记日志并返回，不抛异常。engine 通知失败由调用方
         （``BotRequestWorker.abort_runs_by_session`` 的 ``engine_abort_notifier`` 闭包）
         的 try/except 兜底，不阻断 BaaS 侧 abort 主流程（FAILED + force_done + 本机 cancel）。
+
+        ``tenant`` 由调用方从 ``baas_bot_run.metadata["tenant"]`` 恢复后透传，仅用于
+        解析归属 WS 连接（``_resolve_ws_connection_for_binding`` 取 ``context.tenant``）。
+        缺失 tenant 会让多租户 bot 查询 miss，故尽力恢复。
 
         选用 ``getattr`` 而非 ``isinstance`` 判定 ``send_chat_abort`` 是否可用，避免触达
         ``ClawBotService``（ARCA）与本变更范围无关的改动——仅在 ``BaasBotService`` 上
@@ -383,7 +388,12 @@ class BotRunner:
             bot_id: 目标 bot id。
             session_id: 会话 id（即 sessionKey，用于解析 WS 与 engine 通知）。
             run_id: 本次取消的 run id，None 时仅按 sessionKey 取消。
+            tenant: 原始请求租户，用于 WS 连接解析。
             lifecycle_stage: binding 解析阶段，默认 ``online``。
+
+        Returns:
+            底层 ``chat.abort`` 响应 dict（含 ``ok``/``payload.aborted`` 语义），
+            未送达或被跳过时为 ``None``。
         """
         binding_info = await self._resolve_binding(bot_id, lifecycle_stage)
         if binding_info is None:
@@ -394,7 +404,7 @@ class BotRunner:
                 session_id,
                 lifecycle_stage,
             )
-            return
+            return None
 
         service = self._bot_service_selector.select(binding_info)
         send_chat_abort = getattr(service, "send_chat_abort", None)
@@ -406,10 +416,19 @@ class BotRunner:
                 session_id,
                 type(service).__name__,
             )
-            return
+            return None
 
-        await send_chat_abort(
-            binding_info=binding_info, session_id=session_id, run_id=run_id
+        # 仅透传 tenant 给 _resolve_ws_connection_for_binding；其余字段不参与 abort 解析。
+        context = (
+            BotChatContext.from_api_key(api_key_prefix="", app_id="", tenant=tenant)
+            if tenant
+            else None
+        )
+        return await send_chat_abort(
+            binding_info=binding_info,
+            session_id=session_id,
+            run_id=run_id,
+            context=context,
         )
 
     async def deliver_message_stream(

--- a/src/baas/src/secbaas/community/core/service/bot_run/_runner.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_runner.py
@@ -359,6 +359,59 @@ class BotRunner:
         )
         return message_id, actual_session_id
 
+    async def deliver_chat_abort(
+        self,
+        *,
+        bot_id: str,
+        session_id: str,
+        run_id: str | None = None,
+        lifecycle_stage: str = "online",
+    ) -> None:
+        """向 engine 转发 ``chat.abort`` 控制帧（best-effort）。
+
+        解析 bot 的 binding → 选择 ``BotService`` → 调用 ``service.send_chat_abort``；
+        解析失败（binding 不存在）或该 service 类型不支持 engine abort（无
+        ``send_chat_abort``）时记日志并返回，不抛异常。engine 通知失败由调用方
+        （``BotRequestWorker.abort_runs_by_session`` 的 ``engine_abort_notifier`` 闭包）
+        的 try/except 兜底，不阻断 BaaS 侧 abort 主流程（FAILED + force_done + 本机 cancel）。
+
+        选用 ``getattr`` 而非 ``isinstance`` 判定 ``send_chat_abort`` 是否可用，避免触达
+        ``ClawBotService``（ARCA）与本变更范围无关的改动——仅在 ``BaasBotService`` 上
+        提供该方法。
+
+        Args:
+            bot_id: 目标 bot id。
+            session_id: 会话 id（即 sessionKey，用于解析 WS 与 engine 通知）。
+            run_id: 本次取消的 run id，None 时仅按 sessionKey 取消。
+            lifecycle_stage: binding 解析阶段，默认 ``online``。
+        """
+        binding_info = await self._resolve_binding(bot_id, lifecycle_stage)
+        if binding_info is None:
+            logger.warning(
+                "[runner.deliver_chat_abort] binding not found, skip engine abort: "
+                "bot_id=%s, session_id=%s, lifecycle_stage=%s",
+                bot_id,
+                session_id,
+                lifecycle_stage,
+            )
+            return
+
+        service = self._bot_service_selector.select(binding_info)
+        send_chat_abort = getattr(service, "send_chat_abort", None)
+        if send_chat_abort is None:
+            logger.info(
+                "[runner.deliver_chat_abort] service type has no send_chat_abort, "
+                "skip engine abort: bot_id=%s, session_id=%s, service=%s",
+                bot_id,
+                session_id,
+                type(service).__name__,
+            )
+            return
+
+        await send_chat_abort(
+            binding_info=binding_info, session_id=session_id, run_id=run_id
+        )
+
     async def deliver_message_stream(
         self,
         *,

--- a/src/baas/src/secbaas/community/core/service/bot_run/_worker.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_worker.py
@@ -88,8 +88,9 @@ class BotRequestWorkerConfig:
 
 #: Engine 通知回调类型：``chat.abort`` best-effort 通知 engine 取消 session/run。
 #: 失败仅记录日志，不影响 abort 主流程。``session_id`` 用于 engine 侧 session 定位，
+#: ``bot_id`` 用于解析归属 WS 连接（BaasBotService.send_chat_abort），
 #: ``run_id`` 为本次取消的 run（非 None 时通知 engine 取消该 run）。
-EngineAbortNotifier = Callable[[str, str | None], Awaitable[None]]
+EngineAbortNotifier = Callable[[str, str, str | None], Awaitable[None]]
 
 
 def _default_worker_id() -> str:
@@ -354,7 +355,9 @@ class BotRequestWorker:
         # 4. best-effort 通知 engine（一次 维度通知，run_id 取首个）
         if self._engine_abort_notifier is not None and aborted_run_ids:
             try:
-                await self._engine_abort_notifier(session_id, aborted_run_ids[0])
+                await self._engine_abort_notifier(
+                    session_id, bot_id, aborted_run_ids[0]
+                )
             except Exception as e:
                 logger.warning(
                     "[BotRequestWorker] abort engine notify failed session_id=%s "

--- a/src/baas/src/secbaas/community/core/service/bot_run/_worker.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_worker.py
@@ -90,7 +90,7 @@ class BotRequestWorkerConfig:
 #: 失败仅记录日志，不影响 abort 主流程。``session_id`` 用于 engine 侧 session 定位，
 #: ``bot_id`` 用于解析归属 WS 连接（BaasBotService.send_chat_abort），
 #: ``run_id`` 为本次取消的 run（非 None 时通知 engine 取消该 run）。
-EngineAbortNotifier = Callable[[str, str, str | None], Awaitable[None]]
+EngineAbortNotifier = Callable[[str, str, str | None, str], Awaitable[None]]
 
 
 def _default_worker_id() -> str:
@@ -352,12 +352,28 @@ class BotRequestWorker:
                 record.assigned_worker,
             )
 
-        # 4. best-effort 通知 engine（一次 维度通知，run_id 取首个）
+        # 4. best-effort 通知 engine（一次 维度通知）
+        #    run_id 传 None：BaaS queue run id ≠ engine run id（chat.send 未持久化两者映射），
+        #    传 BaaS run id 会让带 runId 的 gateway 精确查找 miss 且不回退 sessionKey，得到
+        #    aborted:false；故按 sessionKey 维度取消，由 engine 按 sessionKey 查 active run。
+        #    tenant 从 baas_bot_run.metadata["tenant"] 恢复（Runner 入库时写入），透传给
+        #    deliver_chat_abort 解析归属 WS 连接——避免 tenant 空串导致多租户 bot 查询 miss。
         if self._engine_abort_notifier is not None and aborted_run_ids:
+            tenant = ""
+            if self._run_repository is not None:
+                try:
+                    run_record = self._run_repository.get_by_run_id(aborted_run_ids[0])
+                    if run_record is not None and run_record.metadata:
+                        tenant = run_record.metadata.get("tenant", "") or ""
+                except Exception as e:
+                    logger.warning(
+                        "[BotRequestWorker] abort tenant recovery failed run_id=%s: %s",
+                        aborted_run_ids[0],
+                        e,
+                        exc_info=True,
+                    )
             try:
-                await self._engine_abort_notifier(
-                    session_id, bot_id, aborted_run_ids[0]
-                )
+                await self._engine_abort_notifier(session_id, bot_id, None, tenant)
             except Exception as e:
                 logger.warning(
                     "[BotRequestWorker] abort engine notify failed session_id=%s "

--- a/src/baas/tests/unit/bootstrap/test_core_services.py
+++ b/src/baas/tests/unit/bootstrap/test_core_services.py
@@ -314,15 +314,36 @@ class TestBotRequestWorkerEngineAbortNotifierWiring:
         self, worker_container
     ):
         """The notifier closure dispatches to BotRunner.deliver_chat_abort with the
-        (session_id, bot_id, run_id) signature."""
+        (session_id, bot_id, run_id, tenant) signature."""
         c, mock_runner = worker_container
         worker = c.bot_request_worker()
         assert worker._engine_abort_notifier is not None
 
-        await worker._engine_abort_notifier("sess-1", "bot-1", "run-1")
+        await worker._engine_abort_notifier("sess-1", "bot-1", "run-1", "tenant-x")
 
         mock_runner.deliver_chat_abort.assert_awaited_once_with(
-            bot_id="bot-1", session_id="sess-1", run_id="run-1"
+            bot_id="bot-1",
+            session_id="sess-1",
+            run_id="run-1",
+            tenant="tenant-x",
+        )
+
+    @pytest.mark.asyncio
+    async def test_engine_abort_notifier_observes_rejection(self, worker_container):
+        """When deliver_chat_abort returns ok:false / aborted:false the notifier must
+        not raise (best-effort) — the rejection is observable only via logs."""
+        c, mock_runner = worker_container
+        worker = c.bot_request_worker()
+        mock_runner.deliver_chat_abort.return_value = {
+            "ok": False,
+            "error": {"code": "FORBIDDEN"},
+        }
+
+        # Must not raise.
+        await worker._engine_abort_notifier("sess-1", "bot-1", None, "tenant-x")
+
+        mock_runner.deliver_chat_abort.assert_awaited_once_with(
+            bot_id="bot-1", session_id="sess-1", run_id=None, tenant="tenant-x"
         )
 
     @pytest.mark.asyncio
@@ -338,5 +359,8 @@ class TestBotRequestWorkerEngineAbortNotifierWiring:
         await worker._engine_abort_notifier("sess-1", "bot-1", "run-1")
 
         mock_runner.deliver_chat_abort.assert_awaited_once_with(
-            bot_id="bot-1", session_id="sess-1", run_id="run-1"
+            bot_id="bot-1",
+            session_id="sess-1",
+            run_id="run-1",
+            tenant="",
         )

--- a/src/baas/tests/unit/bootstrap/test_core_services.py
+++ b/src/baas/tests/unit/bootstrap/test_core_services.py
@@ -5,12 +5,13 @@ config.from_dict.  Services requiring repo/infra deps are verified
 structurally — they exist and accept overrides.
 """
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from secbaas.community.api.health_check.bot import BotHealthCheckerConfig
 from secbaas.community.bootstrap._core_services import CoreServiceContainer
+from secbaas.community.core.service.bot_run import BotRequestWorkerConfig
 
 
 class TestCoreServiceContainerStandalone:
@@ -246,3 +247,96 @@ class TestSandboxDeviceRouterDIResolution:
         assert callable(getattr(router, "query_active_sandboxes", None))
         assert callable(getattr(router, "warn_device", None))
         assert callable(getattr(router, "renew_ttl", None))
+
+
+class TestBotRequestWorkerEngineAbortNotifierWiring:
+    """Verify bootstrap wires engine_abort_notifier into bot_request_worker.
+
+    Regression: bootstrap previously constructed BotRequestWorker without
+    engine_abort_notifier, so chat.abort never reached the engine and runs
+    survived until the 120s heartbeat-stale fallback. The bootstrap-defined
+    notifier must be non-None, callable, and dispatch via BotRunner.deliver_chat_abort.
+    """
+
+    @pytest.fixture()
+    def worker_container(self):
+        """CoreServiceContainer with the bot_request_worker dep path overridden.
+
+        Overrides all Dependency()/config-heavy providers on bot_request_worker's
+        resolution path so the real BotRequestWorker constructs; bot_runner is
+        overridden with a mock whose deliver_chat_abort is awaitable so we can
+        assert the notifier dispatches end-to-end.
+        """
+        c = CoreServiceContainer()
+        # Dependency() providers consumed directly by bot_request_worker.
+        c.bot_run_queue_repository.override(MagicMock())
+        c.bot_run_repository.override(MagicMock())
+        # Heavy / config-dependent singletons on the worker's dep path: override
+        # to avoid resolving their transitive (config / secret / plugin) deps.
+        c.bot_qpm_manager.override(MagicMock())
+        c.result_guard_executor.override(MagicMock())
+        c.machine_count_provider.override(MagicMock())
+        c.bot_request_worker_config.override(BotRequestWorkerConfig())
+        # post_run_callback_factories providers.Dict resolves these two singletons.
+        c.bcn_uplink_callback.override(MagicMock())
+        c.http_callback.override(MagicMock())
+        # bot_runner: the notifier closure captures this provider and resolves it
+        # via bot_runner() at invoke time; override with a mock so deliver_chat_abort
+        # is assertable without resolving the (deep) bot_runner chain.
+        mock_runner = MagicMock()
+        mock_runner.deliver_chat_abort = AsyncMock()
+        c.bot_runner.override(mock_runner)
+
+        overridden = (
+            "bot_run_queue_repository",
+            "bot_run_repository",
+            "bot_qpm_manager",
+            "result_guard_executor",
+            "machine_count_provider",
+            "bot_request_worker_config",
+            "bcn_uplink_callback",
+            "http_callback",
+            "bot_runner",
+        )
+        yield c, mock_runner
+        for dep in overridden:
+            getattr(c, dep).reset_override()
+
+    def test_engine_abort_notifier_is_wired_and_callable(self, worker_container):
+        """bot_request_worker resolves with a non-None, callable _engine_abort_notifier."""
+        c, _mock_runner = worker_container
+        worker = c.bot_request_worker()
+        assert worker._engine_abort_notifier is not None
+        assert callable(worker._engine_abort_notifier)
+
+    @pytest.mark.asyncio
+    async def test_engine_abort_notifier_invokes_deliver_chat_abort(
+        self, worker_container
+    ):
+        """The notifier closure dispatches to BotRunner.deliver_chat_abort with the
+        (session_id, bot_id, run_id) signature."""
+        c, mock_runner = worker_container
+        worker = c.bot_request_worker()
+        assert worker._engine_abort_notifier is not None
+
+        await worker._engine_abort_notifier("sess-1", "bot-1", "run-1")
+
+        mock_runner.deliver_chat_abort.assert_awaited_once_with(
+            bot_id="bot-1", session_id="sess-1", run_id="run-1"
+        )
+
+    @pytest.mark.asyncio
+    async def test_engine_abort_notifier_swallows_dispatch_error(
+        self, worker_container
+    ):
+        """A failing deliver_chat_abort must not propagate (best-effort, log-only)."""
+        c, mock_runner = worker_container
+        worker = c.bot_request_worker()
+        mock_runner.deliver_chat_abort.side_effect = RuntimeError("dispatch boom")
+
+        # Must not raise.
+        await worker._engine_abort_notifier("sess-1", "bot-1", "run-1")
+
+        mock_runner.deliver_chat_abort.assert_awaited_once_with(
+            bot_id="bot-1", session_id="sess-1", run_id="run-1"
+        )

--- a/src/baas/tests/unit/core/service/bot_run/test_async_chat_client.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_async_chat_client.py
@@ -1880,7 +1880,7 @@ class TestChatAbort:
     async def test_chat_abort_forwards_with_run_id(
         self, mock_bot_ws, mock_bot_ws_instance
     ):
-        """chat_abort forwards (session_key, run_id) to the underlying client."""
+        """chat_abort forwards (session_key, run_id) and returns the underlying response."""
         from secbaas.community.core.service.bot_run._async_chat_client import (
             AsyncChatClient,
         )
@@ -1889,22 +1889,24 @@ class TestChatAbort:
             "server": {"host": "srv"},
             "features": {},
         }
-        mock_bot_ws_instance.chat_abort = AsyncMock()
+        response = {"ok": True, "payload": {"aborted": True, "run_ids": ["run-1"]}}
+        mock_bot_ws_instance.chat_abort = AsyncMock(return_value=response)
 
         client = AsyncChatClient(uri="ws://host/ws")
         await client.connect()
 
-        await client.chat_abort("sk-abort", run_id="run-1")
+        result = await client.chat_abort("sk-abort", run_id="run-1")
 
         mock_bot_ws_instance.chat_abort.assert_awaited_once_with(
             session_key="sk-abort", run_id="run-1"
         )
+        assert result == response
 
     @pytest.mark.asyncio
     async def test_chat_abort_forwards_without_run_id(
         self, mock_bot_ws, mock_bot_ws_instance
     ):
-        """chat_abort forwards run_id=None when not provided."""
+        """chat_abort forwards run_id=None and returns the underlying response."""
         from secbaas.community.core.service.bot_run._async_chat_client import (
             AsyncChatClient,
         )
@@ -1913,20 +1915,22 @@ class TestChatAbort:
             "server": {"host": "srv"},
             "features": {},
         }
-        mock_bot_ws_instance.chat_abort = AsyncMock()
+        response = {"ok": True, "payload": {"aborted": False}}
+        mock_bot_ws_instance.chat_abort = AsyncMock(return_value=response)
 
         client = AsyncChatClient(uri="ws://host/ws")
         await client.connect()
 
-        await client.chat_abort("sk-abort")
+        result = await client.chat_abort("sk-abort")
 
         mock_bot_ws_instance.chat_abort.assert_awaited_once_with(
             session_key="sk-abort", run_id=None
         )
+        assert result == response
 
     @pytest.mark.asyncio
     async def test_chat_abort_client_none_does_not_raise(self, mock_bot_ws):
-        """When _client is None, chat_abort logs and returns without raising."""
+        """When _client is None, chat_abort logs and returns None without raising."""
         from secbaas.community.core.service.bot_run._async_chat_client import (
             AsyncChatClient,
         )
@@ -1935,5 +1939,6 @@ class TestChatAbort:
         # Never connected -> _client is None
         assert client._client is None
 
-        # Should not raise
-        await client.chat_abort("sk-abort", run_id="run-1")
+        # Should not raise and should return None
+        result = await client.chat_abort("sk-abort", run_id="run-1")
+        assert result is None

--- a/src/baas/tests/unit/core/service/bot_run/test_async_chat_client.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_async_chat_client.py
@@ -1868,3 +1868,72 @@ class TestBotSessionError:
         # Session should be cleaned up
         assert "sk-err" not in client._sessions
         assert "sk-err" not in client._active_sessions
+
+
+# ==================== chat_abort tests ====================
+
+
+class TestChatAbort:
+    """AsyncChatClient.chat_abort forwards to BotWebSocketClient.chat_abort."""
+
+    @pytest.mark.asyncio
+    async def test_chat_abort_forwards_with_run_id(
+        self, mock_bot_ws, mock_bot_ws_instance
+    ):
+        """chat_abort forwards (session_key, run_id) to the underlying client."""
+        from secbaas.community.core.service.bot_run._async_chat_client import (
+            AsyncChatClient,
+        )
+
+        mock_bot_ws_instance.connect.return_value = {
+            "server": {"host": "srv"},
+            "features": {},
+        }
+        mock_bot_ws_instance.chat_abort = AsyncMock()
+
+        client = AsyncChatClient(uri="ws://host/ws")
+        await client.connect()
+
+        await client.chat_abort("sk-abort", run_id="run-1")
+
+        mock_bot_ws_instance.chat_abort.assert_awaited_once_with(
+            session_key="sk-abort", run_id="run-1"
+        )
+
+    @pytest.mark.asyncio
+    async def test_chat_abort_forwards_without_run_id(
+        self, mock_bot_ws, mock_bot_ws_instance
+    ):
+        """chat_abort forwards run_id=None when not provided."""
+        from secbaas.community.core.service.bot_run._async_chat_client import (
+            AsyncChatClient,
+        )
+
+        mock_bot_ws_instance.connect.return_value = {
+            "server": {"host": "srv"},
+            "features": {},
+        }
+        mock_bot_ws_instance.chat_abort = AsyncMock()
+
+        client = AsyncChatClient(uri="ws://host/ws")
+        await client.connect()
+
+        await client.chat_abort("sk-abort")
+
+        mock_bot_ws_instance.chat_abort.assert_awaited_once_with(
+            session_key="sk-abort", run_id=None
+        )
+
+    @pytest.mark.asyncio
+    async def test_chat_abort_client_none_does_not_raise(self, mock_bot_ws):
+        """When _client is None, chat_abort logs and returns without raising."""
+        from secbaas.community.core.service.bot_run._async_chat_client import (
+            AsyncChatClient,
+        )
+
+        client = AsyncChatClient(uri="ws://host/ws")
+        # Never connected -> _client is None
+        assert client._client is None
+
+        # Should not raise
+        await client.chat_abort("sk-abort", run_id="run-1")

--- a/src/baas/tests/unit/core/service/bot_run/test_baas_service.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_baas_service.py
@@ -2995,3 +2995,79 @@ class TestSendMessageStreamEvalConsistencyCheck:
                 chat_metadata={"eval_id": "eval-789"},
             ):
                 chunks.append(chunk)
+
+
+class TestSendChatAbort:
+    """BaasBotService.send_chat_abort resolves WS + pool and forwards to client.
+
+    Reuses _resolve_ws_connection_for_binding + _client_pool.get (the same path
+    as send_message) and forwards chat.abort via AsyncChatClient.chat_abort.
+    Errors propagate to the caller (best-effort handled upstream); no session
+    state is marked here (abort does not write session terminal state).
+    """
+
+    @pytest.mark.asyncio
+    async def test_send_chat_abort_forwards_to_client(self, service, mock_pool):
+        """Resolves conn_info via binding, gets client from pool, calls chat_abort."""
+        binding = _make_binding_info()
+        mock_client = AsyncMock()
+        mock_client.chat_abort = AsyncMock()
+        mock_pool.get.return_value = mock_client
+
+        with patch.object(
+            service,
+            "_resolve_ws_connection_for_binding",
+            return_value=_make_conn_info(),
+        ):
+            await service.send_chat_abort(
+                binding_info=binding,
+                session_id=SESSION_ID,
+                run_id="run-1",
+            )
+
+        mock_pool.get.assert_awaited_once_with(
+            TARGET, WS_URL, {"x-proxypass-token": TOKEN}
+        )
+        mock_client.chat_abort.assert_awaited_once_with(SESSION_ID, "run-1")
+
+    @pytest.mark.asyncio
+    async def test_send_chat_abort_run_id_none_forwarded(self, service, mock_pool):
+        """run_id=None is forwarded as-is to the underlying client."""
+        binding = _make_binding_info()
+        mock_client = AsyncMock()
+        mock_client.chat_abort = AsyncMock()
+        mock_pool.get.return_value = mock_client
+
+        with patch.object(
+            service,
+            "_resolve_ws_connection_for_binding",
+            return_value=_make_conn_info(),
+        ):
+            await service.send_chat_abort(
+                binding_info=binding,
+                session_id=SESSION_ID,
+                run_id=None,
+            )
+
+        mock_client.chat_abort.assert_awaited_once_with(SESSION_ID, None)
+
+    @pytest.mark.asyncio
+    async def test_send_chat_abort_propagates_resolve_error(self, service, mock_pool):
+        """A WS resolution error propagates to the caller (best-effort upstream)."""
+        binding = _make_binding_info()
+        mock_client = AsyncMock()
+        mock_pool.get.return_value = mock_client
+
+        with patch.object(
+            service,
+            "_resolve_ws_connection_for_binding",
+            side_effect=RuntimeError("resolve boom"),
+        ):
+            with pytest.raises(RuntimeError, match="resolve boom"):
+                await service.send_chat_abort(
+                    binding_info=binding,
+                    session_id=SESSION_ID,
+                    run_id="run-1",
+                )
+        mock_pool.get.assert_not_awaited()
+        mock_client.chat_abort.assert_not_awaited()

--- a/src/baas/tests/unit/core/service/bot_run/test_baas_service.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_baas_service.py
@@ -3071,3 +3071,37 @@ class TestSendChatAbort:
                 )
         mock_pool.get.assert_not_awaited()
         mock_client.chat_abort.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_send_chat_abort_threads_context_and_returns_response(
+        self, service, mock_pool
+    ):
+        """The ``context`` (carrying tenant) is forwarded to
+        _resolve_ws_connection_for_binding, and the underlying chat.abort response is
+        returned so callers can observe ok:false / aborted:false (no silent success)."""
+        from secbaas.community.api.bot_runtime import BotChatContext
+
+        binding = _make_binding_info()
+        mock_client = AsyncMock()
+        response = {"ok": True, "payload": {"aborted": True, "run_ids": ["run-1"]}}
+        mock_client.chat_abort = AsyncMock(return_value=response)
+        mock_pool.get.return_value = mock_client
+
+        context = BotChatContext.from_api_key(
+            api_key_prefix="", app_id="", tenant="tenant-x"
+        )
+
+        with patch.object(
+            service,
+            "_resolve_ws_connection_for_binding",
+            return_value=_make_conn_info(),
+        ) as mock_resolve:
+            result = await service.send_chat_abort(
+                binding_info=binding,
+                session_id=SESSION_ID,
+                run_id="run-1",
+                context=context,
+            )
+
+        mock_resolve.assert_awaited_once_with(binding, SESSION_ID, context=context)
+        assert result == response

--- a/src/baas/tests/unit/core/service/bot_run/test_runner.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_runner.py
@@ -1555,7 +1555,8 @@ class TestSelectDispatcherConfig:
 
         assert runner._select_dispatcher("bot-1", "openclaw", metadata={}) is queue_d
         assert (
-            runner._select_dispatcher("bot-1", "openclaw", method="stream", metadata={}) is task_d
+            runner._select_dispatcher("bot-1", "openclaw", method="stream", metadata={})
+            is task_d
         )
 
     def test_config_fallback_to_default(
@@ -1694,7 +1695,9 @@ class TestSelectDispatcherBcnSwitch:
             config_service,
             [queue_d, task_d],
         )
-        result = runner._select_dispatcher("bot-1", "openclaw", metadata=_bcn_metadata())
+        result = runner._select_dispatcher(
+            "bot-1", "openclaw", metadata=_bcn_metadata()
+        )
         assert result is queue_d
 
     def test_bcn_switch_off_keeps_task(
@@ -1720,7 +1723,9 @@ class TestSelectDispatcherBcnSwitch:
             config_service,
             [queue_d, task_d],
         )
-        result = runner._select_dispatcher("bot-1", "openclaw", metadata=_bcn_metadata())
+        result = runner._select_dispatcher(
+            "bot-1", "openclaw", metadata=_bcn_metadata()
+        )
         assert result is task_d
 
     def test_bcn_switch_get_config_exception_falls_through(
@@ -1746,7 +1751,9 @@ class TestSelectDispatcherBcnSwitch:
             config_service,
             [queue_d, task_d],
         )
-        result = runner._select_dispatcher("bot-1", "openclaw", metadata=_bcn_metadata())
+        result = runner._select_dispatcher(
+            "bot-1", "openclaw", metadata=_bcn_metadata()
+        )
         assert result is task_d
 
     def test_bcn_metadata_unconfigured_switch_keeps_task(
@@ -1765,7 +1772,9 @@ class TestSelectDispatcherBcnSwitch:
             system_config_service=_make_config_service(),
             eval_session_log=MagicMock(),
         )
-        result = runner._select_dispatcher("bot-1", "openclaw", metadata=_bcn_metadata())
+        result = runner._select_dispatcher(
+            "bot-1", "openclaw", metadata=_bcn_metadata()
+        )
         assert result is task_d
 
     def test_non_bcn_metadata_ignores_switch(
@@ -2693,10 +2702,40 @@ class TestDeliverChatAbort:
         call = abort_service.send_chat_abort.call_args
         assert call.kwargs["session_id"] == "sess-1"
         assert call.kwargs["run_id"] == "run-1"
+        # 无 tenant 时 context=None（不构造空 context）
+        assert call.kwargs["context"] is None
         # binding_info is the resolved BotBindingInfo derived from baas_binding_data
         binding_info = call.kwargs["binding_info"]
         assert isinstance(binding_info, BotBindingInfo)
         assert binding_info.bot_id == BOT_ID
+
+    @pytest.mark.asyncio
+    async def test_deliver_chat_abort_threads_tenant_into_context(
+        self,
+        mock_selector,
+        mock_run_repo,
+        mock_bot_service_plugin,
+        baas_binding_data,
+    ):
+        """WHEN tenant is provided, deliver_chat_abort builds a BotChatContext carrying
+        it and forwards to send_chat_abort, so _resolve_ws_connection_for_binding can
+        resolve the multi-tenant WS connection instead of querying with tenant="".
+        """
+        abort_service = MagicMock()
+        abort_service.send_chat_abort = AsyncMock()
+        mock_selector.select.return_value = abort_service
+        mock_bot_service_plugin.get_binding = AsyncMock(return_value=baas_binding_data)
+
+        runner = _make_runner(mock_selector, mock_run_repo, mock_bot_service_plugin)
+
+        await runner.deliver_chat_abort(
+            bot_id=BOT_ID, session_id="sess-1", run_id=None, tenant="tenant-x"
+        )
+
+        call = abort_service.send_chat_abort.call_args
+        context = call.kwargs["context"]
+        assert isinstance(context, BotChatContext)
+        assert context.tenant == "tenant-x"
 
     @pytest.mark.asyncio
     async def test_deliver_chat_abort_skips_when_service_has_no_send_chat_abort(

--- a/src/baas/tests/unit/core/service/bot_run/test_runner.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_runner.py
@@ -2656,3 +2656,93 @@ class TestEvalSessionLogStream:
             context=context,
             metadata={"eval_id": "eval-str-4", "session_id": "original-sess"},
         )
+
+
+# ==================== deliver_chat_abort (engine abort forwarding) tests ===
+
+
+class TestDeliverChatAbort:
+    """BotRunner.deliver_chat_abort forwards chat.abort best-effort to the bot service.
+
+    resolve_binding → select → getattr(service, "send_chat_abort", None). Binding
+    not found or service lacking send_chat_abort logs and returns without raising.
+    """
+
+    @pytest.mark.asyncio
+    async def test_deliver_chat_abort_dispatches_to_send_chat_abort(
+        self,
+        mock_selector,
+        mock_run_repo,
+        mock_bot_service_plugin,
+        baas_binding_data,
+    ):
+        """WHEN service exposes send_chat_abort, deliver_chat_abort calls it with
+        the resolved binding_info, session_id and run_id."""
+        abort_service = MagicMock()
+        abort_service.send_chat_abort = AsyncMock()
+        mock_selector.select.return_value = abort_service
+        mock_bot_service_plugin.get_binding = AsyncMock(return_value=baas_binding_data)
+
+        runner = _make_runner(mock_selector, mock_run_repo, mock_bot_service_plugin)
+
+        await runner.deliver_chat_abort(
+            bot_id=BOT_ID, session_id="sess-1", run_id="run-1"
+        )
+
+        abort_service.send_chat_abort.assert_awaited_once()
+        call = abort_service.send_chat_abort.call_args
+        assert call.kwargs["session_id"] == "sess-1"
+        assert call.kwargs["run_id"] == "run-1"
+        # binding_info is the resolved BotBindingInfo derived from baas_binding_data
+        binding_info = call.kwargs["binding_info"]
+        assert isinstance(binding_info, BotBindingInfo)
+        assert binding_info.bot_id == BOT_ID
+
+    @pytest.mark.asyncio
+    async def test_deliver_chat_abort_skips_when_service_has_no_send_chat_abort(
+        self,
+        mock_selector,
+        mock_run_repo,
+        mock_bot_service_plugin,
+        baas_binding_data,
+    ):
+        """WHEN the selected service type has no send_chat_abort (e.g. a non-baas
+        service), deliver_chat_abort logs and returns without raising."""
+        # spec=list restricts attrs; getattr(..., "send_chat_abort", None) -> None
+        no_abort_service = MagicMock(
+            spec=["create_session", "send_message", "inject_message", "get_messages"]
+        )
+        no_abort_service.create_session = AsyncMock()
+        no_abort_service.send_message = AsyncMock()
+        no_abort_service.inject_message = AsyncMock()
+        no_abort_service.get_messages = AsyncMock()
+        mock_selector.select.return_value = no_abort_service
+        mock_bot_service_plugin.get_binding = AsyncMock(return_value=baas_binding_data)
+
+        runner = _make_runner(mock_selector, mock_run_repo, mock_bot_service_plugin)
+
+        # Should not raise and should not attempt any send_chat_abort call
+        await runner.deliver_chat_abort(
+            bot_id=BOT_ID, session_id="sess-1", run_id="run-1"
+        )
+
+    @pytest.mark.asyncio
+    async def test_deliver_chat_abort_skips_when_binding_not_found(
+        self,
+        mock_selector,
+        mock_run_repo,
+        mock_bot_service_plugin,
+    ):
+        """WHEN binding resolution returns None (NOT_FOUND), deliver_chat_abort logs
+        and returns without selecting a service or raising."""
+        mock_bot_service_plugin.get_binding.side_effect = PaasError(
+            ErrorCode.NOT_FOUND, "not found"
+        )
+
+        runner = _make_runner(mock_selector, mock_run_repo, mock_bot_service_plugin)
+
+        await runner.deliver_chat_abort(
+            bot_id=BOT_ID, session_id="sess-1", run_id="run-1"
+        )
+
+        mock_selector.select.assert_not_called()

--- a/src/baas/tests/unit/core/service/bot_run/test_worker.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_worker.py
@@ -1126,17 +1126,24 @@ async def test_abort_runs_by_session_empty_session_or_bot_returns_empty(repo, qu
 
 
 async def test_abort_runs_by_session_engine_notifier_best_effort(repo, queue):
-    """engine_abort_notifier is awaited once per (bot,session); failure logged, not raised."""
+    """engine_abort_notifier is awaited once per (bot,session); failure logged, not raised.
+
+    run_id 传 None（BaaS run id ≠ engine run id，按 sessionKey 维度取消）；
+    metadata=None 时 tenant 回退为空串。
+    """
     run_id = _insert_with_session(repo, queue, "bot-1", "sess-abort")
     claimed = queue.claim_pending_by_bot("bot-1", "worker-1", candidates=5)
     assert claimed is not None and claimed.run_id == run_id
 
     notified = asyncio.Event()
 
-    async def notifier(session_id: str, bot_id: str, rid: str | None) -> None:
+    async def notifier(
+        session_id: str, bot_id: str, rid: str | None, tenant: str = ""
+    ) -> None:
         assert session_id == "sess-abort"
         assert bot_id == "bot-1"
-        assert rid == run_id
+        assert rid is None
+        assert tenant == ""
         notified.set()
 
     ex = ResultGuardExecutor(_CompletingExecutor(repo), repo)
@@ -1150,13 +1157,51 @@ async def test_abort_runs_by_session_engine_notifier_best_effort(repo, queue):
     assert notified.is_set()
 
 
+async def test_abort_runs_by_session_engine_notifier_recovers_tenant(repo, queue):
+    """tenant 从 baas_bot_run.metadata["tenant"] 恢复并透传给 notifier。"""
+    run_id = uuid4().hex
+    repo.insert_run(
+        run_id=run_id,
+        bot_id="bot-1",
+        api_key_prefix="sk-",
+        message_long="m",
+        metadata={"tenant": "tenant-x", "app_id": "app-1", "app_type": "UNKNOWN"},
+    )
+    queue.insert_queue(run_id=run_id, bot_id="bot-1", session_id="sess-abort")
+    claimed = queue.claim_pending_by_bot("bot-1", "worker-1", candidates=5)
+    assert claimed is not None and claimed.run_id == run_id
+
+    seen: dict[str, object] = {}
+
+    async def notifier(
+        session_id: str, bot_id: str, rid: str | None, tenant: str = ""
+    ) -> None:
+        seen["session_id"] = session_id
+        seen["bot_id"] = bot_id
+        seen["rid"] = rid
+        seen["tenant"] = tenant
+
+    ex = ResultGuardExecutor(_CompletingExecutor(repo), repo)
+    worker = _worker(
+        queue, repo, ex, run_repository=repo, engine_abort_notifier=notifier
+    )
+
+    outcome = await worker.abort_runs_by_session("sess-abort", "bot-1")
+
+    assert outcome.aborted_run_ids == [run_id]
+    assert seen["rid"] is None
+    assert seen["tenant"] == "tenant-x"
+
+
 async def test_abort_runs_by_session_engine_notifier_error_swallowed(repo, queue):
     """engine_abort_notifier raising must not fail the abort."""
     run_id = _insert_with_session(repo, queue, "bot-1", "sess-abort")
     claimed = queue.claim_pending_by_bot("bot-1", "worker-1", candidates=5)
     assert claimed is not None and claimed.run_id == run_id
 
-    async def notifier(session_id: str, bot_id: str, rid: str | None) -> None:
+    async def notifier(
+        session_id: str, bot_id: str, rid: str | None, tenant: str = ""
+    ) -> None:
         raise RuntimeError("engine notify boom")
 
     ex = ResultGuardExecutor(_CompletingExecutor(repo), repo)

--- a/src/baas/tests/unit/core/service/bot_run/test_worker.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_worker.py
@@ -1133,8 +1133,9 @@ async def test_abort_runs_by_session_engine_notifier_best_effort(repo, queue):
 
     notified = asyncio.Event()
 
-    async def notifier(session_id: str, rid: str | None) -> None:
+    async def notifier(session_id: str, bot_id: str, rid: str | None) -> None:
         assert session_id == "sess-abort"
+        assert bot_id == "bot-1"
         assert rid == run_id
         notified.set()
 
@@ -1155,7 +1156,7 @@ async def test_abort_runs_by_session_engine_notifier_error_swallowed(repo, queue
     claimed = queue.claim_pending_by_bot("bot-1", "worker-1", candidates=5)
     assert claimed is not None and claimed.run_id == run_id
 
-    async def notifier(session_id: str, rid: str | None) -> None:
+    async def notifier(session_id: str, bot_id: str, rid: str | None) -> None:
         raise RuntimeError("engine notify boom")
 
     ex = ResultGuardExecutor(_CompletingExecutor(repo), repo)


### PR DESCRIPTION
## Background

When a session's runs are aborted on the BaaS side
(`BotRequestWorker.abort_runs_by_session`), the local abort flow marks the
runs `FAILED`, forces them done and cancels the in-flight task, but the engine
keeps generating until the existing ~120s stale-heartbeat fallback kicks in.
This change adds an out-of-band `chat.abort` control frame so the engine can
stop promptly for runs owned by the local worker.

## What changes

- `BotRequestWorker` receives an `engine_abort_notifier` dependency and
  invokes it once per aborted session with `(session_id, bot_id, run_id)`.
- `bootstrap/_core_services.py` adds `_EngineAbortNotifier` and wires the
  `engine_abort_notifier` singleton into `BotRequestWorker`, sharing the same
  `BotRunner` instance used by the downlink service.
- `BotRunner.deliver_chat_abort` resolves the bot binding, selects the bot
  service and calls `send_chat_abort`; it skips quietly when the binding is
  not found or the selected service type does not expose `send_chat_abort`.
- `BaasBotService.send_chat_abort` reuses the existing connection-resolution
  path so the abort frame lands on the same owning websocket as `chat.send`.
- `AsyncChatClient.chat_abort` sends the control frame without acquiring the
  `sessionKey` concurrency lock and skips when the underlying client is not
  connected.

The `EngineAbortNotifier` signature widens from `(session_id, run_id)` to
`(session_id, bot_id, run_id)` so the owning connection can be resolved from
the bot binding.

## Best-effort semantics

Engine notification failure is logged and never blocks the local abort flow
(`FAILED` + `force_done` + local cancel), which remains the source of truth
for BaaS-side terminal state. Where the engine frame cannot be delivered
immediately, termination still converges via the existing stale-heartbeat
fallback.

## Tests

Five affected unit modules (production + tests) pass lint and unit tests:
331 passed, 7 xpassed, 0 failed. Added coverage for each new entry point
(`AsyncChatClient.chat_abort`, `BaasBotService.send_chat_abort`,
`BotRunner.deliver_chat_abort`, the bootstrap wiring, and the widened
notifier signature).

## Known limitations

- `deliver_chat_abort` resolves the bot binding under `lifecycle_stage=online`
  by default. For runs whose bot binding only resolves under a verify/draft
  stage, the engine abort is skipped for that edge case; the BaaS-side abort
  still completes and the engine still converges via the stale-heartbeat
  fallback.
- `chat.abort` is sent bypassing the `sessionKey` concurrency lock; framing
  interleaving with concurrent `chat.send` is governed by engine abort
  priority (best-effort).
- Cross-machine immediate cancellation additionally requires the load balancer
  to route `/downlink chat.abort` by `session_id` to the assigned worker. This
  change does not include load-balancer configuration; cross-machine
  immediacy still depends on sticky routing or the stale-heartbeat fallback.

## Rollback

Revert the commit. No schema or persistence migration is introduced; the
notifier is opt-in via dependency injection, and absent wiring simply leaves
engine abort on the existing stale-heartbeat fallback.