### PR TITLE
refactor(backend): move task queries into task context

### DIFF
--- a/src/backend/specs/2026-08-09-task-goal-driven-execution-framework/plan.md
+++ b/src/backend/specs/2026-08-09-task-goal-driven-execution-framework/plan.md
@@ -11,11 +11,11 @@
 | 模块 | 性质 | 职责一句话 | 对外有 API? |
 |---|---|---|---|
 | **TaskService** | 对外 facade | 系统唯一对外入口(2 API);内部含编排核协调其余模块 | ✅ 2 个 |
-| **TaskGraphService** | 内部图谱 SSOT | 图谱原子变更唯一网关(增删改查);`relations` 依赖派生 | ❌ 内部(8 API:5 核心写/读+3 派生只读) |
+| **TaskGraphService** | 内部图谱 SSOT | 图谱原子变更唯一网关；统一承载状态/详情/结果/Bot 任务查询；`relations` 依赖派生 | ❌ 内部 |
 | **TaskPlanner**(零参,内置策略池) | 读图按状态条件 first-match-wins 选内置 `PlanningStrategy` 产逻辑子节点(不含执行信息) | ❌ 内部 |
 | **PlanningStrategy** | 规划优化策略(引擎内置) | 真正的分解智能:产哪些节点。默认 GapBased/Workflow;corp 覆写 `_build_planner` | ❌ 内部策略 |
 | **TaskDispatcher** | 分发策略(可插拔) | 搜推决定"谁来做",把 `run_mode`/`assignee` 填到 `TaskNode.run_info` 后返回 `list[TaskNode]`,多 bot 动态拉协作群;**不写图、不起 run**(编排核落库+起 run) | ❌ 内部 |
-| **TaskRunner** | 执行承载 | `start_run(批量)` 三模态自适应 + `query_status/detail/result/bot_tasks`;`TaskLoopCallback` 回投;`form_coop_group` 复用 BCS | ❌ 内部 |
+| **TaskRunner** | 执行承载 | `start_run(批量)` 三模态自适应；`TaskLoopCallback` 回投；`form_coop_group` 复用 BCS；不承载状态查询 | ❌ 内部 |
 | **TaskHarness** | 旁路常驻 | 周期巡检超时/崩溃,写同网关,不抢正向驱动 | ❌ 内部 |
 | **(编排核)** | TaskService 内部 | 事件驱动 + 状态条件触发协调 plan/graph/dispatch/execution | ❌ 非独立模块 |
 
@@ -25,7 +25,7 @@
 - **单一实现**:规范位置 `core/task`;继承旧 seam 命名、DI 接线(`CommunityTaskModule`)、开源边界纪律。
 - **开源边界**:Avernet 发**契约 seam + Noop/singlebox double**(本地关键词 cover 的 bot catalog、BCS local/mock 拉群、stub decomposer);真实搜推/真实执行/LLM 规划/验收 SKILL 在 corp `ocb` adapter。
 
-对外只有 `TaskService` facade 2 个 API:`execute`/`get_task_dashboard`;图谱内部 5 核心写/读 API(`initialize_graph`/`add_task_nodes`/`update_task_node_info`/`update_task_graph_info`/`query_task_dashboard`)+ 3 派生只读查询(`query_task_nodes`/`get_child_tasks`/`get_parent_task`)由 `TaskGraphService` 独立持有(不合并进 facade)。
+对外只有 `TaskService` facade 2 个 API:`execute`/`get_task_dashboard`;图谱内部 5 核心写/读 API(`initialize_graph`/`add_task_nodes`/`update_task_node_info`/`update_task_graph_info`/`query_task_dashboard`)+ 3 关系派生查询(`query_task_nodes`/`get_child_tasks`/`get_parent_task`)+ 4 状态查询(`query_status`/`query_detail`/`query_result`/`query_bot_tasks`)由 `TaskGraphService` 独立持有(不合并进 facade)。
 
 ---
 
@@ -202,7 +202,7 @@ class ExecutionEngine:   # TaskService 内部编排核(不对外)
 
 > 每个事件 on_* 分段推进,由状态条件(a/b/c + plan 三条件)把关是否进入下一阶段。同 task_id 仍串行(per-task `threading.RLock`,仅保护锁内同步编排写;投递/拉群 IO 锁外 await 不受锁约束)。协程化:`on_*` 锁内 collect(同步)→ 锁外 `_drain` await run/group/miss/finish(投递 gather+Semaphore 在 runner)。
 
-### 3.1 `TaskGraphService`(内部图谱 SSOT,8 API:5 核心写/读+3 派生只读,独立模块)
+### 3.1 `TaskGraphService`(内部图谱 SSOT:5 核心写/读+3 关系派生查询+4 状态查询,独立模块)
 
 > `TaskGraphService` 为独立模块(对齐任务图谱文档 `lunk1txfuv6gtwk2`),`TaskService` facade 持有其引用。图谱原子变更唯一网关。
 
@@ -361,13 +361,13 @@ class DispatchStrategy(Protocol):
 
 ### 3.5 `TaskRunner` 任务执行模块(对齐执行文档 `lxg2mwgmtfqg6d95`)
 
-> 功能:把已派发任务按派发目标发送给**单 bot / 协作群 / BBS**执行,并回收状态/详情/结果。一个 `start_run(批量)` 入口三模态自适应;`form_coop_group`(动态拉群)内部辅助;BBS 认领执行由 bot 自主,**不在此接口内**。
+> 功能:把已派发任务按派发目标发送给**单 bot / 协作群 / BBS**执行。一个 `start_run(批量)` 入口三模态自适应;`form_coop_group`(动态拉群)内部辅助;BBS 认领执行由 bot 自主,**不在此接口内**。状态/详情/结果查询统一由 `TaskGraphService` 提供。
 
 #### 3.5.1 供任务 Loop 内部和产品使用的 API(`TaskRunner`)
 
 ```python
 class TaskRunner:
-    """将已派发 TaskNode 发送给单 bot/协作群/BBS 执行,并回收状态/详情/结果。
+    """将已派发 TaskNode 发送给单 bot/协作群/BBS 执行。
     调用方:编排核(经 TaskService facade 驱动)。"""
 
     async def start_run(self, toDoTaskList: list[TaskNode]) -> list[bool]:
@@ -379,18 +379,6 @@ class TaskRunner:
                           → 自己执行 → 不管验收通过与否都上报结果+验收(经 on_report 正常驱动)
         派发成功仅表示"已投递给执行主体",不等于完成;完成结果经回调(下)回收。"""
 
-    def query_status(self, task_id: str) -> "Status":
-        """产品/系统触发:查询某任务及其所有子任务的状态。"""
-
-    def query_detail(self, node: TaskNode) -> TaskNode:
-        """产品触发:查询任务最新详情(回填 node.run_info)。"""
-
-    def query_result(self, node: TaskNode) -> TaskNode:
-        """产品/系统触发:查询某任务及其所有子任务的产出结果(回填 node.run_info.output)。"""
-
-    def query_bot_tasks(self, bot_id: str) -> list[TaskNode]:
-        """获取某个 Bot 下的所有任务实例列表。"""
-
     async def form_coop_group(self, gf: "GroupFormation") -> str:
         """(内部)HIT_MULTI_BOTS 动态拉协作群,复用 BCS 建群 → group_id。协程化:BCS 建群是网络 IO,`await`(由 engine 锁外 await 调用,不阻塞编排核)。
         CHAT/MANAGER_WORKER/STATE_MACHINE 三模式(group_strategy=collab_mode;state_machine 注入 workflow yaml)。
@@ -400,6 +388,16 @@ class TaskRunner:
         participants[].bot_uuid、manager/worker、participant_bindings[*].bot_ids 均使用 BCS UUID;
         state-machine participant_bindings 的 key 必须是 workflow 逻辑 binding 名,不得使用 Bot ID;
         workflow binding 与 BCS ParticipantRole 分离,participants[].role 只使用 BCS 合法角色。"""
+```
+
+状态查询接口归属于任务上下文：
+
+```python
+class TaskGraphService:
+    def query_status(self, task_id: str) -> "Status": ...
+    def query_detail(self, node: TaskNode) -> TaskNode: ...
+    def query_result(self, node: TaskNode) -> TaskNode: ...
+    def query_bot_tasks(self, bot_id: str) -> list[TaskNode]: ...
 ```
 
 #### 3.5.2 回调服务(供单 bot workflow / bcn 协作群,PUSH 回投)`TaskLoopCallback`
@@ -422,7 +420,7 @@ class TaskLoopCallback:
 
 | 模式 | start_run 内部动作 | 结果回收 | Avernet 实现 | prod 实现 |
 |---|---|---|---|---|
-| 单 Bot | 调单 bot workflow(workflow_type=single_bot) | `TaskLoopCallback.report_result`(PUSH)或 `query_result`(PULL) | seam + singlebox double(本地 bot stub) | corp adapter |
+| 单 Bot | 调单 bot workflow(workflow_type=single_bot) | `TaskLoopCallback.report_result`(PUSH)或 `TaskGraphService.query_result`(PULL) | seam + singlebox double(本地 bot stub) | corp adapter |
 | 协作群 | 触发 bcn 协作群(群可能刚 `form_coop_group` 拉的) | `TaskLoopCallback`(群终态回投) | seam + BCS local/mock 拉群 | corp BCS wiring |
 | BBS | BBS bot 认领任务后自算 gap+规划子任务(落图 `run_mode="bbs"`,`assignee=bot_id`)→ 自执行 | 认领 bot 自主 `report_result` 回投(PASS→触发根 plan / FAIL+gaps→触发该子任务节点 plan) | seam + stub(任务广场) | corp 任务广场 + BBS bot 自能力规划 |
 
@@ -672,7 +670,7 @@ sequenceDiagram
         ORC->>D: dispatch→list[TaskNode]填执行者→(ORC)update(RUNNING)+start_run
     end
     opt 产品/系统探活
-        TS->>R: query_status(task_id) / query_detail(node) / query_result(node)
+        TS->>G: query_status(task_id) / query_detail(node) / query_result(node)
     end
     H-->>G: (旁路) SLA超时→update_task_node_info(HUNG/FAILED)
     ORC->>ORC: plan(root)==[] ∧ 全非根DONE → 触发 owner bot 终验 skill(经 source_channel)
@@ -684,7 +682,7 @@ sequenceDiagram
     G-->>U: TaskExecutionGraph{status=DONE,loop_round,看板}
 ```
 
-> **分层要点**:facade 2 API(execute/get_task_dashboard);编排核 on_* 事件驱动 + 状态条件(a/b/c + plan 三条件)分段推进;Dispatcher 只搜推把 run_mode/assignee 填到 TaskNode 上返回 list[TaskNode](不写图不起 run);编排核落 update_task_node_info + 置 RUNNING + 立即 start_run;执行结果 PUSH `TaskLoopCallback.report_result` 为主,可选 PULL `query_status/detail/result`;`TaskCallbackData.loop_task_id↔(task_id,node_id)`、`result.success→verdict`、`result.data→output` 由适配层完成,再走 `on_report`→`update_task_node_info`。
+> **分层要点**:facade 2 API(execute/get_task_dashboard);编排核 on_* 事件驱动 + 状态条件(a/b/c + plan 三条件)分段推进;Dispatcher 只搜推把 run_mode/assignee 填到 TaskNode 上返回 list[TaskNode](不写图不起 run);编排核落 update_task_node_info + 置 RUNNING + 立即 start_run;执行结果 PUSH `TaskLoopCallback.report_result` 为主,可选从 `TaskGraphService` PULL `query_status/detail/result`;`TaskCallbackData.loop_task_id↔(task_id,node_id)`、`result.success→verdict`、`result.data→output` 由适配层完成,再走 `on_report`→`update_task_node_info`。
 
 ## 7. Case 端到端推演:存储行业尽调(权威剧本 `gwqie46v7hzr1w6h`;从任务输入到任务执行完成按 API 流程串联)
 

--- a/src/backend/specs/2026-08-09-task-goal-driven-execution-framework/spec.md
+++ b/src/backend/specs/2026-08-09-task-goal-driven-execution-framework/spec.md
@@ -15,7 +15,7 @@
 
 需要一个**以目标(Goal + Acceptance)为唯一收敛判据、能跨 单 Bot / 协作群 / BBS 三种执行模态自驱跑完「理解 → 规划 → 派发 → 执行 → 验收 → 重规划」闭环**的任务动态规划执行框架,且必须**严格按最新设计的领域模型与六模块架构实现**。
 
-领域模型收敛为:**`Relation` 一等公民(`TaskNode` 不持 `depends_on`)**、**6 态 `Status`(含 `PLANNING`)**、`TaskNode` 含 `task_id`/`node_run_graph`、`TaskExecutionGraph` 含 `run_id`/`relations`(分解树,承载结构归属;数据流由批规划+结构父聚合上下文承载)、`RuntimeInfo.run_mode` 为 str(无 `collab_mode`)、无 `SLA`/`Scope`/`CollabMode` 枚举、`AcceptanceResult` 无 `verifier`;5 个模块文档进一步明确:`TaskService` 2 facade(`execute`/`get_task_dashboard`)、`TaskGraphService` 独立图谱模块(8 API:5 核心写/读+3 派生只读)、`TaskPlanner.plan` 与 `TaskGraphService.add_task_nodes` 有显式状态触发条件(a/b/c)、`TaskDispatcher.dispatch` 决定"谁来做"写 `assignee`、`TaskRunner.start_run` 一个入口三模态自适应、`TaskLoopCallback` PUSH 回投。代码库按此从零重新实现。
+领域模型收敛为:**`Relation` 一等公民(`TaskNode` 不持 `depends_on`)**、**6 态 `Status`(含 `PLANNING`)**、`TaskNode` 含 `task_id`/`node_run_graph`、`TaskExecutionGraph` 含 `run_id`/`relations`(分解树,承载结构归属;数据流由批规划+结构父聚合上下文承载)、`RuntimeInfo.run_mode` 为 str(无 `collab_mode`)、无 `SLA`/`Scope`/`CollabMode` 枚举、`AcceptanceResult` 无 `verifier`;5 个模块文档进一步明确:`TaskService` 2 facade(`execute`/`get_task_dashboard`)、`TaskGraphService` 独立图谱模块(5 核心写/读+3 关系派生查询+4 状态查询)、`TaskPlanner.plan` 与 `TaskGraphService.add_task_nodes` 有显式状态触发条件(a/b/c)、`TaskDispatcher.dispatch` 决定"谁来做"写 `assignee`、`TaskRunner.start_run` 一个入口三模态自适应、`TaskLoopCallback` PUSH 回投。代码库按此从零重新实现。
 
 ## Solution
 
@@ -29,10 +29,11 @@
    - **`PLANNING` 新态**:承担"待规划/委托中"语义(节点已被/将被分解委托子执行)。
 2. **六模块 = 流程架构图 + 5 模块文档**:
    - **任务中心 `TaskService`**(对外 facade,2 API):`execute(task_info)→TaskOpResult` / `get_task_dashboard(task_id,node_id?)→TaskExecutionGraph`。内部由编排核协调其余模块。
-   - **任务图谱 `TaskGraphService`**(内部 SSOT,8 API:5 核心写/读+3 派生只读):`initialize_graph`/`add_task_nodes`/`update_task_node_info`/`update_task_graph_info`/`query_task_dashboard`。图谱原子变更唯一网关。
+   - **任务图谱 `TaskGraphService`**(内部 SSOT):5 个核心写/读 API + 3 个关系派生查询 + 4 个状态查询。图谱原子变更唯一网关与查询统一入口。
    - **任务规划 `TaskPlanner`**(零参,内置策略池):`plan(TaskExecutionGraph)→list[TaskNode]`,按状态触发条件 first-match-wins 选内置 `PlanningStrategy` 产逻辑子节点(不含物理执行信息)。引擎自带,不开放自定义。
    - **任务派发 `TaskDispatcher`**(零参,内置策略池):`dispatch(toDoTaskList)→list[TaskNode]`,first-match-wins 选内置 `DispatchStrategy`(config 有 `bot`→direct 跳搜推;否则 search 搜推)决定"谁来做",填 `run_info.run_mode`/`assignee`;HIT_MULTI_BOTS 标 `pending_group_formation`(拉群归编排核+runner)。引擎自带,不开放自定义。
-   - **任务执行 `TaskRunner`**:`start_run(list[TaskNode])→list[Boolean]` 三模态自适应 + `query_status`/`query_detail`/`query_result`/`query_bot_tasks`;`TaskLoopCallback` PUSH 回投。
+   - **任务执行 `TaskRunner`**:`start_run(list[TaskNode])→list[Boolean]` 三模态自适应；不承载状态查询；`TaskLoopCallback` PUSH 回投。
+   - **任务上下文 `TaskGraphService`**:图谱 SSOT，并统一提供 `query_status`/`query_detail`/`query_result`/`query_bot_tasks` 只读查询。
    - **任务Harness**(旁路常驻):周期巡检 SLA 超时/崩溃,写同网关,不抢正向驱动。
 3. **事件驱动 + 状态条件触发**:
    - `TaskPlanner.plan` 显式触发条件(规划文档):图谱有更新(新增失败节点/PLANNING 节点)AND 没有派发(RUNNING)或执行中节点 AND 状态图谱有处于 PLANNING 状态的节点。
@@ -57,7 +58,7 @@
 - **reroute 局部化**:补救挂该 FAIL/PLANNING 节点本体下,子全 PASS 传播顶回该节点 DONE;未触下游在依赖满足前不入图,无复位;自动 reroute 不调级联回滚。
 - **深度闸门是引擎决策**:MISS 拆解前查核内派生深度(从 `relations` 递归),达内层 `MAX_DEPTH` → **自动升 BBS**(非 HUNG);BBS 链路 `loop_round` 达 `BBS_MAX_DEPTH` → STUCK → HUNG;规划器保持纯读图。
 - **派发只决定"谁来做"**:`dispatch` 经搜推匹配单 bot / 已有协作群 / 多 bot 动态拉协作群 / MISS;写 `run_info.run_mode`(str)/`assignee`;协作群协作模式(chat/manager_worker/state_machine)作 `form_coop_group` 内部参数(对齐 BCS `GroupStrategy`),**不进 `RuntimeInfo` 持久字段**(模型无 `collab_mode`)。
-- **执行三模态一个入口**:`TaskRunner.start_run(批量)` 按 `run_mode` 自适应分发单 bot/协作群/BBS;BBS = bot 认领任务后自算 gap+自规划子任务(落图 `run_mode="bbs"`,`assignee=bot_id`)→ 自执行 → 上报结果+验收;完成结果经 PUSH `TaskLoopCallback.report_result` 或 PULL `query_status`/`query_detail`/`query_result` 回收。
+- **执行三模态一个入口**:`TaskRunner.start_run(批量)` 按 `run_mode` 自适应分发单 bot/协作群/BBS;BBS = bot 认领任务后自算 gap+自规划子任务(落图 `run_mode="bbs"`,`assignee=bot_id`)→ 自执行 → 上报结果+验收;完成结果经 PUSH `TaskLoopCallback.report_result` 或从 `TaskGraphService` PULL 查询回收。
 - **执行主体只发 `task_loop_id`**:回调数据协议 `TaskCallbackData` 承载 `loop_task_id`/`workflow_type`/`workflow_id`/`instance_id`/`result`;合法终态严格为 `success:bool + data + gaps:list[str]`(FAIL 的 gaps 必须非空),执行/回收异常为 `exec_error`;框架适配层做 `loop_task_id↔(task_id,node_id)`、`success/gaps→verdict`、`data→output` 映射,再走图谱写口。空/非法终态不得默认 PASS,统一进入 Harness。
 - **BCS 身份边界**:任务领域、搜推结果和 `GroupFormation` 只保存产品 Bot ID;动态拉群时框架通过 BotService 权威 owner_id 在 BCS integration 边界转换为 `{product_bot_id}:{owner_id}`。BCS 请求中的 driver/originator/participant/manager/worker/binding bot_ids 使用 BCS UUID;state-machine binding key 是 workflow 逻辑名,不得使用 Bot ID,且 workflow binding 与 BCS ParticipantRole 分离。
 - **执行 SLA 单一所有者**:worker fire-and-poll 执行由结果 Poller 统一判定业务 SLA;Singlebox Adapter 只判传输错误,不得以更短 adapter timeout 提前截断仍在生成的 Bot。SLA/poll_exhausted 属执行异常(`exec_error→Harness`),不属于验收 FAIL。
@@ -91,7 +92,7 @@
 19. 作为 TaskDispatcher,我想 `dispatch(toDoTaskList)`(无 graph 入参)做搜推:单 bot / 已有协作群 / 多 bot 动态拉协作群 / MISS;写 `run_mode`/`assignee`,这样派发职责纯净。
 20. 作为 TaskDispatcher,我想多 bot 合 cover 时经 `TaskRunner.form_coop_group` 动态拉协作群(3 模式 chat/manager_worker/state_machine 经 BCS),协作模式不进 RuntimeInfo 持久字段,这样拉群不外泄为对外 API。
 21. 作为 TaskRunner,我想 `start_run(list[TaskNode])→list[Boolean]` 一个入口按 `run_mode` 自适应分发 SINGLE_BOT/COOP_GROUP/BBS(BBS bot 认领任务→自算 gap+规划子任务→自执行→上报),这样三模态收敛。
-22. 作为 TaskRunner,我想 `query_status(task_id)`/`query_detail(TaskNode)`/`query_result(TaskNode)`/`query_bot_tasks(bot_id)` 查状态/详情/产出/bot 任务列表,这样产品与系统可探活。
+22. 作为任务上下文消费者,我想通过 `TaskGraphService.query_status(task_id)`/`query_detail(TaskNode)`/`query_result(TaskNode)`/`query_bot_tasks(bot_id)` 查状态/详情/产出/bot 任务列表,使只读查询与图谱 SSOT 保持同一模块。
 23. 作为执行实体(bot workflow/bcn 协作群),我想调 `TaskLoopCallback.start_run(TaskCallbackData)` 上报开始、`report_result(TaskCallbackData)` 上报完成/失败,这样 PUSH 回投有统一协议。
 24. 作为框架适配层,我想把 `TaskCallbackData`(loop_task_id/workflow_type/workflow_id/instance_id/result)映射成 `(task_id,node_id)`+`verdict`+`output` 走 `update_task_node_info`,这样回投驱动图谱状态。
 25. 作为 TaskHarness,我想旁路常驻周期检测 SLA 超时/崩溃并自愈(经 `update_task_node_info` 复位 `RUNNING→PENDING` 重投,不直接写 HUNG),这样主链不卡死且旁路与主链同写口。
@@ -105,7 +106,7 @@
 30b. 作为系统,我想每个**父节点**的重规划产子次数计入其 extend_props.plan_round,达 MAX_PLAN_ROUND(默认 10)→该父 HUNG(不再产子),这样单节点 gap 反复读不闭时不会无限产子撑爆图;loop_round 收敛到只数升 BBS 的总次数(MAX_LOOP)。
 31. 作为系统,我想崩溃堆栈/超时标记/miss 事件进 `extend_props`,这样非业务异常态增量合并不污染主字段。
 32. 作为开发者,我想对外服务集中在"任务中心"`TaskService` facade(2 API),图谱/规划/派发/执行/Harness 各管各的内部 API,这样模块边界清晰、调用方只认一处入口。
-33. 作为开发者,我想图谱原子变更收口在"任务图谱"`TaskGraphService`(8 API:5 核心写/读+3 派生只读),这样状态流转有单一写网关、不散在各执行器。
+33. 作为开发者,我想图谱原子变更和只读查询收口在"任务图谱"`TaskGraphService`(5 核心写/读+3 关系派生查询+4 状态查询),这样状态流转有单一网关、不散在各执行器。
 34. 作为开发者,我想规划(`plan` 产逻辑 Node)与派发(`dispatch` 决定谁做)与执行(`start_run` 真投递)三层分开,这样职责不混。
 35. 作为测试,我想以六模块对外契约为断言面,这样行为可回归。
 36. 作为迁移,我想 2026-08-04 的 case 推演(存储行业尽调全链路)在新模型上等价跑通,这样行为不丢。
@@ -116,7 +117,7 @@
 
 ### 什么是好测试
 
-只测外部可观测行为。断言面:**任务中心 facade 契约**(`get_task_dashboard` 返回的 `TaskExecutionGraph`:`status`/`loop_round`/`tasks[].status`/`tasks[].run_info.acceptance_result`/`relations`)、**事件日志重放**、**执行主体侧 `query_result`/`query_detail`**。不断言内部 `update_task_node_info` 实现或内存结构。
+只测外部可观测行为。断言面:**任务中心 facade 契约**(`get_task_dashboard` 返回的 `TaskExecutionGraph`:`status`/`loop_round`/`tasks[].status`/`tasks[].run_info.acceptance_result`/`relations`)、**事件日志重放**、**任务上下文侧 `query_result`/`query_detail`**。不断言内部 `update_task_node_info` 实现或内存结构。
 
 ### 测试 seams(最高 seam 为先)
 

--- a/src/backend/specs/2026-08-09-task-goal-driven-execution-framework/tasks.md
+++ b/src/backend/specs/2026-08-09-task-goal-driven-execution-framework/tasks.md
@@ -8,7 +8,7 @@
 - **协程化(CR 反馈:任务执行是耗时任务)**:`on_execute`/`on_report`/`on_miss`/`on_harness`/`start_run`/`form_coop_group`/`report_result`/`DeliveryPort.deliver`/**`plan`/`dispatch`/策略 `matches`/`apply`** 全链路 `async def`;`plan`/`dispatch`(corp LLM/catalog 耗时 IO)在 per-task `threading.RLock` 锁内 `await`(同 task 串行,设计意图;不同 task 锁隔离);锁内不 `await` 的是高并发外部投递 IO(`start_run`/拉群/`deliver`),这些 `await` 在锁外;`on_*` 锁内 async collect(`await plan/dispatch`+同步 add/patch)→ 锁外 `_drain` await run/group/miss/finish;多节点投递 gather+Semaphore(`_DELIVER_CONCURRENCY=8`)下沉 `TaskRunner.start_run` 内部;`threading.RLock` 适用本仓一次性事件循环/跨线程回调模型(corp 单持久 loop 并发同 task 需切 `asyncio.Lock`);单测经 `asyncio.new_event_loop().run_until_complete` 驱动(不用 `@pytest.mark.asyncio`)。
 - **类型契约**:必填端到端非可选;`T|None` 仅当 `None` 是合法域态或外部输入边界。
 - **TDD / 主 seam 优先**:P8 singlebox E2E 最高 seam;P1–P7 契约单测补 E2E 覆盖不到的分支。
-- **写网关收口**:图谱原子变更只走 `TaskGraphService` 8 API(5 核心写/读 + 3 派生只读);旁路同写口。
+- **图谱网关收口**:图谱原子变更与查询统一走 `TaskGraphService`(5 核心写/读 + 3 关系派生查询 + 4 状态查询);旁路同写口。
 - **框架零 case 知识**:任何具体节点名(`N_overview`/`N_market` 等)只允许出现在 case 的策略 stub 产出或测试 stub,**禁止出现在框架代码**。
 - **不并存两套**:合并为单一实现,删除并行包与旧模型失效代码。
 
@@ -16,10 +16,10 @@
 
 ```
 M0  领域模型(Relation/6态/瘦身后字段) + 中间类型(patch/criteria/op_result/callback_data)
- → M1  TaskGraphService 独立(8 API:5 核心写/读+3 派生只读;relations 依赖派生)
+ → M1  TaskGraphService 独立(5 核心写/读+3 关系派生查询+4 状态查询)
  → M2  编排核 on_*(事件驱动 + 状态条件 a/b/c + plan 三条件;串行锁)
  → M3  TaskPlanner 编排壳 + 内置策略池(零参,去硬编码)
- → M4  TaskDispatcher(搜推4态+form_coop_group)+ TaskRunner(start_run/query_*/TaskLoopCallback;BCS复用)
+ → M4  TaskDispatcher(搜推4态+form_coop_group)+ TaskRunner(start_run/TaskLoopCallback;BCS复用)
  → M5  TaskHarness 旁路 + TaskService facade 2 API
  → M6  singlebox E2E(gwqie46v7hzr1w6h 三阶段三模态)
 ```
@@ -35,7 +35,7 @@ M2 依赖 M1/M3/M4 接口(可 seam/double);M5 集成;M6 验证。
 - T0.5 派生规则注释(分解树统一):① 结构子(`get_child_tasks`)与结构父(`get_parent_task`)均从 `relations` 分解树(src→dst 单入)派生;② `depth` 从 relations 递归;③ 传播读结构子(`get_child_tasks`),就绪=被 add 即就绪(无 `dependencies_satisfied` 闸门);④ 数据流由步进式批规划+结构父聚合上下文承载,无跨兄弟数据边。
 - ✅ 验收:模型与最新 classDiagram 1:1;`grep` 无 `depends_on`/`decomposed_by`/`collab_mode`/`SLA`/`Scope`/`RunMode`/`CollabMode`/`verifier`/`NodeRuntimePatch`/`TaskGraphInfo` 残留;TaskNode 无 `decomposed_by` 字段(结构归属由 relations 分解树派生)。
 
-## M1 — TaskGraphService(独立图谱 SSOT,8 API:5 核心写/读+3 派生只读)
+## M1 — TaskGraphService(独立图谱 SSOT:5 核心写/读+3 关系派生查询+4 状态查询)
 - T1.1 `TaskGraphService.initialize_graph(task_info) -> TaskExecutionGraph`:建图(run_id 分配,根 PENDING);幂等冲突。
 - T1.2 `add_task_nodes(tasks, parent_node_id) -> TaskExecutionGraph`:并子图(**显式传父** `parent_node_id`,方案 C);DEPENDENCY 关系写入 `graph.relations`(src=parent_node_id,dst=新子,单入);父节点进 PLANNING(`_DELEGATABLE_PARENT={PENDING,FAILED,PLANNING}`);单层同构硬约束(本批前序依赖仅指向已存节点,本批内不互依);触发条件 a/b/c 校验(编排核调前判,store 双检)。
 - T1.3 `update_task_node_info(patch) -> NodeOpResult`:节点级原子写;两张状态机——`_ACCEPTANCE_TRANSITIONS`(`RUNNING→{DONE,FAILED}`、`PLANNING→{DONE,FAILED}` 根终验)与 `_DIRECT_TRANSITIONS`(`PENDING→RUNNING` 派发、`RUNNING→PENDING` Harness 复位、`PLANNING→DONE` 传播);acceptance 驱动 PASS→DONE / FAIL+gaps→FAILED(验收 skill 强制要求给 gaps,不存在 FAIL 无 gaps);status 直驱派发写 run_mode/assignee+RUNNING;幂等。
@@ -71,7 +71,7 @@ M2 依赖 M1/M3/M4 接口(可 seam/double);M5 集成;M6 验证。
   - T4a.x 单测:四态填 TaskNode.run_info(HIT_SINGLE/HIT_GROUP/HIT_MULTI_BOTS 填 run_mode/assignee、MISS 不填标 miss_events)、collab_mode 来自 search(内部)、dispatcher 不写图不起 run、编排核落库后 DISPATCHED 必 RUNNING、前序依赖双检、start_run 由编排核触发(批量)、MISS 节点 status 仍 PENDING。
 - **M4b TaskRunner + TaskLoopCallback**
   - T4.4 `async TaskRunner.start_run(toDoTaskList)->list[bool]`:批量;协程化——真实投递(单 bot workflow/BCS/BBS 广场)是网络 IO,内部 `asyncio.gather`+`_DELIVER_CONCURRENCY`(Semaphore=8)并发投递(对齐 backend lifecycle),`await` 不阻塞编排核;按 run_mode(str)自适应投递 single_bot/coop_group/bbs(BBS bot 认领任务→自算 gap+规划子任务→自执行);返回每派发是否成功。`form_coop_group` 同 async(BCS 建群 IO),并在 BCS integration 边界经 `BcsBotIdentityResolver` 将产品 Bot ID 转成权威 `{bot_id}:{owner_id}` UUID。
-  - T4.5 `TaskRunner.query_status(task_id)->Status` / `query_detail(TaskNode)->TaskNode` / `query_result(TaskNode)->TaskNode` / `query_bot_tasks(bot_id)->list[TaskNode]`。
+  - T4.5 `TaskGraphService.query_status(task_id)->Status` / `query_detail(TaskNode)->TaskNode` / `query_result(TaskNode)->TaskNode` / `query_bot_tasks(bot_id)->list[TaskNode]`；`TaskRunner` 不暴露状态查询。
   - T4.6 `TaskRunner.form_coop_group(GroupFormation)->group_id`:(内部)HIT_MULTI_BOTS 动态拉协作群,复用 BCS(`group_strategy=collab_mode`;state_machine 注入 workflow yaml);driver/participants/manager/worker/binding bot_ids 使用 BCS UUID,state-machine binding key 使用 workflow 逻辑名;群自闭环持 `SubDagRef(bcs_run_id)`。Avernet BCS local/mock;prod wiring 属 corp。
   - T4.7 `TaskLoopCallback`:PUSH 回投;`TaskCallbackData{loop_task_id,workflow_type,workflow_id,instance_id,result}`;`async start_run(data)`(进度)/`async report_result(data)`(完成/失败;协程化——`await` 编排核 `on_report` 不阻塞回投调用方);合法终态严格为 `success:bool/data/gaps:list[str]`,FAIL gaps 非空;适配层组装 TaskNodePatch(PASS/FAIL/output),执行/回收异常或非法终态用 `exec_error` 进入 Harness。Poller 统一拥有 worker 执行业务 SLA,超时/poll_exhausted best-effort cancel 后按 exec_error 回投。
   - T4.8 上下文组装:`start_run` 内部 `_build_context(task_id,node)` 用 `get_child_tasks`/`get_parent_task` 组合自动判定——有结构子(`get_child_tasks` 非空)→验收模式聚合结构子(子树)DONE output+node.goal;无结构子→执行模式取结构父 P=`get_parent_task`,聚合 P 的聚合上下文={P.task_spec/goal + P 已DONE结构子(本节点兄弟)output}+本节点 task_spec。无 NODE/SUBTREE/TASK scope 入参,验收只按 (task_id,node_id) 上报节点;数据流经结构父中转,无跨兄弟数据边。
@@ -88,7 +88,7 @@ M2 依赖 M1/M3/M4 接口(可 seam/double);M5 集成;M6 验证。
 - T6.1 singlebox 编排:模型+六模块全接;in-memory `TaskGraphService`;`StubDecomposer`(注入 case 节点);`StubBotDiscover`(本地 catalog 关键词 cover);`form_coop_group` BCS local/mock。
 - T6.2 用权威案例剧本 `gwqie46v7hzr1w6h` 存储行业尽调(三阶段三模态)端到端跑完:`execute→initialize_graph→on_execute(条件a)→plan(decompose(graph) 按三阶段 AC 拆 N_overview/四专题/N_practice_bbs/N_report)→add_task_nodes(根→PLANNING,relations 登记)→dispatch(决定谁来做:single_bot/coop_group 动态拉群 manager_worker;MISS+depth≥MAX→升 BBS)→start_run→TaskLoopCallback.report_result 回投→任一专题 FAIL+gaps→on_report(条件b)→plan(补救挂该节点下,该节点→PLANNING)→二次 PASS→传播治愈→图 status=DONE`。注入一次 MISS+depth 达 MAX→自动升 BBS(remove_subtree)+loop_round+++BBS bot 认领执行+上报;再注入 BBS loop_round≥BBS_MAX_DEPTH→STUCK→HUNG(人介入)。
    - 节点级重规划闸:在 N_report(或中间父)处反复回投 PASS 但根 gap 不闭,经多轮重 plan 产子,断言 plan_round 达 MAX_PLAN_ROUND→该父 HUNG(plan_round_exhausted)+ 不再产子。
-- T6.3 断言面:`get_task_dashboard` 终态(`TaskExecutionGraph`:status/loop_round/tasks[].status/acceptance_result/relations)+ 事件日志可重放 + `query_result`/`query_detail`。
+- T6.3 断言面:`get_task_dashboard` 终态(`TaskExecutionGraph`:status/loop_round/tasks[].status/acceptance_result/relations)+ 事件日志可重放 + `TaskGraphService.query_result`/`query_detail`。
 - T6.4 singlebox 覆盖脚本对齐仓库 ci(`scripts/ci/singlebox_coverage*`),与 PR CI 同一基线。
 
 ## Cross-cutting
@@ -107,10 +107,10 @@ M2 依赖 M1/M3/M4 接口(可 seam/double);M5 集成;M6 验证。
 
 ## 里程碑(M0–M6 已实现并 push;分支 `feat/task-goal-driven-collab-dev`)
 - ✅ **M0** 领域模型(先落模型)。
-- ✅ **M1** TaskGraphService 独立(8 API:5 核心写/读+3 派生只读+relations 派生)。
+- ✅ **M1** TaskGraphService 独立(5 核心写/读+3 关系派生查询+4 状态查询)。
 - ✅ **M2** 编排核 on_*(事件驱动 + 状态条件 a/b/c + plan 三条件)。
 - ✅ **M3** TaskPlanner 编排壳 + 内置策略池(零参,去硬编码)。
-- ✅ **M4** Dispatcher(搜推4态+form_coop_group)+ TaskRunner(start_run/query_*/TaskLoopCallback;BCS复用),singlebox double。
+- ✅ **M4** Dispatcher(搜推4态+form_coop_group)+ TaskRunner(start_run/TaskLoopCallback;BCS复用),状态查询归 TaskGraphService,singlebox double。
 - ✅ **M5** Harness + TaskService facade 2 API 集成。
 - ✅ **M6** singlebox E2E,行为基线对齐 `gwqie46v7hzr1w6h`(机制不变,内容来自 stub decomposer)。
 

--- a/src/backend/src/agentclaw/community/core/task/README.md
+++ b/src/backend/src/agentclaw/community/core/task/README.md
@@ -25,14 +25,14 @@ core/task/
 ├── task_center/                   # TaskService facade + ExecutionEngine 编排核(非独立模块)
 │   ├── task_service.py            #   facade API(execute / get_task_dashboard / list_tasks)
 │   └── engine.py                  #   ExecutionEngine:on_* 事件驱动 + 状态条件(a/b/c)推进
-├── task_context/                    # TaskGraphService 图谱 SSOT(7+2 API,独立模块)
-│   └── task_graph_service.py      #   原子变更唯一网关 + relations 分解树派生查询
+├── task_context/                  # TaskGraphService 图谱 SSOT + 状态/详情/结果查询
+│   └── task_graph_service.py      #   原子变更唯一网关 + relations 派生查询 + query_*
 ├── task_plan/                     # TaskPlanner 规划编排壳 + DecomposerPort seam(可插拔)
 │   └── planner.py                 #   plan(graph) → 委托 decompose(零 case 知识);protocols.py 延后
 ├── task_dispatch/                 # TaskDispatcher 搜推分发 + BotDiscoverPort seam(可插拔)
 │   └── dispatcher.py              #   dispatch(toDoList) → 填 run_mode/assignee 返 list[TaskNode];protocols.py 延后
 ├── task_runner/                   # TaskRunner 三模态执行 + 回投适配
-│   ├── runner.py                  #   start_run(批量)三模态自适应 + form_coop_group/get_group_session
+│   ├── task_runner.py             #   start_run(批量)三模态自适应 + form_coop_group/get_group_session；不承载状态查询
 │   └── callback_adapter.py        #   TaskCallbackData → TaskNodePatch → engine.on_report
 ├── task_harness/                  # TaskHarness 旁路常驻巡检
 │   └── harness.py                 #   周期巡检超时/崩溃 → 复位 PENDING 重投(不抢正向)

--- a/src/backend/src/agentclaw/community/core/task/task_context/task_graph_service.py
+++ b/src/backend/src/agentclaw/community/core/task/task_context/task_graph_service.py
@@ -1,4 +1,4 @@
-"""TaskGraphService:任务图谱 SSOT + 原子变更唯一网关(7+2 API)。
+"""TaskGraphService:任务图谱 SSOT + 原子变更唯一网关 + 状态查询接口。
 
 对齐 plan.md §3.1 + 任务图谱文档 lunk1txfuv6gtwk2。
 in-memory store(M1);ORM 适配按需后续。查询返回引用(D3-A:调用方不应 mutate)。
@@ -757,6 +757,42 @@ class TaskGraphService:
         with self._lock_for(task_id):
             graph = self._require_graph(task_id)
             return graph.effective_status
+
+    def query_status(self, task_id: str) -> Status:
+        """查询任务图当前持久状态。
+
+        保持原 TaskRunner 查询语义，返回图本身的 ``status``；需要以根节点为准的
+        观测口径时使用 ``effective_graph_status``。
+        """
+        return self.query_task_dashboard(task_id).status
+
+    def query_detail(self, node: TaskNode) -> TaskNode:
+        """按 ``task_id/node_id`` 返回图中的最新节点；节点不存在时原样返回输入。"""
+        graph = self.query_task_dashboard(node.task_id)
+        return self._get_node(graph, node.node_id) or node
+
+    def query_result(self, node: TaskNode) -> TaskNode:
+        """返回包含最新 ``run_info.output`` 的节点投影。"""
+        return self.query_detail(node)
+
+    def query_bot_tasks(self, bot_id: str) -> list[TaskNode]:
+        """查询当前进程已加载图中由 ``bot_id`` 承接的任务节点。
+
+        ``TaskGraphRepositoryProtocol`` 当前不提供跨任务枚举接口，因此持久化环境下
+        本方法只覆盖已加载/已 hydrate 的图；后续若要求全库查询，应由持久化读模型承接。
+        """
+        with self._registry_lock:
+            task_ids = list(self._graphs)
+        result: list[TaskNode] = []
+        for task_id in task_ids:
+            with self._lock_for(task_id):
+                graph = self._graphs.get(task_id)
+                if graph is not None:
+                    result.extend(
+                        node for node in graph.tasks
+                        if node.run_info.assignee == bot_id
+                    )
+        return result
 
     # ===== 派生只读查询(均从 relations 分解树派生)=====
     def query_task_nodes(self, task_id: str, criteria: TaskNodeQueryCriteria) -> list[TaskNode]:

--- a/src/backend/src/agentclaw/community/core/task/task_runner/task_runner.py
+++ b/src/backend/src/agentclaw/community/core/task/task_runner/task_runner.py
@@ -1,4 +1,4 @@
-"""TaskRunner 任务执行模块:三模态投递 + 回投。对齐 plan.md §3.5 + tasks.md T4b。
+"""TaskRunner 任务执行模块:三模态投递。对齐 plan.md §3.5 + tasks.md T4b。
 
 Avernet 阶段:form_coop_group stub(不真实 BCS)、start_run stub 投递(记日志,不真实 bot workflow/群/BBS)。
 三类投递后端经 ``set_delivery`` 注入(corp ocb 仓:真实 workflow engine/BCS/BBS 广场);缺省 stub fallback。
@@ -29,7 +29,7 @@ class DeliveryPort(Protocol):
 
 
 class TaskRunner:
-    """将已派发 TaskNode 发送给单 bot/协作群/BBS 执行,并回收状态/详情/结果。
+    """将已派发 TaskNode 发送给单 bot/协作群/BBS 执行。
 
     调用方:编排核(经 TaskService facade 驱动)。一个 start_run(批量)入口三模态自适应。
     三类投递后端经 ``set_delivery(mode, port)`` 注入(corp);缺省 stub 记投递日志返回 True。

--- a/src/backend/tests/community/core/task/e2e/test_e2e.py
+++ b/src/backend/tests/community/core/task/e2e/test_e2e.py
@@ -22,7 +22,6 @@ from agentclaw.community.core.task.domain.models import (
     Status,
     TaskInfo,
     TaskNode,
-    TaskNodePatch,
     TaskSpec,
     TaskCallbackData,
 )
@@ -464,3 +463,14 @@ class TestMissEscalateBbs:
         assert svc._get_node(g, scoped.node_id).status == Status.SUCCESS
         assert svc._get_node(g, "t_case").status == Status.SUCCESS
         assert g.status == Status.SUCCESS
+
+
+# ===== Test 5: dashboard 事件可重放(view 终态断言) =====
+class TestDashboardTerminal:
+    def test_query_result_and_detail(self):
+        facade, svc, *_ = _wire_facade()
+        _exec(facade, _task_info_request("t_case"))
+        _run(facade.callback.report_result(_cb(True, "t_case::N_overview", data="行业全貌")))
+        detail = svc.query_detail(_node("N_overview", "t_case"))
+        assert detail.run_info.output.get("output") == "行业全貌"
+        assert svc.query_result(_node("N_overview", "t_case")).run_info.output.get("output") == "行业全貌"

--- a/src/backend/tests/community/core/task/task_context/test_task_graph_service.py
+++ b/src/backend/tests/community/core/task/task_context/test_task_graph_service.py
@@ -94,6 +94,48 @@ def graph(svc: TaskGraphService):
     return svc.initialize_graph(_task_info())
 
 
+# ===== 状态/详情/结果查询 =====
+class TestStateQueries:
+    def test_query_status_returns_graph_status(self, svc: TaskGraphService, graph):
+        assert svc.query_status("t1") == Status.RUNNING
+        graph.status = Status.DONE
+        assert svc.query_status("t1") == Status.DONE
+
+    def test_query_detail_returns_latest_node(self, svc: TaskGraphService, graph):
+        svc.add_task_nodes([_node("c1")], parent_node_id="t1")
+        svc.update_task_node_info(
+            _patch("t1", "c1", status=Status.RUNNING, run_mode="single_bot", assignee="bot1")
+        )
+        shell = _node("c1")
+        detail = svc.query_detail(shell)
+        assert detail.status == Status.RUNNING
+        assert detail.run_info.run_mode == "single_bot"
+        assert detail.run_info.assignee == "bot1"
+
+    def test_query_detail_unknown_node_returns_input(self, svc: TaskGraphService, graph):
+        shell = _node("unknown")
+        assert svc.query_detail(shell) is shell
+
+    def test_query_result_returns_latest_output(self, svc: TaskGraphService, graph):
+        svc.add_task_nodes([_node("c1")], parent_node_id="t1")
+        svc.update_task_node_info(_patch("t1", "c1", output_patch={"data": "行业全貌"}))
+        assert svc.query_result(_node("c1")).run_info.output == {"data": "行业全貌"}
+
+    def test_query_bot_tasks_matches_loaded_graphs(self, svc: TaskGraphService, graph):
+        svc.add_task_nodes([_node("c1"), _node("c2")], parent_node_id="t1")
+        svc.update_task_node_info(_patch("t1", "c1", run_mode="single_bot", assignee="bot1"))
+        svc.update_task_node_info(_patch("t1", "c2", run_mode="single_bot", assignee="bot2"))
+        svc.initialize_graph(_task_info("t2"))
+        svc.add_task_nodes([_node("c3", "t2")], parent_node_id="t2")
+        svc.update_task_node_info(_patch("t2", "c3", run_mode="single_bot", assignee="bot1"))
+
+        assert {(node.task_id, node.node_id) for node in svc.query_bot_tasks("bot1")} == {
+            ("t1", "c1"),
+            ("t2", "c3"),
+        }
+        assert svc.query_bot_tasks("missing") == []
+
+
 # ===== initialize_graph =====
 class TestInitializeGraph:
     def test_basic(self, svc: TaskGraphService):

--- a/src/backend/tests/community/core/task/task_runner/test_runner.py
+++ b/src/backend/tests/community/core/task/task_runner/test_runner.py
@@ -2,7 +2,7 @@
 
 真实 TaskGraphService 构图场景;Runner 内聚(无额外 stub)。覆盖:
 start_run 三 run_mode 分发(记投递日志/loop_task_id 格式/非法模式 False)、form_coop_group 生成 group_id+记 GroupFormation、
-_build_context 验收/执行双模式自动切换。
+TaskRunner 不暴露状态查询接口、_build_context 验收/执行双模式自动切换。
 """
 from __future__ import annotations
 
@@ -94,6 +94,11 @@ class TestStartRun:
 
         assert _run(runner.start_run([])) == []
         assert runner._run_log == []
+
+    def test_runner_does_not_expose_state_queries(self, svc):
+        runner = TaskRunner(svc)
+        for name in ("query_status", "query_detail", "query_result", "query_bot_tasks"):
+            assert not hasattr(runner, name)
 
     def test_single_bot_dispatched(self, svc, graph):
         runner = TaskRunner(svc)


### PR DESCRIPTION
**Title**

```text
refactor(backend): move task query APIs into task context
```

**Description**

```markdown
## Problem

`TaskRunner` 的职责应聚焦于任务执行与投递，不应同时承担任务状态、详情、结果以及 Bot 任务列表查询。

将 `query_status`、`query_detail`、`query_result` 和 `query_bot_tasks` 放在执行模块中，会混淆任务执行与任务上下文查询的边界，也会让状态查询绕开任务图谱的单一事实来源。

## Solution

- 将以下查询能力统一收口到 `TaskGraphService`：
  - `query_status(task_id)`
  - `query_detail(node)`
  - `query_result(node)`
  - `query_bot_tasks(bot_id)`
- 明确 `TaskRunner` 只负责通过 `start_run` 承接单 Bot、协作群和 BBS 三种执行模态，不再暴露状态查询接口。
- 为 `TaskGraphService` 的新增查询接口补充单元测试和端到端验证。
- 增加边界测试，确保 `TaskRunner` 不再暴露上述查询方法。
- 同步更新任务执行框架的 spec、plan、tasks 和模块 README，使设计文档与代码职责保持一致。

`query_bot_tasks` 当前查询进程内已经加载或 hydrate 的任务图。由于现有 Repository Protocol 尚未提供跨任务枚举能力，本次没有引入新的持久化查询接口。

## Validation

- TaskRunner、TaskGraphService 和任务 E2E 定向测试：85 passed
- TaskRunner、TaskCenter、TaskContext、架构规则及设计守卫测试：464 passed, 5 skipped
- Ruff：通过
- Git diff check：通过
- Pre-push SAST/lint gate：通过

未运行完整 Singlebox coverage/E2E 门禁；本次 pre-push 使用仓库默认的 lint-only 模式。

## Compatibility and risk

本次调整改变了内部模块的接口归属：

- 状态查询调用方需要改为依赖 `TaskGraphService`。
- `TaskRunner.start_run` 及三种执行模态的行为保持不变。
- 不涉及数据库 schema、配置格式或外部 Service API 变更。
- `query_bot_tasks` 暂不保证枚举未加载到当前进程的持久化任务图。

如需回滚，可恢复查询接口原有归属并撤销对应测试和设计文档更新。

## Spec

- `src/backend/specs/2026-08-09-task-goal-driven-execution-framework/spec.md`
- `src/backend/specs/2026-08-09-task-goal-driven-execution-framework/plan.md`
- `src/backend/specs/2026-08-09-task-goal-driven-execution-framework/tasks.md`
```