### PR TITLE
fix(baas): TeClaw 引擎评测流量 session_id 含 evalId + chat.send 透传 eval_id

### DIFF
--- a/src/baas/src/secbaas/community/core/service/bot_run/_baas_service.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_baas_service.py
@@ -1214,8 +1214,18 @@ class BaasBotService(BotService):
             return f"agent:main:session:{session_key}:user:{user_id}"
         elif engine_type == "claude_code":
             return f"agent:{tc_bot_id}:session:{session_key}:user:{user_id}"
+        elif engine_type == "teclaw":
+            # 仅评测流量（eval_id 存在）时构造结构化 key，
+            # 生产流量返回 None，保持 TeClaw adapter 原有 sessionKey 生成逻辑
+            if eval_id:
+                return f"agent:{tc_bot_id}:session:{session_key}:user:{user_id}"
+            return None
         else:
-            # TODO
+            logger.warning(
+                "[_create_session_consistency_key] unsupported engine_type=%s, "
+                "returning None",
+                engine_type,
+            )
             return None
 
 

--- a/src/baas/src/secbaas/community/core/service/bot_run/_bot_run_utils.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_bot_run_utils.py
@@ -225,6 +225,11 @@ def build_chat_metadata(
         "biz_task_id": str(biz_task_id),
         "biz_scene": str(biz_scene),
     }
+    # 评测标识透传：eval_id / default_tag 需传递给引擎 chat.send
+    if metadata.get("eval_id"):
+        chat_metadata["eval_id"] = str(metadata["eval_id"])
+    if metadata.get("default_tag"):
+        chat_metadata["default_tag"] = str(metadata["default_tag"])
     # eval 观测字段注入 — 委托 Plugin
     enriched = eval_session_log.enrich_chat_metadata(
         metadata=chat_metadata,

--- a/src/baas/tests/unit/core/service/bot_run/test_baas_service.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_baas_service.py
@@ -294,6 +294,48 @@ class TestSessionRoutingAffinityPrefix:
             == "existing-session"
         )
 
+    def test_teclaw_eval_id_replaces_run_id_in_key(self, service):
+        """teclaw 引擎评测流量（eval_id 存在）时构造结构化 key。"""
+        assert (
+            service._create_session_consistency_key(
+                engine_type="teclaw",
+                tc_bot_id=BOT_UUID,
+                user_id="u-1",
+                run_id="run-1",
+                session_id=None,
+                eval_id="eval-abc123",
+            )
+            == f"agent:{BOT_UUID}:session:eval-abc123:user:u-1"
+        )
+
+    def test_teclaw_no_eval_id_returns_none(self, service):
+        """teclaw 引擎生产流量（无 eval_id）返回 None，保持原有 sessionKey 生成逻辑。"""
+        assert (
+            service._create_session_consistency_key(
+                engine_type="teclaw",
+                tc_bot_id=BOT_UUID,
+                user_id="u-1",
+                run_id="run-1",
+                session_id=None,
+                eval_id=None,
+            )
+            is None
+        )
+
+    def test_unsupported_engine_type_returns_none_with_warning(self, service):
+        """未知引擎类型返回 None 并记录 WARNING。"""
+        assert (
+            service._create_session_consistency_key(
+                engine_type="unknown_engine",
+                tc_bot_id=BOT_UUID,
+                user_id="u-1",
+                run_id="run-1",
+                session_id=None,
+                eval_id=None,
+            )
+            is None
+        )
+
     @pytest.mark.asyncio
     async def test_create_session_path_strips_prefix_before_resolve(
         self, service, wss_resolver

--- a/src/baas/tests/unit/core/service/bot_run/test_bot_run_utils.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_bot_run_utils.py
@@ -660,3 +660,30 @@ class TestBuildChatMetadataEval:
         assert "eval_id" not in result
         assert "default_tag" not in result
         assert result["biz_scene"] == "default"
+
+    def test_eval_id_passthrough_to_chat_metadata(self):
+        """eval_id 从原始 metadata 透传到 chat_metadata（引擎 chat.send 需要）。"""
+        metadata = {"eval_id": "eval-abc123", "default_tag": "eval"}
+        result = build_chat_metadata(
+            metadata, run_id="run-1", eval_session_log=NoopEvalSessionLog()
+        )
+        assert result["eval_id"] == "eval-abc123"
+        assert result["default_tag"] == "eval"
+
+    def test_default_tag_only_passthrough(self):
+        """仅 default_tag 无 eval_id 时，eval_id 不注入，default_tag 透传。"""
+        metadata = {"default_tag": "staging"}
+        result = build_chat_metadata(
+            metadata, run_id="run-1", eval_session_log=NoopEvalSessionLog()
+        )
+        assert "eval_id" not in result
+        assert result["default_tag"] == "staging"
+
+    def test_eval_id_only_no_default_tag_passthrough(self):
+        """eval_id 存在但 default_tag 不存在时，eval_id 透传，default_tag 不注入。"""
+        metadata = {"eval_id": "eval-xyz789"}
+        result = build_chat_metadata(
+            metadata, run_id="run-1", eval_session_log=NoopEvalSessionLog()
+        )
+        assert result["eval_id"] == "eval-xyz789"
+        assert "default_tag" not in result


### PR DESCRIPTION
## Problem

TeClaw 引擎的评测流量存在两个缺口，导致评测标识（evalId）完全无法到达引擎侧：

1. **session_id 不含 evalId**：`_create_session_consistency_key` 中 teclaw 分支是 `# TODO` 未实现，返回 `None`。TeClaw adapter 自行生成 `agent:{bot_id}:default:c_{random}:user:{uid}` 格式的随机 sessionKey，evalId 未参与构造。导致同一 Trial 的多轮对话无法通过 session_id 关联，SerializingExecutor 锁粒度不对，引擎 Hook 无法从 sessionKey 恢复 evalId。

2. **chat.send body 不含 eval_id**：`build_chat_metadata` 只构造了 `biz_task_id` 和 `biz_scene`，`eval_id` / `default_tag` 未从原始 metadata 透传到 chat_metadata。经 `params.update(chat_metadata)` 展平后，WebSocket chat.send 请求体中无评测标识。OpenClaw 不受此影响（sessionKey 本身含 evalId），但 TeClaw 的 sessionKey 不含 evalId，body 中也没有，引擎侧完全不可达。

影响：TeClaw 引擎不知道是评测流量 → 引擎 Hook 无法恢复 X_EVAL_ID → bcs-cli 无法注入 x-eval-id Header → 多 Bot 协同评测标断裂 → MCP 安全网关无法匹配策略。

## Solution

### 修复 1：`_create_session_consistency_key` 增加 teclaw 分支

仅评测流量（`eval_id` 存在）时构造结构化 key，格式与 claude_code 一致：`agent:{tc_bot_id}:session:{evalId}:user:{uid}`。生产流量（`eval_id` 为 None）仍返回 `None`，保持 TeClaw adapter 原有 sessionKey 生成逻辑不变。

**拒绝的方案**：无条件为所有 teclaw 流量构造结构化 key（包括 `run_id` 作为 session 字段）。这会改变生产 teclaw 流量的 sessionKey 格式，从 `agent:{bot_id}:default:c_{random}` 变为 `agent:{bot_id}:session:{run_id}`，可能影响已有 session 复用和引擎侧格式校验。

### 修复 2：`build_chat_metadata` 透传 eval_id / default_tag

在构造 `chat_metadata` 时从原始 `metadata` 中携带 `eval_id` 和 `default_tag`，仅当字段存在时注入，生产流量（原 metadata 中无此字段）不受影响。

`_real_session_log.py` 的 `enrich_chat_metadata` 不需修改——透传后 `chat_metadata` 已含 `eval_id`，`metadata.get("eval_id")` 能正确取到值并注入观测字段。

## Validation

- 新增 6 个单元测试，覆盖所有变更分支：
  - teclaw eval_id 存在 → 返回结构化 key
  - teclaw eval_id 缺失 → 返回 None
  - 未知引擎类型 → 返回 None + WARNING
  - eval_id + default_tag 同时透传
  - 仅 default_tag 透传，eval_id 不注入
  - 仅 eval_id 透传，default_tag 不注入
- 全量回归：`bot_run/` + `eval_env/` 共 986 passed, 8 xpassed, 0 failed
- 变更代码行覆盖率：100%

**未能运行**：端到端集成测试（预发环境 TeClaw 引擎实际对话验证），需要部署后联调确认 TeClaw adapter 是否接受传入的 session_id 格式。

## Compatibility and risk

- **生产 teclaw 流量**：无影响。`eval_id=None` 时返回 `None`，与修改前行为一致
- **生产 openclaw / claude_code 流量**：无影响，未修改对应分支
- **评测 teclaw 流量**：行为变更（sessionKey 格式从 `default:c_{random}` 变为 `session:{evalId}`），需确认 TeClaw adapter `create_session(session_id=...)` 接受此格式
- **chat_metadata 兼容**：新增 `eval_id` / `default_tag` 字段，下游消费者（引擎、Plugin）需兼容新字段。经 `params.update()` 展平后，引擎侧如果忽略未知字段则无影响
- **回滚路径**：回退此 commit 即可恢复原行为

## Spec                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                            
- **系分文档 6.3 评测标全链路透传**、**5.2.6 Eval 区 TTL 约束**、                                                                                                                                
                                                                                                                                                                                                                                                                                            
## Related issues 
                                                                                                                                                                                                                                                                       
- fixing_teclaw_session_id_missing_eval_id.md
- fixing_teclaw_chat_send_missing_eval_id.md