### PR TITLE
feat(workflow): Add cross-instance workflow run queries and retry options support

### DIFF
--- a/src/evolverun/clawweb/public/modules/workflow/docs/cross-instance-run-tools.md
+++ b/src/evolverun/clawweb/public/modules/workflow/docs/cross-instance-run-tools.md
@@ -1,0 +1,76 @@
+# 跨实例运行查询与重试参数
+
+API 模式下，多个实例使用同一个 ClawWeb、同一组 BOT_ID / OWNER_ID。
+
+```text
+/workflow runs --global --status failed --limit 20
+/workflow runs --global --status failed --limit 20 --beforeId <上一页游标>
+/workflow inspect <flowId>
+/workflow logs <flowId> --nodeId <nodeId> --level error --limit 20
+/workflow logs <flowId> --nodeId <nodeId> --level error --limit 20 --afterId <上一页游标>
+```
+
+MCP 对应 `workflow_runs(global=true, beforeId=...)`、`workflow_inspect`、`workflow_logs(afterId=...)`。
+`workflow_runs` 默认仍查当前会话。`state/debug` 入口共用 inspect。
+
+共享列表按入库 ID 倒序、日志按 ID 正序分页，翻页时保留筛选条件。
+日志序号 seq 可能随进程重启重复，不能用作分页游标。
+每页最多 50 条；单条日志显示前 2000 字符并提示截断，完整归档仍可通过 inspect 获取。
+列表和日志使用运行环境的 bot/owner 范围，MCP 不提供任意 owner 切换。
+无归属的旧记录不包含在共享查询中；空日志只表示尚无匹配的已上报日志。
+内部接口沿用服务级 Ed25519 签名信任，查询 scope 位于签名的 POST body 中；不构成独立的每 bot 身份认证。
+
+## 发布顺序
+
+1. Avernet ClawWeb Shared 数据库迁移 v119：增加 `flow_retry_requests.options_json`，增加共享列表查询索引。
+2. 发布 Avernet workflow 模块和 OCB Host 接线，再更新所有 ClawMind 实例（本地库迁移 v38）。
+3. 用 A 实例创建的 flow，在 B 实例执行上面的列表、详情和日志查询。
+
+托管 MySQL 若没有自动 DDL 权限，先由数据库发布流程执行：
+
+```sql
+ALTER TABLE flow_retry_requests ADD COLUMN options_json TEXT;
+CREATE INDEX idx_flow_runs_origin_id ON flow_runs (origin_bot_id, id);
+```
+
+新增内部接口为 `POST /api/internal/run-reads/runs`、`POST /api/internal/run-reads/logs`。
+新客户端遇到旧查询服务会明确报错，不降级成误导性的空列表。
+
+重试邮箱完整保存 `useCurrentDef`、`debug`、`inputOverrides`。
+带选项的请求发布前会检查服务能力，旧执行实例不能领取带选项的请求。
+因此滚动升级期间，可能需要等待持有该 flow 的实例升级后才能执行重试。
+原实例离线接管、跨实例 recent_events 和状态镜像可靠性增强不在本批范围内。
+
+## Source ownership
+
+Run reads and the retry mailbox are owned by `@avernet/workflow`; schema migrations are in `@avernet/clawweb-shared`. OCB only composes the routers behind its existing internal signature middleware. The ClawMind engine remains in the separate ClawMind repository; Avernet taskguard is unchanged by this migration.
+
+## Internal API contract
+
+All paths below are relative to `/api/internal`, behind the host's service signature middleware.
+Read requests use POST so their scope and filters are covered by the existing body signature.
+
+| Endpoint | Request body | Response `data` |
+|---|---|---|
+| `POST /run-reads/runs` | Required `botId`, `ownerId`; optional `workflowId`, `status`, `identityKey`, `includeHidden`, `beforeId`, `limit` | `{ items: RunSummary[], nextCursor: number \| null }` |
+| `POST /run-reads/logs` | Required `botId`, `ownerId`, `flowId`; optional `nodeId`, `level`, `afterId`, `limit` | `{ items: RunLog[], nextCursor: number \| null }` |
+| `GET /retry-requests/capabilities` | None | `{ executionOptionsVersion: 1 }` |
+| `POST /retry-requests` | Existing fields plus optional `options: { useCurrentDef?: boolean, debug?: boolean, inputOverrides?: Record<string,string> }` | Existing retry row, including nullable `options_json` |
+| `POST /retry-requests/claim` | Existing fields plus optional `options_version: 1` | Existing `{ claimed: RetryRequest[] }`, each including `options_json` |
+
+Success envelope: `{ success: true, data: ... }`. Read errors return
+`{ success: false, message: string }`: 400 for invalid scope/filters/cursors,
+404 for a log flow outside the requested ownership scope, and 500 for a database failure.
+Missing/invalid signatures are rejected by the host before querying repositories.
+
+`limit` defaults to 20 and is restricted to integers 1–50. Cursors are nonnegative safe integers.
+Runs are ordered by descending database ID and use an exclusive `beforeId`; logs use ascending
+ID and an exclusive `afterId`. `nextCursor: null` ends the current filtered result set.
+Run summaries omit state/credentials payloads. Logs contain `id`, `node_id`, `level`, `source`,
+`message`, `message_length`, and `timestamp`; the message is capped at 2000 characters.
+Ownership matches the exact persisted `origin_bot_id = botId + ':' + ownerId`.
+
+Retry options are optional so existing rows remain readable. Consumers without
+`options_version: 1` can claim only requests with no execution options. The ClawMind client
+checks server capabilities before posting an options-bearing request and verifies the persisted
+options in the response; existing open requests retain their original parameters.

--- a/src/evolverun/clawweb/public/modules/workflow/server/repositories/__tests__/flow-retry-request-repository.test.ts
+++ b/src/evolverun/clawweb/public/modules/workflow/server/repositories/__tests__/flow-retry-request-repository.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Tests for FlowRetryRequestRepository — the cross-engine retry mailbox.
+ * Claim is a CAS: exactly one concurrent claimer wins; expired leases become
+ * claimable again; release returns a row to the pool with attempts+1.
+ */
+import { describe, it, expect } from "vitest";
+import type { IDatabase } from "@avernet/clawweb-shared/server/db";
+import { sqliteDialect } from "@avernet/clawweb-shared/server/db/dialect";
+import { FlowRetryRequestRepository } from "../flow-retry-request-repository.js";
+import Database from "better-sqlite3";
+
+function createTestDb(): IDatabase {
+  const raw = new Database(":memory:");
+  raw.exec(`
+    CREATE TABLE flow_retry_requests (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      request_id VARCHAR(255) NOT NULL,
+      flow_id VARCHAR(255) NOT NULL,
+      node_id VARCHAR(255),
+      reason TEXT,
+      requester VARCHAR(255),
+      options_json TEXT,
+      status VARCHAR(255) NOT NULL DEFAULT 'pending',
+      claim_engine VARCHAR(255),
+      claimed_at INTEGER,
+      attempts INTEGER NOT NULL DEFAULT 0,
+      result_message TEXT,
+      gmt_create INTEGER NOT NULL DEFAULT (unixepoch()),
+      gmt_modified INTEGER NOT NULL DEFAULT (unixepoch())
+    );
+    CREATE UNIQUE INDEX uk_flow_retry_requests_request_id ON flow_retry_requests (request_id);
+    CREATE INDEX idx_flow_retry_requests_status ON flow_retry_requests (status);
+    CREATE INDEX idx_flow_retry_requests_flow_id ON flow_retry_requests (flow_id);
+  `);
+
+  return {
+    dbType: "sqlite",
+    dialect: sqliteDialect,
+    query: async <T>(sql: string, params?: unknown[]) => {
+      const stmt = raw.prepare(sql);
+      const rows = params ? stmt.all(...params) : stmt.all();
+      return rows as T[];
+    },
+    exec: async (sql: string, params?: unknown[]) => {
+      const stmt = raw.prepare(sql);
+      const result = params ? stmt.run(...params) : stmt.run();
+      return { affectedRows: result.changes, insertId: result.lastInsertRowid as number };
+    },
+    transaction: async <T>(fn: (db: IDatabase) => Promise<T>) => {
+      return raw.transaction(() => fn(createTestDb()))();
+    },
+    close: async () => { raw.close(); },
+  };
+}
+
+describe("FlowRetryRequestRepository", () => {
+  it("create inserts a pending request and dedupes on an open request for the same flow", async () => {
+    const db = createTestDb();
+    const repo = new FlowRetryRequestRepository(db);
+    try {
+      const first = await repo.create({ requestId: "r1", flowId: "flow-a", nodeId: "content-analysis", reason: "cortex-recovery:x", requester: "bot-1" });
+      expect(first?.status).toBe("pending");
+      expect(first?.request_id).toBe("r1");
+
+      // duplicate retry for the same flow returns the existing open row
+      const dup = await repo.create({ requestId: "r2", flowId: "flow-a", reason: "again" });
+      expect(dup?.request_id).toBe("r1");
+
+      // a different flow gets its own row
+      const other = await repo.create({ requestId: "r3", flowId: "flow-b" });
+      expect(other?.request_id).toBe("r3");
+    } finally {
+      await db.close();
+    }
+  });
+
+  it("claimPending CAS: exactly one winner per row, loser gets nothing", async () => {
+    const db = createTestDb();
+    const repo = new FlowRetryRequestRepository(db);
+    try {
+      await repo.create({ requestId: "r1", flowId: "flow-a" });
+      const now = Math.floor(Date.now() / 1000);
+
+      const first = await repo.claimPending(10, 600, "engine-1", now);
+      expect(first).toHaveLength(1);
+      expect(first[0].claim_engine).toBe("engine-1");
+      expect(first[0].status).toBe("claimed");
+
+      // second engine polling right after: nothing left to claim
+      const second = await repo.claimPending(10, 600, "engine-2", now);
+      expect(second).toHaveLength(0);
+    } finally {
+      await db.close();
+    }
+  });
+
+  it("expired lease becomes claimable again (dead claimer recovery)", async () => {
+    const db = createTestDb();
+    const repo = new FlowRetryRequestRepository(db);
+    try {
+      await repo.create({ requestId: "r1", flowId: "flow-a" });
+      const t0 = 1_000_000;
+      await repo.claimPending(10, 600, "engine-1", t0);
+
+      // within lease: still owned by engine-1
+      expect(await repo.claimPending(10, 600, "engine-2", t0 + 300)).toHaveLength(0);
+      // after lease expiry: engine-2 wins
+      const reclaimed = await repo.claimPending(10, 600, "engine-2", t0 + 601);
+      expect(reclaimed).toHaveLength(1);
+      expect(reclaimed[0].claim_engine).toBe("engine-2");
+    } finally {
+      await db.close();
+    }
+  });
+
+  it("release returns the row to pending with attempts+1; complete marks terminal", async () => {
+    const db = createTestDb();
+    const repo = new FlowRetryRequestRepository(db);
+    try {
+      await repo.create({ requestId: "r1", flowId: "flow-a" });
+      const now = Math.floor(Date.now() / 1000);
+      await repo.claimPending(10, 600, "engine-1", now);
+
+      // wrong host → release back to pool
+      expect(await repo.release("r1")).toBe(true);
+      const after = await repo.claimPending(10, 600, "engine-2", now);
+      expect(after).toHaveLength(1);
+      expect(after[0].attempts).toBe(1);
+
+      // executor finishes
+      expect(await repo.complete("r1", true, "retried on owner host")).toBe(true);
+
+      // completed rows are never claimable again, and create no longer dedupes on them
+      expect(await repo.claimPending(10, 600, "engine-3", now)).toHaveLength(0);
+      const fresh = await repo.create({ requestId: "r4", flowId: "flow-a" });
+      expect(fresh?.request_id).toBe("r4");
+
+      expect(await repo.complete("missing", false, "x")).toBe(false);
+      expect(await repo.release("missing")).toBe(false);
+    } finally {
+      await db.close();
+    }
+  });
+});
+
+
+it("preserves retry options through persistence and claim", async () => {
+ const db = createTestDb(); const repo = new FlowRetryRequestRepository(db);
+ try {
+  const options = {useCurrentDef: true, debug: true, inputOverrides: {ticket: "42"}};
+  const row = await repo.create({requestId:"options-r",flowId:"options-f",options});
+  expect(JSON.parse(row!.options_json!)).toEqual(options);
+  const claimed = await repo.claimPending(1,600,"engine-a",Math.floor(Date.now()/1000),["options-f"]);
+  expect(JSON.parse(claimed[0].options_json!)).toEqual(options);
+  expect(await repo.claimPending(1,600,"engine-b",Math.floor(Date.now()/1000),["options-f"])).toEqual([]);
+ } finally { await db.close(); }
+});
+
+
+it("old consumers cannot claim requests carrying execution options", async () => {
+ const db = createTestDb(); const repo = new FlowRetryRequestRepository(db);
+ try {
+  await repo.create({requestId:"old-consumer-r",flowId:"old-consumer-f",options:{debug:true}});
+  expect(await repo.claimPending(1,600,"old-engine",Math.floor(Date.now()/1000),["old-consumer-f"],false)).toEqual([]);
+  expect(await repo.claimPending(1,600,"new-engine",Math.floor(Date.now()/1000),["old-consumer-f"],true)).toHaveLength(1);
+ } finally {await db.close();}
+});

--- a/src/evolverun/clawweb/public/modules/workflow/server/repositories/__tests__/run-read-repository.test.ts
+++ b/src/evolverun/clawweb/public/modules/workflow/server/repositories/__tests__/run-read-repository.test.ts
@@ -1,0 +1,70 @@
+import express from "express";
+import { createInternalRunReadsRouter } from "../../routes/internal/run-reads.js";
+import { describe, it, expect } from "vitest";
+import Database from "better-sqlite3";
+import { RunReadRepository } from "../run-read-repository.js";
+import { sqliteDialect } from "@avernet/clawweb-shared/server/db/dialect";
+import type { IDatabase } from "@avernet/clawweb-shared/server/db";
+
+function fixture() {
+  const raw = new Database(":memory:");
+  raw.exec(`CREATE TABLE flow_runs (id INTEGER PRIMARY KEY, flow_id TEXT, workflow_id TEXT, status TEXT, origin_bot_id TEXT, identity_key TEXT, started_at INTEGER, gmt_modified INTEGER, state_json TEXT);
+  INSERT INTO flow_runs VALUES (1,'f1','wf','failed','bot:owner','identity',1,2,NULL),(2,'f2','wf','failed','bot:owner','identity',1,2,NULL),(3,'other','wf','failed','bot:other','identity',1,2,NULL),(4,'legacy','wf','failed',NULL,'identity',1,2,NULL);
+  CREATE TABLE run_logs (id INTEGER PRIMARY KEY,flow_id TEXT,node_id TEXT,level TEXT,source TEXT,message TEXT,timestamp INTEGER,seq INTEGER);
+  INSERT INTO run_logs VALUES (1,'f1','n','error','engine','first',100,1),(2,'f1','n','error','engine','second',100,1),(3,'f1','n','info','engine','info',100,2);`);
+  const db = { dbType: "sqlite", dialect: sqliteDialect, query: async (sql: string, args: any[] = []) => raw.prepare(sql).all(...args) } as unknown as IDatabase;
+  return { raw, repo: new RunReadRepository(db), close: () => raw.close() };
+}
+const scope = { botId: "bot", ownerId: "owner" };
+describe("scoped shared run reads", () => {
+ it("paginates records across instances without leaking other owners or unowned legacy rows", async () => {
+  const f = fixture(); try {
+   const first = await f.repo.listRuns({ ...scope, limit: 1, status: "failed" });
+   expect(first.items.map(r => r.flow_id)).toEqual(["f2"]);
+   const second = await f.repo.listRuns({ ...scope, limit: 1, beforeId: first.nextCursor! });
+   expect(second.items.map(r => r.flow_id)).toEqual(["f1"]); expect(second.nextCursor).toBeNull();
+  } finally { f.close(); }
+ });
+ it("paginates duplicate-sequence logs by persistent id and applies filters", async () => {
+  const f = fixture(); try {
+   const q = {...scope, flowId: "f1", nodeId: "n", level: "error", limit: 1};
+   const first = await f.repo.readLogs(q); const second = await f.repo.readLogs({...q, afterId: first.nextCursor!});
+   expect(first.items[0].message).toBe("first"); expect(second.items[0].message).toBe("second"); expect(second.nextCursor).toBeNull();
+   await expect(f.repo.readLogs({...q, ownerId: "other"})).rejects.toThrow(/not found/i);
+  } finally { f.close(); }
+ });
+ it("refuses unscoped queries", async () => {
+  const f=fixture(); try { await expect(f.repo.listRuns({botId:"bot",ownerId:""})).rejects.toThrow(/scope/i); } finally {f.close();}
+ });
+});
+
+
+it("HTTP read routes enforce scope, validate filters, and return pagination data", async () => {
+ const f=fixture(); const app=express(); app.use(express.json()); app.use(createInternalRunReadsRouter(f.repo));
+ const server = app.listen(0, "127.0.0.1");
+ await new Promise<void>(resolve => server.once("listening", resolve));
+ const url = `http://127.0.0.1:${(server.address() as import("node:net").AddressInfo).port}`;
+ const request = (_app: unknown) => ({post:(path:string)=>({send:async(body:unknown)=>{
+   const response=await fetch(url+path,{method:"POST",headers:{"content-type":"application/json"},body:JSON.stringify(body)});
+   return {status:response.status,body:await response.json()};
+ }})});
+ try {
+  const first=await request(app).post("/runs").send({...scope,limit:1});
+  expect(first.status).toBe(200);expect(first.body.data.items[0].flow_id).toBe("f2");
+  expect((await request(app).post("/runs").send({botId:"bot"})).status).toBe(400);
+  expect((await request(app).post("/runs").send({...scope,beforeId:"2"})).status).toBe(400);
+  expect((await request(app).post("/logs").send({...scope,flowId:"other"})).status).toBe(404);
+  const logs=await request(app).post("/logs").send({...scope,flowId:"f1",nodeId:"n",level:"error",limit:1});
+  expect(logs.status).toBe(200);expect(logs.body.data.items[0].message).toBe("first");expect(logs.body.data.nextCursor).toBe(1);
+ } finally {server.closeAllConnections(); await new Promise<void>((resolve,reject)=>server.close(e=>e?reject(e):resolve())); f.close();}
+});
+
+
+it("shared lists respect hidden records and explicit includeHidden", async () => {
+ const f=fixture();
+ try {
+  f.raw.prepare("UPDATE flow_runs SET state_json=? WHERE flow_id='f2'").run(JSON.stringify({workflowData:{flowHidden:true}}));
+  expect((await f.repo.listRuns(scope)).items.map(r=>r.flow_id)).toEqual(["f1"]);
+  expect((await f.repo.listRuns({...scope,includeHidden:true})).items.map(r=>r.flow_id)).toEqual(["f2","f1"]);
+ } finally {f.close();}
+});

--- a/src/evolverun/clawweb/public/modules/workflow/server/repositories/flow-retry-request-repository.ts
+++ b/src/evolverun/clawweb/public/modules/workflow/server/repositories/flow-retry-request-repository.ts
@@ -1,0 +1,138 @@
+/**
+ * FlowRetryRequestRepository — mailbox table for cross-engine retry handoff.
+ *
+ * When a retry command lands on an engine instance that does not hold the
+ * flow's TaskFlow state (different host), the requester posts a row here;
+ * every engine polls, claims via CAS (exactly one winner), checks its LOCAL
+ * openclaw registry for the flow, and either executes (state is local) or
+ * releases for the next engine. A claimed row whose lease expires becomes
+ * claimable again, so an engine dying mid-execution cannot wedge a request.
+ */
+import type { IDatabase } from "@avernet/clawweb-shared/server/db";
+
+export type RetryExecutionOptions = { useCurrentDef?: boolean; debug?: boolean; inputOverrides?: Record<string, string> };
+
+export type FlowRetryRequestRow = {
+  options_json?: string | null;
+  id: number;
+  request_id: string;
+  flow_id: string;
+  node_id: string | null;
+  reason: string | null;
+  requester: string | null;
+  status: string; // pending | claimed | completed | failed
+  claim_engine: string | null;
+  claimed_at: number | null;
+  attempts: number;
+  result_message: string | null;
+  gmt_create: number;
+  gmt_modified: number | null;
+};
+
+export type FlowRetryRequestInsert = {
+  options?: RetryExecutionOptions;
+  requestId: string;
+  flowId: string;
+  nodeId?: string | null;
+  reason?: string | null;
+  requester?: string | null;
+};
+
+export class FlowRetryRequestRepository {
+  constructor(private db: IDatabase) {}
+
+  /**
+   * Post a retry request. If the same flow already has an open (pending or
+   * claimed) request, returns that one instead of duplicating — duplicate
+   * retry commands for one flow must not multiply executions.
+   */
+  async create(input: FlowRetryRequestInsert): Promise<FlowRetryRequestRow | null> {
+    try {
+      const open = await this.db.query<FlowRetryRequestRow>(
+        "SELECT * FROM flow_retry_requests WHERE flow_id = ? AND status IN ('pending','claimed') ORDER BY id ASC LIMIT 1",
+        [input.flowId],
+      );
+      if (open[0]) return open[0];
+      const now = this.db.dialect.now();
+      await this.db.exec(
+        `INSERT INTO flow_retry_requests (request_id, flow_id, node_id, reason, requester, options_json, status, attempts, gmt_create, gmt_modified)
+         VALUES (?, ?, ?, ?, ?, ?, 'pending', 0, ?, ?)`,
+        [input.requestId, input.flowId, input.nodeId ?? null, input.reason ?? null, input.requester ?? null, input.options ? JSON.stringify(input.options) : null, now, now],
+      );
+      const rows = await this.db.query<FlowRetryRequestRow>(
+        "SELECT * FROM flow_retry_requests WHERE request_id = ?",
+        [input.requestId],
+      );
+      return rows[0] ?? null;
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      console.warn(`[db] FlowRetryRequestRepository.create failed: ${msg} (dbType=${this.db.dbType}, flowId=${input.flowId})`);
+      return null;
+    }
+  }
+
+  /**
+   * Claim open requests. Two-step: select candidates, then CAS each one.
+   * Only rows where the CAS lands (affectedRows > 0) are returned, so
+   * concurrent engine processes never execute the same request twice.
+   * `leaseSecs` makes a dead claimer's row claimable again.
+   */
+  async claimPending(limit: number, leaseSecs: number, claimEngine: string, nowSecs: number, flowIds?: string[], supportsOptions = true): Promise<FlowRetryRequestRow[]> {
+    try {
+      const leaseCutoff = nowSecs - leaseSecs;
+      const flowFilter = flowIds && flowIds.length > 0
+        ? `flow_id IN (${flowIds.map(() => "?").join(", ")}) AND `
+        : "";
+      const candidates = await this.db.query<FlowRetryRequestRow>(
+        `SELECT * FROM flow_retry_requests
+         WHERE ${supportsOptions ? "" : "(options_json IS NULL OR options_json = '{}') AND "}${flowFilter}(status = 'pending' OR (status = 'claimed' AND claimed_at IS NOT NULL AND claimed_at < ?))
+         ORDER BY id ASC LIMIT ?`,
+        [...(flowIds ?? []), leaseCutoff, limit],
+      );
+      const claimed: FlowRetryRequestRow[] = [];
+      for (const row of candidates) {
+        const result = await this.db.exec(
+          `UPDATE flow_retry_requests SET status = 'claimed', claim_engine = ?, claimed_at = ?
+           WHERE request_id = ? AND (status = 'pending' OR (status = 'claimed' AND claimed_at IS NOT NULL AND claimed_at < ?))`,
+          [claimEngine, nowSecs, row.request_id, leaseCutoff],
+        );
+        if (result.affectedRows > 0) claimed.push({ ...row, status: "claimed", claim_engine: claimEngine, claimed_at: nowSecs });
+      }
+      return claimed;
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      console.warn(`[db] FlowRetryRequestRepository.claimPending failed: ${msg} (dbType=${this.db.dbType})`);
+      return [];
+    }
+  }
+
+  /** Mark a claimed request finished (ok=true → completed, ok=false → failed). */
+  async complete(requestId: string, ok: boolean, message: string): Promise<boolean> {
+    try {
+      const result = await this.db.exec(
+        "UPDATE flow_retry_requests SET status = ?, result_message = ? WHERE request_id = ?",
+        [ok ? "completed" : "failed", message, requestId],
+      );
+      return result.affectedRows > 0;
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      console.warn(`[db] FlowRetryRequestRepository.complete failed: ${msg} (dbType=${this.db.dbType}, requestId=${requestId})`);
+      return false;
+    }
+  }
+
+  /** Hand a claimed request back to the pool (state not on this host). */
+  async release(requestId: string): Promise<boolean> {
+    try {
+      const result = await this.db.exec(
+        "UPDATE flow_retry_requests SET status = 'pending', attempts = attempts + 1, claim_engine = NULL, claimed_at = NULL WHERE request_id = ?",
+        [requestId],
+      );
+      return result.affectedRows > 0;
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      console.warn(`[db] FlowRetryRequestRepository.release failed: ${msg} (dbType=${this.db.dbType}, requestId=${requestId})`);
+      return false;
+    }
+  }
+}

--- a/src/evolverun/clawweb/public/modules/workflow/server/repositories/run-read-repository.ts
+++ b/src/evolverun/clawweb/public/modules/workflow/server/repositories/run-read-repository.ts
@@ -1,0 +1,56 @@
+import type { IDatabase } from "@avernet/clawweb-shared/server/db";
+
+export type RunReadScope = { botId: string; ownerId: string };
+export type RunListQuery = RunReadScope & { limit?: number; beforeId?: number; workflowId?: string; status?: string; identityKey?: string; includeHidden?: boolean };
+export type RunLogQuery = RunReadScope & { flowId: string; limit?: number; afterId?: number; nodeId?: string; level?: string };
+export type ReadPage = { items: Record<string, unknown>[]; nextCursor: number | null };
+
+function scopeKey(scope: RunReadScope): string {
+  if (!scope.botId?.trim() || !scope.ownerId?.trim()) throw new Error("Missing bot/owner scope");
+  return `${scope.botId}:${scope.ownerId}`;
+}
+function pageLimit(value = 20): number {
+  if (!Number.isSafeInteger(value) || value < 1 || value > 50) throw new Error("limit must be an integer between 1 and 50");
+  return value;
+}
+function cursor(value?: number): void {
+  if (value !== undefined && (!Number.isSafeInteger(value) || value < 0)) throw new Error("Invalid cursor");
+}
+function page(rows: Record<string, unknown>[], limit: number): ReadPage {
+  return { items: rows.slice(0, limit), nextCursor: rows.length > limit ? Number(rows[limit - 1].id) : null };
+}
+
+/** Internal service callers supply bot scope from runtime configuration, never tool arguments.
+ * Exact origin ownership deliberately excludes legacy rows without provable ownership. */
+export class RunReadRepository {
+  constructor(private db: IDatabase) {}
+
+  async listRuns(q: RunListQuery): Promise<ReadPage> {
+    const key = scopeKey(q); const limit = pageLimit(q.limit); cursor(q.beforeId);
+    const where = ["origin_bot_id = ?"]; const args: unknown[] = [key];
+    for (const [col, val] of [["workflow_id", q.workflowId], ["status", q.status], ["identity_key", q.identityKey]]) {
+      if (val) { where.push(`${col} = ?`); args.push(val); }
+    }
+    if (q.beforeId !== undefined) { where.push("id < ?"); args.push(q.beforeId); }
+    if (!q.includeHidden) where.push("COALESCE(CAST(JSON_EXTRACT(state_json, '$.workflowData.flowHidden') AS CHAR), 'false') NOT IN ('true', '1')");
+    const rows = await this.db.query<Record<string, unknown>>(
+      `SELECT id, flow_id, workflow_id, status, origin_bot_id, identity_key, started_at, gmt_modified
+       FROM flow_runs WHERE ${where.join(" AND ")} ORDER BY id DESC LIMIT ?`, [...args, limit + 1]);
+    return page(rows, limit);
+  }
+
+  async readLogs(q: RunLogQuery): Promise<ReadPage> {
+    const key = scopeKey(q); const limit = pageLimit(q.limit); cursor(q.afterId);
+    const owned = await this.db.query(`SELECT flow_id FROM flow_runs WHERE flow_id = ? AND origin_bot_id = ?`, [q.flowId, key]);
+    if (!owned.length) throw new Error("Flow not found in bot/owner scope");
+    const where = ["flow_id = ?", "id > ?"]; const args: unknown[] = [q.flowId, q.afterId ?? 0];
+    for (const [col, val] of [["node_id", q.nodeId], ["level", q.level]]) {
+      if (val) { where.push(`${col} = ?`); args.push(val); }
+    }
+    const rows = await this.db.query<Record<string, unknown>>(
+      `SELECT id, node_id, level, source, SUBSTR(message, 1, 2000) AS message,
+       ${this.db.dialect.driver === "mysql2" ? "CHAR_LENGTH" : "LENGTH"}(message) AS message_length, timestamp FROM run_logs
+       WHERE ${where.join(" AND ")} ORDER BY id ASC LIMIT ?`, [...args, limit + 1]);
+    return page(rows, limit);
+  }
+}

--- a/src/evolverun/clawweb/public/modules/workflow/server/routes/internal/retry-requests.ts
+++ b/src/evolverun/clawweb/public/modules/workflow/server/routes/internal/retry-requests.ts
@@ -1,0 +1,142 @@
+/**
+ * Internal API routes for flow_retry_requests — the cross-engine retry mailbox.
+ * Requesters post a row; every engine instance polls/claims via CAS; the
+ * instance holding the flow's TaskFlow state executes and completes it.
+ */
+import { Router, type Request, type Response } from "express";
+import { FlowRetryRequestRepository } from "../../repositories/flow-retry-request-repository.js";
+import { apiLog, apiLogBody } from "../internal-logger.js";
+import { asyncHandler } from "@avernet/clawweb-shared/server/middleware/async-handler";
+
+export function createInternalRetryRequestsRouter(retryRequestRepo: FlowRetryRequestRepository | null): Router {
+  const router = Router();
+  router.get("/capabilities", (_req, res) => res.json({ success: true, data: { executionOptionsVersion: 1 } }));
+
+  /** POST / — post a retry request (dedupes on an open request for the same flow) */
+  router.post("/", asyncHandler(async (req: Request, res: Response) => {
+    apiLogBody("WRITE", "/retry-requests", req.body, {});
+    if (!retryRequestRepo) {
+      apiLog("WRITE", "/retry-requests", { status: 503, error: "Database not configured" });
+      res.status(503).json({ success: false, error: "Service Unavailable", message: "Database not configured" });
+      return;
+    }
+    try {
+      const { request_id, flow_id, node_id, reason, requester, options } = req.body as {
+        request_id?: string; flow_id?: string; node_id?: string; reason?: string; requester?: string; options?: import("../../repositories/flow-retry-request-repository.js").RetryExecutionOptions;
+      };
+      if (!request_id || !flow_id) {
+        apiLog("WRITE", "/retry-requests", { status: 400, error: "Missing request_id or flow_id" });
+        res.status(400).json({ success: false, error: "Bad Request", message: "Missing required fields: request_id, flow_id" });
+        return;
+      }
+      if (options !== undefined && (!options || typeof options !== "object" || Array.isArray(options)
+        || Object.keys(options).some(k => !["useCurrentDef", "debug", "inputOverrides"].includes(k))
+        || (options.useCurrentDef !== undefined && typeof options.useCurrentDef !== "boolean")
+        || (options.debug !== undefined && typeof options.debug !== "boolean")
+        || (options.inputOverrides !== undefined && (!options.inputOverrides || typeof options.inputOverrides !== "object" || Array.isArray(options.inputOverrides) || Object.values(options.inputOverrides).some(v => typeof v !== "string")))
+        || JSON.stringify(options).length > 64000)) {
+        res.status(400).json({ success: false, message: "Invalid retry execution options" }); return;
+      }
+      const row = await retryRequestRepo.create({ requestId: request_id, flowId: flow_id, nodeId: node_id ?? null, reason: reason ?? null, requester: requester ?? null, options });
+      if (!row) {
+        apiLog("WRITE", "/retry-requests", { status: 500, error: "create returned null" });
+        res.status(500).json({ success: false, error: "Internal Server Error", message: "Failed to create retry request" });
+        return;
+      }
+      apiLog("WRITE", "/retry-requests", { status: 200, requestId: row.request_id, flowId: row.flow_id, deduped: row.request_id !== request_id });
+      res.json({ success: true, data: row });
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      apiLog("WRITE", "/retry-requests", { status: 500, error: msg });
+      res.status(500).json({ success: false, error: "Internal Server Error", message: msg });
+    }
+  }));
+
+  /** POST /claim — CAS-claim open requests; only winners are returned */
+  router.post("/claim", asyncHandler(async (req: Request, res: Response) => {
+    apiLogBody("WRITE", "/retry-requests/claim", req.body, {});
+    if (!retryRequestRepo) {
+      apiLog("WRITE", "/retry-requests/claim", { status: 503, error: "Database not configured" });
+      res.status(503).json({ success: false, error: "Service Unavailable", message: "Database not configured" });
+      return;
+    }
+    try {
+      const { limit, lease_secs, claim_engine, flow_ids, options_version } = req.body as { limit?: number; lease_secs?: number; claim_engine?: string; flow_ids?: string[]; options_version?: number };
+      if (!claim_engine) {
+        apiLog("WRITE", "/retry-requests/claim", { status: 400, error: "Missing claim_engine" });
+        res.status(400).json({ success: false, error: "Bad Request", message: "Missing required field: claim_engine" });
+        return;
+      }
+      const safeLimit = Math.min(Math.max(Number(limit) || 10, 1), 50);
+      const safeLease = Math.max(Number(lease_secs) || 600, 60);
+      const safeFlowIds = Array.isArray(flow_ids)
+        ? flow_ids.filter((id): id is string => typeof id === "string" && id.length > 0)
+        : undefined;
+      const claimed = await retryRequestRepo.claimPending(safeLimit, safeLease, claim_engine, Math.floor(Date.now() / 1000), safeFlowIds, options_version === 1);
+      apiLog("WRITE", "/retry-requests/claim", { status: 200, claimEngine: claim_engine, claimed: claimed.length });
+      res.json({ success: true, data: { claimed } });
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      apiLog("WRITE", "/retry-requests/claim", { status: 500, error: msg });
+      res.status(500).json({ success: false, error: "Internal Server Error", message: msg });
+    }
+  }));
+
+  /** POST /:requestId/complete — mark a claimed request finished */
+  router.post("/:requestId/complete", asyncHandler(async (req: Request, res: Response) => {
+    const requestId = String(req.params.requestId);
+    apiLogBody("WRITE", `/retry-requests/${requestId}/complete`, req.body, { requestId });
+    if (!retryRequestRepo) {
+      apiLog("WRITE", `/retry-requests/${requestId}/complete`, { requestId, status: 503, error: "Database not configured" });
+      res.status(503).json({ success: false, error: "Service Unavailable", message: "Database not configured" });
+      return;
+    }
+    try {
+      const { ok, message } = req.body as { ok?: boolean; message?: string };
+      if (typeof ok !== "boolean") {
+        apiLog("WRITE", `/retry-requests/${requestId}/complete`, { requestId, status: 400, error: "Missing or invalid ok" });
+        res.status(400).json({ success: false, error: "Bad Request", message: "Missing required field: ok (boolean)" });
+        return;
+      }
+      const done = await retryRequestRepo.complete(requestId, ok, message ?? "");
+      if (!done) {
+        apiLog("WRITE", `/retry-requests/${requestId}/complete`, { requestId, status: 404 });
+        res.status(404).json({ success: false, error: "Not Found", message: `Retry request "${requestId}" not found` });
+        return;
+      }
+      apiLog("WRITE", `/retry-requests/${requestId}/complete`, { requestId, status: 200, ok });
+      res.json({ success: true });
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      apiLog("WRITE", `/retry-requests/${requestId}/complete`, { requestId, status: 500, error: msg });
+      res.status(500).json({ success: false, error: "Internal Server Error", message: msg });
+    }
+  }));
+
+  /** POST /:requestId/release — hand a claimed request back to the pool */
+  router.post("/:requestId/release", asyncHandler(async (req: Request, res: Response) => {
+    const requestId = String(req.params.requestId);
+    apiLog("WRITE", `/retry-requests/${requestId}/release`, { requestId });
+    if (!retryRequestRepo) {
+      apiLog("WRITE", `/retry-requests/${requestId}/release`, { requestId, status: 503, error: "Database not configured" });
+      res.status(503).json({ success: false, error: "Service Unavailable", message: "Database not configured" });
+      return;
+    }
+    try {
+      const done = await retryRequestRepo.release(requestId);
+      if (!done) {
+        apiLog("WRITE", `/retry-requests/${requestId}/release`, { requestId, status: 404 });
+        res.status(404).json({ success: false, error: "Not Found", message: `Retry request "${requestId}" not found` });
+        return;
+      }
+      apiLog("WRITE", `/retry-requests/${requestId}/release`, { requestId, status: 200 });
+      res.json({ success: true });
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      apiLog("WRITE", `/retry-requests/${requestId}/release`, { requestId, status: 500, error: msg });
+      res.status(500).json({ success: false, error: "Internal Server Error", message: msg });
+    }
+  }));
+
+  return router;
+}

--- a/src/evolverun/clawweb/public/modules/workflow/server/routes/internal/run-reads.ts
+++ b/src/evolverun/clawweb/public/modules/workflow/server/routes/internal/run-reads.ts
@@ -1,0 +1,34 @@
+import { Router } from "express";
+import { RunReadRepository } from "../../repositories/run-read-repository.js";
+
+/** Mounted behind the existing internal signature middleware. POST binds scope/filters to the signed body. */
+export function createInternalRunReadsRouter(repo: RunReadRepository): Router {
+  const router = Router();
+  for (const kind of ["runs", "logs"] as const) {
+    router.post(`/${kind}`, async (req, res) => {
+      try {
+        const q = req.body;
+        if (!q || typeof q.botId !== "string" || typeof q.ownerId !== "string"
+          || !q.botId.trim() || !q.ownerId.trim()
+          || (kind === "logs" && (typeof q.flowId !== "string" || !q.flowId))) {
+          res.status(400).json({ success: false, message: "Missing bot/owner scope or flowId" }); return;
+        }
+        for (const key of ["workflowId", "status", "identityKey", "nodeId", "level"]) {
+          if (q[key] !== undefined && typeof q[key] !== "string") {
+            res.status(400).json({success:false,message:`Invalid ${key}`}); return;
+          }
+        }
+        if (q.includeHidden !== undefined && typeof q.includeHidden !== "boolean") {
+          res.status(400).json({success:false,message:"Invalid includeHidden"}); return;
+        }
+        const data = kind === "runs" ? await repo.listRuns(q) : await repo.readLogs(q);
+        res.json({ success: true, data });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        const status = message.includes("not found") ? 404 : /scope|cursor|limit must/.test(message) ? 400 : 500;
+        res.status(status).json({ success: false, message: status === 500 ? "Shared run query failed" : message });
+      }
+    });
+  }
+  return router;
+}

--- a/src/evolverun/clawweb/public/shared/server/__tests__/retry-options-migration.test.ts
+++ b/src/evolverun/clawweb/public/shared/server/__tests__/retry-options-migration.test.ts
@@ -1,0 +1,15 @@
+import { expect, it } from "vitest";
+import Database from "better-sqlite3";
+import { migrations } from "../schema.js";
+
+it("upgrades existing retry rows and adds the scoped run index", () => {
+  const db = new Database(":memory:");
+  try {
+    db.exec("CREATE TABLE flow_retry_requests (request_id TEXT, flow_id TEXT); INSERT INTO flow_retry_requests VALUES ('old-request', 'old-flow'); CREATE TABLE flow_runs (id INTEGER PRIMARY KEY, origin_bot_id TEXT)");
+    const migration = migrations.find(item => item.version === 119);
+    expect(migration).toBeDefined();
+    for (const sql of migration!.sql) db.exec(sql);
+    expect(db.prepare("SELECT * FROM flow_retry_requests").get()).toEqual({request_id:"old-request",flow_id:"old-flow",options_json:null});
+    expect(db.prepare("PRAGMA index_info(idx_flow_runs_origin_id)").all().map(row => (row as {name:string}).name)).toEqual(["origin_bot_id", "id"]);
+  } finally { db.close(); }
+});

--- a/src/evolverun/clawweb/public/shared/server/schema.ts
+++ b/src/evolverun/clawweb/public/shared/server/schema.ts
@@ -2884,4 +2884,12 @@ END`,
     ],
   },
 
+  {
+    version: 119,
+    description: "Preserve cross-instance retry execution options",
+    sql: [
+      `ALTER TABLE flow_retry_requests ADD COLUMN options_json TEXT`,
+      `CREATE INDEX IF NOT EXISTS idx_flow_runs_origin_id ON flow_runs (origin_bot_id, id)`,
+    ],
+  },
 ];


### PR DESCRIPTION
Description
Enable bots to query workflow runs and execution logs across instances through shared internal APIs. Queries enforce bot and owner scope and support pagination, with optional node and log-level filters.
Move the retry request repository and routes into the shared workflow package. Preserve retry execution options in the mailbox and prevent older consumers from claiming requests whose options they cannot process.
Includes a database migration adding flow_retry_requests.options_json and an index on flow_runs(origin_bot_id, id).
Validation: all 161 workflow and shared-package tests passed.