### PR TITLE
fix(backend): retry transient BaaS skill sync

### DIFF
--- a/src/backend/src/agentclaw/community/core/devices/services/baas_device_sync.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/baas_device_sync.py
@@ -7,6 +7,7 @@ behavior without making the service profile-aware.
 """
 from __future__ import annotations
 
+import time
 from typing import Any, Optional
 
 from agentclaw.community.core.devices.services.baas_invoke_transport import BaasTransport
@@ -20,6 +21,9 @@ from agentclaw.community.plugin_api.http_client import (
 from agentclaw.community.core.devices.services import mcp_device_transport as mcp_transport
 
 logger = get_logger()
+
+_SYMLINK_RETRY_DELAYS_SECONDS = (1, 2, 4)
+_RETRYABLE_SYMLINK_STATUS_CODES = frozenset({502, 503, 504})
 
 
 class BaasDeviceSyncService(DeviceSync):
@@ -65,30 +69,20 @@ class BaasDeviceSyncService(DeviceSync):
 
         try:
             if symlinks_count == 0:
+                path = "/api/skills/symlink/clean"
                 body = {"directories": ["/home/admin/.openclaw/workspace/skills"]}
-                response = self._transport.post(
-                    "/api/skills/symlink/clean", json=body
-                )
-                response.raise_for_status()
-                return {
-                    "success": True,
-                    "message": "同步成功",
-                    "data": response.json(),
+            else:
+                valid_symlinks = self._ensure_center_skills(symlinks)
+                path = "/api/skills/symlink/bindpath"
+                body = {
+                    "symlinks": [
+                        {"source": s["source"], "target": s["target"]}
+                        for s in valid_symlinks
+                    ],
+                    "clean_target_dir": True,
                 }
 
-            valid_symlinks = self._ensure_center_skills(symlinks)
-
-            body = {
-                "symlinks": [
-                    {"source": s["source"], "target": s["target"]}
-                    for s in valid_symlinks
-                ],
-                "clean_target_dir": True,
-            }
-            response = self._transport.post(
-                "/api/skills/symlink/bindpath", json=body
-            )
-            response.raise_for_status()
+            response = self._post_symlink_request(path, body)
             return {
                 "success": True,
                 "message": "同步成功",
@@ -106,6 +100,40 @@ class BaasDeviceSyncService(DeviceSync):
         except Exception as e:
             logger.exception("[BaasDeviceSyncService.sync_symlinks] error: %s", e)
             return {"success": False, "message": f"同步失败: {e}"}
+
+    def _post_symlink_request(self, path: str, body: dict[str, Any]) -> Any:
+        """Post a symlink mutation, retrying only engine-startup failures."""
+        for attempt, delay_seconds in enumerate(
+            (*_SYMLINK_RETRY_DELAYS_SECONDS, None), start=1
+        ):
+            try:
+                response = self._transport.post(path, json=body)
+                response.raise_for_status()
+                return response
+            except HttpClientStatusError as error:
+                if (
+                    error.response.status_code not in _RETRYABLE_SYMLINK_STATUS_CODES
+                    or delay_seconds is None
+                ):
+                    raise
+                error_detail = f"HTTP {error.response.status_code}"
+            except HttpClientRequestError as error:
+                if delay_seconds is None:
+                    raise
+                error_detail = str(error)
+
+            logger.warning(
+                "[BaasDeviceSyncService.sync_symlinks] transient failure; "
+                "retrying bot_uuid=%s path=%s attempt=%d delay_seconds=%d error=%s",
+                self._bot_uuid,
+                path,
+                attempt,
+                delay_seconds,
+                error_detail,
+            )
+            time.sleep(delay_seconds)
+
+        raise AssertionError("symlink retry loop must return or raise")
 
     def sync_bot_config(
         self,

--- a/src/backend/tests/community/core/devices/test_baas_device_sync.py
+++ b/src/backend/tests/community/core/devices/test_baas_device_sync.py
@@ -8,7 +8,7 @@ docs/superpowers/specs/2026-06-17-baas-transport-bot-type-strategy-design.md)。
 sync_symlinks 必须是 sync — 11 个 call site 不 await(见
 docs/superpowers/plans/2026-05-18-fix-baas-device-sync-async-mismatch.md)。
 """
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import httpx
 
@@ -112,6 +112,79 @@ def test_sync_symlinks_returns_failure_on_request_error():
 
     assert result["success"] is False
     assert "请求失败" in result["message"] or "connection" in result["message"]
+
+
+def test_sync_symlinks_retries_transient_http_status_until_success():
+    from agentclaw.community.core.devices.services.baas_device_sync import BaasDeviceSyncService
+
+    unavailable = httpx.Response(
+        status_code=502,
+        content=b"engine starting",
+        request=httpx.Request("POST", "http://fake/"),
+    )
+    transport = _make_transport()
+    transport.post.side_effect = [unavailable, _ok_response()]
+    plugin = BaasDeviceSyncService(transport=transport, conn_info=_conn_info())
+
+    with patch("agentclaw.community.core.devices.services.baas_device_sync.time.sleep") as sleep:
+        result = plugin.sync_symlinks([])
+
+    assert result["success"] is True
+    assert transport.post.call_count == 2
+    sleep.assert_called_once_with(1)
+
+
+def test_sync_symlinks_does_not_retry_non_transient_http_status():
+    from agentclaw.community.core.devices.services.baas_device_sync import BaasDeviceSyncService
+
+    bad_request = httpx.Response(
+        status_code=400,
+        content=b"invalid request",
+        request=httpx.Request("POST", "http://fake/"),
+    )
+    transport = _make_transport(response=bad_request)
+    plugin = BaasDeviceSyncService(transport=transport, conn_info=_conn_info())
+
+    with patch("agentclaw.community.core.devices.services.baas_device_sync.time.sleep") as sleep:
+        result = plugin.sync_symlinks([])
+
+    assert result["success"] is False
+    transport.post.assert_called_once()
+    sleep.assert_not_called()
+
+
+def test_sync_symlinks_retries_request_error_until_success():
+    from agentclaw.community.core.devices.services.baas_device_sync import BaasDeviceSyncService
+
+    transport = _make_transport()
+    transport.post.side_effect = [httpx.RequestError("connection refused"), _ok_response()]
+    plugin = BaasDeviceSyncService(transport=transport, conn_info=_conn_info())
+
+    with patch("agentclaw.community.core.devices.services.baas_device_sync.time.sleep") as sleep:
+        result = plugin.sync_symlinks([])
+
+    assert result["success"] is True
+    assert transport.post.call_count == 2
+    sleep.assert_called_once_with(1)
+
+
+def test_sync_symlinks_stops_after_bounded_transient_retries():
+    from agentclaw.community.core.devices.services.baas_device_sync import BaasDeviceSyncService
+
+    unavailable = httpx.Response(
+        status_code=503,
+        content=b"engine starting",
+        request=httpx.Request("POST", "http://fake/"),
+    )
+    transport = _make_transport(response=unavailable)
+    plugin = BaasDeviceSyncService(transport=transport, conn_info=_conn_info())
+
+    with patch("agentclaw.community.core.devices.services.baas_device_sync.time.sleep") as sleep:
+        result = plugin.sync_symlinks([])
+
+    assert result["success"] is False
+    assert transport.post.call_count == 4
+    assert sleep.call_args_list == [call(1), call(2), call(4)]
 
 
 def test_sync_symlinks_is_not_async():


### PR DESCRIPTION
## Problem
BaaS restart publish can arrive before the Claude Code engine accepts requests. The resulting 502 prevents the Skill symlink clean/bind operation from converging, leaving the restart marker for a later publish.

## Solution
Retry only BaaS Skill symlink requests that fail with 502, 503, 504, or a request-level connection failure. Use bounded 1s, 2s, and 4s delays after the first attempt. Other failures remain immediate failures; exhausted retries preserve the existing marker behavior.

## Validation
- `uv run pytest tests/community/core/devices/test_baas_device_sync.py tests/community/core/bot_management/services/test_restart_authorization_refresh.py -q` (44 passed)
- `uv run pytest -q` (17,744 passed, 60 skipped)
- `uv run ruff check src/agentclaw/community/core/devices/services/baas_device_sync.py tests/community/core/devices/test_baas_device_sync.py`
- Standards/Spec two-axis review: no remaining findings.

## Compatibility and risk
No public API, schema, configuration, or non-BaaS provider behavior changes. At most, BaaS Skill symlink delivery waits 7 seconds before the existing failure and restart-marker fallback applies.