### PR TITLE
fix(backend): project default MCPs in SkillSet listing

### DIFF
--- a/src/backend/specs/2026-08-20-skill-capability-upgrade/spec.md
+++ b/src/backend/specs/2026-08-20-skill-capability-upgrade/spec.md
@@ -503,7 +503,7 @@ Canonical 前缀：`/openapi/v1/bots/{bot_id}/skill-sets`。
 | POST | `/skill-sets/{set_id}/activate` | 原子激活全部 Skill/MCP，一次 reconcile |
 | POST | `/skill-sets/{set_id}/deactivate` | 原子停用全部 Skill/MCP，一次 reconcile |
 | GET | `/skill-sets/resources` | 所有 Set 的 MCP/Default CLI 聚合 |
-| GET | `/skill-sets/{set_id}/mcps` | MCP Membership |
+| GET | `/skill-sets/{set_id}/mcps` | MCP Membership；Default Set 同时投影 Engine/Template 默认 MCP，并扣除当前 Bot 排除项 |
 | PUT | `/skill-sets/{set_id}/mcps/{server_code}` | 权限校验后添加 MCP |
 | DELETE | `/skill-sets/{set_id}/mcps/{server_code}` | 移除 MCP |
 | GET | `/skill-sets/{set_id}/mcp-permissions` | 聚合显式 MCP 与 Skill 依赖的权限状态 |

--- a/src/backend/src/agentclaw/community/core/skill_center/legacy_skill_set_compatibility.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/legacy_skill_set_compatibility.py
@@ -3,7 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from collections.abc import Mapping
 from typing import Any, Protocol, runtime_checkable
+
+from agentclaw.community.core.repository.protocols.capability_desired_state import (
+    CapabilityDesiredStateRepositoryProtocol,
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -70,3 +75,37 @@ class LegacySkillSetCompatibilityFactoryProtocol(Protocol):
     def create(
         self, *args: Any, **kwargs: Any
     ) -> LegacySkillSetCompatibilityProtocol: ...
+
+
+def list_skill_set_mcp_projection(
+    *,
+    repository: CapabilityDesiredStateRepositoryProtocol,
+    legacy_factory: LegacySkillSetCompatibilityFactoryProtocol,
+    bot: Mapping[str, Any],
+    target: Mapping[str, Any],
+    bot_id: str,
+    owner_id: str,
+    engine_type: str,
+    default_engine_types: tuple[str, ...],
+) -> list[dict[str, Any]]:
+    """Project Default policy MCPs; read ordinary Set membership directly."""
+    if target["is_default"]:
+        legacy = legacy_factory.create(
+            entity_id=str(bot.get("entity_id") or owner_id),
+            bot_id=bot_id,
+            engine_type=engine_type,
+            entity_type=bot.get("entity_type") or "staff",
+        )
+        return legacy.get_set_mcp_servers(
+            str(target["id"]),
+            user_id=owner_id,
+            bot_id=bot_id,
+            engine_type=engine_type,
+        )
+    return repository.list_mcps(
+        bot_id=bot_id,
+        owner_id=owner_id,
+        set_id=str(target["id"]),
+        engine_type=engine_type,
+        default_engine_types=default_engine_types,
+    )

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_management_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_management_service.py
@@ -32,6 +32,7 @@ from agentclaw.community.plugin_api.mcp_center import MCPCenterPlugin
 from agentclaw.community.core.skill_center.legacy_skill_set_compatibility import (
     LegacySkillSetCompatibilityFactoryProtocol,
     LegacySkillSetScope,
+    list_skill_set_mcp_projection,
 )
 from agentclaw.community.core.skill_center.runtime_projection_contract import (
     BotRuntimeProjectorProtocol,
@@ -541,10 +542,14 @@ class SkillSetManagementService(SkillSetManagementServiceProtocol):
         self, *, bot_id: str, owner_id: str, user_id: str, set_id: str
     ) -> list[dict]:
         bot = self._bot(bot_id=bot_id, owner_id=owner_id, user_id=user_id)
-        return self._repository.list_mcps(
+        target = self._target_set(bot=bot, bot_id=bot_id, set_id=set_id)
+        return list_skill_set_mcp_projection(
+            repository=self._repository,
+            legacy_factory=self._legacy_factory,
+            bot=bot,
             bot_id=bot_id,
             owner_id=str(bot["owner_id"]),
-            set_id=set_id,
+            target=target,
             engine_type=self._engine(bot),
             default_engine_types=self._default_engine_types(bot),
         )
@@ -552,7 +557,7 @@ class SkillSetManagementService(SkillSetManagementServiceProtocol):
     def list_mcp_permissions(
         self, *, bot_id: str, owner_id: str, user_id: str, set_id: str
     ) -> list[dict]:
-        mcps = self.list_mcps(
+        mcps = self._list_mcp_memberships(
             bot_id=bot_id,
             owner_id=owner_id,
             user_id=user_id,
@@ -577,7 +582,7 @@ class SkillSetManagementService(SkillSetManagementServiceProtocol):
         set_id: str,
         reason: str,
     ) -> list[dict]:
-        mcps = self.list_mcps(
+        mcps = self._list_mcp_memberships(
             bot_id=bot_id,
             owner_id=owner_id,
             user_id=user_id,
@@ -596,6 +601,20 @@ class SkillSetManagementService(SkillSetManagementServiceProtocol):
             }
             for item in mcps
         ]
+
+    def _list_mcp_memberships(
+        self, *, bot_id: str, owner_id: str, user_id: str, set_id: str
+    ) -> list[dict]:
+        """Read persisted MCP members without expanding Default policy."""
+        bot = self._bot(bot_id=bot_id, owner_id=owner_id, user_id=user_id)
+        target = self._target_set(bot=bot, bot_id=bot_id, set_id=set_id)
+        return self._repository.list_mcps(
+            bot_id=bot_id,
+            owner_id=str(bot["owner_id"]),
+            set_id=str(target["id"]),
+            engine_type=self._engine(bot),
+            default_engine_types=self._default_engine_types(bot),
+        )
 
     async def add_mcp(
         self,
@@ -798,38 +817,18 @@ class SkillSetManagementService(SkillSetManagementServiceProtocol):
             engine_type=self._engine(bot),
             default_engine_types=self._default_engine_types(bot),
         )
-        # Default MCPs are not stored as ordinary ac_skill_set_mcp rows.  The
-        # legacy service combines engine/template defaults, explicit rows, and
-        # ac_default_skillset_mcp_exclusion.  Keep that proven projection for
-        # the published BFF resource response; ordinary Sets stay canonical.
-        legacy = (
-            self._legacy_factory.create(
-                entity_id=str(bot.get("entity_id") or owner_id),
-                bot_id=bot_id,
-                engine_type=self._engine(bot),
-                entity_type=bot.get("entity_type") or "staff",
-            )
-            if any(item["is_default"] for item in items)
-            else None
-        )
         resources: list[dict] = []
         for item in items:
-            if item["is_default"]:
-                assert legacy is not None
-                mcps = legacy.get_set_mcp_servers(
-                    str(item["id"]),
-                    user_id=owner_id,
-                    bot_id=bot_id,
-                    engine_type=self._engine(bot),
-                )
-            else:
-                mcps = self._repository.list_mcps(
-                    bot_id=bot_id,
-                    owner_id=owner_id,
-                    set_id=item["id"],
-                    engine_type=self._engine(bot),
-                    default_engine_types=self._default_engine_types(bot),
-                )
+            mcps = list_skill_set_mcp_projection(
+                repository=self._repository,
+                legacy_factory=self._legacy_factory,
+                bot=bot,
+                bot_id=bot_id,
+                owner_id=owner_id,
+                target=item,
+                engine_type=self._engine(bot),
+                default_engine_types=self._default_engine_types(bot),
+            )
             resources.append(
                 {
                     **item,

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
@@ -1621,6 +1621,11 @@ class SkillSetService:
                     self.skill_set_repo.get_excluded_mcps(user_id, effective_bot_id, int(skill_set_id))
                 )
 
+            associations = [
+                association
+                for association in associations
+                if association.get("server_code") not in excluded_codes
+            ]
             db_codes = {a.get("server_code") for a in associations}
             logger.info(
                 f"[get_set_mcp_servers] skill_set_id={skill_set_id}, is_default=True, "

--- a/src/backend/tests/community/core/skill_center/services/test_skill_set_service.py
+++ b/src/backend/tests/community/core/skill_center/services/test_skill_set_service.py
@@ -227,6 +227,40 @@ class TestGetSetMcpServers:
         codes = {r["server_code"] for r in result}
         assert "mcp.ant.antprocessai.anttaskmcp" not in codes
 
+    def test_default_skillset_excludes_persisted_mcp_membership(self):
+        from agentclaw.community.core.skill_center.services.skill_set_service import SkillSetService
+        mock_repo = MagicMock()
+        mock_repo.get_by_id.return_value = {"id": "1", "is_default": True}
+        mock_repo.get_mcp_servers_in_set.return_value = [
+            {
+                "id": 10,
+                "server_code": "mcp.persisted.default",
+                "name": "persisted",
+                "description": "desc",
+                "icon": None,
+            }
+        ]
+        mock_repo.get_excluded_mcps.return_value = ["mcp.persisted.default"]
+
+        with patch("agentclaw.community.core.skill_center.services.skill_set_service.WorkspacePathFactory"):
+            svc = SkillSetService(
+                skill_repo=MagicMock(),
+                skill_set_repo=MagicMock(),
+                mcp_center=MagicMock(),
+                mcp_config_service=MagicMock(),
+                skill_service=MagicMock(),
+                bot_repo=MagicMock(),
+                path_factory=MagicMock(),
+            )
+        svc.skill_set_repo = mock_repo
+        svc.bot_id = "default"
+
+        result = svc.get_set_mcp_servers("1", user_id="user1")
+
+        assert "mcp.persisted.default" not in {
+            item["server_code"] for item in result
+        }
+
     def test_normal_skillset_returns_db_mcps_only(self):
         from agentclaw.community.core.skill_center.services.skill_set_service import SkillSetService
         mock_repo = MagicMock()

--- a/src/backend/tests/community/core/skill_center/test_skill_set_management_service.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_set_management_service.py
@@ -437,6 +437,13 @@ class _DefaultResourceRepository(_ResourceRepository):
         self.list_set_calls.append(kwargs)
         return [{"id": "global-default", "is_default": True}]
 
+    def get_set(self, **kwargs):
+        return {
+            "id": kwargs["set_id"],
+            "is_default": kwargs["set_id"] == "global-default",
+            "is_active": True,
+        }
+
     def list_mcps(self, **kwargs):
         self.list_mcp_calls.append(kwargs)
         return [{"server_code": "visible-default-mcp"}]
@@ -469,6 +476,7 @@ class _McpAuth:
     def __init__(self, allowed: bool) -> None:
         self.allowed = allowed
         self.calls: list[tuple[str, str]] = []
+        self.apply_calls: list[dict] = []
 
     def check_mcp_permission_detail(self, actor_id: str, server_code: str) -> dict:
         self.calls.append((actor_id, server_code))
@@ -478,6 +486,7 @@ class _McpAuth:
         }
 
     def apply_permission(self, **_kwargs) -> dict:
+        self.apply_calls.append(_kwargs)
         return {"success": True, "process_url": None, "error": None}
 
 
@@ -1674,6 +1683,157 @@ def test_resources_reads_global_default_mcp_projection_for_collaborator_owner_sc
             "engine_type": "openclaw",
         }
     ]
+
+
+def test_list_mcps_reads_global_default_projection_for_collaborator_owner_scope():
+    repository = _DefaultResourceRepository()
+    legacy = _ResourceLegacyFactory()
+    service = SkillSetManagementService(
+        repository=repository,
+        bot_repo=_Bots(),
+        runtime=_SuccessfulRuntime(),
+        legacy_factory=legacy,
+        passport=object(),
+        authorization=_Authorization(),
+        audit_log_repo=_Audit(),
+        mcp_center=_McpCenter(allowed=True),
+        mcp_auth=_McpAuth(allowed=True),
+        ext_info_provider=lambda _bot_id: None,
+    )
+
+    result = service.list_mcps(
+        bot_id="bot-1",
+        owner_id="true-owner",
+        user_id="collaborator",
+        set_id="global-default",
+    )
+
+    assert result == [{"server_code": "legacy-default-mcp"}]
+    assert repository.list_mcp_calls == []
+    assert legacy.service.default_mcp_calls == [
+        {
+            "skill_set_id": "global-default",
+            "user_id": "true-owner",
+            "bot_id": "bot-1",
+            "engine_type": "openclaw",
+        }
+    ]
+
+
+def test_list_mcps_keeps_ordinary_membership_on_canonical_repository_path():
+    repository = _MixedResourceRepository()
+    legacy = _ResourceLegacyFactory()
+    service = SkillSetManagementService(
+        repository=repository,
+        bot_repo=_Bots(),
+        runtime=_SuccessfulRuntime(),
+        legacy_factory=legacy,
+        passport=object(),
+        authorization=_Authorization(),
+        audit_log_repo=_Audit(),
+        mcp_center=_McpCenter(allowed=True),
+        mcp_auth=_McpAuth(allowed=True),
+        ext_info_provider=lambda _bot_id: None,
+    )
+
+    result = service.list_mcps(
+        bot_id="bot-1",
+        owner_id="true-owner",
+        user_id="true-owner",
+        set_id="ordinary-set",
+    )
+
+    assert result == [{"server_code": "ordinary-set-mcp"}]
+    assert legacy.calls == []
+    assert repository.list_mcp_calls == [
+        {
+            "bot_id": "bot-1",
+            "owner_id": "true-owner",
+            "set_id": "ordinary-set",
+            "engine_type": "openclaw",
+            "default_engine_types": ("openclaw",),
+        }
+    ]
+
+
+def test_default_mcp_permissions_remain_scoped_to_persisted_membership():
+    repository = _DefaultResourceRepository()
+    legacy = _ResourceLegacyFactory()
+    mcp_center = _McpCenter(allowed=True)
+    service = SkillSetManagementService(
+        repository=repository,
+        bot_repo=_Bots(),
+        runtime=_SuccessfulRuntime(),
+        legacy_factory=legacy,
+        passport=object(),
+        authorization=_Authorization(),
+        audit_log_repo=_Audit(),
+        mcp_center=mcp_center,
+        mcp_auth=_McpAuth(allowed=True),
+        ext_info_provider=lambda _bot_id: None,
+    )
+
+    result = service.list_mcp_permissions(
+        bot_id="bot-1",
+        owner_id="true-owner",
+        user_id="collaborator",
+        set_id="global-default",
+    )
+
+    assert result == [
+        {
+            "server_code": "visible-default-mcp",
+            "has_permission": True,
+            "access_level": "LOCAL",
+        }
+    ]
+    assert mcp_center.calls == [("collaborator", "visible-default-mcp")]
+    assert legacy.calls == []
+
+
+def test_default_mcp_permission_request_does_not_expand_platform_defaults():
+    repository = _DefaultResourceRepository()
+    legacy = _ResourceLegacyFactory()
+    mcp_auth = _McpAuth(allowed=True)
+    service = SkillSetManagementService(
+        repository=repository,
+        bot_repo=_Bots(),
+        runtime=_SuccessfulRuntime(),
+        legacy_factory=legacy,
+        passport=object(),
+        authorization=_Authorization(),
+        audit_log_repo=_Audit(),
+        mcp_center=_McpCenter(allowed=True),
+        mcp_auth=mcp_auth,
+        ext_info_provider=lambda _bot_id: None,
+    )
+
+    result = service.request_mcp_permissions(
+        bot_id="bot-1",
+        owner_id="true-owner",
+        user_id="collaborator",
+        set_id="global-default",
+        reason="needed",
+    )
+
+    assert result == [
+        {
+            "server_code": "visible-default-mcp",
+            "success": True,
+            "process_url": None,
+            "error": None,
+        }
+    ]
+    assert mcp_auth.apply_calls == [
+        {
+            "staff_no": "collaborator",
+            "service_code": "visible-default-mcp",
+            "tool_list": [],
+            "is_public": True,
+            "reason": "needed",
+        }
+    ]
+    assert legacy.calls == []
 
 
 def test_resources_keeps_ordinary_mcp_membership_on_canonical_repository_path():

--- a/src/backend/tests/community/endpoints/test_openapi_skill_sets.py
+++ b/src/backend/tests/community/endpoints/test_openapi_skill_sets.py
@@ -939,6 +939,21 @@ def _seed_excluded_default_mcp(world) -> None:
         )
 
 
+def _seed_excluded_platform_default_mcp(world) -> None:
+    _seed_default_member(world)
+    server_code = "mcp.ant.antprocessai.anttaskmcp"
+    with avernet_tenant_scope(_TENANT):
+        world.get(CapabilityDesiredStateRepositoryProtocol).exclude_default_mcp(
+            bot_id=_BOT_ID,
+            owner_id=_OWNER,
+            set_id="2",
+            server_code=server_code,
+            engine_type="openclaw",
+            default_engine_types=("openclaw",),
+            platform_default_codes=frozenset({server_code}),
+        )
+
+
 def _excluded_skill_ids(world) -> set[int]:
     with avernet_tenant_scope(_TENANT):
         return world.get(
@@ -971,6 +986,63 @@ def _assert_mcp_excluded(_response, world) -> None:
 def _assert_mcp_unexcluded(_response, world) -> None:
     assert _excluded_mcp_codes(world) == set()
     _assert_reconciled(_response, world)
+
+
+def _assert_default_mcp_projection(response, _world) -> None:
+    codes = {item["server_code"] for item in response.json()["data"]}
+    assert "mcp.default" in codes
+    assert "mcp.ant.antprocessai.anttaskmcp" in codes
+
+
+def _assert_excluded_default_mcp_absent(response, _world) -> None:
+    codes = {item["server_code"] for item in response.json()["data"]}
+    assert "mcp.ant.antprocessai.anttaskmcp" not in codes
+    assert "mcp.ant.arkai.dimamcpserver" in codes
+
+
+def _assert_excluded_persisted_default_mcp_absent(response, _world) -> None:
+    codes = {item["server_code"] for item in response.json()["data"]}
+    assert "mcp.default" not in codes
+    assert "mcp.ant.antprocessai.anttaskmcp" in codes
+
+
+@_case(
+    "GET",
+    "/openapi/v1/bots/{bot_id}/skill-sets/{set_id}/mcps",
+    "lists_default_members_and_platform_defaults",
+    ExpectSuccess(status=200),
+    seed=_seed_default_member,
+    path_params=_DEFAULT_SET_PARAMS,
+    extra=(_assert_default_mcp_projection,),
+)
+def list_default_mcps_projects_platform_defaults():
+    """Default Set reads include code policy as well as persisted members."""
+
+
+@_case(
+    "GET",
+    "/openapi/v1/bots/{bot_id}/skill-sets/{set_id}/mcps",
+    "filters_excluded_default_mcp",
+    ExpectSuccess(status=200),
+    seed=_seed_excluded_platform_default_mcp,
+    path_params=_DEFAULT_SET_PARAMS,
+    extra=(_assert_excluded_default_mcp_absent,),
+)
+def list_default_mcps_filters_bot_exclusions():
+    """A Bot exclusion hides that Default Set MCP from the read projection."""
+
+
+@_case(
+    "GET",
+    "/openapi/v1/bots/{bot_id}/skill-sets/{set_id}/mcps",
+    "filters_excluded_persisted_default_mcp",
+    ExpectSuccess(status=200),
+    seed=_seed_excluded_default_mcp,
+    path_params=_DEFAULT_SET_PARAMS,
+    extra=(_assert_excluded_persisted_default_mcp_absent,),
+)
+def list_default_mcps_filters_persisted_membership_exclusions():
+    """Default exclusions apply to persisted members and code policy alike."""
 
 
 @_case(


### PR DESCRIPTION
## Problem

`GET /openapi/v1/bots/{bot_id}/skill-sets/{set_id}/mcps` returned only persisted `ac_skill_set_mcp` rows. A System Default SkillSet therefore appeared empty when its MCPs came from the Engine/Template `_defaults` policy. The existing Default projection also failed to hide an excluded MCP when that MCP had a persisted Default membership row.

## Solution

- Route Default Set reads through the established compatibility projection: persisted Default membership plus Engine/Template defaults, minus the addressed Bot's exclusions.
- Keep ordinary Set listing on the canonical membership repository.
- Keep MCP permission inspection and permission application membership-scoped so this read fix cannot apply for every platform default MCP.
- Share the same projection helper with `/skill-sets/resources` and document the Default Set exception in the Phase 2 contract.

## Validation

- `169 passed`: SkillSet management, legacy Default projection, MCP defaults, OpenAPI SkillSet adapter, and architecture tests.
- `3 passed`: live endpoint-framework cases for platform defaults, platform-default exclusions, and persisted-default exclusions.
- `ruff check`: passed for every changed Python file.
- changed-file Python SAST: passed.
- Standards/Spec review: no remaining findings.
- Full Community suite reached `17751 passed, 60 skipped`; its single failure was the 1000-line architecture cap after the first implementation. The helper was moved to the existing compatibility seam, and the failed architecture gate plus all affected suites were rerun successfully.

## Compatibility and risk

No database or response-schema change. Ordinary SkillSets and MCP permission operations retain their previous behavior. The pinned Gateway OpenAPI artifact is unchanged because the wire shape is unchanged; regenerating it currently includes unrelated repository-wide artifact drift. OCB `dev` was checked at gitlink `8aaec59e`; no Corp override of this path exists, so OCB only needs the normal Avernet gitlink update after merge.
