### PR TITLE
chore(skill-center): add actionable MCP projection timing logs

### DIFF
--- a/src/backend/src/agentclaw/community/core/skill_center/services/bot_runtime_projector.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/bot_runtime_projector.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import time
 from collections.abc import Mapping, Sequence
-import time
 
 from injector import inject
 
@@ -423,13 +422,33 @@ class BotRuntimeProjector(BotRuntimeProjectorProtocol):
         # Resolved here, with the other pre-flight checks, because it can fail:
         # doing it at the Passport call would abort after the device allow-list
         # was already written, and compensation would hit the same failure.
-        identity_modes = self._resolve_mcp_identity_modes(
-            bot=bot, bot_id=bot_id, engine=engine
+        started_at = time.perf_counter()
+        try:
+            identity_modes = self._resolve_mcp_identity_modes(
+                bot=bot, bot_id=bot_id, engine=engine
+            )
+        except Exception:
+            self._log_plan_timing(
+                stage="resolve_mcp_identity_modes",
+                bot_id=bot_id,
+                engine=engine,
+                started_at=started_at,
+                outcome="error",
+            )
+            raise
+        self._log_plan_timing(
+            stage="resolve_mcp_identity_modes",
+            bot_id=bot_id,
+            engine=engine,
+            started_at=started_at,
+            outcome="success",
+            mcp_count=len(identity_modes),
         )
         # The legacy SkillSet service remains the authority for effective
         # System Defaults during Phase 1. It resolves template presets and
         # applies ac_default_skillset_mcp_exclusion.
         try:
+            started_at = time.perf_counter()
             effective_mcp_entries = service.collect_bot_active_mcps(
                 entity_id=str(bot.get("entity_id") or owner_id),
                 bot_id=bot_id,
@@ -439,32 +458,88 @@ class BotRuntimeProjector(BotRuntimeProjectorProtocol):
                 strict_policy_context=True,
             )
         except Exception as exc:
+            self._log_plan_timing(
+                stage="collect_effective_mcps", bot_id=bot_id, engine=engine,
+                started_at=started_at, outcome="error",
+            )
             raise SkillSetRuntimeReconcileError() from exc
+        self._log_plan_timing(
+            stage="collect_effective_mcps", bot_id=bot_id, engine=engine,
+            started_at=started_at, outcome="success", mcp_count=len(effective_mcp_entries),
+        )
         effective_default_mcp_codes = frozenset(
             str(item.get("server_code") or item.get("serverCode") or "").strip()
             for item in effective_mcp_entries
             if item.get("server_code") or item.get("serverCode")
         )
         try:
+            started_at = time.perf_counter()
             # Passport is the authority for the effective Default CLI scope.
             effective_cli_items = self._passport.query_passport_clis(bot_id, owner_id)
         except Exception as exc:
-            raise SkillSetRuntimeReconcileError() from exc
-        projection = RuntimeProjectionResolver().resolve(
-            RuntimeDesiredState(
-                skills=skill_plan.projection.skill_assets,
-                installed_mcp_server_codes=frozenset(
-                    self._repository.list_installed_mcps(
-                        bot_id=bot_id, owner_id=owner_id
-                    )
-                ),
-                system_default_mcp_server_codes=effective_default_mcp_codes,
-                system_default_cli_commands=tuple(
-                    str(item["cli_code"])
-                    for item in effective_cli_items
-                    if item.get("cli_code")
-                ),
+            self._log_plan_timing(
+                stage="query_passport_clis", bot_id=bot_id, engine=engine,
+                started_at=started_at, outcome="error",
             )
+            raise SkillSetRuntimeReconcileError() from exc
+        self._log_plan_timing(
+            stage="query_passport_clis", bot_id=bot_id, engine=engine,
+            started_at=started_at, outcome="success", cli_count=len(effective_cli_items),
+        )
+        started_at = time.perf_counter()
+        try:
+            installed_mcp_codes = frozenset(
+                self._repository.list_installed_mcps(
+                    bot_id=bot_id, owner_id=owner_id
+                )
+            )
+        except Exception:
+            self._log_plan_timing(
+                stage="read_installed_mcps",
+                bot_id=bot_id,
+                engine=engine,
+                started_at=started_at,
+                outcome="error",
+            )
+            raise
+        self._log_plan_timing(
+            stage="read_installed_mcps",
+            bot_id=bot_id,
+            engine=engine,
+            started_at=started_at,
+            outcome="success",
+            mcp_count=len(installed_mcp_codes),
+        )
+        started_at = time.perf_counter()
+        try:
+            projection = RuntimeProjectionResolver().resolve(
+                RuntimeDesiredState(
+                    skills=skill_plan.projection.skill_assets,
+                    installed_mcp_server_codes=installed_mcp_codes,
+                    system_default_mcp_server_codes=effective_default_mcp_codes,
+                    system_default_cli_commands=tuple(
+                        str(item["cli_code"])
+                        for item in effective_cli_items
+                        if item.get("cli_code")
+                    ),
+                )
+            )
+        except Exception:
+            self._log_plan_timing(
+                stage="resolve_effective_capabilities",
+                bot_id=bot_id,
+                engine=engine,
+                started_at=started_at,
+                outcome="error",
+            )
+            raise
+        self._log_plan_timing(
+            stage="resolve_effective_capabilities",
+            bot_id=bot_id,
+            engine=engine,
+            started_at=started_at,
+            outcome="success",
+            mcp_count=len(projection.mcp_server_codes),
         )
 
         return ResolvedCapabilityPlan(

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
@@ -3,10 +3,11 @@
 Migrated from: services/openclawserver/server/services/skill_set_service.py
 """
 import asyncio
+import time
 import zlib
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, List, Mapping, Optional
+from typing import TYPE_CHECKING, Any, Callable, List, Mapping, Optional, TypeVar
 
 from agentclaw.community.core.devices.models import SynlinkMappingInfo
 from agentclaw.community.core.devices.services.device_accessor import DeviceAccessor
@@ -60,6 +61,8 @@ SKILLS_REPO_DIR = SKILLS_DIR / "skills-repo"
 SKILLS_LOCAL_DIR = SKILLS_DIR / "skills-local"
 
 logger = get_logger()
+
+_T = TypeVar("_T")
 
 
 def _get_bot_paths(
@@ -1699,34 +1702,63 @@ class SkillSetService:
                 "SkillSetServiceFactory"
             )
         effective_engine = engine_type if engine_type is not None else self.engine_type
-        effective_ext_info = self._get_default_capabilities_ext_info(
-            effective_engine,
-            bot_id,
-            strict=strict_policy_context,
-        )
-        effective_template_type = self._get_default_capabilities_template_type(
-            bot_id,
-            strict=strict_policy_context,
-        )
-        active_skill_sets = self._get_all_active_skill_sets_with_default_fallback(
-            user_id=entity_id,
-            bolt_id=bot_id,
+        effective_ext_info = self._run_effective_mcp_stage(
+            stage="default_ext_info",
+            bot_id=bot_id,
             engine_type=effective_engine,
+            operation=lambda: self._get_default_capabilities_ext_info(
+                effective_engine,
+                bot_id,
+                strict=strict_policy_context,
+            ),
+            report_has_value=True,
+        )
+        effective_template_type = self._run_effective_mcp_stage(
+            stage="default_template_type",
+            bot_id=bot_id,
+            engine_type=effective_engine,
+            operation=lambda: self._get_default_capabilities_template_type(
+                bot_id,
+                strict=strict_policy_context,
+            ),
+            report_has_value=True,
+        )
+        active_skill_sets = self._run_effective_mcp_stage(
+            stage="active_skill_sets",
+            bot_id=bot_id,
+            engine_type=effective_engine,
+            operation=lambda: self._get_all_active_skill_sets_with_default_fallback(
+                user_id=entity_id,
+                bolt_id=bot_id,
+                engine_type=effective_engine,
+            ),
+            item_count=len,
         )
 
         # This Bot's exclusions silence a Default member entirely — the row
         # half too: ``get_set_mcp_servers`` filters only the static default
         # codes, and the flush already treats an exclusion as the Default
         # Set's per-Bot deactivation.
-        excluded_codes = set(self.skill_set_repo.get_all_excluded_mcps(user_id, bot_id))
+        excluded_codes = self._run_effective_mcp_stage(
+            stage="default_mcp_exclusions",
+            bot_id=bot_id,
+            engine_type=effective_engine,
+            operation=lambda: set(
+                self.skill_set_repo.get_all_excluded_mcps(user_id, bot_id)
+            ),
+            item_count=len,
+        )
 
         # Each phase appends entries and marks their codes in
         # ``seen_server_codes``, so a later phase never duplicates an earlier
         # one; ordering is the union's precedence (rows, policy, installed).
         active_mcps: List[dict] = []
         seen_server_codes: set = set()
-        active_mcps.extend(
-            self._default_set_mcp_rows(
+        default_set_rows = self._run_effective_mcp_stage(
+            stage="default_set_mcp_rows",
+            bot_id=bot_id,
+            engine_type=effective_engine,
+            operation=lambda: self._default_set_mcp_rows(
                 active_skill_sets,
                 user_id=user_id,
                 bot_id=bot_id,
@@ -1735,40 +1767,128 @@ class SkillSetService:
                 ext_info=effective_ext_info,
                 excluded_codes=excluded_codes,
                 seen_server_codes=seen_server_codes,
-            )
+            ),
+            item_count=len,
         )
-        active_mcps.extend(
-            self._default_policy_mcp_entries(
+        active_mcps.extend(default_set_rows)
+        default_policy_entries = self._run_effective_mcp_stage(
+            stage="default_policy_mcp_entries",
+            bot_id=bot_id,
+            engine_type=effective_engine,
+            operation=lambda: self._default_policy_mcp_entries(
                 engine_type=effective_engine,
                 template_type=effective_template_type,
                 ext_info=effective_ext_info,
                 excluded_codes=excluded_codes,
                 seen_server_codes=seen_server_codes,
-            )
+            ),
+            item_count=len,
         )
-        effective_non_default_codes = resolve_effective_mcp_server_codes(
-            RuntimeDesiredState(
-                skills=self._active_skill_assets(
-                    entity_id=entity_id, bot_id=bot_id, user_id=user_id
-                ),
-                installed_mcp_server_codes=self._installed_mcp_codes(
-                    entity_id=entity_id, bot_id=bot_id, user_id=user_id
-                ),
-            )
+        active_mcps.extend(default_policy_entries)
+        active_skill_assets = self._run_effective_mcp_stage(
+            stage="active_skill_assets",
+            bot_id=bot_id,
+            engine_type=effective_engine,
+            operation=lambda: self._active_skill_assets(
+                entity_id=entity_id, bot_id=bot_id, user_id=user_id
+            ),
+            item_count=len,
         )
-        active_mcps.extend(
-            self._non_default_effective_mcp_entries(
+        installed_mcp_codes = self._run_effective_mcp_stage(
+            stage="installed_mcp_codes",
+            bot_id=bot_id,
+            engine_type=effective_engine,
+            operation=lambda: self._installed_mcp_codes(
+                entity_id=entity_id, bot_id=bot_id, user_id=user_id
+            ),
+            item_count=len,
+        )
+        effective_non_default_codes = self._run_effective_mcp_stage(
+            stage="resolve_non_default_codes",
+            bot_id=bot_id,
+            engine_type=effective_engine,
+            operation=lambda: resolve_effective_mcp_server_codes(
+                RuntimeDesiredState(
+                    skills=active_skill_assets,
+                    installed_mcp_server_codes=installed_mcp_codes,
+                )
+            ),
+            item_count=len,
+        )
+        non_default_entries = self._run_effective_mcp_stage(
+            stage="non_default_mcp_entries",
+            bot_id=bot_id,
+            engine_type=effective_engine,
+            operation=lambda: self._non_default_effective_mcp_entries(
                 effective_codes=effective_non_default_codes,
                 active_skill_sets=active_skill_sets,
                 seen_server_codes=seen_server_codes,
-            )
+            ),
+            item_count=len,
         )
+        active_mcps.extend(non_default_entries)
 
         logger.info(
             f"[collect_bot_active_mcps] bot_id={bot_id}, engine_type={effective_engine}, "
             f"total_mcps={len(active_mcps)}, codes={[m.get('server_code') for m in active_mcps]}"
         )
         return active_mcps
+
+    def _run_effective_mcp_stage(
+        self,
+        *,
+        stage: str,
+        bot_id: str,
+        engine_type: str | None,
+        operation: Callable[[], _T],
+        item_count: Callable[[_T], int] | None = None,
+        report_has_value: bool = False,
+    ) -> _T:
+        started_at = time.perf_counter()
+        try:
+            result = operation()
+        except Exception:
+            self._log_effective_mcp_timing(
+                stage=stage,
+                bot_id=bot_id,
+                engine_type=engine_type,
+                started_at=started_at,
+                outcome="error",
+            )
+            raise
+        self._log_effective_mcp_timing(
+            stage=stage,
+            bot_id=bot_id,
+            engine_type=engine_type,
+            started_at=started_at,
+            outcome="success",
+            item_count=item_count(result) if item_count is not None else None,
+            has_value=result is not None if report_has_value else None,
+        )
+        return result
+
+    @staticmethod
+    def _log_effective_mcp_timing(
+        *,
+        stage: str,
+        bot_id: str,
+        engine_type: str | None,
+        started_at: float,
+        outcome: str,
+        item_count: int | None = None,
+        has_value: bool | None = None,
+    ) -> None:
+        logger.info(
+            "[collect_bot_active_mcps] timing stage=%s bot_id=%s engine_type=%s "
+            "duration_ms=%s outcome=%s item_count=%s has_value=%s",
+            stage,
+            bot_id,
+            engine_type,
+            round((time.perf_counter() - started_at) * 1000),
+            outcome,
+            item_count,
+            has_value,
+        )
 
     def _default_set_mcp_rows(
         self,

--- a/src/backend/tests/community/core/skill_center/services/test_skill_set_service.py
+++ b/src/backend/tests/community/core/skill_center/services/test_skill_set_service.py
@@ -1,4 +1,5 @@
 """Tests for agentclaw.community.core.services.skill_set_service.SkillSetService."""
+import logging
 from unittest.mock import patch, MagicMock, AsyncMock
 
 import pytest
@@ -259,7 +260,7 @@ class TestGetSetMcpServers:
 class TestCollectBotActiveMcps:
     """collect_bot_active_mcps filters out user-excluded default MCPs."""
 
-    def test_collect_excludes_user_excluded_default_mcps(self):
+    def test_collect_excludes_user_excluded_default_mcps(self, caplog):
         from agentclaw.community.core.skill_center.services.skill_set_service import SkillSetService
         mock_repo = MagicMock()
         mock_repo.get_all_active_skill_sets.return_value = [
@@ -287,12 +288,118 @@ class TestCollectBotActiveMcps:
         svc.skill_set_repo = mock_repo
         svc.bot_id = "default"
 
+        caplog.set_level(logging.INFO)
         with patch.object(svc, "get_set_mcp_servers") as mock_get_mcps:
             mock_get_mcps.return_value = []
             result = svc.collect_bot_active_mcps("entity1", "default", "user1", "staff")
 
         codes = {r["server_code"] for r in result}
         assert "mcp.ant.antprocessai.anttaskmcp" not in codes
+        messages = [record.getMessage() for record in caplog.records]
+        for stage in (
+            "default_ext_info",
+            "active_skill_sets",
+            "default_mcp_exclusions",
+            "active_skill_assets",
+            "installed_mcp_codes",
+            "resolve_non_default_codes",
+        ):
+            assert any(
+                "[collect_bot_active_mcps] timing" in message
+                and f"stage={stage}" in message
+                and "duration_ms=" in message
+                and "outcome=success" in message
+                for message in messages
+            )
+
+    def test_collect_logs_stage_error_before_reraising(self, caplog):
+        from agentclaw.community.core.skill_center.services.skill_set_service import (
+            SkillSetService,
+        )
+
+        mock_repo = MagicMock()
+        mock_repo.get_all_active_skill_sets.return_value = []
+        mock_repo.get_all_excluded_mcps.return_value = []
+        svc = SkillSetService(
+            skill_repo=MagicMock(),
+            skill_set_repo=mock_repo,
+            mcp_center=MagicMock(),
+            mcp_config_service=MagicMock(),
+            skill_service=MagicMock(),
+            bot_repo=MagicMock(),
+            path_factory=MagicMock(),
+            reader=MagicMock(),
+        )
+        failure = RuntimeError("active skill read failed")
+
+        caplog.set_level(logging.INFO)
+        with (
+            patch.object(svc, "_active_skill_assets", side_effect=failure),
+            pytest.raises(RuntimeError, match="active skill read failed"),
+        ):
+            svc.collect_bot_active_mcps("entity1", "bot-1", "user1", "staff")
+
+        messages = [record.getMessage() for record in caplog.records]
+        assert any(
+            "[collect_bot_active_mcps] timing" in message
+            and "stage=active_skill_assets" in message
+            and "outcome=error" in message
+            for message in messages
+        )
+
+    def test_collect_logs_each_enrichment_cardinality(self, caplog):
+        from agentclaw.community.core.skill_center.services.skill_set_service import (
+            SkillSetService,
+        )
+
+        svc = SkillSetService(
+            skill_repo=MagicMock(),
+            skill_set_repo=MagicMock(),
+            mcp_center=MagicMock(),
+            mcp_config_service=MagicMock(),
+            skill_service=MagicMock(),
+            bot_repo=MagicMock(),
+            path_factory=MagicMock(),
+            reader=MagicMock(),
+        )
+        caplog.set_level(logging.INFO)
+        with (
+            patch.object(
+                svc,
+                "_get_all_active_skill_sets_with_default_fallback",
+                return_value=[],
+            ),
+            patch.object(svc.skill_set_repo, "get_all_excluded_mcps", return_value=[]),
+            patch.object(
+                svc,
+                "_default_set_mcp_rows",
+                return_value=[{"server_code": "default-row"}],
+            ),
+            patch.object(
+                svc,
+                "_default_policy_mcp_entries",
+                return_value=[{"server_code": "default-policy"}],
+            ),
+            patch.object(svc, "_active_skill_assets", return_value=[]),
+            patch.object(svc, "_installed_mcp_codes", return_value={"direct"}),
+            patch.object(
+                svc,
+                "_non_default_effective_mcp_entries",
+                return_value=[{"server_code": "direct"}],
+            ),
+        ):
+            svc.collect_bot_active_mcps("entity1", "bot-1", "user1", "staff")
+
+        messages = [record.getMessage() for record in caplog.records]
+        for stage in (
+            "default_set_mcp_rows",
+            "default_policy_mcp_entries",
+            "non_default_mcp_entries",
+        ):
+            assert any(
+                f"stage={stage}" in message and "item_count=1" in message
+                for message in messages
+            )
 
     def test_get_bot_mcp_codes_for_env_uses_only_explicit_env_repository_reads(self):
         from agentclaw.community.core.skill_center.services.skill_set_service import (

--- a/src/backend/tests/community/core/skill_center/test_bot_runtime_projector_timing.py
+++ b/src/backend/tests/community/core/skill_center/test_bot_runtime_projector_timing.py
@@ -2,9 +2,14 @@ from __future__ import annotations
 
 import logging
 
+import pytest
+
 from agentclaw.community.core.skill_center.runtime_projection_contract import (
     ProjectionScope,
     ResolvedCapabilityPlan,
+)
+from agentclaw.community.core.skill_center.runtime_resolver import (
+    RuntimeProjectionResolver,
 )
 from agentclaw.community.core.skill_center.services.bot_runtime_projector import (
     BotRuntimeProjector,
@@ -63,8 +68,8 @@ class _IdentityRepository:
         return {}
 
 
-def test_runtime_projector_logs_skill_and_mcp_plan_timing(caplog) -> None:
-    projector = BotRuntimeProjector(
+def _projector() -> BotRuntimeProjector:
+    return BotRuntimeProjector(
         factory=_Factory(),
         bot_repo=_Bots(),
         repository=_Repository(),
@@ -73,6 +78,10 @@ def test_runtime_projector_logs_skill_and_mcp_plan_timing(caplog) -> None:
         passport=_Passport(),
         caller_identity_repo=_IdentityRepository(),
     )
+
+
+def test_runtime_projector_logs_skill_and_mcp_plan_timing(caplog) -> None:
+    projector = _projector()
     caplog.set_level(logging.INFO)
 
     plan = projector._resolve_plan(
@@ -83,11 +92,61 @@ def test_runtime_projector_logs_skill_and_mcp_plan_timing(caplog) -> None:
 
     assert isinstance(plan, ResolvedCapabilityPlan)
     messages = [record.getMessage() for record in caplog.records]
-    for stage in ("build_skill_plan", "build_mcp_plan"):
+    for stage in (
+        "build_skill_plan",
+        "build_mcp_plan",
+        "resolve_mcp_identity_modes",
+        "collect_effective_mcps",
+        "query_passport_clis",
+        "read_installed_mcps",
+        "resolve_effective_capabilities",
+    ):
         assert any(
             "[BotRuntimeProjector] timing" in message
             and f"stage={stage}" in message
             and "bot_id=bot-1" in message
             and "duration_ms=" in message
+            and "outcome=success" in message
             for message in messages
         )
+
+
+@pytest.mark.parametrize(
+    "stage",
+    (
+        "resolve_mcp_identity_modes",
+        "read_installed_mcps",
+        "resolve_effective_capabilities",
+    ),
+)
+def test_runtime_projector_logs_substage_errors(
+    caplog, monkeypatch, stage: str
+) -> None:
+    projector = _projector()
+    failure = RuntimeError(stage)
+
+    def fail(*_args, **_kwargs):
+        raise failure
+
+    if stage == "resolve_mcp_identity_modes":
+        monkeypatch.setattr(projector, "_resolve_mcp_identity_modes", fail)
+    elif stage == "read_installed_mcps":
+        monkeypatch.setattr(projector._repository, "list_installed_mcps", fail)
+    else:
+        monkeypatch.setattr(RuntimeProjectionResolver, "resolve", fail)
+
+    caplog.set_level(logging.INFO)
+    with pytest.raises(RuntimeError, match=stage):
+        projector._resolve_plan(
+            bot_id="bot-1",
+            owner_id="owner-1",
+            scope=ProjectionScope(skills=True, mcp=True),
+        )
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert any(
+        "[BotRuntimeProjector] timing" in message
+        and f"stage={stage}" in message
+        and "outcome=error" in message
+        for message in messages
+    )


### PR DESCRIPTION
## Problem

Desktop Bot MCP mutations synchronously rebuild effective MCP state and project it to device and Passport consumers. Existing logs expose only broad projection duration, so slow Default policy, Installation, identity, Passport, or final resolution stages cannot be attributed. The original delivery PR #1830 was closed because its old required-check state no longer converged.

## Solution

- Add duration, outcome, and stage-local cardinality logs for Default capability lookup, active Sets, exclusions, active Skills, installed MCPs, and non-default enrichment.
- Add Projector timings for identity resolution, effective MCP collection, Passport CLI reads, Installation MCP reads, and final capability resolution.
- Record the exact failing substage before re-raising the original exception.
- Preserve query order, writes, Runtime calls, response contracts, and projection behavior.

## Validation

- `uv run ruff check` on the four changed files: passed.
- Focused Skill Center tests: 37 passed.
- Architecture module-boundary tests: 3 passed.
- Full Avernet Backend suite: 17,749 passed, 60 skipped.
- OCB `origin/dev@642358c13e` with `ocb-public` temporarily pointed to this commit: Corp compose equivalence, MCP adapter, DI binding parity, and Service API conformance: 61 passed.
- Standards/Spec dual review completed. The initial error-stage and cumulative-cardinality findings were fixed; both axes passed on re-review.

## Compatibility and risk

No API, DDL, cache, ordering, or Runtime-delivery behavior changes. The change adds INFO logs only. OCB validation proves the current Corp composition and contract tests accept the updated community implementation; it is not deployment or live-environment proof.

## Related issues

Supersedes closed PR #1830.
