### PR TITLE
fix(bcs): resolve historical conversation IDs from session metadata

### DIFF
--- a/src/bcs/crates/service-api/bcs-service-api/src/application/channel.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/channel.rs
@@ -176,6 +176,10 @@ pub trait ChannelService: Send + Sync {
         channel_type: Option<ChannelType>,
     ) -> Result<Vec<ChannelBinding>, ChannelUseCaseError>;
     /// Query the channel conversation mappings associated with a BCS session.
+    /// When no stored mappings remain, return the historical `meta.channel` route,
+    /// filtering by its `source` instead of requiring the binding to still exist.
+    /// Missing source/binding/conversation IDs yield no result. Historical routes
+    /// use the session update time as `last_active_at` and never restore live mappings.
     async fn list_conversations_by_session(
         &self,
         bcs_session_id: &str,

--- a/src/bcs/crates/service-api/bcs-service-api/src/port/repo/session.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/port/repo/session.rs
@@ -107,6 +107,12 @@ pub trait SessionRepoPort: Send + Sync {
         self.create(group_id, params).await
     }
     async fn get(&self, session_id: &str) -> Option<Session>;
+    /// Return `None` only for a missing session; storage/decoding failures are errors.
+    /// Fallible stores must override this default, which is for infallible repositories.
+    async fn try_get(&self, session_id: &str) -> ServiceResult<Option<Session>> {
+        Ok(self.get(session_id).await)
+    }
+
     async fn belongs_to_group(&self, session_id: &str, group_id: &str) -> bool;
     async fn list_by_group(
         &self,

--- a/src/bcs/crates/services/bcs-channel/src/lib.rs
+++ b/src/bcs/crates/services/bcs-channel/src/lib.rs
@@ -1487,6 +1487,30 @@ impl ChannelService for BcsChannelService {
             .conversations
             .list_by_bcs_session(bcs_session_id)
             .await?;
+        // Rollover replaces the live mapping, but the old session retains its source.
+        if mappings.is_empty() {
+            let Some(session) = self.sessions.get(bcs_session_id).await else {
+                return Ok(Vec::new());
+            };
+            let source = session.meta.as_ref()
+                .and_then(|meta| meta.get("channel"))
+                .and_then(|channel| channel.get("source"))
+                .and_then(|value| value.as_str())
+                .filter(|source| !source.trim().is_empty());
+            let Some(source) = source else {
+                return Ok(Vec::new());
+            };
+            if channel_type.is_some_and(|expected| source != expected) {
+                return Ok(Vec::new());
+            }
+            return Ok(self.channel_route_from_session_meta(&session)
+                .filter(|mapping| {
+                    !mapping.binding_id.trim().is_empty()
+                        && !mapping.im_conversation_id.trim().is_empty()
+                })
+                .into_iter()
+                .collect());
+        }
         let mut filtered = Vec::with_capacity(mappings.len());
         for mapping in mappings {
             let Some(binding) = self.bindings.get(&mapping.binding_id).await? else {
@@ -3647,6 +3671,20 @@ mod tests {
                 .await?;
         }
 
+        harness.session_repo.create("group_1", NewSessionParams {
+            id: Some("group_1:session_1".to_string()),
+            meta: Some(serde_json::json!({"channel": {
+                "source": "metadata_only",
+                "binding_id": "old_binding",
+                "conversation_id": "old_conversation"
+            }})),
+            ..Default::default()
+        }).await?;
+        // Existing mappings win even when the requested type only matches metadata.
+        assert!(harness.service.list_conversations_by_session(
+            "group_1:session_1", Some("metadata_only".to_string())
+        ).await?.is_empty());
+
         let mappings = harness
             .service
             .list_conversations_by_session(" group_1:session_1 ", Some(" dingtalk ".to_string()))
@@ -3656,6 +3694,59 @@ mod tests {
         assert_eq!(mappings[0].binding_id, "binding_dingtalk");
         assert_eq!(mappings[0].im_conversation_id, "ding_conversation");
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn list_conversations_by_session_reads_historical_metadata_without_binding() -> TestResult {
+        let harness = TestHarness::new(manager_group("group_1")).await?;
+        let session_id = "group_1:historical";
+        let channel = serde_json::json!({
+            "source": "dingtalk",
+            "binding_id": "deleted_binding",
+            "conversation_id": "historical_conversation",
+            "conversation_type": "2",
+            "session_scope": "per_sender",
+            "im_user_id": "u1"
+        });
+        let session = harness.session_repo.create("group_1", NewSessionParams {
+            id: Some(session_id.to_string()),
+            meta: Some(serde_json::json!({"channel": channel})),
+            ..Default::default()
+        }).await?;
+
+        for filter in [None, Some(" dingtalk ".to_string())] {
+            let mappings = harness.service
+                .list_conversations_by_session(session_id, filter).await?;
+            assert_eq!(mappings.len(), 1);
+            assert_eq!(mappings[0].binding_id, "deleted_binding");
+            assert_eq!(mappings[0].im_conversation_id, "historical_conversation");
+            assert_eq!(mappings[0].bcs_session_id, session_id);
+            assert_eq!(mappings[0].session_scope, SessionScope::PerSender);
+            assert_eq!(mappings[0].im_user_id.as_deref(), Some("u1"));
+            assert_eq!(mappings[0].last_active_at, session.updated_at);
+        }
+        assert!(harness.service.list_conversations_by_session(
+            session_id, Some("other".to_string())
+        ).await?.is_empty());
+        assert!(harness.conversation_repo.list_by_bcs_session(session_id).await?.is_empty());
+        assert!(harness.service.list_conversations_by_session(
+            "group_1:missing", None
+        ).await?.is_empty());
+
+        for invalid in [
+            serde_json::Value::Null,
+            serde_json::json!({}),
+            serde_json::json!({"channel": {"source": "dingtalk"}}),
+            serde_json::json!({"channel": {"source": "dingtalk", "binding_id": "b", "conversation_id": " "}}),
+            serde_json::json!({"channel": {"binding_id": "b", "conversation_id": "c"}}),
+        ] {
+            harness.session_repo.sessions.lock().await
+                .get_mut(session_id).expect("session").meta = Some(invalid);
+            assert!(harness.service.list_conversations_by_session(
+                session_id, Some("dingtalk".to_string())
+            ).await?.is_empty());
+        }
         Ok(())
     }
 
@@ -7270,6 +7361,19 @@ mod tests {
             .await?
             .expect("mapping rolled over");
         assert_ne!(mapping_new.bcs_session_id, old_session_id);
+        // Historical lookup survives /new without changing the current mapping.
+        let historical = harness.service.list_conversations_by_session(
+            &old_session_id, Some("dingtalk".to_string())
+        ).await?;
+        assert_eq!(historical.len(), 1);
+        assert_eq!(historical[0].im_conversation_id, "conv_1");
+        assert_eq!(historical[0].bcs_session_id, old_session_id);
+        assert!(harness.conversation_repo.list_by_bcs_session(&old_session_id).await?.is_empty());
+        let current = harness.service.list_conversations_by_session(
+            &mapping_new.bcs_session_id, Some("dingtalk".to_string())
+        ).await?;
+        assert_eq!(current.len(), 1);
+        assert_eq!(current[0].bcs_session_id, mapping_new.bcs_session_id);
         let new_session = harness
             .session_repo
             .get(&mapping_new.bcs_session_id)

--- a/src/bcs/crates/services/bcs-channel/src/lib.rs
+++ b/src/bcs/crates/services/bcs-channel/src/lib.rs
@@ -1489,7 +1489,7 @@ impl ChannelService for BcsChannelService {
             .await?;
         // Rollover replaces the live mapping, but the old session retains its source.
         if mappings.is_empty() {
-            let Some(session) = self.sessions.get(bcs_session_id).await else {
+            let Some(session) = self.sessions.try_get(bcs_session_id).await? else {
                 return Ok(Vec::new());
             };
             let source = session.meta.as_ref()
@@ -3747,6 +3747,19 @@ mod tests {
                 session_id, Some("dingtalk".to_string())
             ).await?.is_empty());
         }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn list_conversations_by_session_propagates_historical_read_failure() -> TestResult {
+        let harness = TestHarness::new(manager_group("group_1")).await?;
+        *harness.session_repo.fail_get.lock().await = Some("session read failed".to_string());
+        let error = harness.service.list_conversations_by_session(
+            "group_1:historical", Some("dingtalk".to_string())
+        ).await.expect_err("storage failure must not become an empty result");
+        assert!(matches!(error, ChannelUseCaseError::Internal(
+            ServiceError::InternalError(message)
+        ) if message == "session read failed"));
         Ok(())
     }
 
@@ -6334,6 +6347,7 @@ mod tests {
         sessions: Mutex<HashMap<String, Session>>,
         added_participants: Mutex<Vec<(String, Participant)>>,
         fail_create: Mutex<Option<String>>,
+        fail_get: Mutex<Option<String>>,
         fail_add_participant: Mutex<Option<String>>,
     }
 
@@ -6379,6 +6393,13 @@ mod tests {
 
         async fn get(&self, session_id: &str) -> Option<Session> {
             self.sessions.lock().await.get(session_id).cloned()
+        }
+
+        async fn try_get(&self, session_id: &str) -> ServiceResult<Option<Session>> {
+            if let Some(error) = self.fail_get.lock().await.clone() {
+                return Err(ServiceError::InternalError(error));
+            }
+            Ok(self.get(session_id).await)
         }
 
         async fn belongs_to_group(&self, session_id: &str, group_id: &str) -> bool {

--- a/src/bcs/crates/services/bcs-session-store/src/mysql.rs
+++ b/src/bcs/crates/services/bcs-session-store/src/mysql.rs
@@ -607,6 +607,10 @@ impl SessionRepoPort for MySqlSessionStore {
     }
 
     async fn get(&self, session_id: &str) -> Option<Session> {
+        self.try_get(session_id).await.ok().flatten()
+    }
+
+    async fn try_get(&self, session_id: &str) -> ServiceResult<Option<Session>> {
         let select_cols = self.select_cols();
         let sql = format!(
             "SELECT {select_cols} FROM bcs_group_sessions \
@@ -622,9 +626,8 @@ impl SessionRepoPort for MySqlSessionStore {
                 ],
             ))
             .await
-            .ok()?;
-        let row = rows.into_iter().next()?;
-        row_to_session(&row).ok()
+            .map_err(|e| ServiceError::InternalError(format!("session db: {e}")))?;
+        rows.into_iter().next().map(|row| row_to_session(&row)).transpose()
     }
 
     async fn belongs_to_group(&self, session_id: &str, group_id: &str) -> bool {

--- a/src/bcs/crates/services/bcs-session-store/tests/conformance_session_repo.rs
+++ b/src/bcs/crates/services/bcs-session-store/tests/conformance_session_repo.rs
@@ -254,3 +254,23 @@ async fn memory_session_metrics_snapshot_port_contract() {
     bcs_test_support::contract::port::group_session_metrics_snapshot_port_contract_tests(&repo)
         .await;
 }
+
+#[tokio::test]
+async fn fallible_session_lookup_distinguishes_missing_rows_and_failures() {
+    let db = sqlite_db().await;
+    let sql_repo = MySqlSessionStore::sqlite(db, "dev".to_string());
+    let memory_repo = MemorySessionRepo::new();
+    for repo in [&sql_repo as &dyn SessionRepoPort, &memory_repo] {
+        assert!(repo.try_get("missing").await.expect("missing lookup").is_none());
+        let session = repo.create("group_1", NewSessionParams::default())
+            .await.expect("create session");
+        let stored = repo.try_get(&session.id).await.expect("successful lookup")
+            .expect("stored session");
+        assert_eq!(stored.id, session.id);
+    }
+    let failing = MySqlSessionStore::sqlite(Arc::new(AlwaysFailDb), "dev".to_string());
+    let error = failing.try_get("group_1:session").await.expect_err("query failure");
+    assert!(error.to_string().contains("forced session query failure"));
+    let malformed = MySqlSessionStore::sqlite(Arc::new(MalformedMembershipRowDb), "dev".to_string());
+    assert!(malformed.try_get("group_1:session").await.is_err());
+}

--- a/src/bcs/docs/superpowers/specs/2026-08-17-bcs-cli-session-conversation-query-design.md
+++ b/src/bcs/docs/superpowers/specs/2026-08-17-bcs-cli-session-conversation-query-design.md
@@ -32,6 +32,9 @@ BCS 已持久化 `bcs_session_id` 到 IM conversation 的映射，出站投递�
 在映射表中没有任何记录时，应用服务回查 session 的 `meta.channel`，返回历史
 conversation ID；不要求原 binding 仍存在。`channel_type` 按元数据的 `source`
 过滤，缺少有效 source、binding ID 或 conversation ID 时仍返回空列表。
+回查使用 `SessionRepoPort::try_get`，数据库查询或行解析失败向调用方返回错误，
+只有 session 不存在或元数据缺失才返回空列表。内存实现复用无失败的读取，SQL
+实现显式传播错误；原 `get` 接口保留兼容行为。
 元数据路线沿用现有解析规则：缺省 conversation type 为 `2`，缺省 scope 为
 conversation；`last_active_at` 使用 session 的更新时间。
 

--- a/src/bcs/docs/superpowers/specs/2026-08-17-bcs-cli-session-conversation-query-design.md
+++ b/src/bcs/docs/superpowers/specs/2026-08-17-bcs-cli-session-conversation-query-design.md
@@ -26,6 +26,19 @@ BCS 已持久化 `bcs_session_id` 到 IM conversation 的映射，出站投递�
 5. 响应使用列表而不是单值。同一 BCS session 可能存在多个 binding 或 per-sender 映射，
    调用方不能假设 conversation ID 唯一。
 
+## 历史会话查询（2026-09-07）
+
+`/new` 后下一条消息会覆盖 live mapping 的 `bcs_session_id`。当目标 session
+在映射表中没有任何记录时，应用服务回查 session 的 `meta.channel`，返回历史
+conversation ID；不要求原 binding 仍存在。`channel_type` 按元数据的 `source`
+过滤，缺少有效 source、binding ID 或 conversation ID 时仍返回空列表。
+元数据路线沿用现有解析规则：缺省 conversation type 为 `2`，缺省 scope 为
+conversation；`last_active_at` 使用 session 的更新时间。
+
+已有映射保持优先，即使经 channel 类型过滤后为空，也不使用元数据覆盖结果。
+回查是只读操作，不重建映射、不改变出站路由。HTTP 权限校验、响应结构和 CLI
+参数保持不变；部署服务端更新后，支持该命令的现有 CLI 即可查询历史 session。
+
 ## Contract 传播范围
 
 - Service API：`ChannelService::list_conversations_by_session`，additive change。
@@ -41,6 +54,8 @@ BCS 已持久化 `bcs_session_id` 到 IM conversation 的映射，出站投递�
 - 空白 `bcs_session_id` 返回参数错误。
 - CLI 查询只返回 `dingtalk` binding 对应的映射。
 - 同一 session 的多条映射全部返回且顺序沿用 repository 的稳定顺序。
+- `/new` 完结并切换映射后，旧 session 可通过元数据查出原 conversation ID。
+- 元数据回查支持 channel 类型过滤；缺失、不完整元数据返回空列表。
 - session ID 通过 HTTP query 编码传输，不拼接到 URL 或 SQL。
 
 ## 用法


### PR DESCRIPTION
## Problem
After `/new` rolls a DingTalk conversation over to a new BCS session, `bcs-cli channel conversation-id --session <old-session>` returns no results even though the old session retains its conversation ID in metadata.

## Solution
When no stored conversation mappings exist for the requested session, resolve the historical route from `meta.channel` and filter by its source channel. Existing mappings retain precedence. Historical lookup works without the original binding and does not recreate mappings or change outbound routing. Use the fallible `SessionRepoPort::try_get` path to propagate database query and row decoding errors instead of reporting empty results. Preserve the legacy `get` interface for existing callers. Document the additive Service API behavior; HTTP authorization and response shape remain unchanged.

## Validation
- `cargo test --manifest-path src/bcs/Cargo.toml -p bcs-channel -p bcs-session-store --quiet`: 139 passed, including rollover, metadata fallback, query and decoding failures, and memory/SQL repository contracts.
- `cargo test -p bcs-session --quiet`: 27 passed.
- `cargo test -p bcs-http --test session_files_member_gate_contract channel_conversation_lookup --quiet`: 4 passed.
- `git diff --check origin/dev...HEAD`: passed.
- All listed tests passed on the follow-up error-propagation fix.
- Full workspace and Singlebox E2E suites were not run locally. The previous PR head passed BCS unit and E2E CI; Singlebox Coverage failed. CI must validate the updated head.
- Commit and push hooks skipped with `--no-verify` per the repository publishing workflow; tests ran explicitly.

## Compatibility and risk
No CLI argument, response schema, database schema, or configuration changes. Requires deploying the BCS service update. Historical results use session update time as `last_active_at`; incomplete metadata yields an empty result. Reverting this change restores mapping-only lookup.