### PR TITLE
fix(backend): synchronize BCS bot publication state to BCSFuse

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_public/README.md
+++ b/src/backend/src/agentclaw/community/core/bot_public/README.md
@@ -40,3 +40,25 @@ internal_dependencies:
 ### Change impact
 
 Owns visible-to-other-users state; bugs here can leak unpublished bots or block legitimate publication. The approval callback path crosses with core/antprocess.
+
+### BCSFuse publication synchronization
+
+- Legacy `POST /api/bots/{bot_id}/public` syncs user publication through
+  `PUT /v1/workers/{worker_id}/{online|offline}`. Community defaults to the
+  bare bot ID; internal Backend overlays must set
+  `user_config.bcsfuse.worker_id_with_owner: true` for `bot_id:owner_id`.
+- `POST /openapi/v1/collaboration/bots/{bot_uuid}/public` uses the exact BCS
+  UUID, independently of that legacy ID configuration. For `public_scope=user`,
+  Backend syncs runtime state only after the BCS attribute PATCH succeeds:
+  private becomes offline, public/protected become online. Approval submission,
+  rejection, cancellation, and skipped/failed BCS writes do not change runtime.
+- For `public_scope=agent`, the BCS Provider attributes PATCH dispatches the
+  existing visibility sync after persisting `visibility`. BCS sends
+  `POST /v1/workers/{bot_uuid}/sync` with `availability` set to the persisted
+  visibility; it does not overwrite user-publication runtime state. This needs
+  BCS's `bcsfuse.enabled` configuration and deployment of the updated BCS runtime.
+- BCSFuse failure remains best-effort and is logged. User-publication logs use
+  `[_sync_bcsfuse_runtime_state]` with the exact `worker_id`; Agent-publication
+  logs live in BCS (`Worker synced to bcsfuse` / `Worker sync failed, retrying`).
+  Successful publication is not proof of downstream synchronization; use these
+  logs and the BCSFuse worker record when verifying a rollout.

--- a/src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py
@@ -388,6 +388,17 @@ class BotPublicService(BotPublicServiceProtocol):
         self, bot_id: str, owner_id: str, public: str
     ) -> None:
         """Best-effort sync bot visibility to BCSFuse runtime state."""
+        worker_id = (
+            f"{bot_id}:{owner_id}"
+            if self._bcsfuse_config.worker_id_with_owner is True
+            else bot_id
+        )
+        self._sync_bcsfuse_worker_runtime_state(bot_id, worker_id, public)
+
+    def _sync_bcsfuse_worker_runtime_state(
+        self, bot_id: str, worker_id: str, public: str
+    ) -> None:
+        """Sync an exact worker identity; BCS UUIDs must not be qualified again."""
         base_url = self._resolve_bcsfuse_base_url()
         if not base_url:
             logger.info(
@@ -399,11 +410,6 @@ class BotPublicService(BotPublicServiceProtocol):
             return
 
         runtime_state = "online" if public == "1" else "offline"
-        worker_id = (
-            f"{bot_id}:{owner_id}"
-            if self._bcsfuse_config.worker_id_with_owner is True
-            else bot_id
-        )
         url = f"{base_url}/v1/workers/{worker_id}/{runtime_state}"
         request = Request(url, data=b"", method="PUT")
         request.add_header("Content-Type", "application/json")
@@ -929,6 +935,8 @@ class BotPublicService(BotPublicServiceProtocol):
         # provider creds (non prod/pre); report that truthfully as SKIPPED
         # instead of faking COMPLETED.
         skipped = isinstance(patched, dict) and bool(patched.get("skipped"))
+        if public_scope == "user" and not skipped:
+            self._sync_bcsfuse_worker_runtime_state(bot_uid, bot_uid, "0")
         return {
             "success": True,
             "state": "SKIPPED" if skipped else "COMPLETED",
@@ -985,7 +993,11 @@ class BotPublicService(BotPublicServiceProtocol):
             friend_ext[_BCS_VIEW_SCOPE_DEPS_KEY_BY_SCOPE[public_scope]] = (
                 block.get("view_friend_deps") or []
             )
-        self._bcn_service.patch_attributes(bot_uuid=bot_uid, body=body)
+        patched = self._bcn_service.patch_attributes(bot_uuid=bot_uid, body=body)
+        skipped = isinstance(patched, dict) and bool(patched.get("skipped"))
+        if public_scope == "user" and block["status"] == "AGREE" and not skipped:
+            public = "0" if body["user_visibility"] == "private" else "1"
+            self._sync_bcsfuse_worker_runtime_state(bot_uid, bot_uid, public)
         return {
             "success": True, "public": None,
             "message": f"public_scope={public_scope} callback status={block['status']}",
@@ -1009,10 +1021,8 @@ class BotPublicService(BotPublicServiceProtocol):
         # New-version publish (public_scope non-empty, e.g. "user"/"agent"): the
         # bot's visibility is delegated to BCS, so this callback must NOT flip
         # ac_bots.public or run the passport / auth-relationship / device-sync
-        # side effects of the legacy path. For now we only LOG the would-be BCS
-        # status update; the real call is wired once BCS exposes its internal
-        # (no-auth) API, invoked via httpclient — no end-user cookie is involved
-        # on this callback path. public_scope's value is preserved for that call.
+        # side effects of the legacy path. Persist BCS attributes first, then
+        # sync user publication to BCSFuse using the exact BCS identity.
         if public_scope:
             # New-version callback (public_scope 非空 → bot_id 即 bot_uid):
             # GET friend_ext → 按 public_scope 子块 (public_user_approval/

--- a/src/backend/tests/community/core/bot_public/test_bcs_publication_sync.py
+++ b/src/backend/tests/community/core/bot_public/test_bcs_publication_sync.py
@@ -1,0 +1,134 @@
+"""BCS publication must sync only committed user visibility to BCSFuse."""
+
+from unittest.mock import MagicMock
+from urllib.error import HTTPError
+
+import pytest
+
+from agentclaw.community.core.bot_management.services.bcn_service import BcnServiceError
+from agentclaw.community.plugin_api.approval_workflow import NO_WORKFLOW_MARKER
+from tests.community.core.bot_public.test_bot_public_service import (
+    _make_bot,
+    _make_operator,
+    _make_service,
+)
+
+MODULE = "agentclaw.community.core.bot_public.services.bot_public_service"
+BOT_UUID = "20260902_s1kxfp9l:334018"
+
+
+@pytest.fixture
+def publication(monkeypatch):
+    bcn = MagicMock()
+    bcn.patch_attributes.return_value = {}
+    bcn.get_attributes.return_value = {
+        "friend_ext": {
+            "public_user_approval": {"visibility": "public", "status": "PROCESSING"},
+            "public_agent_approval": {"status": "PROCESSING"},
+        },
+        "friend_check_in_strategy": "OPEN",
+    }
+    config = MagicMock(base_url="http://bcsfuse.test", base_url_pre="", worker_id_with_owner=True)
+    service = _make_service(bcn_service=bcn, bcsfuse_config=config)
+    http = MagicMock()
+    http.return_value.__enter__.return_value.status = 200
+    monkeypatch.setattr(f"{MODULE}.urlopen", http)
+    monkeypatch.setattr(f"{MODULE}.get_current_env", lambda: "prod")
+    return service, bcn, http
+
+
+@pytest.mark.parametrize("qualified", [False, True])
+def test_private_user_syncs_exact_bcs_uuid_after_persistence(publication, qualified):
+    service, bcn, http = publication
+    service._bcsfuse_config.worker_id_with_owner = qualified
+    bcn.patch_attributes.side_effect = lambda **kwargs: assert_no_http_yet(http)
+    result = service.public_bcs_bot(BOT_UUID, "334018", "user", _make_operator(), visibility="private")
+    assert result["state"] == "COMPLETED"
+    bcn.patch_attributes.assert_called_once_with(bot_uuid=BOT_UUID, body={"user_visibility": "private"})
+    http.assert_called_once()
+    request = http.call_args.args[0]
+    assert request.get_method() == "PUT"
+    assert request.full_url == f"http://bcsfuse.test/v1/workers/{BOT_UUID}/offline"
+
+
+def assert_no_http_yet(http):
+    http.assert_not_called()
+    return {}
+
+
+@pytest.mark.parametrize("visibility, state", [("public", "online"), ("protected", "online"), ("private", "offline")])
+def test_agreed_user_callback_syncs_persisted_visibility(publication, visibility, state):
+    service, bcn, http = publication
+    bcn.get_attributes.return_value["friend_ext"]["public_user_approval"]["visibility"] = visibility
+    bcn.patch_attributes.side_effect = lambda **kwargs: assert_no_http_yet(http)
+    result = service.handle_public_approval_callback(BOT_UUID, "334018", "p1", "AGREE", public_scope="user")
+    assert result["success"]
+    assert bcn.patch_attributes.call_args.kwargs["body"]["user_visibility"] == visibility
+    http.assert_called_once()
+    assert http.call_args.args[0].full_url == f"http://bcsfuse.test/v1/workers/{BOT_UUID}/{state}"
+
+
+@pytest.mark.parametrize("scope, decision", [("agent", "AGREE"), ("user", "DISAGREE"), ("user", "CANCEL")])
+def test_other_scope_or_rejection_does_not_change_runtime(publication, scope, decision):
+    service, _, http = publication
+    service.handle_public_approval_callback(BOT_UUID, "334018", "p1", decision, public_scope=scope)
+    http.assert_not_called()
+
+
+def test_private_agent_does_not_change_user_runtime(publication):
+    service, bcn, http = publication
+    service.public_bcs_bot(BOT_UUID, "334018", "agent", _make_operator(), visibility="private")
+    bcn.patch_attributes.assert_called_once_with(bot_uuid=BOT_UUID, body={"visibility": "private"})
+    http.assert_not_called()
+
+
+@pytest.mark.parametrize("callback", [False, True])
+def test_skipped_bcs_patch_does_not_sync(publication, callback):
+    service, bcn, http = publication
+    bcn.patch_attributes.return_value = {"skipped": True}
+    if callback:
+        service.handle_public_approval_callback(BOT_UUID, "334018", "p1", "AGREE", public_scope="user")
+    else:
+        result = service.public_bcs_bot(BOT_UUID, "334018", "user", _make_operator(), visibility="private")
+        assert result["state"] == "SKIPPED"
+    http.assert_not_called()
+
+
+def test_failed_bcs_patch_does_not_sync(publication):
+    service, bcn, http = publication
+    bcn.patch_attributes.side_effect = BcnServiceError("write failed")
+    with pytest.raises(BcnServiceError):
+        service.public_bcs_bot(BOT_UUID, "334018", "user", _make_operator(), visibility="private")
+    http.assert_not_called()
+
+
+def test_pending_approval_does_not_sync(publication):
+    service, _, http = publication
+    service._process_service.start_approval.return_value = {"success": True, "state": "PROCESSING", "puid": "p1"}
+    service.public_bcs_bot(BOT_UUID, "334018", "user", _make_operator(), visibility="public")
+    http.assert_not_called()
+
+
+@pytest.mark.parametrize("approval", [
+    {"success": True, "state": "COMPLETED", "lastOperate": "AGREE", "puid": "p1"},
+    {"success": False, "error_msg": f"{NO_WORKFLOW_MARKER} unavailable"},
+])
+def test_inline_approval_and_community_fallback_sync_user_publication(publication, approval):
+    service, _, http = publication
+    service._bot_repository.get_by_id_and_owner.return_value = _make_bot()
+    service._process_service.start_approval.return_value = approval
+    result = service.public_bcs_bot(BOT_UUID, "334018", "user", _make_operator(), visibility="public")
+    assert result["success"]
+    http.assert_called_once()
+    assert http.call_args.args[0].full_url == f"http://bcsfuse.test/v1/workers/{BOT_UUID}/online"
+
+
+def test_bcsfuse_failure_is_logged_without_reverting_bcs(publication, caplog):
+    service, bcn, http = publication
+    http.side_effect = HTTPError("http://bcsfuse.test", 404, "Worker not found", {}, None)
+    result = service.public_bcs_bot(BOT_UUID, "334018", "user", _make_operator(), visibility="private")
+    assert result["state"] == "COMPLETED"
+    bcn.patch_attributes.assert_called_once()
+    assert "[_sync_bcsfuse_runtime_state]" in caplog.text
+    assert f"worker_id={BOT_UUID}" in caplog.text
+    assert "status=404" in caplog.text

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/bots.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/bots.rs
@@ -922,7 +922,7 @@ fn bot_use_case_error_to_visibility_response(error: BotUseCaseError, bot_uuid: &
     }
 }
 
-async fn dispatch_visibility_sync_after_update(
+pub(super) async fn dispatch_visibility_sync_after_update(
     state: &HttpAppState,
     bot_uuid: &str,
     visibility: &str,

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/providers.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/providers.rs
@@ -378,10 +378,19 @@ pub async fn patch_provider_bot_attributes(
         has_friend_check_in_strategy = body.friend_check_in_strategy.is_some(),
         "Provider Bot attributes patch accepted"
     );
+    let sync_visibility = body.visibility.is_some();
     let attributes = internal_bot_attributes_service(&state)?
         .patch(body.into_command(bot_uuid.clone()))
         .await
         .map_err(internal_attributes_error)?;
+    if sync_visibility {
+        super::bots::dispatch_visibility_sync_after_update(
+            &state,
+            &bot_uuid,
+            &attributes.visibility,
+        )
+        .await;
+    }
     info!(
         provider_id,
         bot_uuid, "Provider Bot attributes patch completed"

--- a/src/bcs/crates/adapters/http/bcs-http/tests/provider_routes_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/provider_routes_contract.rs
@@ -205,6 +205,7 @@ fn test_app_with_options(
     let provider_management = Arc::new(provider_management);
 
     let services = Services::builder()
+        .bot_query(Arc::new(bcs_bot::Bot::new(registry_service.clone())))
         .registry(registry_service)
         .provider_core(provider_core)
         .provider_bot_core(provider_bot_core)
@@ -3098,6 +3099,57 @@ async fn seed_allowed_provider(
 ) {
     seed_provider_admin(provider_repo, provider_credentials, provider_id, admin_token, "11111111")
         .await;
+}
+
+#[tokio::test]
+async fn provider_attributes_sync_agent_visibility_but_not_user_or_approval_metadata() {
+    let provider_id = "prv_publication_sync".to_string();
+    let admin_token = "admin-token";
+    let sync = Arc::new(RecordingVisibilitySyncPort::default());
+    let TestApp { app, provider_repo, provider_credentials, .. } =
+        test_app_with_allowed_switch_provider_ids_and_visibility_sync(
+            vec![provider_id.clone()], sync.clone(),
+        );
+    seed_allowed_provider(&provider_repo, &provider_credentials, &provider_id, admin_token).await;
+    let bot_uuid = "teamclaw-bot:alice";
+    register_provider_bot(&app, &provider_id, admin_token, bot_uuid).await;
+    sync.wait_for(1).await;
+
+    for (index, visibility) in ["public", "protected", "private"].iter().enumerate() {
+        let response = app.clone().oneshot(
+            Request::builder()
+                .method("PATCH")
+                .uri(format!("/providers/{provider_id}/bots/{bot_uuid}/attributes"))
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {admin_token}"))
+                .body(Body::from(json!({"visibility": visibility}).to_string()))
+                .unwrap(),
+        ).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        sync.wait_for(index + 2).await;
+        let requests = sync.requests.lock().await;
+        assert_eq!(requests[index + 1].bot_uuid, bot_uuid);
+        assert_eq!(requests[index + 1].visibility, *visibility);
+    }
+
+    for (body, expected) in [
+        (json!({"user_visibility": "private"}), StatusCode::OK),
+        (json!({"friend_ext": {"public_user_approval": {"status": "PROCESSING"}}}), StatusCode::OK),
+        (json!({"visibility": "public", "unknown_field": true}), StatusCode::BAD_REQUEST),
+    ] {
+        let response = app.clone().oneshot(
+            Request::builder()
+                .method("PATCH")
+                .uri(format!("/providers/{provider_id}/bots/{bot_uuid}/attributes"))
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {admin_token}"))
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        ).await.unwrap();
+        assert_eq!(response.status(), expected);
+    }
+    tokio::task::yield_now().await;
+    assert_eq!(sync.requests.lock().await.len(), 4);
 }
 
 #[tokio::test]

--- a/src/bcsfuse/src/interfaces/api/schemas/worker_management_schemas.py
+++ b/src/bcsfuse/src/interfaces/api/schemas/worker_management_schemas.py
@@ -135,7 +135,8 @@ class WorkerSyncRequest(BaseModel):
     """
     Worker sync request.
 
-    Atomic sync operation: create/update worker + set online + upsert profile.
+    Sync worker and profile; preserve existing runtime state when omitted.
+    New workers default to online unless an explicit runtime state is supplied.
     Sent by BCS during bot onboard. Idempotent — safe to call repeatedly.
 
     Aligned with original root contract (worker_routes.py::SyncWorkerRequest).
@@ -163,7 +164,7 @@ class WorkerSyncRequest(BaseModel):
     )
     runtime_state: Optional[str] = Field(
         default=None,
-        description="Runtime state (online/offline). None means no change",
+        description="Runtime state (online/offline). Omitted/null preserves existing state; new workers default online.",
     )
     capabilities: list[dict[str, Any]] = Field(
         default_factory=list,

--- a/src/bcsfuse/src/interfaces/api/worker_profile_parity_routes.py
+++ b/src/bcsfuse/src/interfaces/api/worker_profile_parity_routes.py
@@ -171,17 +171,17 @@ async def batch_query_workers(request: Request, req: WorkerBatchQueryRequest):
 @api_router.post(
     "/workers/{worker_id}/sync",
     summary="Sync worker",
-    description="Atomic sync: create + online + profile activation.",
+    description="Sync worker and profile; preserve existing runtime state when omitted.",
     response_model=WorkerSyncResponse,
     tags=["Workers"],
 )
 async def sync_worker(worker_id: str, request: Request, req: WorkerSyncRequest):
     """
-    P1: Sync worker (create + online + activate profile).
+    P1: Sync worker and profile without changing omitted runtime state.
 
     Atomic sync operation aligned with root_original contract:
     - Create or update worker
-    - Set runtime_state to online
+    - Apply explicit runtime_state; otherwise preserve it (new workers default online)
     - Upsert and activate profile
     - Return canonical response schema
     """
@@ -213,15 +213,33 @@ async def sync_worker(worker_id: str, request: Request, req: WorkerSyncRequest):
     worker_created = False  # For compensation logic
     profile_activated = False
     profile_id = req.profile.profile_id  # Use profile_id from request (root_original contract)
-    effective_runtime_state = req.runtime_state or "online"  # 传入则用传入值，否则默认 online
+    effective_runtime_state = req.runtime_state
 
     try:
         from src.domain.models.worker import Worker, WorkerType, WorkerIdentity, WorkerState
         from src.domain.models.worker_lifecycle_state import WorkerLifecycleState
         from src.domain.models.worker_source_info import WorkerSourceType
+        from src.domain.models.worker_runtime_state import WorkerRuntimeState
 
         # Step 1: Create or update worker
         existing = worker_store.get_by_id(worker_id)
+        update_runtime_state = existing is None or req.runtime_state is not None
+        if effective_runtime_state is None:
+            if existing is None:
+                effective_runtime_state = "online"
+            else:
+                # Read for response/analysis only. Do not write a snapshot back:
+                # user publication owns runtime state independently of visibility.
+                stored_state = (
+                    runtime_state_store.get_runtime_state(worker_id)
+                    if runtime_state_store is not None else None
+                )
+                current_state = stored_state if stored_state is not None else existing.state.runtime_state
+                # The in-memory store retains the mapping written by this route;
+                # persistent stores return the runtime-state enum.
+                if isinstance(current_state, dict):
+                    current_state = current_state["state"]
+                effective_runtime_state = WorkerRuntimeState(current_state).value
 
         # Phase 2.6.5: Map availability string to enum
         availability_map = {
@@ -286,12 +304,11 @@ async def sync_worker(worker_id: str, request: Request, req: WorkerSyncRequest):
             worker_store.update(updated_worker)
             logger.info(f"[Workers R3 Sync] Worker updated: {worker_id}, availability={availability.value}")
 
-        # Step 2: Set runtime state (use request value, default to online if not provided)
+        # Step 2: Only explicit changes or new workers write runtime state.
         try:
-            if runtime_state_store is not None:
+            if runtime_state_store is not None and update_runtime_state:
                 from src.application.services.worker_runtime_state_service import WorkerRuntimeStateService
                 from src.domain.models.worker_runtime_state import WorkerRuntimeState
-                from datetime import datetime
 
                 # Upsert runtime state (set_runtime_state handles both create and update)
                 # Use effective_runtime_state from request (or default "online")
@@ -336,6 +353,13 @@ async def sync_worker(worker_id: str, request: Request, req: WorkerSyncRequest):
                     except Exception as sync_err:
                         logger.warning(f"[Workers R3 Sync] Vector payload sync failed: {sync_err}")
 
+            elif not update_runtime_state:
+                logger.info(f"[Workers R3 Sync] Runtime state preserved: {worker_id} -> {effective_runtime_state}")
+                # Availability still changed even though runtime state did not.
+                try:
+                    _sync_availability_to_vector_store(worker_id, availability.value)
+                except Exception as sync_err:
+                    logger.warning(f"[Workers R3 Sync] Vector availability sync failed: {sync_err}")
             else:
                 logger.warning(f"[Workers R3 Sync] Runtime state store not available, skipping runtime state update")
         except Exception as e:
@@ -368,7 +392,7 @@ async def sync_worker(worker_id: str, request: Request, req: WorkerSyncRequest):
         # Step 4: Upsert and activate profile
         logger.info(
             f"[SYNC_STEP_START] worker_id={worker_id}, profile_id={profile_id}, "
-            f"profile_key={worker_id}:{profile_id}, request_activate=True, runtime_state_requested=online"
+            f"profile_key={worker_id}:{profile_id}, request_activate=True, runtime_state_requested={req.runtime_state}"
         )
         logger.info(
             f"[SYNC_PROVIDER_RESOLUTION] worker_registry_store_class={type(worker_store).__name__}, "
@@ -384,7 +408,7 @@ async def sync_worker(worker_id: str, request: Request, req: WorkerSyncRequest):
             f"created={created}, active_profile_key={worker_id}:{profile_id}, success=True"
         )
         logger.info(
-            f"[SYNC_RUNTIME_STATE_SET] worker_id={worker_id}, target_state=online, "
+            f"[SYNC_RUNTIME_STATE_SET] worker_id={worker_id}, target_state={effective_runtime_state}, update_requested={update_runtime_state}, "
             f"runtime_state_store_class={type(runtime_state_store).__name__ if runtime_state_store else 'None'}, "
             f"success=True"
         )
@@ -393,7 +417,7 @@ async def sync_worker(worker_id: str, request: Request, req: WorkerSyncRequest):
         # Use profile data from request (req.profile) instead of req.profile_content
         logger.info(
             f"[SYNC_STEP_START] worker_id={worker_id}, profile_id={req.profile.profile_id}, "
-            f"profile_key={worker_id}:{req.profile.profile_id}, request_activate={req.profile.activate}, runtime_state_requested=online"
+            f"profile_key={worker_id}:{req.profile.profile_id}, request_activate={req.profile.activate}, runtime_state_requested={req.runtime_state}"
         )
         logger.info(
             f"[SYNC_PROVIDER_RESOLUTION] worker_registry_store_class={type(worker_store).__name__}, "
@@ -711,7 +735,7 @@ async def sync_worker(worker_id: str, request: Request, req: WorkerSyncRequest):
 @compat_router.post(
     "/workers/{worker_id}/sync",
     summary="Sync worker (backward-compatible)",
-    description="Atomic sync: create + online + profile activation. "
+    description="Sync worker and profile; preserve existing runtime state when omitted. "
                 "Legacy path at /v1 for backward compatibility; prefer /api/v1.",
     response_model=WorkerSyncResponse,
     tags=["Workers"],

--- a/src/bcsfuse/tests/contract/test_public_safe_contract_models.py
+++ b/src/bcsfuse/tests/contract/test_public_safe_contract_models.py
@@ -138,7 +138,7 @@ class TestMinimalValidPayloads:
         """Test minimal WorkerSyncRequest instantiation."""
         from src.interfaces.api.schemas.worker_management_schemas import WorkerSyncRequest
 
-        req = WorkerSyncRequest(name="Test Worker")
+        req = WorkerSyncRequest(name="Test Worker", profile={"profile_id": "default"})
         assert req.name == "Test Worker"
         assert req.description is None
 
@@ -269,11 +269,11 @@ class TestOptionalFieldsPayloads:
         req = WorkerSyncRequest(
             name="Test Worker",
             description="A test worker",
-            profile_content="Profile content",
+            profile={"profile_id": "default", "contents": {"profile": "Profile content"}},
             identity_handle="test_worker",
             identity_title="Test Title",
             domains=["domain1", "domain2"],
-            capabilities=["cap1"],
+            capabilities=[{"name": "cap1"}],
             external_id="ext_001",
             metadata={"key": "value"},
         )

--- a/src/bcsfuse/tests/contract/test_sync_preserves_runtime_state.py
+++ b/src/bcsfuse/tests/contract/test_sync_preserves_runtime_state.py
@@ -1,0 +1,109 @@
+"""Both OSS sync routes preserve runtime state on visibility-only updates."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.domain.models.worker import Availability, TrustLevel, Worker, WorkerIdentity, WorkerState, WorkerType
+from src.domain.models.worker_runtime_state import WorkerRuntimeState
+from src.infra.adapters.in_memory_worker_registry_store import InMemoryWorkerRegistryStore
+from src.infra.adapters.in_memory_worker_runtime_state_store import InMemoryWorkerRuntimeStateStore
+from src.interfaces.api import worker_profile_parity_routes as routes
+
+
+@pytest.fixture
+def sync_app(monkeypatch):
+    workers = InMemoryWorkerRegistryStore()
+    runtime = InMemoryWorkerRuntimeStateStore()
+    profiles = MagicMock()
+    app = FastAPI()
+    app.state.context = SimpleNamespace(registry={
+        "worker_registry_store": workers,
+        "worker_runtime_state_store": runtime,
+        "worker_profile_content_store": profiles,
+    })
+    app.include_router(routes.api_router, prefix="/api/v1")
+    app.include_router(routes.compat_router, prefix="/v1")
+    monkeypatch.setattr(routes, "_require_auth", lambda request: None)
+    monkeypatch.setattr(routes, "_sync_runtime_state_to_vector_store", MagicMock())
+    availability_sync = MagicMock()
+    monkeypatch.setattr(routes, "_sync_availability_to_vector_store", availability_sync)
+    monkeypatch.setattr(routes, "_analyze_and_persist_async", AsyncMock())
+    with TestClient(app) as client:
+        yield client, workers, runtime, profiles, availability_sync
+
+
+def seed_worker(workers, runtime, state):
+    workers.create(Worker(
+        id="bot:owner", type=WorkerType.BOT,
+        responsibilities=[], capabilities=[],
+        identity=WorkerIdentity(name="Bot", handle="@bot:owner"),
+        state=WorkerState(availability=Availability.PRIVATE, trust_level=TrustLevel.UNVERIFIED, runtime_state=state),
+    ))
+    runtime.set_runtime_state("bot:owner", state, updated_by="user-publication")
+
+
+@pytest.mark.parametrize("prefix", ["/v1", "/api/v1"])
+@pytest.mark.parametrize("state", [WorkerRuntimeState.OFFLINE, WorkerRuntimeState.ONLINE])
+@pytest.mark.parametrize("availability", ["public", "protected", "private"])
+def test_visibility_sync_preserves_runtime_and_still_updates_profile(sync_app, monkeypatch, prefix, state, availability):
+    client, workers, runtime, profiles, availability_sync = sync_app
+    seed_worker(workers, runtime, state)
+    runtime_write = MagicMock(wraps=runtime.set_runtime_state)
+    monkeypatch.setattr(runtime, "set_runtime_state", runtime_write)
+    response = client.post(f"{prefix}/workers/bot:owner/sync", json={
+        "name": "Updated Bot", "availability": availability,
+        "profile": {"profile_id": "default", "contents": {"profile": "Updated profile"}},
+    })
+    assert response.status_code == 200, response.text
+    assert response.json()["runtime_state"] == state.value
+    runtime_write.assert_not_called()
+    assert runtime.get_runtime_state("bot:owner") == state
+    assert workers.get_by_id("bot:owner").state.runtime_state == state
+    assert workers.get_by_id("bot:owner").state.availability.value == availability
+    profiles.upsert_profile.assert_called_once()
+    availability_sync.assert_called_with("bot:owner", availability)
+
+
+@pytest.mark.parametrize("prefix", ["/v1", "/api/v1"])
+@pytest.mark.parametrize("explicit", [None, "offline", "online"])
+def test_new_worker_defaults_online_and_explicit_runtime_is_honored(sync_app, prefix, explicit):
+    client, workers, runtime, _, _ = sync_app
+    payload = {"name": "New Bot", "availability": "private", "profile": {"profile_id": "default"}}
+    if explicit is not None:
+        payload["runtime_state"] = explicit
+    response = client.post(f"{prefix}/workers/bot:owner/sync", json=payload)
+    assert response.status_code == 200, response.text
+    expected = explicit or "online"
+    assert response.json()["created"] is True
+    assert response.json()["runtime_state"] == expected
+    assert workers.get_by_id("bot:owner").state.runtime_state.value == expected
+    # Sync's in-memory adapter retains the mapping supplied by the handler.
+    assert runtime.get_runtime_state("bot:owner")["state"] == expected
+    again = client.post(f"{prefix}/workers/bot:owner/sync", json={"name": "Still here", "profile": {"profile_id": "default"}})
+    assert again.status_code == 200, again.text
+    assert again.json()["runtime_state"] == expected
+
+
+@pytest.mark.parametrize("explicit", ["offline", "online"])
+def test_explicit_runtime_updates_existing_worker(sync_app, explicit):
+    client, workers, runtime, _, _ = sync_app
+    seed_worker(workers, runtime, WorkerRuntimeState.OFFLINE if explicit == "online" else WorkerRuntimeState.ONLINE)
+    response = client.post("/v1/workers/bot:owner/sync", json={"name": "Bot", "runtime_state": explicit, "profile": {"profile_id": "default"}})
+    assert response.status_code == 200, response.text
+    assert response.json()["runtime_state"] == explicit
+    assert workers.get_by_id("bot:owner").state.runtime_state.value == explicit
+
+
+def test_null_runtime_with_missing_runtime_record_preserves_registry_state(sync_app):
+    client, workers, runtime, _, _ = sync_app
+    seed_worker(workers, runtime, WorkerRuntimeState.OFFLINE)
+    runtime._states.clear()
+    response = client.post("/v1/workers/bot:owner/sync", json={"name": "Bot", "runtime_state": None, "profile": {"profile_id": "default"}})
+    assert response.status_code == 200, response.text
+    assert response.json()["runtime_state"] == "offline"
+    assert runtime.get_runtime_state("bot:owner") is None
+    assert workers.get_by_id("bot:owner").state.runtime_state == WorkerRuntimeState.OFFLINE


### PR DESCRIPTION
## Problem

The collaboration bot publication API updates BCS visibility but does not propagate those changes to BCSFuse. Publishing or unpublishing a bot can therefore leave its BCSFuse state stale.

## Solution

- Sync user publication to BCSFuse online/offline state after a successful BCS update.
- Preserve the exact BCS bot UUID, including the owner suffix, without qualifying it again.
- Trigger the existing BCS visibility sync when the Provider attributes API updates Agent visibility.
- Keep user publication and Agent visibility independent.
- Skip runtime synchronization for pending, rejected, or cancelled approvals and skipped or failed BCS writes.
- Preserve legacy worker ID configuration and best-effort BCSFuse error logging.

## Validation

- Backend publication, endpoint, and architecture tests: 187 passed.
- Final publication synchronization regression suite: 16 passed.
- BCS route contract tests: 95 passed.
- BCSFuse client and fusion tests: 54 passed.
- Oversized-module check, changed-file lint, and pre-push checks passed.

## Compatibility and risk

No public API schema changes. Legacy worker ID behavior remains configurable.

Deploy both Backend and BCS to activate both synchronization paths. Internal deployments also require the companion OCB configuration update enabling owner-qualified legacy worker IDs.

BCSFuse failures remain best-effort and are logged; successful publication alone does not guarantee downstream synchronization.