### PR TITLE
feat(bot-public): resolve agent-scope callback visibility from reques…

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py
@@ -948,11 +948,9 @@ class BotPublicService(BotPublicServiceProtocol):
           (public_user_approval/public_agent_approval) 的 status 写成 last_operate
           (AGREE/DISAGREE/CANCEL)。
         - AGREE 时同时翻 BCS 可见性字段 (_BCS_VISIBILITY_FIELD_BY_SCOPE):
-            - public_scope=user → user_visibility = block.visibility (block 存的请求值,
-              缺省 protected);
-            - public_scope=agent → visibility = "public" if
-              BCS friend_check_in_strategy=="OPEN" else "protected" (BCS top-level
-              friend_check_in_strategy; agent 要考虑它, user 不考虑)。
+            - user → user_visibility, agent → visibility, 都取 block.visibility
+              (审批时存的请求值, 缺省 protected) —— 一律以请求值为准, 不再同步查询
+              BCS top-level friend_check_in_strategy 来推导 agent 的目标可见性。
         所有变更合一 PATCH (friend_ext + 可见性字段) 回。BCS 跳过 (非 prod/pre 或
         凭据空) 时静默返回。
         """
@@ -976,12 +974,11 @@ class BotPublicService(BotPublicServiceProtocol):
         if block["status"] == "AGREE":
             field = _BCS_VISIBILITY_FIELD_BY_SCOPE.get(public_scope)
             if field:
-                if public_scope == "user":
-                    # user: user_visibility 直接取 block 里存的 visibility 字段
-                    body[field] = block.get("visibility") or "protected"
-                else:  # agent: 由 BCS friend_check_in_strategy 决断
-                    strategy = str(attrs.get("friend_check_in_strategy") or "").upper()
-                    body[field] = "public" if strategy == "OPEN" else "protected"
+                # user 与 agent 都直接按审批时存的用户请求 visibility 值更新 BCS 可见性
+                # 字段 (user→user_visibility, agent→visibility), 缺省 protected。不再同步
+                # 查询 BCS top-level friend_check_in_strategy 推导 agent 的目标可见性
+                # (agent 与 user 一致, 一律以请求值为准)。
+                body[field] = block.get("visibility") or "protected"
             # AGREE 还把 block.view_friend_deps 从 public_*_approval 子块提升到
             # friend_ext 顶层(scope-联动 key: user→view_scope_user_friend_deps;
             # agent→view_scope_agent_friend_deps)。

--- a/src/backend/tests/community/core/bot_public/test_bot_public_service.py
+++ b/src/backend/tests/community/core/bot_public/test_bot_public_service.py
@@ -561,10 +561,12 @@ class TestPublicBcsBot:
         )
         assert bcn.patch_attributes.call_args.kwargs["body"]["user_visibility"] == "protected"
 
-    def test_callback_agree_agent_public_when_friend_check_open(self):
+    def test_callback_agree_agent_writes_block_visibility_to_visibility(self):
         bcn = MagicMock()
         bcn.get_attributes.return_value = {
-            "friend_ext": {"public_agent_approval": {"puid": "p1", "status": "PROCESSING"}},
+            "friend_ext": {"public_agent_approval": {"puid": "p1", "status": "PROCESSING", "visibility": "public"}},
+            # friend_check_in_strategy intentionally OPEN to prove the agent callback
+            # no longer consults it; visibility comes from the approval block.
             "friend_check_in_strategy": "OPEN",
         }
         svc = _make_service(bcn_service=bcn)
@@ -574,20 +576,35 @@ class TestPublicBcsBot:
         )
         body = bcn.patch_attributes.call_args.kwargs["body"]
         assert body["friend_ext"]["public_agent_approval"]["status"] == "AGREE"
-        # agent: visibility 由 friend_check_in_strategy=OPEN → public
+        # agent: visibility 直接取 block.visibility, 不再读 friend_check_in_strategy
         assert body["visibility"] == "public"
 
-    def test_callback_agree_agent_protected_when_friend_check_not_open(self):
+    def test_callback_agree_agent_uses_protected_from_block(self):
         bcn = MagicMock()
         bcn.get_attributes.return_value = {
-            "friend_ext": {"public_agent_approval": {"puid": "p1", "status": "PROCESSING"}},
-            "friend_check_in_strategy": "APPROVAL",
+            "friend_ext": {"public_agent_approval": {"puid": "p1", "status": "PROCESSING", "visibility": "protected"}},
+            "friend_check_in_strategy": "OPEN",
         }
         svc = _make_service(bcn_service=bcn)
         svc.handle_public_approval_callback(
             bot_id="b", owner_id="u", puid="p1",
             last_operate="AGREE", public_scope="agent",
         )
+        assert bcn.patch_attributes.call_args.kwargs["body"]["visibility"] == "protected"
+
+    def test_callback_agree_agent_defaults_protected_without_block_visibility(self):
+        bcn = MagicMock()
+        bcn.get_attributes.return_value = {
+            "friend_ext": {"public_agent_approval": {"puid": "p1", "status": "PROCESSING"}},
+            # friend_check_in_strategy=OPEN no longer lifts agent visibility to public
+            "friend_check_in_strategy": "OPEN",
+        }
+        svc = _make_service(bcn_service=bcn)
+        svc.handle_public_approval_callback(
+            bot_id="b", owner_id="u", puid="p1",
+            last_operate="AGREE", public_scope="agent",
+        )
+        # block 无 visibility → 缺省 protected; strategy=OPEN 不再抬升为 public
         assert bcn.patch_attributes.call_args.kwargs["body"]["visibility"] == "protected"
 
     def test_callback_agree_lifts_view_friend_deps_for_user(self):


### PR DESCRIPTION
## Problem

  The `POST /openapi/v1/collaboration/bots/{bot_uuid}/public` publish endpoint opens an approval ticket and persists the requested `visibility` on the block, to be
  The `POST /openapi/v1/collaboration/bots/{bot_uuid}/public` publish endpoint opens an approval ticket and persists the requested `visibility` on the block, to be
  applied later by the AGREE callback. For the `agent` scope, that callback did not honor the caller's requested visibility — it derived the target BCS `visibility`
  from the bot's top-level `friend_check_in_strategy` field (`"public"` when the strategy was `"OPEN"`, else `"protected"`). As a result an agent-scope publish could
  not land the explicit visibility the user requested, and a publish with no explicit `visibility` was auto-promoted to `public` whenever the BCS strategy flag
  happened to be `OPEN`, regardless of intent.

  ## Solution

  In `BotPublicService._apply_callback_decision`, the AGREE branch now writes the BCS visibility field from the user's requested visibility persisted on the approval
  block (`block["visibility"]`, defaulting to `"protected"`) — for both `user` and `agent` scopes. The agent-specific `friend_check_in_strategy` lookup is removed;
  the two scopes collapse to one line: `body[field] = block.get("visibility") or "protected"`. The scope→BCS-field mapping (`user` → `user_visibility`, `agent` →
  `visibility`, via `_BCS_VISIBILITY_FIELD_BY_SCOPE`) is unchanged, and the friend_ext sub-block status write plus the AGREE `view_friend_deps` lift to
  `view_scope_*_friend_deps` are untouched.

  Rejected: keeping a per-scope branch. After this change agent and user have identical visibility-write behavior, so a single line is the correct shape; a branch
  would only restate the same expression.

  ## Validation

  - `ruff check` on the two changed files → All checks passed.
  - `pytest tests/community/core/bot_public/test_bot_public_service.py` → 140 passed.
  - `pytest tests/community/adapters/http/openapi_v1/test_collaboration_bots_endpoints.py` → 3 passed.
  - Replaced the two `friend_check_in_strategy`-driven agent callback tests with three block-driven ones
  (`test_callback_agree_agent_writes_block_visibility_to_visibility`, `test_callback_agree_agent_uses_protected_from_block`,
  `test_callback_agree_agent_defaults_protected_without_block_visibility`). Fixtures deliberately keep `friend_check_in_strategy: "OPEN"` to prove it no longer drives
  the outcome.
  - Not run: the full backend suite and the pre-push gate (the latter is push-time only). `tests/community/endpoints/test_openapi_public_bcs.py` collects 0 under
  standard pytest — it uses `public_bcs_*` function names that don't match the `test_*` filter; pre-existing and unaffected by this change.

  ## Compatibility and risk

  Behavior change for the agent-scope publish callback. Previously, an agent-scope AGREE with `friend_check_in_strategy=OPEN` and no explicit request `visibility`
  wrote BCS `visibility=public`; now it writes `protected` (or the explicit request value). This is the intended effect of resolving visibility from the user's
  request rather than the strategy flag. No API path, request schema, response (`BcsPublishResult`), DB, or config change. Rollback: revert the single method edit.