### PR TITLE
fix(bcs): write MySQL-compatible gmt_modified timestamps in group store

### DIFF
--- a/src/bcs/crates/services/bcs-group-store/src/lib.rs
+++ b/src/bcs/crates/services/bcs-group-store/src/lib.rs
@@ -19,7 +19,7 @@ use bcs_event_store::{
     EventAppendTransactionPlan, GroupDeletionEventTransactionPlan,
     GroupProvisioningEventTransactionPlan,
 };
-use chrono::{SecondsFormat, TimeZone, Utc};
+use chrono::{TimeZone, Utc};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -98,9 +98,12 @@ fn transaction_lock_row_is_missing(error: &DbError) -> bool {
 fn db_timestamp_from_millis(timestamp_ms: u64) -> ServiceResult<String> {
     let timestamp_ms = i64::try_from(timestamp_ms)
         .map_err(|_| ServiceError::InternalError("Group timestamp is out of range".to_string()))?;
+    // `YYYY-MM-DD HH:MM:SS.mmm` is accepted by both MySQL `timestamp` columns
+    // (RFC3339 `T`/`Z` forms fail with ERROR 1292) and SQLite `strftime('%s')`
+    // reads.
     Utc.timestamp_millis_opt(timestamp_ms)
         .single()
-        .map(|timestamp| timestamp.to_rfc3339_opts(SecondsFormat::Millis, true))
+        .map(|timestamp| timestamp.format("%Y-%m-%d %H:%M:%S%.3f").to_string())
         .ok_or_else(|| ServiceError::InternalError("Group timestamp is invalid".to_string()))
 }
 
@@ -4353,6 +4356,18 @@ mod tests {
 
         assert!(deleted.is_none());
         assert!(repo.cache.read().await.get("group-1").is_none());
+    }
+
+    #[test]
+    fn test_db_timestamp_from_millis_is_mysql_compatible() {
+        // The `gmt_modified` value must stay in `YYYY-MM-DD HH:MM:SS.mmm`
+        // form: MySQL `timestamp` columns reject RFC3339 `T`/`Z` strings with
+        // ERROR 1292, while SQLite `strftime('%s')` reads keep parsing this
+        // form.
+        let formatted = db_timestamp_from_millis(1_756_902_260_462).expect("valid timestamp");
+        assert_eq!(formatted, "2025-09-03 12:24:20.462");
+        assert!(!formatted.contains('T'));
+        assert!(!formatted.ends_with('Z'));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

On MySQL deployments, every group mutation transaction (e.g. `remove_group_participant` → `GroupServiceImpl::remove_participant`) fails with:

```
ERROR 22007 (1292): Incorrect datetime value: '2026-09-04T13:24:20.462Z' for column 'gmt_modified'
```

`bcs-group-store` formats the `gmt_modified` bind parameter as an RFC3339 string (`T` separator + `Z` suffix). SQLite stores the column as TEXT so it never fails locally, but the MySQL `bcs_groups.gmt_modified` column is `timestamp`, which rejects this format.

## Solution

`db_timestamp_from_millis` now emits `YYYY-MM-DD HH:MM:SS.mmm` (UTC) instead of RFC3339:

- MySQL `timestamp`/`datetime` columns parse this format directly.
- SQLite read paths (`strftime('%s', gmt_modified)` via `DbSqlFlavor::unix_ts`) parse both the new format and existing RFC3339 rows, so no migration is needed for stored data.
- Matches the existing precedent in `bcs-event-store/src/timestamp.rs`.

This single function feeds every `gmt_modified` binding in the group-store mutation transaction (patch/status/participant add-remove/mode/routing-policy/service-spec paths), so all group updates on MySQL are fixed at once.

## Validation

- New unit test `test_db_timestamp_from_millis_is_mysql_compatible` locks the format (no `T`, no `Z`).
- `cargo test --package bcs-group-store`: 87 tests pass.
- `cargo test` for bcs-group, bcs-session, bcs-app-group, bcs-app-session: all pass.
- `cargo check --workspace --all-targets`: clean.
- Not run: live MySQL instance verification (no MySQL environment locally); the format is the one MySQL documents for datetime literals.

## Compatibility and risk (optional)

Write-format-only change; read paths on both backends accept old and new values. Rollback: revert the commit (MySQL writes would break again).