### PR TITLE
feat(agent): per-engine provider configs with NAS merge and qwen3.8-max

### DIFF
--- a/docker/agent/avernet-entrypoint.sh
+++ b/docker/agent/avernet-entrypoint.sh
@@ -10,10 +10,13 @@
 #
 # Flow:
 #   1. Create runtime directories (system dirs as root, /home/admin as admin)
-#   2. Verify build artifacts
-#   3. Generate ~/.openclaw/openclaw.json from template + env vars (as admin)
-#   4. Allow private-network model provider endpoints (openclaw config set)
-#   5. exec supervisord (becomes PID 1)
+#   2. Verify build artifacts and expose the bcs-coordination skill
+#   3. exec supervisord (becomes PID 1)
+#
+# Engine-agnostic bootstrap only. Per-engine provider config lives in the
+# per-engine startup scripts: openclaw.json rendering + the
+# allowPrivateNetwork patch in start_openclaw.sh, claude settings.json /
+# models.json staging in start_claude_code.sh.
 #
 # The platform invokes start_service.sh externally (docker exec) with
 # --token/--client_id to save credentials and start the engine.
@@ -22,10 +25,8 @@ set -euo pipefail
 
 export HOME="${HOME:-/home/admin}"
 CONFIG_DIR="${HOME}/.openclaw"
-CONFIG_FILE="${CONFIG_DIR}/openclaw.json"
 WORKSPACE_DIR="${CONFIG_DIR}/workspace"
 LOG_DIR="${HOME}/logs"
-TEMPLATE_FILE="/opt/openclaw.json.template"
 BCS_SKILL_SOURCE="/usr/local/lib/node_modules/openclaw/skills/bcs-coordination"
 BCS_SKILL_TARGET="${WORKSPACE_DIR}/skills/bcs-coordination"
 
@@ -77,74 +78,7 @@ echo "     Engine:   /opt/engine (port 20003)"
 echo "     OpenClaw: ${CONFIG_DIR} (port ${OPENCLAW_PORT:-18789})"
 echo "     Logs:     ${LOG_DIR}"
 
-# --- 3. Generate openclaw.json from template if none mounted
-
-if [ ! -f "${CONFIG_FILE}" ]; then
-    echo "===> generating ${CONFIG_FILE} from template"
-
-    # Run config generation as admin so all files are admin-owned.
-    _gen_config() {
-        cp "${TEMPLATE_FILE}" "${CONFIG_FILE}"
-
-        _sub() {
-            local val
-            val="${!1:-UNSET}"
-            val="${val//\//\\/}"
-            sed -i "s/${2}/${val}/g" "${CONFIG_FILE}"
-        }
-
-        _sub OPENCLAW_OPENAI_BASE_URL  OPENCLAW_OPENAI_BASE_URL
-        _sub MODEL_PROVIDER_HOST       MODEL_PROVIDER_HOST
-        _sub OPENCLAW_OPENAI_API_KEY   OPENCLAW_OPENAI_API_KEY
-        _sub OPENCLAW_OPENAI_MODEL_ID  OPENCLAW_OPENAI_MODEL_ID
-        _sub OPENCLAW_OPENAI_MODEL_NAME OPENCLAW_OPENAI_MODEL_NAME
-        _sub OPENCLAW_GATEWAY_TOKEN    OPENCLAW_GATEWAY_TOKEN
-        _sub BCS_URL                   BCS_URL
-        _sub BCS_BOT_ID                BCS_BOT_ID
-        _sub BCS_BOT_NAME              BCS_BOT_NAME
-
-        if [ "${OPENCLAW_GATEWAY_TOKEN:-UNSET}" = "UNSET" ]; then
-            sed -i '/"auth": {/{N;s/"mode": "token", "token": "UNSET"//' "${CONFIG_FILE}" 2>/dev/null || true
-        fi
-    }
-    export -f _gen_config
-    # MODEL_PROVIDER_HOST: model provider host (bare host, no scheme or path —
-    # the template carries the https:// prefix and the provider-specific path
-    # suffix). Shared contract with start_claude_code.sh, which substitutes
-    # the same placeholder into the claude_code settings.json. The default
-    # keeps the shipped dashscope scenario when the pod env does not inject
-    # it and must NOT fall through to _sub's UNSET literal (https://UNSET/...).
-    export MODEL_PROVIDER_HOST="${MODEL_PROVIDER_HOST:-dashscope.aliyuncs.com}"
-    export TEMPLATE_FILE CONFIG_FILE OPENCLAW_OPENAI_BASE_URL OPENCLAW_OPENAI_API_KEY \
-           OPENCLAW_OPENAI_MODEL_ID OPENCLAW_OPENAI_MODEL_NAME OPENCLAW_GATEWAY_TOKEN \
-           BCS_URL BCS_BOT_ID BCS_BOT_NAME
-    su admin -s /bin/bash -c '_gen_config'
-
-    echo "    config written"
-else
-    echo "===> using existing ${CONFIG_FILE} (mounted or pre-built)"
-fi
-
-# --- 4. Allow private-network model provider endpoints ---
-# MODEL_PROVIDER_HOST can point at internal hosts (e.g. *.inner.avernet.com).
-# openclaw blocks requests to private networks on a provider unless
-# request.allowPrivateNetwork is true, so lift the restriction for the
-# openai-compatible provider. Deliberate: the provider URL is
-# operator-controlled (image template + pod env), not bot-controlled, so the
-# SSRF guard is not needed here. Runs on EVERY boot, not only at first-boot
-# rendering, so NAS-persisted configs from older images are patched too.
-# Best-effort — a CLI failure must not block pod start (the restriction then
-# surfaces as per-request model errors instead of a dead entrypoint).
-if [ -x /usr/local/bin/openclaw ] && [ -f "${CONFIG_FILE}" ]; then
-    if su admin -s /bin/bash -c \
-        'openclaw config set models.providers.openai-compatible.request.allowPrivateNetwork true'; then
-        echo "===> openclaw: private-network model endpoints allowed (allowPrivateNetwork=true)"
-    else
-        echo "WARNING: openclaw config set allowPrivateNetwork failed — private model hosts will be blocked" >&2
-    fi
-fi
-
-# --- 5. exec supervisord — becomes PID 1
+# --- 3. exec supervisord — becomes PID 1
 # Engine and openclaw are both autostart=false.
 # The platform invokes start_service.sh externally (e.g. docker exec)
 # with --token/--client_id to orchestrate pod startup.

--- a/docker/agent/avernet.dockerfile
+++ b/docker/agent/avernet.dockerfile
@@ -303,8 +303,15 @@ RUN if [ -f /tmp/mitm-ca.crt ]; then \
     && ln -sf /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-bundle.crt
 
 # Recreate admin user at runtime stage (uid/gid 10001).
+# `admin:*` locking the password is REQUIRED: the startup scripts
+# (start_openclaw.sh, start_claude_code.sh, avernet-entrypoint.sh) run as
+# root and drop to admin via non-interactive `su admin -c ...`; su needs a
+# usable (locked-with-`*`) password field for that path. useradd alone
+# leaves the account as "!" (disabled login) → su prompts for a password
+# and fails ("Authentication failure").
 RUN groupadd --gid 10001 admin 2>/dev/null || true \
     && useradd --uid 10001 --gid admin --create-home --shell /bin/bash admin 2>/dev/null || true \
+    && echo 'admin:*' | chpasswd -e \
     && echo 'admin ALL=(ALL) NOPASSWD: /usr/local/bin/supervisorctl *' > /etc/sudoers.d/admin-supervisorctl \
     && chmod 440 /etc/sudoers.d/admin-supervisorctl \
     && mkdir -p /var/log/supervisor /var/run/agentclaw \
@@ -319,7 +326,26 @@ RUN groupadd --gid 10001 admin 2>/dev/null || true \
 # Supervisor configuration: engine(autostart=false) + openclaw(autostart=false).
 COPY docker/agent/avernet-supervisord.conf /etc/supervisor/supervisord.conf
 
-# OpenClaw default config template (env-var placeholders substituted at runtime).
+# Config deep-merge helper. /home/admin is NAS-mounted and outlives image
+# upgrades, so first-boot-generated configs (openclaw.json, models.json)
+# would stay stale forever. start_openclaw.sh / start_claude_code.sh call
+# this on every startup to merge the freshly rendered image template INTO
+# the NAS copy: image-defined keys take the image value, user/deployment-
+# only keys survive, no-op merges write nothing. See merge-config.py for
+# the exact merge rules.
+COPY docker/agent/merge-config.py /usr/local/bin/merge-config
+
+# merge key allowlists, one per engine config (see merge-config --keys).
+# Maintained in the repo next to their configs: adding a template key to
+# openclaw.json means adding it to openclaw.path for image updates to
+# reach pods with an existing NAS copy; claude_code.path carries '*' since
+# models.json's top level is an array merged entry-by-id.
+COPY docker/agent/openclaw.path /opt/openclaw.path
+COPY docker/agent/claude_code.path /opt/claude_code.path
+
+# OpenClaw default config template (rendered with pod env at startup by
+# start_openclaw.sh: installed on first boot, deep-merged into the NAS copy
+# on later boots via merge-config).
 COPY docker/agent/openclaw.json /opt/openclaw.json.template
 
 # Claude Code provider settings template — staged like openclaw.json above:
@@ -327,7 +353,7 @@ COPY docker/agent/openclaw.json /opt/openclaw.json.template
 # there, so the file must live in /opt and be copied into ~/.claude AFTER
 # the mount (start_claude_code.sh does the copy, substituting the
 # MODEL_PROVIDER_HOST placeholder from the pod env — same variable and
-# bare-host contract as the entrypoint's openclaw.json rendering, defaulting
+# bare-host contract as start_openclaw.sh's openclaw.json rendering, defaulting
 # to dashscope.aliyuncs.com; mount-wins: a file already on the NAS is kept).
 # Everything else is static, mirroring openclaw.json's hardcoded config:
 # model (glm-5.2), and the auth token as the literal
@@ -339,6 +365,19 @@ COPY docker/agent/openclaw.json /opt/openclaw.json.template
 # RELAY_MODEL_SETTINGS_SOURCE (set in start_claude_code.sh). A deployment
 # with a different provider scenario mounts its own file at the final path.
 COPY docker/agent/claude-settings.json /opt/claude-settings.json.template
+
+# Claude Code model catalogue (relay providers file) — array of ProviderConfig
+# (id/name/enabled/models[].env), the schema the relay gateway's claude-code-
+# router.ts parses via RELAY_MODELS_FILE. Each model entry selects itself
+# through env overrides (ANTHROPIC_MODEL set per-model at request time, so
+# session/default model selection in the workbench routes to the right one —
+# e.g. glm-5.2 vs the multimodal qwen3.8-max). Staged like the templates
+# above: /opt hosts the copy, start_claude_code.sh installs it into ~/.claude/
+# after the NAS mount on first boot and deep-merges it into the NAS copy on
+# later boots (merge-config, array entries merged by id), then points
+# RELAY_MODELS_FILE at it.
+# Without it the relay serves its built-in default anthropic catalogue.
+COPY docker/agent/models.json /opt/models.json.template
 
 # HEARTBEAT.md template — staged in /opt like the templates above, but with
 # opposite runtime semantics. openclaw appends its own tasks to
@@ -364,9 +403,10 @@ RUN chmod +x /usr/local/bin/avernet-entrypoint \
              /usr/local/bin/start_service.sh \
              /usr/local/bin/start_openclaw.sh \
              /usr/local/bin/start_claude_code.sh \
-             /usr/local/bin/util.sh
+             /usr/local/bin/util.sh \
+             /usr/local/bin/merge-config
 
-EXPOSE 20003 18789 18900
+EXPOSE 20003
 
 HEALTHCHECK --interval=10s --timeout=5s --start-period=120s --retries=6 \
     CMD curl -fsS "http://127.0.0.1:20003/health" >/dev/null || exit 1

--- a/docker/agent/claude_code.path
+++ b/docker/agent/claude_code.path
@@ -1,0 +1,14 @@
+# claude_code.path — keys merge-config takes from the image catalogue into
+# the NAS copy of ~/.claude/models.json (applied by start_claude_code.sh on
+# every startup; merge-config reads this via --keys).
+#
+# One key or dot-path per line; '#' comments and blank lines are ignored.
+# models.json's top level is an ARRAY of providers, so there are no
+# dot-path keys to select — '*' merges the whole tree. Entry-level
+# protection comes from the array merge itself: providers and models merge
+# by id, image entries update/append, and the deployment's own
+# providers/models (e.g. a private-model provider) survive untouched.
+#
+# To stop the image catalogue from reaching a deployment entirely, replace
+# '*' with the empty allowlist (delete the line) — merges become no-ops.
+*

--- a/docker/agent/merge-config.py
+++ b/docker/agent/merge-config.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""merge-config.py — deep-merge an image-rendered JSON config into a
+persistent user copy.
+
+Problem this solves: /home/admin is NAS-mounted and outlives image upgrades,
+so a config generated on first boot (mount-wins, e.g. ~/.openclaw/openclaw.json
+and ~/.claude/models.json) stays stale forever — image-side key additions and
+value updates never reach running pods.
+
+On every engine startup the freshly rendered image template (base) is merged
+INTO the user file (target):
+
+- dict + dict   → recursive merge: target-only keys survive, base-only keys
+                  are added, conflicting leaves take the base (image) value,
+                  so image updates heal the stale copy while user/deployment
+                  customizations that the image does not define are kept.
+- list + list   → when every element is an object with an "id" field, both
+                  lists merge by id: base entries update matching target
+                  entries (recursively) and new base entries are appended;
+                  target-only entries stay in place. Lists that are not
+                  id-objects are replaced by the base list wholesale.
+- other / type mismatch → base value replaces the target value.
+- --keys FILE   → optional allowlist file maintained alongside the image:
+                  one key or dot-path per line ('#' comments, blank lines
+                  ignored; the shipped files are docker/agent/openclaw.path
+                  and docker/agent/claude_code.path). Only the listed
+                  subtrees merge from the image side — everything else the
+                  base carries behaves as user-owned and is never touched.
+                  A '*' line merges the whole base (used for top-level
+                  arrays like models.json, where entry-level id merging
+                  already protects user entries). A path that misses in the
+                  base is skipped with a warning; an allowlist that lists
+                  nothing is a deliberate no-op. Without --keys the whole
+                  base merges.
+- UNSET guard   → base string values exactly equal to "UNSET" are dropped
+                  before merging: that literal is the renderer's marker for
+                  an un-injected env var and must never clobber a real value.
+
+Idempotence: when nothing changes, the target file is not written (no mtime
+churn on repeated boots). Effective changes are written atomically (temp
+file + rename in the target directory), preserve the target's owner, group
+and mode, and save a .bak snapshot of the pre-merge content next to it.
+
+Exit codes: 0 merged or no-change, 2 usage error, 3 target unreadable or
+invalid JSON (file untouched), 4 base unreadable or invalid JSON,
+5 write failure, 6 keys file unreadable.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import stat
+import sys
+import tempfile
+
+#: Renderer marker for "env var was not injected" — never let it clobber.
+_UNSET = "UNSET"
+
+
+def drop_unset(value):
+    """Remove dict entries whose value is the literal "UNSET" marker."""
+    if isinstance(value, dict):
+        return {
+            k: drop_unset(v)
+            for k, v in value.items()
+            if not (isinstance(v, str) and v == _UNSET)
+        }
+    if isinstance(value, list):
+        return [drop_unset(v) for v in value]
+    return value
+
+
+def _mergeable_by_id(seq: list) -> bool:
+    """True when every element is a dict carrying an "id" field."""
+    return all(isinstance(e, dict) and "id" in e for e in seq)
+
+
+def _get_path(node, dotted: str):
+    """Walk a dot-separated path (e.g. "agents.defaults") through dicts.
+
+    Returns (found, value). Any non-dict hop or missing key → not found. Path
+    segments are literal keys — no wildcards, no index addressing.
+    """
+    cur = node
+    for seg in dotted.split("."):
+        if not isinstance(cur, dict) or seg not in cur:
+            return False, None
+        cur = cur[seg]
+    return True, cur
+
+
+def restrict_to_paths(base, paths: list[str]):
+    """Trim the base to only the given dotted paths (the --keys allowlist).
+
+    Builds a fresh tree containing just the whitelisted subtrees, so merges
+    confine themselves to those paths; everything else the base carries is
+    user-owned (the target keeps its value). A path that misses anywhere
+    along its segments is skipped ENTIRELY — no partial skeleton is emitted,
+    so a missing path can never inject empty objects into the target. An
+    allowlist that matches nothing collapses the base to {}, a pure no-op
+    merge. Requires a dict base; a non-dict base also yields {}.
+    """
+    if not isinstance(base, dict):
+        return {}
+    out: dict = {}
+    for dotted in paths:
+        found, val = _get_path(base, dotted)
+        if not found:
+            continue
+        cur = out
+        segs = dotted.split(".")
+        for seg in segs[:-1]:
+            cur = cur.setdefault(seg, {})
+        cur[segs[-1]] = val
+    return out
+
+
+def load_keys(path: str) -> tuple[bool, list[str]]:
+    """Parse a --keys allowlist file: one key or dot-path per line.
+
+    '#' starts a comment (also allowed after a path on the same line),
+    blank lines are ignored. Returns (whole, paths): whole is True when the
+    file contains a '*' line — merge the entire base; paths lists the
+    dot-paths otherwise. A file with only comments yields (False, []),
+    a deliberate merge-nothing allowlist.
+    """
+    with open(path, "r", encoding="utf-8") as fh:
+        lines = fh.read().splitlines()
+    paths: list[str] = []
+    for ln in lines:
+        ln = ln.split("#", 1)[0].strip()
+        if not ln:
+            continue
+        if ln == "*":
+            return True, []
+        paths.append(ln)
+    return False, paths
+
+
+def deep_merge(base, target):
+    """Merge base (image) into target (user); base wins conflicts."""
+    if isinstance(base, dict) and isinstance(target, dict):
+        out = dict(target)  # target order preserved; target-only keys kept
+        for k, bv in base.items():
+            out[k] = deep_merge(bv, target[k]) if k in target else bv
+        return out
+    if isinstance(base, list) and isinstance(target, list):
+        if _mergeable_by_id(base) and _mergeable_by_id(target):
+            base_by_id = {e["id"]: e for e in base}
+            target_ids = set()
+            out = []
+            for t in target:  # target order preserved
+                target_ids.add(t["id"])
+                b = base_by_id.get(t["id"])
+                out.append(deep_merge(b, t) if b is not None else t)
+            for b in base:  # new image entries appended in template order
+                if b["id"] not in target_ids:
+                    out.append(b)
+            return out
+        return base
+    return base
+
+
+def _leaves(node, prefix=()):
+    """Flatten a JSON tree into {path-tuple: scalar} for diff statistics."""
+    out = {}
+    if isinstance(node, dict):
+        for k, v in node.items():
+            out.update(_leaves(v, prefix + (str(k),)))
+    elif isinstance(node, list):
+        for i, v in enumerate(node):
+            out.update(_leaves(v, prefix + (str(i),)))
+    else:
+        out[prefix] = node
+    return out
+
+
+def _diff_stats(merged, target):
+    m, t = _leaves(merged), _leaves(target)
+    added = sum(1 for p in m if p not in t)
+    changed = sum(1 for p in m if p in t and m[p] != t[p])
+    return added, changed
+
+
+def _atomic_write(path: str, text: str) -> None:
+    """Write text to path preserving owner/group/mode; temp+rename atomic."""
+    st = os.stat(path)
+    fd, tmp = tempfile.mkstemp(
+        dir=os.path.dirname(path) or ".", prefix=".merge-config-"
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+            fh.flush()
+        os.chmod(tmp, stat.S_IMODE(st.st_mode))
+        try:
+            os.chown(tmp, st.st_uid, st.st_gid)  # best-effort (NAS may refuse)
+        except OSError:
+            pass
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Deep-merge a rendered image JSON template into a "
+                    "persistent user copy (image keys land, user-only keys "
+                    "survive)."
+    )
+    parser.add_argument("--base", required=True,
+                        help="image-rendered template JSON (winning side)")
+    parser.add_argument("--target", required=True,
+                        help="persistent user file to merge into")
+    parser.add_argument("--keys",
+                        help="optional allowlist file: one key or dot-path "
+                             "per line (see docker/agent/openclaw.path / "
+                             "claude_code.path); only listed subtrees "
+                             "merge, '*' merges the whole base. Omitted = "
+                             "merge the whole base.")
+    args = parser.parse_args()
+
+    try:
+        with open(args.base, "r", encoding="utf-8") as fh:
+            base = json.load(fh)
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"merge-config: ERROR reading base {args.base}: {e}",
+              file=sys.stderr)
+        return 4
+    try:
+        with open(args.target, "r", encoding="utf-8") as fh:
+            target_text = fh.read()
+            target = json.loads(target_text)
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"merge-config: ERROR reading target {args.target}: {e} "
+              f"— target untouched, keeping it as-is", file=sys.stderr)
+        return 3
+
+    if args.keys:
+        try:
+            whole, paths = load_keys(args.keys)
+        except OSError as e:
+            print(f"merge-config: ERROR reading keys {args.keys}: {e}",
+                  file=sys.stderr)
+            return 6
+        if not whole:
+            # Warn on allowlist entries missing from the base — a typo or a
+            # stale patch file should surface during startup, not silently
+            # drop a key the operator expects to be merged.
+            if isinstance(base, dict):
+                missed = [p for p in paths if not _get_path(base, p)[0]]
+            else:
+                missed = list(paths)
+            if missed:
+                print(f"merge-config: WARNING: keys not in base, skipped: "
+                      f"{', '.join(missed)}", file=sys.stderr)
+            base = restrict_to_paths(base, paths)
+    base = drop_unset(base)
+
+    merged = deep_merge(base, target)
+
+    if merged == target:
+        print(f"merge-config: {args.target}: no changes")
+        return 0
+
+    added, changed = _diff_stats(merged, target)
+    bak = args.target + ".bak"
+    try:
+        with open(bak, "w", encoding="utf-8") as fh:
+            fh.write(target_text)
+        _atomic_write(args.target, json.dumps(merged, indent=2) + "\n")
+    except OSError as e:
+        print(f"merge-config: ERROR writing {args.target}: {e}",
+              file=sys.stderr)
+        return 5
+    print(f"merge-config: {args.target}: {added} key(s) added, "
+          f"{changed} updated (backup: {bak})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docker/agent/models.json
+++ b/docker/agent/models.json
@@ -1,0 +1,21 @@
+[
+  {
+    "id": "antchat",
+    "name": "AntChat",
+    "enabled": true,
+    "models": [
+      {
+        "id": "glm-5.2",
+        "name": "glm-5.2",
+        "display_name": "glm-5.2",
+        "env": { "ANTHROPIC_MODEL": "glm-5.2", "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "1000000" }
+      },
+      {
+        "id": "qwen3.8-max",
+        "name": "qwen3.8-max",
+        "display_name": "qwen3.8-max",
+        "env": { "ANTHROPIC_MODEL": "qwen3.8-max", "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "1000000" }
+      }
+    ]
+  }
+]

--- a/docker/agent/openclaw.json
+++ b/docker/agent/openclaw.json
@@ -16,9 +16,33 @@
             "id": "glm-5.2",
             "name": "glm-5.2",
             "reasoning": false,
-            "input": ["text"],
-            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 },
+            "input": [
+              "text"
+            ],
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
             "contextWindow": 200000,
+            "maxTokens": 8192
+          },
+          {
+            "id": "qwen3.8-max",
+            "name": "qwen3.8-max",
+            "reasoning": false,
+            "input": [
+              "text",
+              "image"
+            ],
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "contextWindow": 1000000,
             "maxTokens": 8192
           }
         ],
@@ -38,9 +62,12 @@
         "primary": "openai-compatible/glm-5.2"
       },
       "models": {
-        "openai-compatible/glm-5.2": {}
+        "openai-compatible/glm-5.2": {},
+        "openai-compatible/qwen3.8-max": {}
       },
-      "compaction": { "mode": "safeguard" },
+      "compaction": {
+        "mode": "safeguard"
+      },
       "maxConcurrent": 4,
       "subagents": {
         "maxConcurrent": 8,
@@ -49,9 +76,14 @@
     }
   },
   "tools": {
-    "alsoAllow": ["bcs_route"],
+    "alsoAllow": [
+      "bcs_route"
+    ],
     "media": {
-      "image": { "enabled": true, "maxBytes": 20971520 }
+      "image": {
+        "enabled": true,
+        "maxBytes": 20971520
+      }
     }
   },
   "commands": {
@@ -66,9 +98,15 @@
     "maxFileBytes": 10485760
   },
   "skills": {
-    "entries": { "acp-router": { "enabled": false } },
+    "entries": {
+      "acp-router": {
+        "enabled": false
+      }
+    },
     "load": {
-      "extraDirs": ["/home/admin/.openclaw/skills"],
+      "extraDirs": [
+        "/home/admin/.openclaw/skills"
+      ],
       "watch": true,
       "watchDebounceMs": 250
     }
@@ -81,23 +119,38 @@
   },
   "session": {
     "dmScope": "per-channel-peer",
-    "reset": { "mode": "idle", "idleMinutes": 5256000 }
+    "reset": {
+      "mode": "idle",
+      "idleMinutes": 5256000
+    }
   },
   "messages": {
-    "groupChat": { "visibleReplies": "automatic" }
+    "groupChat": {
+      "visibleReplies": "automatic"
+    }
   },
   "discovery": {
-    "mdns": { "mode": "off" },
-    "wideArea": { "enabled": false }
+    "mdns": {
+      "mode": "off"
+    },
+    "wideArea": {
+      "enabled": false
+    }
   },
   "channels": {
     "bcs": {
       "enabled": true,
       "capabilities": {
         "summary": "OpenClaw bot",
-        "domains": ["general"],
-        "skills": ["general"],
-        "scopes": ["production"]
+        "domains": [
+          "general"
+        ],
+        "skills": [
+          "general"
+        ],
+        "scopes": [
+          "production"
+        ]
       },
       "heartbeatIntervalMs": 60000,
       "reconnectIntervalMs": 5000,
@@ -113,19 +166,30 @@
     },
     "nodes": {
       "denyCommands": [
-        "camera.snap", "camera.clip", "screen.record",
-        "calendar.add", "contacts.add", "reminders.add"
+        "camera.snap",
+        "camera.clip",
+        "screen.record",
+        "calendar.add",
+        "contacts.add",
+        "reminders.add"
       ]
     }
   },
   "plugins": {
     "load": {
       "paths": [
-        "/opt/openclawExt/openclaw-channel-bcn"
+        "/opt/openclawExt/openclaw-channel-bcn",
+        "/opt/openclawExt/taskguard"
       ]
     },
     "entries": {
       "openclaw-channel-bcn": {
+        "enabled": true
+      },
+      "memory-core": {
+        "config": {}
+      },
+      "taskguard": {
         "enabled": true
       }
     }

--- a/docker/agent/openclaw.path
+++ b/docker/agent/openclaw.path
@@ -1,0 +1,14 @@
+# openclaw.path — keys merge-config takes from the image-rendered template
+# into the NAS copy of ~/.openclaw/openclaw.json (applied by
+# start_openclaw.sh on every startup; merge-config reads this via --keys).
+#
+# One key or dot-path per line; '#' comments and blank lines are ignored.
+# Keys NOT listed here belong to the user/deployment copy and are never
+# overwritten by a merge — add a key here when the image template grows one
+# and image updates should reach pods with an existing NAS config.
+#
+# 'meta' is deliberately absent: the openclaw CLI's own lastTouched*
+# bookkeeping lives in the running copy.
+models
+plugins
+agents.defaults.models

--- a/docker/agent/start_claude_code.sh
+++ b/docker/agent/start_claude_code.sh
@@ -25,14 +25,22 @@
 # /opt/claude-settings.json.template (NOT under /home/admin — that path is
 # NAS-mounted at pod start and shadows image content) and Step 1 copies it
 # into ~/.claude/settings.json AFTER the mount, mount-wins, substituting the
-# MODEL_PROVIDER_HOST placeholder from the pod env (same variable the
-# entrypoint's openclaw.json rendering uses, same bare-host contract: no
-# scheme or path — the template carries https:// and /apps/anthropic).
+# MODEL_PROVIDER_HOST placeholder from the pod env (bare host, no scheme or
+# path — the template carries https:// and /apps/anthropic).
 # Everything else — model glm-5.2, and the auth token as the literal
-# placeholder "Bearer ${API-KEY}" — mirrors openclaw.json ("apiKey":
-# "Bearer ${API-KEY}"): the gateway on the upstream side replaces the
-# placeholder with the real key. Swap the whole provider scenario by
-# mounting a file at the final path.
+# placeholder "Bearer ${API-KEY}" — is static: the gateway on the upstream
+# side replaces the placeholder with the real key. Swap the whole provider
+# scenario by mounting a file at the final path.
+#
+# Model catalogue: the image also stages docker/agent/models.json at
+# /opt/models.json.template (ProviderConfig[] with per-model env overrides).
+# Step 1 installs it into ~/.claude/models.json on first boot (AFTER-mount
+# staging) and on later boots deep-merges the image catalogue into the NAS
+# copy (image entries by id update/append, deployment-only entries survive),
+# then exports RELAY_MODELS_FILE so the relay's router serves the catalogue
+# (providers.list/models.list up to the engine, per-model ANTHROPIC_MODEL
+# routing e.g. qwen3.8-max). Without it the relay serves its built-in
+# anthropic-only default catalogue.
 #
 # Reads (pod env):
 #   MODEL_PROVIDER_HOST          optional, defaults dashscope.aliyuncs.com
@@ -50,8 +58,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Source util.sh for logging
 source "$SCRIPT_DIR/util.sh"
 
-# Same log file as the dispatcher (and start_openclaw.sh) so one file
-# holds the whole pod startup trace, whatever the engine.
+# Same log file as the dispatcher so one file holds the whole pod startup
+# trace, whatever the engine.
 LOG_FILE="/home/admin/logs/start_service.log"
 set_log_file "$LOG_FILE"
 
@@ -74,8 +82,7 @@ section "start_claude_code.sh - claude_code engine startup"
 # default is applied at the copy step below): every other provider field —
 # model, and the auth token (the literal placeholder "Bearer ${API-KEY}") —
 # is static in the settings.json template baked into the image. The gateway
-# on the upstream side replaces the placeholder with the real key, exactly
-# like openclaw.json's "apiKey": "Bearer ${API-KEY}" placeholder.
+# on the upstream side replaces the placeholder with the real key.
 
 # --- Step 1: Configure engine + relay environment ---
 
@@ -93,16 +100,25 @@ EOF
 # stay in sync); CLAUDE_CODE_DEFAULT_CWD / RELAY_DEFAULT_CWD anchor the
 # engine-side workspace resolution (same pattern as
 # scripts/run_bcs_mixed_provider.sh).
+# OPENCLAW_WORKSPACE_DIR redirects the engine's shared workspace resolver
+# (plugin_api/workspace_root.py) to the claude_code workspace so the
+# skills-repo downloader's paths (skills_repo_download.py reads
+# workspace_root() for the skills-pool / legacy skills-repo targets) land
+# under ~/.claude_code/workspace instead of its default ~/.openclaw/
+# workspace — without it this engine writes skills into the openclaw
+# engine's directory. This is the same per-override handle Desktop uses
+# for per-bot workspaces.
 cat >> "$ADAPTOR_ENV_FILE" <<EOF
 export CLAUDE_CODE_RELAY_URL=ws://127.0.0.1:$CLAUDE_RELAY_PORT
-export CLAUDE_CODE_DEFAULT_CWD=/home/admin/.openclaw/workspace
-export RELAY_DEFAULT_CWD=/home/admin/.openclaw/workspace
+export CLAUDE_CODE_DEFAULT_CWD=/home/admin/.claude_code/workspace
+export RELAY_DEFAULT_CWD=/home/admin/.claude_code/workspace
+export OPENCLAW_WORKSPACE_DIR=/home/admin/.claude_code/workspace
 EOF
 success "Engine env file written to $ADAPTOR_ENV_FILE"
 
 mkdir -p "$RELAY_STATE_DIR/data" "$RELAY_STATE_DIR/logs" \
-         /home/admin/.claude /home/admin/.openclaw/workspace
-chown -R admin:admin "$RELAY_STATE_DIR" /home/admin/.claude 2>/dev/null || true
+         /home/admin/.claude /home/admin/.claude_code/workspace
+chown -R admin:admin "$RELAY_STATE_DIR" "/home/admin/.claude_code" 2>/dev/null || true
 
 RELAY_ENV_FILE="/home/admin/.relayEnv"
 cat > "$RELAY_ENV_FILE" <<EOF
@@ -111,30 +127,29 @@ export CLAUDE_CODE_PATH=${CLAUDE_CODE_PATH:-/usr/local/bin/claude}
 export RELAY_DATA_DIR=$RELAY_STATE_DIR/data
 export RELAY_LOG_DIR=$RELAY_STATE_DIR/logs
 export RELAY_CLAUDE_CONFIG_DIR=/home/admin/.claude
-export RELAY_DEFAULT_CWD=/home/admin/.openclaw/workspace
+export RELAY_DEFAULT_CWD=/home/admin/.claude_code/workspace
 export RELAY_DEFAULT_PERMISSION_MODE=$CLAUDE_RELAY_PERMISSION_MODE
 EOF
 chown admin:admin "$RELAY_ENV_FILE" 2>/dev/null || true
 chmod 600 "$RELAY_ENV_FILE"
 success "Relay env file written to $RELAY_ENV_FILE (mode 600)"
-# --- settings.json: copy AFTER the NAS mount, like openclaw's config ---
+# --- settings.json: copy AFTER the NAS mount ---
 # /home/admin is NAS-mounted at pod start, which shadows anything baked into
 # the image there — so the image stages the file at
 # /opt/claude-settings.json.template and we copy it in here, at service
 # start, AFTER the mount is live. Mount-wins: a settings.json already
 # present on the NAS (a deployment's own provider scenario) is kept
 # untouched. The copy substitutes the MODEL_PROVIDER_HOST placeholder (sed on
-# the bare variable name, same literal pattern as the entrypoint's
-# openclaw.json _sub — NOT the token's ${...} placeholder style). Only "/"
-# is escaped in the sed replacement; hosts must not carry sed metacharacters.
+# the bare variable name, literal pattern — NOT the token's ${...}
+# placeholder style). Only "/" is escaped in the sed replacement; hosts
+# must not carry sed metacharacters.
 CLAUDE_SETTINGS_FILE="/home/admin/.claude/settings.json"
 CLAUDE_SETTINGS_TEMPLATE="/opt/claude-settings.json.template"
 if [ ! -f "$CLAUDE_SETTINGS_FILE" ]; then
     if [ -f "$CLAUDE_SETTINGS_TEMPLATE" ]; then
         cp "$CLAUDE_SETTINGS_TEMPLATE" "$CLAUDE_SETTINGS_FILE"
-        # Same default as the entrypoint's openclaw.json MODEL_PROVIDER_HOST
-        # rendering (avernet-entrypoint.sh): an un-injected pod env keeps
-        # the shipped dashscope scenario. "Bearer ${API-KEY}" is untouched.
+        # Default keeps the shipped dashscope scenario when the pod env
+        # does not inject the host. "Bearer ${API-KEY}" is untouched.
         MODEL_PROVIDER_HOST="${MODEL_PROVIDER_HOST:-dashscope.aliyuncs.com}"
         _esc_model_provider_host="${MODEL_PROVIDER_HOST//\//\\/}"
         sed -i "s/MODEL_PROVIDER_HOST/${_esc_model_provider_host}/g" "$CLAUDE_SETTINGS_FILE"
@@ -144,6 +159,51 @@ if [ ! -f "$CLAUDE_SETTINGS_FILE" ]; then
     else
         warn "No $CLAUDE_SETTINGS_FILE on the mount and no template in the image; claude/relay fall back to their defaults"
     fi
+fi
+
+# --- models.json: relay providers catalogue, same staging pattern ---
+# The relay gateway's router (claude-code-router.ts) reads this via
+# RELAY_MODELS_FILE: ProviderConfig[] where each model entry carries env
+# overrides (ANTHROPIC_MODEL per model), so selecting e.g. qwen3.8-max in the
+# workbench routes the session to that model. Staged AFTER the NAS mount like
+# settings.json above: first boot copies the template; later boots
+# deep-merge the image catalogue INTO the NAS copy (merge-config.py: image
+# model entries update/append by id, deployment-only entries survive; a
+# no-op merge writes nothing) — /home/admin outlives image upgrades, so
+# without the merge new image model entries could never reach running pods.
+# Without the catalogue at all the relay falls back to its built-in
+# anthropic-only default.
+CLAUDE_MODELS_FILE="/home/admin/.claude/models.json"
+CLAUDE_MODELS_TEMPLATE="/opt/models.json.template"
+if [ -f "$CLAUDE_MODELS_FILE" ] && [ -x /usr/local/bin/merge-config ] \
+        && [ -f "$CLAUDE_MODELS_TEMPLATE" ]; then
+    # Allowlist in /opt/claude_code.path (maintained as
+    # docker/agent/claude_code.path in the repo) carries '*', so the whole
+    # image catalogue merges — merge-config.py: arrays merge entry-by-id,
+    # image model entries update/append and the deployment's own
+    # providers/models survive; a no-op merge writes nothing. Without the
+    # catalogue at all the relay falls back to its built-in
+    # anthropic-only default. (This script always runs AS ADMIN — the
+    # platform launches the chain via `su admin -c 'nohup
+    # start_service.sh ...'` — so no su/sudo drop around the call.)
+    if merge-config --base "${CLAUDE_MODELS_TEMPLATE}" \
+            --target "${CLAUDE_MODELS_FILE}" --keys /opt/claude_code.path; then
+        success "Claude models.json merged from image template into $CLAUDE_MODELS_FILE"
+    else
+        warn "merge-config failed for $CLAUDE_MODELS_FILE — keeping existing file (new image model entries may be missing)"
+    fi
+elif [ -f "$CLAUDE_MODELS_TEMPLATE" ] && [ ! -f "$CLAUDE_MODELS_FILE" ]; then
+    cp "$CLAUDE_MODELS_TEMPLATE" "$CLAUDE_MODELS_FILE"
+    chown admin:admin "$CLAUDE_MODELS_FILE" 2>/dev/null || true
+    chmod 600 "$CLAUDE_MODELS_FILE" 2>/dev/null || true
+    success "Claude models.json staged from template to $CLAUDE_MODELS_FILE"
+fi
+# Always point the relay at the catalogue when one exists (staged copy or a
+# deployment's mounted models.json); without it the relay serves its
+# built-in anthropic-only default catalogue.
+if [ -f "$CLAUDE_MODELS_FILE" ]; then
+    echo "export RELAY_MODELS_FILE=$CLAUDE_MODELS_FILE" >> "$RELAY_ENV_FILE"
+    success "Relay will load model catalogue from $CLAUDE_MODELS_FILE"
 fi
 
 # Point the gateway's model-provider loader at the settings.json above. The

--- a/docker/agent/start_openclaw.sh
+++ b/docker/agent/start_openclaw.sh
@@ -17,10 +17,16 @@
 #      Then reset workspace/HEARTBEAT.md from the image template — openclaw
 #      appends tasks to that file at runtime and the /home/admin mount makes
 #      the runtime copy persist, so every startup must overwrite it.
-#   2. Wait for the supervisord socket
-#   3. Start the engine program via supervisorctl
-#   4. Wait for the engine /health endpoint
-#   5. Write the ready marker and print status
+#   2. Render ~/.openclaw/openclaw.json from the image template: install on
+#      first boot, deep-merge into the NAS copy on later boots (image keys
+#      land, user-only keys survive). Then patch allowPrivateNetwork for
+#      private model hosts. Moved here from the container entrypoint —
+#      openclaw-specific config does not belong in the engine-agnostic
+#      image bootstrap.
+#   3. Wait for the supervisord socket
+#   4. Start the engine program via supervisorctl
+#   5. Wait for the engine /health endpoint
+#   6. Write the ready marker and print status
 ##############################################
 
 set -e
@@ -78,9 +84,132 @@ else
     warn "Heartbeat template missing at $HEARTBEAT_TEMPLATE - keeping existing file"
 fi
 
-# --- Step 2: Wait for supervisord socket ---
+# --- Step 2: Generate and patch ~/.openclaw/openclaw.json ---
 
-section "Step 2: Waiting for supervisord..."
+section "Step 2: Configuring openclaw provider config..."
+
+# Moved here from avernet-entrypoint.sh (which keeps only engine-agnostic
+# image bootstrap): openclaw.json rendering + the allowPrivateNetwork patch
+# below are openclaw-specific. This script runs before the engine starts
+# openclaw on demand, so the program still sees the config it needs.
+CONFIG_DIR="/home/admin/.openclaw"
+CONFIG_FILE="${CONFIG_DIR}/openclaw.json"
+TEMPLATE_FILE="/opt/openclaw.json.template"
+
+# This script always runs AS ADMIN (the platform launches the whole chain
+# via `su admin -c 'nohup start_service.sh ...'`), so no su/sudo drop here:
+# admin identity keeps the generated files admin-owned and gives the CLI a
+# correct $HOME. su from admin would prompt for a password and fail
+# non-interactively.
+
+# Render the image template with the pod env into a fresh candidate, on
+# EVERY startup — not only first boot. The candidate is either installed
+# (first boot) or deep-merged into the NAS copy below: /home/admin outlives
+# image upgrades, so without the merge, image-side key additions/value
+# updates (new provider flags, new model entries, changed defaults) could
+# never reach pods that always have a persistent openclaw.json.
+RENDER_OUT=$(mktemp /tmp/openclaw-config.XXXXXXXX)
+chmod 644 "${RENDER_OUT}"
+
+_gen_config() {
+    cp "${TEMPLATE_FILE}" "${RENDER_OUT}"
+
+    _sub() {
+        local val
+        val="${!1:-UNSET}"
+        val="${val//\//\\/}"
+        sed -i "s/${2}/${val}/g" "${RENDER_OUT}"
+    }
+
+    _sub OPENCLAW_OPENAI_BASE_URL  OPENCLAW_OPENAI_BASE_URL
+    _sub MODEL_PROVIDER_HOST       MODEL_PROVIDER_HOST
+    _sub OPENCLAW_OPENAI_API_KEY   OPENCLAW_OPENAI_API_KEY
+    _sub OPENCLAW_OPENAI_MODEL_ID  OPENCLAW_OPENAI_MODEL_ID
+    _sub OPENCLAW_OPENAI_MODEL_NAME OPENCLAW_OPENAI_MODEL_NAME
+    _sub OPENCLAW_GATEWAY_TOKEN    OPENCLAW_GATEWAY_TOKEN
+    _sub BCS_URL                   BCS_URL
+    _sub BCS_BOT_ID                BCS_BOT_ID
+    _sub BCS_BOT_NAME              BCS_BOT_NAME
+
+    if [ "${OPENCLAW_GATEWAY_TOKEN:-UNSET}" = "UNSET" ]; then
+        sed -i '/"auth": {/{N;s/"mode": "token", "token": "UNSET"//' "${RENDER_OUT}" 2>/dev/null || true
+    fi
+}
+# MODEL_PROVIDER_HOST: model provider host (bare host, no scheme or path —
+# the template carries the https:// prefix and the provider-specific path
+# suffix). Shared contract with start_claude_code.sh, which substitutes
+# the same placeholder into the claude_code settings.json. The default
+# keeps the shipped dashscope scenario when the pod env does not inject
+# it and must NOT fall through to _sub's UNSET literal (https://UNSET/...).
+MODEL_PROVIDER_HOST="${MODEL_PROVIDER_HOST:-dashscope.aliyuncs.com}"
+_gen_config
+
+if [ ! -f "${CONFIG_FILE}" ]; then
+    # First boot (or the NAS copy was removed): install the rendered
+    # candidate as the config.
+    cp "${RENDER_OUT}" "${CONFIG_FILE}"
+    success "OpenClaw config written to ${CONFIG_FILE}"
+else
+    info "Existing ${CONFIG_FILE} found (NAS-mounted)"
+    if [ -x /usr/local/bin/merge-config ]; then
+        # Deep-merge the freshly rendered template INTO the NAS copy,
+        # restricted to the allowlist in /opt/openclaw.path (maintained as
+        # docker/agent/openclaw.path in the repo): keys listed there take
+        # the image (post-upgrade) value, everything the user file carries
+        # outside the list survives untouched — "meta" is not listed, so
+        # the CLI's own lastTouched* bookkeeping stays user-owned. A no-op
+        # merge writes nothing; changes are atomic with a .bak snapshot,
+        # see merge-config.py.
+        if merge-config --base "${RENDER_OUT}" --target "${CONFIG_FILE}" \
+                --keys /opt/openclaw.path; then
+            success "OpenClaw config merged from image template into ${CONFIG_FILE}"
+        else
+            warn "merge-config failed for ${CONFIG_FILE} — keeping existing file (image key updates may be missing)"
+        fi
+    else
+        warn "merge-config not installed; using existing ${CONFIG_FILE} as-is"
+    fi
+fi
+rm -f "${RENDER_OUT}"
+
+# Allow private-network model provider endpoints.
+# MODEL_PROVIDER_HOST can point at internal hosts (e.g. *.inner.avernet.com).
+# openclaw blocks requests to private networks on a provider unless
+# request.allowPrivateNetwork is true, so lift the restriction for the
+# openai-compatible provider. Deliberate: the provider URL is
+# operator-controlled (image template + pod env), not bot-controlled, so the
+# SSRF guard is not needed here. Runs on EVERY startup, not only at
+# first-boot rendering, so NAS-persisted configs from older images are
+# patched too — but written only when the value is not already true, so
+# startups with nothing to do never rewrite the file. Best-effort — a CLI
+# failure must not block startup (the restriction then surfaces as
+# per-request model errors instead of a dead startup).
+if [ -x /usr/local/bin/openclaw ] && [ -f "${CONFIG_FILE}" ]; then
+    # Idempotence: read the current value and only write when it is not
+    # exactly "true" (a plain set on every boot keeps rewriting the
+    # NAS-persisted config). The CLI prints its banner on every invocation,
+    # so compare the LAST line of stdout, whitespace-stripped; "Config path
+    # not found" and CLI failures both read as not-true and fall through to
+    # the set. Exit codes are swallowed — config get exits non-zero on
+    # not-found.
+    _allow_private=$(openclaw config get \
+        models.providers.openai-compatible.request.allowPrivateNetwork \
+        2>/dev/null | tail -n 1 | tr -d '[:space:]' || true)
+    if [ "${_allow_private}" != "true" ]; then
+        if openclaw config set \
+            models.providers.openai-compatible.request.allowPrivateNetwork true; then
+            success "openclaw: private-network model endpoints allowed (allowPrivateNetwork=true)"
+        else
+            warn "openclaw config set allowPrivateNetwork failed — private model hosts will be blocked"
+        fi
+    else
+        info "openclaw: allowPrivateNetwork already true (skipping config set)"
+    fi
+fi
+
+# --- Step 3: Wait for supervisord socket ---
+
+section "Step 3: Waiting for supervisord..."
 
 SUPERVISOR_SOCK="/var/run/supervisor.sock"
 MAX_WAIT=30
@@ -96,9 +225,9 @@ while [ ! -S "$SUPERVISOR_SOCK" ]; do
 done
 success "supervisord ready (waited ${waited}s)"
 
-# --- Step 3: Start engine via supervisorctl ---
+# --- Step 4: Start engine via supervisorctl ---
 
-section "Step 3: Starting engine program..."
+section "Step 4: Starting engine program..."
 
 ENGINE_RUNNING=$(sudo /usr/local/bin/supervisorctl status engine 2>/dev/null | grep -c "RUNNING" || true)
 
@@ -117,9 +246,9 @@ fi
 # The engine starts the openclaw program on demand (first bot session) via
 # `sudo supervisorctl start openclaw` — nothing to do for it here.
 
-# --- Step 4: Wait for engine /health endpoint ---
+# --- Step 5: Wait for engine /health endpoint ---
 
-section "Step 4: Waiting for engine health (port $ADAPTOR_PORT)..."
+section "Step 5: Waiting for engine health (port $ADAPTOR_PORT)..."
 
 HEALTH_CHECK_TIMEOUT=120
 HEARTBEAT_INTERVAL=10
@@ -144,7 +273,7 @@ else
     success "Engine health check passed"
 fi
 
-# --- Step 5: Write ready marker & print status ---
+# --- Step 6: Write ready marker & print status ---
 
 echo "SUCCEEDED" > "$MARKER_FILE"
 

--- a/src/evolverun/taskguard/package.json
+++ b/src/evolverun/taskguard/package.json
@@ -71,7 +71,7 @@
   "scripts": {
     "build": "tshy && node ./scripts/build/fix-exports-wildcards.mjs && node ./scripts/build/bundle-runtime.mjs && node ./scripts/build/generate-facade-skills.mjs && node ./scripts/build/copy-runtime-assets.mjs",
     "build:all": "npm run build",
-    "test": "node --import tsx --test \"tests/**/*.test.ts\""
+    "test": "find tests -name '*.test.ts' -print0 | xargs -0 node --import tsx --test"
   },
   "peerDependencies": {
     "openclaw": "*"

--- a/src/evolverun/taskguard/package.json
+++ b/src/evolverun/taskguard/package.json
@@ -71,7 +71,7 @@
   "scripts": {
     "build": "tshy && node ./scripts/build/fix-exports-wildcards.mjs && node ./scripts/build/bundle-runtime.mjs && node ./scripts/build/generate-facade-skills.mjs && node ./scripts/build/copy-runtime-assets.mjs",
     "build:all": "npm run build",
-    "test": "find tests -name '*.test.ts' -print0 | xargs -0 node --import tsx --test"
+    "test": "node --import tsx --test \"tests/**/*.test.ts\""
   },
   "peerDependencies": {
     "openclaw": "*"


### PR DESCRIPTION
- Problem:
    /home/admin is NAS-mounted and outlives image upgrades, so first-boot
    generated configs (~/.openclaw/openclaw.json, ~/.claude/models.json) go
    stale forever: image-side key additions and value updates (new provider
    flags, new model entries, corrected model metadata) could never reach
    running pods short of deleting the NAS files by hand. The openclaw.json
    rendering also lived in the container entrypoint, forcing the
    engine-agnostic bootstrap to know openclaw-specific config details.
    Both engine catalogues lacked the multimodal qwen3.8-max on the
    claude_code side entirely (no relay providers file was shipped).
    
- Solution:
    - Add merge-config.py (installed at /usr/local/bin/merge-config): a
      deep-merge helper with dict recursion, id-keyed array merging, an
      UNSET guard so un-injected env placeholders never clobber real
      values, atomic writes preserving owner/mode, a .bak snapshot, and
      no-write idempotence. Merge scope is driven by a --keys allowlist
      file instead of CLI flags: docker/agent/openclaw.path lists the
      template keys image updates may touch (all top-level keys except
      meta, which stays user-owned), docker/agent/claude_code.path carries
      '*' since models.json's top level is an array already protected by
      entry-by-id merging. Maintaining the allowlist is editing the file —
      template keys are added to openclaw.path when they should reach
      existing NAS copies; paths that miss in the base warn on stderr.
    - start_openclaw.sh now renders the image template with pod env on
      EVERY startup into a throwaway candidate: install on first boot,
      deep-merge into the NAS copy on later boots, then the idempotent
      allowPrivateNetwork patch. This block moved here from
      avernet-entrypoint.sh, which now holds only engine-agnostic image
      bootstrap.
    - Ship docker/agent/models.json (ProviderConfig[] catalogue for the
      relay router via RELAY_MODELS_FILE): antchat provider with glm-5.2
      and the multimodal qwen3.8-max. start_claude_code.sh installs it on
      first boot, deep-merges it into the NAS copy on later boots, and
      always exports RELAY_MODELS_FILE for the relay program.
    - Register qwen3.8-max (text+image, 1M context) in the openclaw.json
      model catalogue; default primary/imageModel still target glm-5.2.
      Also register the taskguard plugin path/entry and memory-core in
      openclaw.json (user's taskguard rollout).
    
    claude-settings.json is deliberately not merged: its mount-wins
    semantics is the documented whole-scenario injection channel.
    
- Validation:
    - 23-assertion harness exercising the real tool through its CLI:
      allowlist subset/multi/dot-path merges, '*' (full base), misses
      warned and skipped without skeleton injection, comments-only
      allowlist no-op, unreadable keys file exit 6, no-keys full-merge
      regression, idempotent repeat, UNSET guard under keys.
    - real-file integration: rendered openclaw.json + openclaw.path into a
      stale NAS copy (qwen + allowPrivateNetwork + template baseUrl land,
      meta/user-only keys preserved, second merge a no-op); models.json +
      claude_code.path into a deployment catalogue (glm env healed, qwen
      appended, custom provider survives).
    - bash -n on both startup scripts, py_compile on merge-config.py.


 - Compatibility and risk:
    - Image-defined keys LISTED in openclaw.path take the image value on
    merged boots, so hand edits of those keys on the NAS are overwritten;
    everything else always survives. Rollback risk is bounded by the .bak
    snapshot written next to each merged file.