### PR TITLE
fix(engine): normalize early-final followup session keys

### DIFF
--- a/src/engine/src/engine/community/openclaw/client/gateway_client.py
+++ b/src/engine/src/engine/community/openclaw/client/gateway_client.py
@@ -717,7 +717,11 @@ class OpenClawGatewayClient:
                     return announce_matches_parent_session(payload)
                 if pending_early_final is not None and payload.get("state") not in ("final", "error", "aborted"):
                     payload_session_key = payload.get("sessionKey")
-                    return payload_session_key == session_key
+                    # COSEC: Fold only the default-agent alias, preserving other agents' isolation.
+                    return isinstance(payload_session_key, str) and (
+                        payload_session_key.strip().lower().removeprefix("agent:main:")
+                        == session_key.strip().lower().removeprefix("agent:main:")
+                    )
                 return False
 
             payload_session_key = payload.get("sessionKey")

--- a/src/engine/src/engine/community/openclaw/client/tests/test_gateway_client.py
+++ b/src/engine/src/engine/community/openclaw/client/tests/test_gateway_client.py
@@ -291,8 +291,28 @@ async def test_chat_stream_discards_early_final_when_followup_run_arrives(monkey
 
 
 @pytest.mark.asyncio
-async def test_chat_stream_accepts_immediate_followup_after_early_final(monkeypatch):
-    monkeypatch.setenv("OPENCLAW_EARLY_FINAL_GRACE_SECONDS", "1")
+@pytest.mark.parametrize(
+    "request_key,event_key,accept_followup",
+    [
+        ("sk-1", "sk-1", True),
+        ("session:step:user:123", "agent:main:session:step:user:123", True),
+        ("agent:main:session:step:user:123", "session:step:user:123", True),
+        ("session:STEP-ABC:user:AbC", "agent:main:session:step-abc:user:abc", True),
+        ("agent:main:session:STEP:user:AbC", "agent:main:session:step:user:abc", True),
+        (" session:STEP:user:123 ", " Agent:Main:session:step:user:123 ", True),
+        ("session:step:user:123", "agent:other:session:step:user:123", False),
+        ("agent:other:session:step:user:123", "agent:main:session:step:user:123", False),
+        ("session:step:user:123", "agent:main:session:other:user:123", False),
+        ("session:step:user:123", "agent:main:session:step:user:456", False),
+        ("session:step:user:123", "agent:main:session:step:user:1234", False),
+        ("session:step:user:123", None, False),
+        ("session:step:user:123", 123, False),
+    ],
+)
+async def test_chat_stream_accepts_immediate_followup_after_early_final(
+    monkeypatch, request_key, event_key, accept_followup
+):
+    monkeypatch.setenv("OPENCLAW_EARLY_FINAL_GRACE_SECONDS", "0.01")
     client = _make_client()
 
     async def fake_send_request(*_args, **_kwargs) -> ResponseFrame:
@@ -300,7 +320,7 @@ async def test_chat_stream_accepts_immediate_followup_after_early_final(monkeypa
             client,
             "chat",
             {
-                "sessionKey": "sk-1",
+                "sessionKey": request_key,
                 "runId": "expected-run",
                 "state": "final",
                 "seq": 1,
@@ -310,7 +330,7 @@ async def test_chat_stream_accepts_immediate_followup_after_early_final(monkeypa
             client,
             "agent",
             {
-                "sessionKey": "sk-1",
+                "sessionKey": event_key,
                 "runId": "followup-run",
                 "stream": "lifecycle",
                 "data": {"phase": "start"},
@@ -321,10 +341,11 @@ async def test_chat_stream_accepts_immediate_followup_after_early_final(monkeypa
             client,
             "chat",
             {
-                "sessionKey": "sk-1",
+                "sessionKey": event_key,
                 "runId": "followup-run",
                 "state": "final",
                 "seq": 2,
+                "message": {"content": [{"type": "text", "text": "real answer"}]},
             },
         )
         return ResponseFrame.ok_response("rid", {"runId": "expected-run"})
@@ -333,14 +354,20 @@ async def test_chat_stream_accepts_immediate_followup_after_early_final(monkeypa
 
     events = await _collect(
         client.chat_stream(
-            session_key="sk-1",
+            session_key=request_key,
             message="hello",
             idempotency_key="expected-run",
         )
     )
 
-    assert [event["runId"] for event in events] == ["followup-run", "followup-run"]
-    assert [event.get("state") for event in events] == [None, "final"]
+    if accept_followup:
+        assert [event["runId"] for event in events] == ["followup-run", "followup-run"]
+        assert [event.get("state") for event in events] == [None, "final"]
+        assert events[-1]["message"]["content"][0]["text"] == "real answer"
+    else:
+        assert [event["runId"] for event in events] == ["expected-run"]
+        assert events[0]["state"] == "final"
+        assert "message" not in events[0]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem
Early-final followup runs are matched using the original session key verbatim. OpenClaw may add the default agent:main: prefix and lowercase the key, causing the real followup response to be dropped and the held empty final to be returned instead.

## Solution
Normalize case and whitespace and remove only the default-agent prefix for the early-final followup comparison. Keep exact equality after normalization; other agents, sessions and users remain isolated. Leave normal runId matching, announce handling, other session fallback branches and BaaS unchanged.

## Validation
- Rebased onto latest origin/dev (36b898b54).
- OpenClaw client tests: 57 passed.
- Changed executable production-line coverage: 100% (1/1); the multiline comparison is recorded as one executable line by coverage.py.
- Parameterized coverage for equal keys, prefix variants, case/whitespace normalization, different agents/sessions/users, substring collisions and invalid event keys.
- Pre-push Python SAST gate passed.
- Full singlebox/E2E not run locally; remote CI pending.

## Compatibility and risk
No HTTP schema, configuration or database changes. The behavior change is limited to linking a followup run while an early empty final is pending.