### PR TITLE
feat(backend): make SQLAlchemy DB pool sizing configurable

### DIFF
--- a/src/backend/src/agentclaw/community/configs/application-community.yaml
+++ b/src/backend/src/agentclaw/community/configs/application-community.yaml
@@ -182,6 +182,16 @@ user_config:
     backend: "mysql"
     url: "${DATABASE_URL}"
     create_schema: false
+    # Optional SQLAlchemy QueuePool sizing (SQLite ignores these). Omit a key
+    # to keep SQLAlchemy's default (pool_size=5, max_overflow=10,
+    # pool_timeout=30). Tune per deployment: each worker process owns its own
+    # pool, so pool_size × worker_count × instance_count must stay under the
+    # DB's max_connections. Lowering pool_timeout makes a saturated pool fail
+    # fast instead of hanging up to the default 30s (the cliff observed on the
+    # /openapi/v1/bots list surface during deploy-time connection contention).
+    # pool_size: 10
+    # max_overflow: 20
+    # pool_timeout: 10
 
   # Cache + distributed lock — consumed by the community CommunityCache.
   # Set redis_url to a Redis endpoint for a multi-worker deploy (KV + SET NX

--- a/src/backend/src/agentclaw/community/di/config_community.py
+++ b/src/backend/src/agentclaw/community/di/config_community.py
@@ -63,6 +63,17 @@ class CommunityDatabaseConfig:
     backend: str = "sqlite"
     url: str = "sqlite:///./data/agentclaw.db"
     create_schema: bool = True
+    # Optional SQLAlchemy ``QueuePool`` sizing for the MySQL/Postgres engine
+    # (SQLite ignores these). ``None`` for each keeps SQLAlchemy's defaults
+    # (pool_size=5, max_overflow=10, pool_timeout=30) — sourced from the
+    # optional ``pool_size`` / ``max_overflow`` / ``pool_timeout`` keys of the
+    # ``database`` block. See ``plugins/community/database.py`` for the sizing
+    # tradeoff (worker_count × pool_size vs the DB's ``max_connections``); the
+    # default ``pool_timeout=30`` is the cliff behind the ~30s hang-then-502
+    # seen on the bots list surface during deploy-time pool contention.
+    pool_size: int | None = None
+    max_overflow: int | None = None
+    pool_timeout: float | None = None
 
 
 #: Accepted ``database.backend`` values mapped to the SQLAlchemy URL scheme each

--- a/src/backend/src/agentclaw/community/di/modules/infrastructure/community/database.py
+++ b/src/backend/src/agentclaw/community/di/modules/infrastructure/community/database.py
@@ -60,8 +60,22 @@ class CommunityDatabaseModule(Module):
                 "set both to the same store"
             )
 
+        pool_size = block.get("pool_size")
+        max_overflow = block.get("max_overflow")
+        pool_timeout = block.get("pool_timeout")
+        # Coerce defensively so a quoted ``"10"`` behaves like the bare int and
+        # a bad value fails loudly at boot rather than at first checkout.
+        pool_size = None if pool_size is None else int(pool_size)
+        max_overflow = None if max_overflow is None else int(max_overflow)
+        pool_timeout = None if pool_timeout is None else float(pool_timeout)
+
         return cfg.CommunityDatabaseConfig(
-            backend=backend, url=url, create_schema=bool(create_schema)
+            backend=backend,
+            url=url,
+            create_schema=bool(create_schema),
+            pool_size=pool_size,
+            max_overflow=max_overflow,
+            pool_timeout=pool_timeout,
         )
 
     @singleton
@@ -79,9 +93,19 @@ class CommunityDatabaseModule(Module):
         except Exception:  # pragma: no cover — malformed URL surfaces on connect
             safe_url = "<unparseable>"
         logger.info(
-            "DatabasePlugin: CommunityDatabase (backend=%s, url=%s, create_schema=%s)",
+            "DatabasePlugin: CommunityDatabase (backend=%s, url=%s, "
+            "create_schema=%s, pool_size=%s, max_overflow=%s, pool_timeout=%s)",
             config.backend,
             safe_url,
             config.create_schema,
+            config.pool_size,
+            config.max_overflow,
+            config.pool_timeout,
         )
-        return CommunityDatabase(config.url, create_schema=config.create_schema)
+        return CommunityDatabase(
+            config.url,
+            create_schema=config.create_schema,
+            pool_size=config.pool_size,
+            max_overflow=config.max_overflow,
+            pool_timeout=config.pool_timeout,
+        )

--- a/src/backend/src/agentclaw/community/plugins/community/database.py
+++ b/src/backend/src/agentclaw/community/plugins/community/database.py
@@ -20,6 +20,7 @@ A real, deployable implementation (not a ``MockSeam`` test double).
 from __future__ import annotations
 
 from contextlib import contextmanager
+from typing import Any
 
 from sqlalchemy import create_engine, event
 from sqlalchemy.orm import sessionmaker
@@ -42,21 +43,61 @@ def _is_mysql(url: str) -> bool:
 class CommunityDatabase(DatabasePlugin, LifecycleBase):
     """DatabasePlugin backed by a configured SQLAlchemy engine."""
 
-    def __init__(self, url: str, *, create_schema: bool = True) -> None:
+    def __init__(
+        self,
+        url: str,
+        *,
+        create_schema: bool = True,
+        pool_size: int | None = None,
+        max_overflow: int | None = None,
+        pool_timeout: float | None = None,
+    ) -> None:
         self._url = url
         self._create_schema = create_schema
-        self._engine = self._make_engine(url)
+        self._engine = self._make_engine(
+            url,
+            pool_size=pool_size,
+            max_overflow=max_overflow,
+            pool_timeout=pool_timeout,
+        )
         self._session_factory = sessionmaker(
             autocommit=False, autoflush=False, bind=self._engine
         )
 
     @staticmethod
-    def _make_engine(url: str):
+    def _make_engine(
+        url: str,
+        *,
+        pool_size: int | None = None,
+        max_overflow: int | None = None,
+        pool_timeout: float | None = None,
+    ):
+        # Optional SQLAlchemy ``QueuePool`` sizing. Each key is applied only
+        # when configured; omitting all three keeps SQLAlchemy's defaults
+        # (pool_size=5, max_overflow=10, pool_timeout=30). That default
+        # ``pool_timeout=30`` is the cliff behind the ~30s/hang-then-502
+        # signature observed on the bots list surface during deploy-time
+        # connection contention — making it configurable lets a deployment
+        # fail fast or size the pool to its worker count without a code change.
+        # NB each worker process owns its own pool, so
+        # ``pool_size`` × worker_count × instance_count must stay under the
+        # database's ``max_connections`` — tune per deployment, don't blindly
+        # raise it.
+        pool_kwargs: dict[str, Any] = {}
+        if pool_size is not None:
+            pool_kwargs["pool_size"] = pool_size
+        if max_overflow is not None:
+            pool_kwargs["max_overflow"] = max_overflow
+        if pool_timeout is not None:
+            pool_kwargs["pool_timeout"] = pool_timeout
+
         if _is_sqlite(url):
             # SQLite needs ``check_same_thread=False`` for FastAPI's threaded
             # request handling, and a per-connection ``PRAGMA foreign_keys=ON``
             # so ``ON DELETE CASCADE`` fires (parity with prod and the local
-            # impl — SQLite does not enforce FKs otherwise).
+            # impl — SQLite does not enforce FKs otherwise). SQLite's default
+            # pool is not a QueuePool, so pool_size/overflow/timeout do not
+            # apply and are intentionally ignored here.
             engine = create_engine(
                 url, connect_args={"check_same_thread": False}
             )
@@ -80,10 +121,12 @@ class CommunityDatabase(DatabasePlugin, LifecycleBase):
                 url,
                 pool_pre_ping=True,
                 pool_recycle=3600,
+                **pool_kwargs,
             )
 
-        # Postgres / etc.: default pooling is appropriate.
-        return create_engine(url)
+        # Postgres / etc.: default pooling is appropriate, with the optional
+        # QueuePool sizing layered on top when configured.
+        return create_engine(url, **pool_kwargs)
 
     async def bootstrap(self) -> None:
         """Lifecycle hook — create the schema unless the operator owns it."""

--- a/src/backend/tests/community/di/test_community_data_infra_wiring.py
+++ b/src/backend/tests/community/di/test_community_data_infra_wiring.py
@@ -111,6 +111,62 @@ def test_mysql_backend_builds_a_pooled_engine(monkeypatch):
     assert plugin._engine.pool._recycle == 3600
 
 
+def test_database_config_reads_optional_pool_sizing(monkeypatch):
+    monkeypatch.setattr(
+        "agentclaw.community.di.modules.config_module._block",
+        lambda name: {
+            "backend": "mysql",
+            "url": "mysql+pymysql://u:p@db.example:3306/agentclaw",
+            "pool_size": 8,
+            "max_overflow": 16,
+            "pool_timeout": 10,
+        },
+    )
+    config = CommunityDatabaseModule().database_config()
+    assert config.pool_size == 8
+    assert config.max_overflow == 16
+    assert config.pool_timeout == 10
+
+
+def test_database_config_defaults_pool_sizing_to_none(monkeypatch):
+    # No pool keys → None each → SQLAlchemy defaults apply downstream.
+    monkeypatch.setattr(
+        "agentclaw.community.di.modules.config_module._block",
+        lambda name: {
+            "backend": "mysql",
+            "url": "mysql+pymysql://u:p@db.example:3306/agentclaw",
+        },
+    )
+    config = CommunityDatabaseModule().database_config()
+    assert config.pool_size is None
+    assert config.max_overflow is None
+    assert config.pool_timeout is None
+
+
+def test_mysql_pool_sizing_reaches_the_engine_pool(monkeypatch):
+    # End-to-end: yaml block -> config -> CommunityDatabase -> engine pool.
+    # mysql+pymysql is lazy, so no server is contacted.
+    monkeypatch.setattr(
+        "agentclaw.community.di.modules.config_module._block",
+        lambda name: {
+            "backend": "mysql",
+            "url": "mysql+pymysql://u:p@db.example:3306/agentclaw?charset=utf8mb4",
+            "create_schema": False,
+            "pool_size": 8,
+            "max_overflow": 16,
+            "pool_timeout": 10,
+        },
+    )
+    config = CommunityDatabaseModule().database_config()
+    plugin = CommunityDatabaseModule().database(config)
+    pool = plugin._engine.pool
+    assert pool.size() == 8
+    assert pool._max_overflow == 16
+    assert pool._timeout == 10
+    assert pool._pre_ping is True
+    assert pool._recycle == 3600
+
+
 def test_community_binds_cache(community_injector):
     resolved = community_injector.get(CachePlugin)
     assert isinstance(resolved, CommunityCache)

--- a/src/backend/tests/community/plugins/community/test_database.py
+++ b/src/backend/tests/community/plugins/community/test_database.py
@@ -192,3 +192,82 @@ class TestBootstrapSchemaOwnership:
         await database.bootstrap()
 
         assert calls[0]["mysql"] is True
+
+
+def test_mysql_pool_sizing_is_forwarded_when_configured(monkeypatch):
+    # The optional pool knobs reach create_engine alongside pre_ping/recycle.
+    import agentclaw.community.plugins.community.database as dbmod
+
+    seen: dict = {}
+
+    def fake_create_engine(url, **kwargs):
+        seen["kwargs"] = kwargs
+        return object()  # dummy engine; sessionmaker only stores the bind
+
+    monkeypatch.setattr(dbmod, "create_engine", fake_create_engine)
+    CommunityDatabase(
+        "mysql+pymysql://u:p@db.example:3306/agentclaw?charset=utf8mb4",
+        pool_size=8,
+        max_overflow=16,
+        pool_timeout=10,
+    )
+    kw = seen["kwargs"]
+    assert kw["pool_pre_ping"] is True
+    assert kw["pool_recycle"] == 3600
+    assert kw["pool_size"] == 8
+    assert kw["max_overflow"] == 16
+    assert kw["pool_timeout"] == 10
+
+
+def test_mysql_pool_sizing_omitted_when_not_configured(monkeypatch):
+    # Unset knobs must stay out of create_engine's kwargs so SQLAlchemy's own
+    # defaults apply — i.e. this is an additive knob with no behaviour change.
+    import agentclaw.community.plugins.community.database as dbmod
+
+    seen: dict = {}
+
+    def fake_create_engine(url, **kwargs):
+        seen["kwargs"] = kwargs
+        return object()
+
+    monkeypatch.setattr(dbmod, "create_engine", fake_create_engine)
+    CommunityDatabase(
+        "mysql+pymysql://u:p@db.example:3306/agentclaw?charset=utf8mb4"
+    )
+    kw = seen["kwargs"]
+    assert kw["pool_pre_ping"] is True
+    assert kw["pool_recycle"] == 3600
+    for absent in ("pool_size", "max_overflow", "pool_timeout"):
+        assert absent not in kw
+
+
+def test_postgres_plain_engine_forwards_pool_sizing(monkeypatch):
+    import agentclaw.community.plugins.community.database as dbmod
+
+    seen: dict = {}
+
+    def fake_create_engine(url, **kwargs):
+        seen["kwargs"] = kwargs
+        return object()
+
+    monkeypatch.setattr(dbmod, "create_engine", fake_create_engine)
+    CommunityDatabase(
+        "postgresql://user:pw@localhost/agentclaw",
+        pool_size=4,
+        pool_timeout=5,
+    )
+    kw = seen["kwargs"]
+    assert kw["pool_size"] == 4
+    assert kw["pool_timeout"] == 5
+    assert "pool_pre_ping" not in kw  # MySQL-only setup not applied here
+
+
+def test_sqlite_ignores_pool_sizing(tmp_path):
+    # SQLite's default pool is not a QueuePool, so pool sizing is deliberately
+    # dropped — it must not error and must not leak into connect_args.
+    db = CommunityDatabase(f"sqlite:///{tmp_path}/pool.db", pool_size=8)
+    Base.metadata.create_all(db._engine)
+    with db.orm_session() as s:
+        s.add(_Parent(id=42, name="pool-check"))
+    with db.session() as s:
+        assert s.query(_Parent).filter_by(id=42).one().name == "pool-check"


### PR DESCRIPTION
## Problem
`GET /openapi/v1/bots?...&page_size=100` 被报「耗时 29 秒」(缺陷 2026090700118859868)。预发 AntLogs 交叉验证后:同一时刻(2026-09-07 10:44–10:46)所有 openapi 端点(`unread-count` / `bots` / `bots/all` / `spaces` / `personal/initialize`)、多用户、多 worker 全部从百毫秒飙到 8–23s 并拌 502——根因是预发滚动重启期的连接争用,**不是 bots 列表代码,也不是 `ac_bots` 索引**(`idx_owner` 存在,`AUTO_INCREMENT≈23w`,owner 查询走索引)。

但这次排查暴露出一个**结构性放大因子**:`CommunityDatabase` 的 `create_engine` 没有显式设置 `pool_size` / `max_overflow` / `pool_timeout`,全部走 SQLAlchemy 默认(`5` / `10` / `30`)。默认 `pool_timeout=30` 正是「~30s hang 然后 502」悬崖的直接来源;且每个 worker 各自持有池,`pool_size × worker_count × instance_count` 可能撞到 DB `max_connections`,而这些参数当前**不可调,必须改代码**。

## Solution
把 QueuePool 三个参数做成**配置驱动**(纯增量,默认不改运行时行为):

- `CommunityDatabaseConfig` 增 `pool_size` / `max_overflow` / `pool_timeout`(均 `None` 默认 = 沿用 SQLAlchemy 默认)。
- provider 从 `application-community.yaml` 的 `database` block 读取并透传(`int`/`float` 防御性强转,坏值启动即失败)。
- `CommunityDatabase._make_engine` 仅在非 `None` 时把参数传给 `create_engine`;SQLite 分支不传(非 QueuePool);MySQL/Postgres 在既有 `pool_pre_ping` / `pool_recycle` 之上叠加。
- yaml 增加注释,说明按部署调参的权衡(尤其 `worker_count × pool_size vs max_connections`,以及下调 `pool_timeout` 可在争用时 fail-fast 而非挂满 30s)。

## Validation
- 新增单测:配置读取(有值 / 默认 `None`)、端到端到 engine pool(mysql 真实 `create_engine` 校 `pool.size()` / `_max_overflow` / `_timeout`)、插件层 mysql/pg 透传与默认不透传、sqlite 忽略 pool 参数。
- 本地全量 `scripts/ci_test.sh`:**17747 passed / 0 failed**;line coverage **88.75%**(≥75%);**change-line coverage 93.49%**(≥80%);`backend CI gate passed`。
- `ruff check` 通过;corp-identifier shipped-surface 守卫通过。

## Notes
- 默认行为不变:三个 key 都 unset 时 engine 完全等同改动前。是否下调 `pool_timeout` / 调大池是按部署规格拍板的运维决定,本 PR 只提供旋钮 + 文档,**不擅自改运行时数值**(避免在不知 worker 数 / DB `max_connections` 下贸然放大池)。
- 29s 缺陷主因是预发发布抖动;本 PR 针对其暴露的「默认池不可调」放大因子做加固,不是 29s 的直接修复。
