### PR TITLE
feat(aicoding): write codefuse token into every live runtime binding

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/aicoding/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/aicoding/router.py
@@ -25,11 +25,9 @@ from agentclaw.community.adapters.http.dependencies import get_request_context, 
 from agentclaw.community.adapters.http.auth.models import AuthenticatedUser
 from agentclaw.community.adapters.http.auth.dependencies import get_current_user
 from agentclaw.community.api.bot_service import BotServiceProtocol
-from agentclaw.community.api.baas_service import BaasServiceProtocol
 from agentclaw.community.core.aicoding.protocols import (
     AicodingBotResolutionServiceProtocol,
 )
-from agentclaw.community.api.device_service import DeviceServiceProtocol
 from agentclaw.community.api.workflow_catalog_service import WorkflowCatalogServiceProtocol
 from agentclaw.community.core.bot_collaborator.interceptor import (
     CollaboratorPermissionInterceptor,
@@ -42,14 +40,7 @@ from agentclaw.community.core.bot_management.services.bot_service import (
 )
 from agentclaw.community.utils.env_utils import get_current_env
 from agentclaw.community.core.bot_management import codefuse_token as _codefuse_token
-from agentclaw.community.core.repository.protocols.devices import DeviceBindingRepository
-from agentclaw.community.core.repository.protocols.publishing import (
-    BotPublishRepositoryProtocol,
-)
-from agentclaw.community.core.bot_management.codefuse_runtime_targets import (
-    resolve_codefuse_runtime_binding_ids,
-    SERVICE_BOT_TYPE,
-)
+from agentclaw.community.core.bot_management.codefuse_write import CodefuseWriteOutcome
 from agentclaw.community.core.services.identity import VALID_ENTITY_TYPES
 from agentclaw.community.api.workspace_service import WorkspaceServiceProtocol
 from agentclaw.community.core.repository.protocols.bot import BotRepository
@@ -415,162 +406,61 @@ def _build_codefuse_write_cmd(token: str, workid: str, owner_id: str = "") -> st
     return _codefuse_token.build_codefuse_write_cmd(token, workid)
 
 
-def _exec_codefuse_write_to_binding(
-    binding,
-    cmd: str,
-    baas_service: BaasServiceProtocol,
-    device_service: DeviceServiceProtocol,
-    *,
-    log_prefix: str = "save_codefuse_token",
-) -> tuple:
-    """Exec the codefuse.json write command into a single binding's container.
-
-    Returns ``(ok, status_code, detail, provider)``. ``ok`` 为 True 时 status
-    恒为 200。失败沿用原 single-binding 语义返回 400（缺 bot_uuid）/ 502（exec
-    异常或非零退出码）：personal 路径据此直接转 HTTPException，service 路径
-    聚合后择首个失败上报。
-    """
-    provider = getattr(binding, "device_provider", None) or ""
-    if provider == "baas":
-        # BaaS / poolab: use bot-level exec API
-        bot_uuid = (getattr(binding, "device_props", None) or {}).get("bot_uuid")
-        if not bot_uuid:
-            return False, 400, "Bot has no BaaS bot_uuid in device_props", provider
-        try:
-            result = baas_service.exec_command_on_bot(
-                bot_uuid=bot_uuid, cmd=cmd, timeout_seconds=30
-            )
-        except Exception as e:
-            log.error("[%s] exec_command_on_bot failed: bot_uuid=%s error=%s", log_prefix, bot_uuid, e)
-            return False, 502, f"Failed to write token to container: {e}", provider
-        exit_code = result.get("exit_code", -1) if isinstance(result, dict) else -1
-        if exit_code != 0:
-            log.warning("[%s] non-zero exit: bot_uuid=%s result=%s", log_prefix, bot_uuid, result)
-            return False, 502, f"Command exited with code {exit_code}", provider
-        return True, 200, "", provider
-
-    # Arca / local: use DeviceService.exec_shell (routed by device_id)
-    device_id = getattr(binding, "device_id", None)
-    try:
-        device_service.exec_shell(device_id=device_id, shell_cmd=cmd)
-    except Exception as e:
-        log.error("[%s] exec_shell failed: device_id=%s error=%s", log_prefix, device_id, e)
-        return False, 502, f"Failed to write token to container: {e}", provider
-    return True, 200, "", provider
-
-
 @router.put("/bots/{bot_id}/codefuse/auth")
 async def save_codefuse_token(
     bot_id: str,
     request: CodefuseTokenRequest,
     user: AuthenticatedUser = Depends(get_current_user),
     bot_repo: BotRepository = Injected(BotRepository),
-    device_repo: DeviceBindingRepository = Injected(DeviceBindingRepository),
-    baas_service: BaasServiceProtocol = Injected(BaasServiceProtocol),
-    device_service: DeviceServiceProtocol = Injected(DeviceServiceProtocol),
-    publish_repo: BotPublishRepositoryProtocol = Injected(BotPublishRepositoryProtocol),
+    bot_service: BotServiceProtocol = Injected(BotServiceProtocol),
 ) -> dict:
-    """Write CodeFuse token into the bot's container.
+    """Write CodeFuse token into the bot's container (every live runtime).
 
-    Only the bot owner can call this endpoint.
+    Only the bot owner can call this. ``token`` is a base64 CodeFuse SSO auth_code;
+    decoded it yields ``{"t":"<token>","w":"<workid>"}``. This endpoint keeps to
+    transport-layer responsibility (ownership / decode validation) and delegates the
+    multi-runtime fan-out to ``BotService.write_codefuse_token_to_runtimes``; the
+    returned ``CodefuseWriteResult`` is translated here to HTTP status / shape only
+    (arch.rules.md Rule 7 — core owns domain policy, delivery is a thin adapter).
 
-    The ``token`` field is a base64-encoded auth_code from CodeFuse SSO callback.
-    Decoded it yields ``{"t":"<token>","w":"<workid>"}``.  The endpoint:
-
-    1. Decodes auth_code → extracts token + workid
-    2. Validates token is non-empty, ≥16 chars, hex format
-    3. Writes into ``/home/admin/.codefuse/fuse/codefuse.json`` (merges with
-       existing file, forces token/workid/authType update) of every live
-       runtime of the bot
-    4. Verifies the file is readable
-
-    Bot 拓扑：
-    - personal：仅草稿 binding（``ac_bots.binding_id``），行为与历史一致。
-    - service：草稿 + 预发(verify) + 线上(online) 全部在运行的 runtime 都写一遍，
-      拓扑与 ``engine_runtime.stage.resolve_stage_bind_id`` /
-      ``_hot_update_service_bot_passport_token`` 一致，避免"写到草稿、对话却在
-      预发/线上容器"导致 codefuse.json 缺失。
+    Bot 拓扑（由 core 解析，见 ``resolve_codefuse_runtime_binding_ids``）：
+    - personal：仅草稿 binding（``ac_bots.binding_id``）。
+    - service：草稿 + 预发(verify) + 线上(online) 在运行的 runtime 全写。
     """
     owner_id = user.staffId
 
-    # ── Ownership check ──
+    # ── Ownership / preconditions（transport 翻译层职责） ──
     bot = bot_repo.get_by_id_and_owner(bot_id, owner_id)
     if not bot:
         raise HTTPException(status_code=404, detail=f"Bot not found or no permission: {bot_id}")
-
-    binding_id = bot.get("binding_id")
-    if not binding_id:
+    if not bot.get("binding_id"):
         raise HTTPException(status_code=400, detail="Bot has no device binding")
 
-    binding = device_repo.get_by_id(int(binding_id))
-    if not binding:
-        raise HTTPException(status_code=404, detail="Device binding not found")
+    # ── Decode & validate auth_code → 400 ──
+    _decode_auth_code(request.token)
 
-    # ── Decode & validate auth_code ──
-    token, workid = _decode_auth_code(request.token)
-    cmd = _build_codefuse_write_cmd(token, workid, owner_id)
-
-    bot_type = (bot.get("bot_type") or "personal") if isinstance(bot, dict) else "personal"
-
-    # ── personal：单 binding，行为与历史完全一致 ──
-    if bot_type != SERVICE_BOT_TYPE:
-        ok, status_code, detail, provider = _exec_codefuse_write_to_binding(
-            binding, cmd, baas_service, device_service,
-        )
-        if not ok:
-            raise HTTPException(status_code=status_code, detail=detail)
-        log.info("[save_codefuse_token] token written: bot_id=%s provider=%s", bot_id, provider)
-        return {"success": True, "bot_id": bot_id, "provider": provider}
-
-    # ── service：把 codefuse.json 写进所有在运行的 runtime（草稿/预发/线上） ──
-    runtime_binding_ids = resolve_codefuse_runtime_binding_ids(
-        bot=bot, publish_repo=publish_repo, binding_repo=device_repo,
+    # ── 写入编排由 core 负责；这里只翻译结果 ──
+    env = get_current_env()
+    result = bot_service.write_codefuse_token_to_runtimes(
+        bot=bot, plaintext_token=request.token, env=env,
     )
-    if not runtime_binding_ids:
+
+    if result.wrote_any:
+        ps = result.ok_providers
+        return {
+            "success": True,
+            "bot_id": bot_id,
+            "provider": ps[0] if ps else "",
+            "providers": ps,
+            "targets": result.attempted,
+        }
+
+    # 未写入：按 outcome 翻译为 HTTP
+    if result.outcome is CodefuseWriteOutcome.NO_BINDING:
         raise HTTPException(status_code=400, detail="Bot has no device binding")
-
-    targets = []
-    for bid in runtime_binding_ids:
-        rt_binding = device_repo.get_by_id(int(bid))
-        if rt_binding is None:
-            log.warning("[save_codefuse_token] binding not found, skip: bot_id=%s binding_id=%s", bot_id, bid)
-            continue
-        targets.append(rt_binding)
-
-    if not targets:
+    if result.outcome is CodefuseWriteOutcome.NO_TARGET:
         raise HTTPException(status_code=404, detail="No live device binding found")
-
-    results = []
-    wrote_any = False
-    first_failure = None
-    for rt_binding in targets:
-        ok, status_code, detail, provider = _exec_codefuse_write_to_binding(
-            rt_binding, cmd, baas_service, device_service,
-            log_prefix="save_codefuse_token[service]",
-        )
-        results.append({
-            "binding_id": getattr(rt_binding, "id", None),
-            "provider": provider,
-            "ok": ok,
-        })
-        if ok:
-            wrote_any = True
-        elif first_failure is None:
-            first_failure = (status_code, detail)
-
-    log.info(
-        "[save_codefuse_token] service bot token written: bot_id=%s targets=%s wrote_any=%s results=%s",
-        bot_id, len(results), wrote_any, results,
+    status_code, detail = result.first_failure or (
+        502, "No live runtime accepted the codefuse token",
     )
-    if not wrote_any:
-        status_code, detail = first_failure or (502, "No live runtime accepted the codefuse token")
-        raise HTTPException(status_code=status_code, detail=detail)
-
-    ok_providers = [r["provider"] for r in results if r["ok"]]
-    return {
-        "success": True,
-        "bot_id": bot_id,
-        "provider": ok_providers[0] if ok_providers else "",
-        "providers": ok_providers,
-        "targets": len(results),
-    }
+    raise HTTPException(status_code=status_code, detail=detail)

--- a/src/backend/src/agentclaw/community/adapters/http/aicoding/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/aicoding/router.py
@@ -43,6 +43,13 @@ from agentclaw.community.core.bot_management.services.bot_service import (
 from agentclaw.community.utils.env_utils import get_current_env
 from agentclaw.community.core.bot_management import codefuse_token as _codefuse_token
 from agentclaw.community.core.repository.protocols.devices import DeviceBindingRepository
+from agentclaw.community.core.repository.protocols.publishing import (
+    BotPublishRepositoryProtocol,
+)
+from agentclaw.community.core.bot_management.codefuse_runtime_targets import (
+    resolve_codefuse_runtime_binding_ids,
+    SERVICE_BOT_TYPE,
+)
 from agentclaw.community.core.services.identity import VALID_ENTITY_TYPES
 from agentclaw.community.api.workspace_service import WorkspaceServiceProtocol
 from agentclaw.community.core.repository.protocols.bot import BotRepository
@@ -408,6 +415,50 @@ def _build_codefuse_write_cmd(token: str, workid: str, owner_id: str = "") -> st
     return _codefuse_token.build_codefuse_write_cmd(token, workid)
 
 
+def _exec_codefuse_write_to_binding(
+    binding,
+    cmd: str,
+    baas_service: BaasServiceProtocol,
+    device_service: DeviceServiceProtocol,
+    *,
+    log_prefix: str = "save_codefuse_token",
+) -> tuple:
+    """Exec the codefuse.json write command into a single binding's container.
+
+    Returns ``(ok, status_code, detail, provider)``. ``ok`` 为 True 时 status
+    恒为 200。失败沿用原 single-binding 语义返回 400（缺 bot_uuid）/ 502（exec
+    异常或非零退出码）：personal 路径据此直接转 HTTPException，service 路径
+    聚合后择首个失败上报。
+    """
+    provider = getattr(binding, "device_provider", None) or ""
+    if provider == "baas":
+        # BaaS / poolab: use bot-level exec API
+        bot_uuid = (getattr(binding, "device_props", None) or {}).get("bot_uuid")
+        if not bot_uuid:
+            return False, 400, "Bot has no BaaS bot_uuid in device_props", provider
+        try:
+            result = baas_service.exec_command_on_bot(
+                bot_uuid=bot_uuid, cmd=cmd, timeout_seconds=30
+            )
+        except Exception as e:
+            log.error("[%s] exec_command_on_bot failed: bot_uuid=%s error=%s", log_prefix, bot_uuid, e)
+            return False, 502, f"Failed to write token to container: {e}", provider
+        exit_code = result.get("exit_code", -1) if isinstance(result, dict) else -1
+        if exit_code != 0:
+            log.warning("[%s] non-zero exit: bot_uuid=%s result=%s", log_prefix, bot_uuid, result)
+            return False, 502, f"Command exited with code {exit_code}", provider
+        return True, 200, "", provider
+
+    # Arca / local: use DeviceService.exec_shell (routed by device_id)
+    device_id = getattr(binding, "device_id", None)
+    try:
+        device_service.exec_shell(device_id=device_id, shell_cmd=cmd)
+    except Exception as e:
+        log.error("[%s] exec_shell failed: device_id=%s error=%s", log_prefix, device_id, e)
+        return False, 502, f"Failed to write token to container: {e}", provider
+    return True, 200, "", provider
+
+
 @router.put("/bots/{bot_id}/codefuse/auth")
 async def save_codefuse_token(
     bot_id: str,
@@ -417,6 +468,7 @@ async def save_codefuse_token(
     device_repo: DeviceBindingRepository = Injected(DeviceBindingRepository),
     baas_service: BaasServiceProtocol = Injected(BaasServiceProtocol),
     device_service: DeviceServiceProtocol = Injected(DeviceServiceProtocol),
+    publish_repo: BotPublishRepositoryProtocol = Injected(BotPublishRepositoryProtocol),
 ) -> dict:
     """Write CodeFuse token into the bot's container.
 
@@ -428,8 +480,16 @@ async def save_codefuse_token(
     1. Decodes auth_code → extracts token + workid
     2. Validates token is non-empty, ≥16 chars, hex format
     3. Writes into ``/home/admin/.codefuse/fuse/codefuse.json`` (merges with
-       existing file, forces token/workid/authType update)
+       existing file, forces token/workid/authType update) of every live
+       runtime of the bot
     4. Verifies the file is readable
+
+    Bot 拓扑：
+    - personal：仅草稿 binding（``ac_bots.binding_id``），行为与历史一致。
+    - service：草稿 + 预发(verify) + 线上(online) 全部在运行的 runtime 都写一遍，
+      拓扑与 ``engine_runtime.stage.resolve_stage_bind_id`` /
+      ``_hot_update_service_bot_passport_token`` 一致，避免"写到草稿、对话却在
+      预发/线上容器"导致 codefuse.json 缺失。
     """
     owner_id = user.staffId
 
@@ -450,36 +510,67 @@ async def save_codefuse_token(
     token, workid = _decode_auth_code(request.token)
     cmd = _build_codefuse_write_cmd(token, workid, owner_id)
 
-    # ── Execute command via the correct provider ──
-    provider = binding.device_provider
-    device_id = binding.device_id
+    bot_type = (bot.get("bot_type") or "personal") if isinstance(bot, dict) else "personal"
 
-    if provider == "baas":
-        # BaaS / poolab: use bot-level exec API
-        bot_uuid = (binding.device_props or {}).get("bot_uuid")
-        if not bot_uuid:
-            raise HTTPException(
-                status_code=400, detail="Bot has no BaaS bot_uuid in device_props"
-            )
-        try:
-            result = baas_service.exec_command_on_bot(
-                bot_uuid=bot_uuid, cmd=cmd, timeout_seconds=30
-            )
-        except Exception as e:
-            log.error("[save_codefuse_token] exec_command_on_bot failed: bot_uuid=%s error=%s", bot_uuid, e)
-            raise HTTPException(status_code=502, detail=f"Failed to write token to container: {e}")
+    # ── personal：单 binding，行为与历史完全一致 ──
+    if bot_type != SERVICE_BOT_TYPE:
+        ok, status_code, detail, provider = _exec_codefuse_write_to_binding(
+            binding, cmd, baas_service, device_service,
+        )
+        if not ok:
+            raise HTTPException(status_code=status_code, detail=detail)
+        log.info("[save_codefuse_token] token written: bot_id=%s provider=%s", bot_id, provider)
+        return {"success": True, "bot_id": bot_id, "provider": provider}
 
-        exit_code = result.get("exit_code", -1) if isinstance(result, dict) else -1
-        if exit_code != 0:
-            log.warning("[save_codefuse_token] non-zero exit: bot_uuid=%s result=%s", bot_uuid, result)
-            raise HTTPException(status_code=502, detail=f"Command exited with code {exit_code}")
-    else:
-        # Arca / local: use DeviceService.exec_shell (routed by device_id)
-        try:
-            device_service.exec_shell(device_id=device_id, shell_cmd=cmd)
-        except Exception as e:
-            log.error("[save_codefuse_token] exec_shell failed: device_id=%s error=%s", device_id, e)
-            raise HTTPException(status_code=502, detail=f"Failed to write token to container: {e}")
+    # ── service：把 codefuse.json 写进所有在运行的 runtime（草稿/预发/线上） ──
+    runtime_binding_ids = resolve_codefuse_runtime_binding_ids(
+        bot=bot, publish_repo=publish_repo, binding_repo=device_repo,
+    )
+    if not runtime_binding_ids:
+        raise HTTPException(status_code=400, detail="Bot has no device binding")
 
-    log.info("[save_codefuse_token] token written: bot_id=%s provider=%s", bot_id, provider)
-    return {"success": True, "bot_id": bot_id, "provider": provider}
+    targets = []
+    for bid in runtime_binding_ids:
+        rt_binding = device_repo.get_by_id(int(bid))
+        if rt_binding is None:
+            log.warning("[save_codefuse_token] binding not found, skip: bot_id=%s binding_id=%s", bot_id, bid)
+            continue
+        targets.append(rt_binding)
+
+    if not targets:
+        raise HTTPException(status_code=404, detail="No live device binding found")
+
+    results = []
+    wrote_any = False
+    first_failure = None
+    for rt_binding in targets:
+        ok, status_code, detail, provider = _exec_codefuse_write_to_binding(
+            rt_binding, cmd, baas_service, device_service,
+            log_prefix="save_codefuse_token[service]",
+        )
+        results.append({
+            "binding_id": getattr(rt_binding, "id", None),
+            "provider": provider,
+            "ok": ok,
+        })
+        if ok:
+            wrote_any = True
+        elif first_failure is None:
+            first_failure = (status_code, detail)
+
+    log.info(
+        "[save_codefuse_token] service bot token written: bot_id=%s targets=%s wrote_any=%s results=%s",
+        bot_id, len(results), wrote_any, results,
+    )
+    if not wrote_any:
+        status_code, detail = first_failure or (502, "No live runtime accepted the codefuse token")
+        raise HTTPException(status_code=status_code, detail=detail)
+
+    ok_providers = [r["provider"] for r in results if r["ok"]]
+    return {
+        "success": True,
+        "bot_id": bot_id,
+        "provider": ok_providers[0] if ok_providers else "",
+        "providers": ok_providers,
+        "targets": len(results),
+    }

--- a/src/backend/src/agentclaw/community/core/bot_management/README.md
+++ b/src/backend/src/agentclaw/community/core/bot_management/README.md
@@ -54,6 +54,8 @@ internal_dependencies:
   - agentclaw.community.core.desktop_bot
   - agentclaw.community.core.mcp
   - agentclaw.community.core.devices
+  - agentclaw.community.core.engine_runtime.errors    # EngineStageNotLiveError used by codefuse runtime-target resolution
+  - agentclaw.community.core.engine_runtime.stage    # resolve_stage_bind_id / STAGE_* reused by codefuse runtime-target resolution
   - agentclaw.community.core.events
   - agentclaw.community.core.resources
   - agentclaw.community.core.service_bot

--- a/src/backend/src/agentclaw/community/core/bot_management/bot_service_protocol.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/bot_service_protocol.py
@@ -88,6 +88,9 @@ class BotServiceProtocol(Protocol):
     def release_bot_for_others(self, *args: Any, **kwargs: Any) -> Any: ...
 
     def hot_update_passport_token_to_device(self, *args: Any, **kwargs: Any) -> Any: ...
+    # Write CodeFuse token into every live runtime of a bot (fan-out + aggregate);
+    # the HTTP save_codefuse_token endpoint and the async on-device refresher both call it.
+    def write_codefuse_token_to_runtimes(self, *args: Any, **kwargs: Any) -> Any: ...
 
     # ── Bot lifecycle (called by other services / not the router) ──────
     # ``BotService`` exposes ``stop_bot`` / ``start_bot`` which are used by

--- a/src/backend/src/agentclaw/community/core/bot_management/codefuse_runtime_targets.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/codefuse_runtime_targets.py
@@ -27,11 +27,15 @@ from agentclaw.community.core.repository.protocols.publishing import (
 from agentclaw.community.core.repository.protocols.devices import (
     DeviceBindingRepository,
 )
-from agentclaw.community.utils.env_utils import get_current_env
 from agentclaw.community.log import get_logger
 
 logger = get_logger()
 
+# 这是 ``engine_runtime.stage.SERVICE_BOT_TYPE`` 的 "gate 副本"，故意不在模块顶部
+# import engine_runtime.stage（其 __init__ 会 eager 拉起 connection→device_context_resolver
+# 重链/潜在环），以便 personal bot 在此常量上短路、不触发重链。两值必须保持一致——
+# 由 ``test_codefuse_token.py`` 的 guard 测试把守（arch.rules.md Rule 2：单一来源，
+# 重复定义须有 drift 防护）。
 SERVICE_BOT_TYPE = "service"
 
 
@@ -40,7 +44,7 @@ def resolve_codefuse_runtime_binding_ids(
     bot: dict,
     publish_repo: BotPublishRepositoryProtocol,
     binding_repo: DeviceBindingRepository,
-    env: str | None = None,
+    env: str,
 ) -> List[int]:
     """Return the live runtime binding ids to write codefuse.json into.
 
@@ -48,7 +52,8 @@ def resolve_codefuse_runtime_binding_ids(
         bot: bot 行（需含 ``bot_type``/``bot_id``/``id``(pk)/``binding_id``）。
         publish_repo: ``ac_bot_publish`` 仓库（service bot 的 verify/online 用）。
         binding_repo: ``ac_entity_device_binding`` 仓库（retained-verify ACTIVE 检查用）。
-        env: 显式环境；不传则取 ``get_current_env()``，与 ``resolve_stage_bind_id`` 同口径。
+        env: 调用方在边界解析好的环境（``get_current_env()``），与 ``resolve_stage_bind_id``
+            同口径；**必填**——core 不再用 ``env or get_current_env()`` 兜底解析（arch.rules Rule 14）。
 
     Returns:
         去重后的 binding_id 列表，draft 在前；personal 仅含 draft；找不到任何
@@ -71,7 +76,7 @@ def resolve_codefuse_runtime_binding_ids(
 
     bot_pk = bot.get("id") if isinstance(bot, dict) else None
     bot_id = (bot.get("bot_id") or "") if isinstance(bot, dict) else ""
-    runtime_env = env or get_current_env()
+    runtime_env = env
 
     # 惰性 import：engine_runtime 包 __init__ 会 eagerly 拉 connection →
     # device_context_resolver（BaasService 等重依赖），放模块顶部会引入重链/潜在环。

--- a/src/backend/src/agentclaw/community/core/bot_management/codefuse_runtime_targets.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/codefuse_runtime_targets.py
@@ -1,0 +1,129 @@
+"""Resolve the live-runtime binding ids a CodeFuse token must be written into.
+
+背景：一个 service bot 最多有三条长期在运行的 runtime，按 binding 存放位置区分
+（与 ``engine_runtime.stage.resolve_stage_bind_id`` 的三运行时模型一致）：
+
+- draft —— ``ac_bots.binding_id``（预发布草稿容器）
+- verify —— ``ac_bot_publish.ext.binding.verify``（预发/验证容器，含晋升后保留）
+- online —— ``ac_bot_publish.ext.binding.online``（线上容器）
+
+CodeFuse 重授权（HTTP ``PUT /aicoding/bots/{bot_id}/codefuse/auth``）与 token
+变更后的异步刷新（``BotService._refresh_codefuse_token_on_device``）都必须把
+``codefuse.json`` 写进**每一条在运行的 runtime**，否则真正承接对话的容器
+（由 ``resolve_stage_bind_id`` 按 stage 选中的 verify/online）会一直缺 token。
+
+本模块只回答"该 bot 有哪些在运行的 runtime binding_id"，**draft 直接读
+``ac_bots.binding_id``，verify/online 复用 ``resolve_stage_bind_id``**（同一套
+服务链路解析规则，含"晋升后 retained verify 仍 ACTIVE 即 live"的回退），避免再
+造一套会与对话链路漂移的解析逻辑。是否真正写入仍由调用方按 provider 逐个 exec。
+"""
+from __future__ import annotations
+
+from typing import List
+
+from agentclaw.community.core.repository.protocols.publishing import (
+    BotPublishRepositoryProtocol,
+)
+from agentclaw.community.core.repository.protocols.devices import (
+    DeviceBindingRepository,
+)
+from agentclaw.community.utils.env_utils import get_current_env
+from agentclaw.community.log import get_logger
+
+logger = get_logger()
+
+SERVICE_BOT_TYPE = "service"
+
+
+def resolve_codefuse_runtime_binding_ids(
+    *,
+    bot: dict,
+    publish_repo: BotPublishRepositoryProtocol,
+    binding_repo: DeviceBindingRepository,
+    env: str | None = None,
+) -> List[int]:
+    """Return the live runtime binding ids to write codefuse.json into.
+
+    Args:
+        bot: bot 行（需含 ``bot_type``/``bot_id``/``id``(pk)/``binding_id``）。
+        publish_repo: ``ac_bot_publish`` 仓库（service bot 的 verify/online 用）。
+        binding_repo: ``ac_entity_device_binding`` 仓库（retained-verify ACTIVE 检查用）。
+        env: 显式环境；不传则取 ``get_current_env()``，与 ``resolve_stage_bind_id`` 同口径。
+
+    Returns:
+        去重后的 binding_id 列表，draft 在前；personal 仅含 draft；找不到任何
+        binding 时返回空列表（调用方据此跳过）。
+    """
+    bot_type = (bot.get("bot_type") or "personal") if isinstance(bot, dict) else "personal"
+    draft_bid = bot.get("binding_id") if isinstance(bot, dict) else None
+    ids: List[int] = []
+    if draft_bid:
+        try:
+            ids.append(int(draft_bid))
+        except (TypeError, ValueError):
+            logger.warning(
+                "[codefuse_runtime_targets] non-int draft binding_id=%s bot_id=%s",
+                draft_bid, bot.get("bot_id") if isinstance(bot, dict) else "",
+            )
+
+    if bot_type != SERVICE_BOT_TYPE:
+        return ids
+
+    bot_pk = bot.get("id") if isinstance(bot, dict) else None
+    bot_id = (bot.get("bot_id") or "") if isinstance(bot, dict) else ""
+    runtime_env = env or get_current_env()
+
+    # 惰性 import：engine_runtime 包 __init__ 会 eagerly 拉 connection →
+    # device_context_resolver（BaasService 等重依赖），放模块顶部会引入重链/潜在环。
+    # 仅在 service bot 真正需要解析发布态时才加载。
+    from agentclaw.community.core.engine_runtime.stage import (
+        STAGE_ONLINE,
+        STAGE_VERIFY,
+        resolve_stage_bind_id,
+    )
+    from agentclaw.community.core.engine_runtime.errors import (
+        EngineStageNotLiveError,
+    )
+    from agentclaw.community.core.devices.services.device_context import (
+        DeviceNotBoundError,
+    )
+
+    # draft(草稿)已加入；verify/online 复用对话链路同款解析器，逐 stage 取 live runtime。
+    # 某 stage 不存在 live runtime（EngineStageNotLiveError）或缺主键
+    # （DeviceNotBoundError）/draft 这种非法 stage（ValueError）→ 跳过；其余异常
+    # 也按 best-effort 跳过，保证一个 stage 的查询失败不影响其它 runtime 写入。
+    for stage in (STAGE_VERIFY, STAGE_ONLINE):
+        try:
+            bid = resolve_stage_bind_id(
+                publish_repo,
+                binding_repo,
+                bot_pk=int(bot_pk or 0),
+                bot_id=bot_id,
+                stage=stage,
+                env=runtime_env,
+            )
+        except (EngineStageNotLiveError, DeviceNotBoundError, ValueError):
+            continue
+        except Exception as exc:  # 仓库查询等失败：不阻断其它 runtime
+            logger.warning(
+                "[codefuse_runtime_targets] resolve stage=%s failed: bot_id=%s error=%s",
+                stage, bot_id, exc,
+            )
+            continue
+        if not bid:
+            continue
+        try:
+            bid_int = int(bid)
+        except (TypeError, ValueError):
+            logger.warning(
+                "[codefuse_runtime_targets] non-int published binding_id=%s bot_id=%s stage=%s",
+                bid, bot_id, stage,
+            )
+            continue
+        if bid_int not in ids:
+            ids.append(bid_int)
+
+    return ids
+
+
+__all__ = ["resolve_codefuse_runtime_binding_ids", "SERVICE_BOT_TYPE"]

--- a/src/backend/src/agentclaw/community/core/bot_management/codefuse_write.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/codefuse_write.py
@@ -1,0 +1,53 @@
+"""Core result types for the multi-runtime CodeFuse token write orchestration.
+
+Only data: the orchestration itself lives in
+``BotService.write_codefuse_token_to_runtimes``; the HTTP adapter and the async
+device-refresher both consume the ``CodefuseWriteResult`` and translate it
+(HTTP status / log) without re-implementing the fan-out policy.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+
+class CodefuseWriteOutcome(str, Enum):
+    """Aggregate outcome of writing a CodeFuse token across all live runtimes."""
+
+    NO_BINDING = "no_binding"   # resolve 出 0 条 binding
+    NO_TARGET = "no_target"     # 解到 binding id 但实体都取不到
+    ALL_FAILED = "all_failed"   # 有 target 但全部写入失败
+    WROTE = "wrote"             # 至少一条 runtime 写入成功
+
+
+@dataclass
+class CodefuseTargetResult:
+    """Per-runtime write attempt result."""
+
+    binding_id: int | None
+    provider: str
+    ok: bool
+    status_code: int           # 200 成功，否则失败码（400 缺字段 / 502 exec 失败）
+    detail: str = ""
+
+
+@dataclass
+class CodefuseWriteResult:
+    """Aggregated result returned by ``BotService.write_codefuse_token_to_runtimes``."""
+
+    resolved_binding_ids: list[int] = field(default_factory=list)
+    results: list[CodefuseTargetResult] = field(default_factory=list)
+    wrote_any: bool = False
+    first_failure: tuple[int, str] | None = None
+    outcome: CodefuseWriteOutcome = CodefuseWriteOutcome.NO_BINDING
+
+    @property
+    def attempted(self) -> int:
+        return len(self.results)
+
+    @property
+    def ok_providers(self) -> list[str]:
+        return [r.provider for r in self.results if r.ok]
+
+
+__all__ = ["CodefuseWriteOutcome", "CodefuseTargetResult", "CodefuseWriteResult"]

--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -35,6 +35,11 @@ from agentclaw.community.core.bot_management.bot_quota import (
 )
 from agentclaw.community.core.bot_management.services.template_service import TemplateService
 from agentclaw.community.core.bot_management.services.aicoding.workspace_hosting_service import WorkspaceHostingService
+from agentclaw.community.core.bot_management.codefuse_write import (
+    CodefuseWriteResult,
+    CodefuseTargetResult,
+    CodefuseWriteOutcome,
+)
 from agentclaw.community.core.desktop_bot.device_status_client import DeviceStatusClient
 from agentclaw.community.core.desktop_bot.status_mapping import map_baas_to_display
 
@@ -3176,28 +3181,116 @@ class BotService(BotServiceProtocol):
             )
             return
 
+        env = get_current_env()
         thread = threading.Thread(
             target=bind_current_avernet_tenant(self._refresh_codefuse_token_on_device),
-            kwargs={"bot_id": bot_id, "user_id": user_id, "plaintext_token": plaintext},
+            kwargs={"bot_id": bot_id, "user_id": user_id, "plaintext_token": plaintext, "env": env},
             daemon=True,
             name=f"refresh-codefuse-token-{bot_id}",
         )
         thread.start()
 
+    def write_codefuse_token_to_runtimes(
+        self, *, bot: dict, plaintext_token: str, env: str,
+    ) -> CodefuseWriteResult:
+        """core 拥有的 "按 N 条 live runtime 写 codefuse token + 聚合" 领域策略。
+
+        HTTP 同步路径（``aicoding/router.save_codefuse_token``）与异步刷新
+        （``_refresh_codefuse_token_on_device``）都调这里，避免 adapter 内再造一份
+        fan-out/exec 逻辑（arch.rules.md Rule 7）。baas 走 ``write_codefuse_token_baas``，
+        arca/local 走 ``DeviceService.exec_shell``；单 runtime 失败隔离，聚合后由调用方
+        翻译为 HTTPException / log。
+        """
+        from agentclaw.community.core.bot_management.codefuse_runtime_targets import (
+            resolve_codefuse_runtime_binding_ids,
+        )
+
+        binding_ids = resolve_codefuse_runtime_binding_ids(
+            bot=bot, publish_repo=self._bot_publish_repo,
+            binding_repo=self._device_binding_repo, env=env,
+        )
+        result = CodefuseWriteResult(resolved_binding_ids=list(binding_ids))
+        if not binding_ids:
+            return result  # outcome=NO_BINDING
+
+        baas_service = self._baas_service_provider()
+        device_service = self._device_service_provider()
+        for binding_id in binding_ids:
+            binding = self._device_binding_repo.get_by_id(binding_id)
+            if not binding:
+                # 解到 id 但实体缺失：跳过，不记入 results（影响 outcome=NO_TARGET 判定）
+                continue
+
+            provider = getattr(binding, "device_provider", None) or ""
+            if provider == "baas":
+                bot_uuid = (getattr(binding, "device_props", None) or {}).get("bot_uuid")
+                if not bot_uuid:
+                    tr = CodefuseTargetResult(
+                        getattr(binding, "id", None), provider, False, 400,
+                        "Bot has no BaaS bot_uuid in device_props",
+                    )
+                else:
+                    try:
+                        from agentclaw.community.core.devices.services.baas_codefuse_writer import (
+                            write_codefuse_token_baas,
+                        )
+                        write_codefuse_token_baas(baas_service, bot_uuid, plaintext_token)
+                        tr = CodefuseTargetResult(
+                            getattr(binding, "id", None), provider, True, 200, "",
+                        )
+                    except Exception as exc:
+                        tr = CodefuseTargetResult(
+                            getattr(binding, "id", None), provider, False, 502,
+                            f"Failed to write token to container: {exc}",
+                        )
+            else:
+                # arca / local：经 DeviceService.exec_shell 写 codefuse.json
+                device_id = getattr(binding, "device_id", None)
+                if not device_id:
+                    tr = CodefuseTargetResult(
+                        getattr(binding, "id", None), provider, False, 400,
+                        "Device binding has no device_id",
+                    )
+                else:
+                    try:
+                        from agentclaw.community.core.bot_management.codefuse_token import (
+                            build_codefuse_write_cmd_from_auth_code,
+                        )
+                        cmd = build_codefuse_write_cmd_from_auth_code(plaintext_token)
+                        device_service.exec_shell(device_id=device_id, shell_cmd=cmd)
+                        tr = CodefuseTargetResult(
+                            getattr(binding, "id", None), provider, True, 200, "",
+                        )
+                    except Exception as exc:
+                        tr = CodefuseTargetResult(
+                            getattr(binding, "id", None), provider, False, 502,
+                            f"Failed to write token to container: {exc}",
+                        )
+
+            result.results.append(tr)
+            if tr.ok:
+                result.wrote_any = True
+            elif result.first_failure is None:
+                result.first_failure = (tr.status_code, tr.detail)
+
+        if result.wrote_any:
+            result.outcome = CodefuseWriteOutcome.WROTE
+        elif not result.attempted:
+            result.outcome = CodefuseWriteOutcome.NO_TARGET
+        else:
+            result.outcome = CodefuseWriteOutcome.ALL_FAILED
+        return result
+
     def _refresh_codefuse_token_on_device(
-        self, *, bot_id: str, user_id: str, plaintext_token: str
+        self, *, bot_id: str, user_id: str, plaintext_token: str, env: str,
     ) -> None:
-        """把明文 codefuse auth_code 写入 bot 所有在运行行时的 codefuse.json。
+        """把明文 codefuse auth_code 写入 bot 所有在运行行时的 codefuse.json（异步 best-effort）。
 
-        personal：仅草稿 binding；service：草稿 + 预发(verify) + 线上(online)，
-        拓扑与 ``aicoding/router.save_codefuse_token`` 及
-        ``engine_runtime.stage.resolve_stage_bind_id`` 一致——避免 token 只写
-        草稿、而对话实际承接在预发/线上容器导致 codefuse.json 缺失。
+        只负责 "找到 bot → 调用 core 编排 ``write_codefuse_token_to_runtimes``"，不再自造
+        fan-out/exec 逻辑；单 runtime 失败已由 core 隔离，这里据 outcome 记日志。
 
-        baas 设备走 ``write_codefuse_token_baas``（exec_command_on_bot），
-        arca / local 设备走 ``DeviceService.exec_shell``。任一 runtime 缺
-        bot_uuid / device_id / binding / exec 失败均只告警跳过，不抛出（异步
-        线程上下文，无法回传错误）；只要有一条 runtime 写入成功即视为刷新完成。
+        ``env`` 由调用方（``_maybe_refresh_codefuse_token_async`` 在请求边界）解析后透传，
+        core 不在此处 ``get_current_env()`` 兜底（arch.rules Rule 14）。
         """
         try:
             bot = self._repository.get_by_id_and_owner(bot_id, user_id)
@@ -3208,85 +3301,18 @@ class BotService(BotServiceProtocol):
                 )
                 return
 
-            from agentclaw.community.core.bot_management.codefuse_runtime_targets import (
-                resolve_codefuse_runtime_binding_ids,
+            result = self.write_codefuse_token_to_runtimes(
+                bot=bot, plaintext_token=plaintext_token, env=env,
             )
-
-            binding_ids = resolve_codefuse_runtime_binding_ids(
-                bot=bot, publish_repo=self._bot_publish_repo,
-                binding_repo=self._device_binding_repo,
-            )
-            if not binding_ids:
-                logger.warning(
-                    "[bot_service._refresh_codefuse_token_on_device] no binding for bot %s",
-                    bot_id,
-                )
-                return
-
-            device_service = self._device_service_provider()
-            baas_service = self._baas_service_provider()
-            wrote_any = False
-            for binding_id in binding_ids:
-                binding = self._device_binding_repo.get_by_id(binding_id)
-                if not binding:
-                    logger.warning(
-                        "[bot_service._refresh_codefuse_token_on_device] binding %s not found",
-                        binding_id,
-                    )
-                    continue
-
-                provider = getattr(binding, "device_provider", None) or ""
-                if provider == "baas":
-                    bot_uuid = (getattr(binding, "device_props", None) or {}).get("bot_uuid")
-                    if not bot_uuid:
-                        logger.warning(
-                            "[bot_service._refresh_codefuse_token_on_device] no bot_uuid for "
-                            "bot %s binding %s", bot_id, binding_id,
-                        )
-                        continue
-                    from agentclaw.community.core.devices.services.baas_codefuse_writer import (
-                        write_codefuse_token_baas,
-                    )
-                    # 单 runtime 写入失败只告警跳过，不中断其它 runtime（异步 best-effort）。
-                    try:
-                        write_codefuse_token_baas(baas_service, bot_uuid, plaintext_token)
-                    except Exception as exc:
-                        logger.warning(
-                            "[bot_service._refresh_codefuse_token_on_device] write failed (baas) "
-                            "for bot %s binding %s: %s", bot_id, binding_id, exc, exc_info=True,
-                        )
-                        continue
-                else:
-                    device_id = getattr(binding, "device_id", None)
-                    if not device_id:
-                        logger.warning(
-                            "[bot_service._refresh_codefuse_token_on_device] no device_id for "
-                            "bot %s binding %s", bot_id, binding_id,
-                        )
-                        continue
-                    from agentclaw.community.core.bot_management.codefuse_token import (
-                        build_codefuse_write_cmd_from_auth_code,
-                    )
-                    try:
-                        cmd = build_codefuse_write_cmd_from_auth_code(plaintext_token)
-                        device_service.exec_shell(device_id=device_id, shell_cmd=cmd)
-                    except Exception as exc:
-                        logger.warning(
-                            "[bot_service._refresh_codefuse_token_on_device] write failed (%s) "
-                            "for bot %s binding %s: %s", provider, bot_id, binding_id, exc, exc_info=True,
-                        )
-                        continue
-
-                wrote_any = True
+            if result.wrote_any:
                 logger.info(
                     "[bot_service._refresh_codefuse_token_on_device] codefuse.json refreshed: "
-                    "bot_id=%s binding_id=%s provider=%s", bot_id, binding_id, provider,
+                    "bot_id=%s targets=%s", bot_id, result.attempted,
                 )
-
-            if not wrote_any:
+            else:
                 logger.warning(
                     "[bot_service._refresh_codefuse_token_on_device] codefuse.json not written "
-                    "to any runtime: bot_id=%s", bot_id,
+                    "to any runtime: bot_id=%s outcome=%s", bot_id, result.outcome.value,
                 )
         except Exception as e:
             logger.warning(

--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -3187,12 +3187,17 @@ class BotService(BotServiceProtocol):
     def _refresh_codefuse_token_on_device(
         self, *, bot_id: str, user_id: str, plaintext_token: str
     ) -> None:
-        """把明文 codefuse auth_code 写入 bot 当前绑定设备的 codefuse.json。
+        """把明文 codefuse auth_code 写入 bot 所有在运行行时的 codefuse.json。
+
+        personal：仅草稿 binding；service：草稿 + 预发(verify) + 线上(online)，
+        拓扑与 ``aicoding/router.save_codefuse_token`` 及
+        ``engine_runtime.stage.resolve_stage_bind_id`` 一致——避免 token 只写
+        草稿、而对话实际承接在预发/线上容器导致 codefuse.json 缺失。
 
         baas 设备走 ``write_codefuse_token_baas``（exec_command_on_bot），
-        arca / local 设备走 ``DeviceService.exec_shell``，与
-        ``aicoding/router.save_codefuse_token`` 的双分支对称。设备未 ACTIVE /
-        无 binding / exec 失败均只告警，不抛出（异步线程上下文，无法回传错误）。
+        arca / local 设备走 ``DeviceService.exec_shell``。任一 runtime 缺
+        bot_uuid / device_id / binding / exec 失败均只告警跳过，不抛出（异步
+        线程上下文，无法回传错误）；只要有一条 runtime 写入成功即视为刷新完成。
         """
         try:
             bot = self._repository.get_by_id_and_owner(bot_id, user_id)
@@ -3202,8 +3207,16 @@ class BotService(BotServiceProtocol):
                     bot_id,
                 )
                 return
-            binding_id = bot.get("binding_id")
-            if not binding_id:
+
+            from agentclaw.community.core.bot_management.codefuse_runtime_targets import (
+                resolve_codefuse_runtime_binding_ids,
+            )
+
+            binding_ids = resolve_codefuse_runtime_binding_ids(
+                bot=bot, publish_repo=self._bot_publish_repo,
+                binding_repo=self._device_binding_repo,
+            )
+            if not binding_ids:
                 logger.warning(
                     "[bot_service._refresh_codefuse_token_on_device] no binding for bot %s",
                     bot_id,
@@ -3211,48 +3224,70 @@ class BotService(BotServiceProtocol):
                 return
 
             device_service = self._device_service_provider()
-            binding = self._device_binding_repo.get_by_id(binding_id)
-            if not binding:
+            baas_service = self._baas_service_provider()
+            wrote_any = False
+            for binding_id in binding_ids:
+                binding = self._device_binding_repo.get_by_id(binding_id)
+                if not binding:
+                    logger.warning(
+                        "[bot_service._refresh_codefuse_token_on_device] binding %s not found",
+                        binding_id,
+                    )
+                    continue
+
+                provider = getattr(binding, "device_provider", None) or ""
+                if provider == "baas":
+                    bot_uuid = (getattr(binding, "device_props", None) or {}).get("bot_uuid")
+                    if not bot_uuid:
+                        logger.warning(
+                            "[bot_service._refresh_codefuse_token_on_device] no bot_uuid for "
+                            "bot %s binding %s", bot_id, binding_id,
+                        )
+                        continue
+                    from agentclaw.community.core.devices.services.baas_codefuse_writer import (
+                        write_codefuse_token_baas,
+                    )
+                    # 单 runtime 写入失败只告警跳过，不中断其它 runtime（异步 best-effort）。
+                    try:
+                        write_codefuse_token_baas(baas_service, bot_uuid, plaintext_token)
+                    except Exception as exc:
+                        logger.warning(
+                            "[bot_service._refresh_codefuse_token_on_device] write failed (baas) "
+                            "for bot %s binding %s: %s", bot_id, binding_id, exc, exc_info=True,
+                        )
+                        continue
+                else:
+                    device_id = getattr(binding, "device_id", None)
+                    if not device_id:
+                        logger.warning(
+                            "[bot_service._refresh_codefuse_token_on_device] no device_id for "
+                            "bot %s binding %s", bot_id, binding_id,
+                        )
+                        continue
+                    from agentclaw.community.core.bot_management.codefuse_token import (
+                        build_codefuse_write_cmd_from_auth_code,
+                    )
+                    try:
+                        cmd = build_codefuse_write_cmd_from_auth_code(plaintext_token)
+                        device_service.exec_shell(device_id=device_id, shell_cmd=cmd)
+                    except Exception as exc:
+                        logger.warning(
+                            "[bot_service._refresh_codefuse_token_on_device] write failed (%s) "
+                            "for bot %s binding %s: %s", provider, bot_id, binding_id, exc, exc_info=True,
+                        )
+                        continue
+
+                wrote_any = True
+                logger.info(
+                    "[bot_service._refresh_codefuse_token_on_device] codefuse.json refreshed: "
+                    "bot_id=%s binding_id=%s provider=%s", bot_id, binding_id, provider,
+                )
+
+            if not wrote_any:
                 logger.warning(
-                    "[bot_service._refresh_codefuse_token_on_device] binding %s not found",
-                    binding_id,
+                    "[bot_service._refresh_codefuse_token_on_device] codefuse.json not written "
+                    "to any runtime: bot_id=%s", bot_id,
                 )
-                return
-
-            from agentclaw.community.core.bot_management.codefuse_token import (
-                build_codefuse_write_cmd_from_auth_code,
-            )
-
-            provider = getattr(binding, "device_provider", None) or ""
-            if provider == "baas":
-                bot_uuid = (getattr(binding, "device_props", None) or {}).get("bot_uuid")
-                if not bot_uuid:
-                    logger.warning(
-                        "[bot_service._refresh_codefuse_token_on_device] no bot_uuid for "
-                        "bot %s", bot_id,
-                    )
-                    return
-                from agentclaw.community.core.devices.services.baas_codefuse_writer import (
-                    write_codefuse_token_baas,
-                )
-                write_codefuse_token_baas(
-                    self._baas_service_provider(), bot_uuid, plaintext_token
-                )
-            else:
-                device_id = getattr(binding, "device_id", None)
-                if not device_id:
-                    logger.warning(
-                        "[bot_service._refresh_codefuse_token_on_device] no device_id for "
-                        "bot %s", bot_id,
-                    )
-                    return
-                cmd = build_codefuse_write_cmd_from_auth_code(plaintext_token)
-                device_service.exec_shell(device_id=device_id, shell_cmd=cmd)
-
-            logger.info(
-                "[bot_service._refresh_codefuse_token_on_device] codefuse.json refreshed: "
-                "bot_id=%s provider=%s", bot_id, provider,
-            )
         except Exception as e:
             logger.warning(
                 "[bot_service._refresh_codefuse_token_on_device] failed for bot %s: %s",

--- a/src/backend/tests/community/api/aicoding/test_token_save.py
+++ b/src/backend/tests/community/api/aicoding/test_token_save.py
@@ -20,11 +20,9 @@ from agentclaw.community.adapters.http.aicoding.router import (
 )
 from agentclaw.community.adapters.http.auth.dependencies import get_current_user
 from agentclaw.community.adapters.http.auth.models import AuthenticatedUser
-from agentclaw.community.api.baas_service import BaasServiceProtocol
-from agentclaw.community.api.device_service import DeviceServiceProtocol
 from agentclaw.community.core.repository.protocols.bot import BotRepository
-from agentclaw.community.core.repository.protocols.devices import DeviceBindingRepository
-from agentclaw.community.core.repository.protocols.publishing import BotPublishRepositoryProtocol
+from agentclaw.community.api.bot_service import BotServiceProtocol
+from agentclaw.community.core.bot_management.services.bot_service import BotService
 from agentclaw.community.core.devices.repository.record import DeviceBindingRecord
 
 
@@ -58,6 +56,42 @@ def _binding_record(
     )
 
 
+def _make_bot_service_for_router(
+    *,
+    device_binding_repo,
+    bot_publish_repo,
+    device_service,
+    baas_service,
+) -> BotService:
+    """构造一个真实 BotService，把 mock 的 device/baas/publish 接线进去，
+    使 router 委托的 ``write_codefuse_token_to_runtimes`` 走核心路径并由同一批 mock 驱动。"""
+    return BotService(
+        caller_identity_repo=MagicMock(),
+        drm_reader=MagicMock(),
+        repository=MagicMock(),
+        allocation_config=MagicMock(),
+        device_binding_repo=device_binding_repo,
+        skill_set_factory=MagicMock(),
+        cleanup_service=MagicMock(),
+        bcn_service=MagicMock(),
+        bot_publish_repo=bot_publish_repo,
+        passport_plugin=MagicMock(),
+        oss_record_repo=MagicMock(),
+        bot_publish_service_provider=lambda: MagicMock(),
+        device_service_provider=lambda: device_service,
+        bot_app_grant_service_provider=lambda: MagicMock(),
+        path_factory=MagicMock(),
+        template_service=MagicMock(),
+        workspace_hosting_service=MagicMock(),
+        collaborator_repo=MagicMock(),
+        restart_lock_repo=MagicMock(),
+        teclaw_provision_service_provider=lambda: MagicMock(is_teclaw=MagicMock(return_value=False)),
+        device_status_client=MagicMock(),
+        cron_auto_setup_service_provider=lambda: MagicMock(),
+        baas_service_provider=lambda: baas_service,
+    )
+
+
 def _make_client(
     bot_repo=None,
     device_repo=None,
@@ -71,6 +105,13 @@ def _make_client(
     _device_svc = device_service or MagicMock()
     _publish_repo = publish_repo or MagicMock()
 
+    _bot_service = _make_bot_service_for_router(
+        device_binding_repo=_device_repo,
+        bot_publish_repo=_publish_repo,
+        device_service=_device_svc,
+        baas_service=_baas,
+    )
+
     class _TestModule(Module):
         @provider
         @singleton
@@ -79,23 +120,8 @@ def _make_client(
 
         @provider
         @singleton
-        def provide_device_repo(self) -> DeviceBindingRepository:
-            return _device_repo
-
-        @provider
-        @singleton
-        def provide_baas(self) -> BaasServiceProtocol:
-            return _baas
-
-        @provider
-        @singleton
-        def provide_device_service(self) -> DeviceServiceProtocol:
-            return _device_svc
-
-        @provider
-        @singleton
-        def provide_publish_repo(self) -> BotPublishRepositoryProtocol:
-            return _publish_repo
+        def provide_bot_service(self) -> BotServiceProtocol:
+            return _bot_service
 
     app = FastAPI()
     app.include_router(router)

--- a/src/backend/tests/community/api/aicoding/test_token_save.py
+++ b/src/backend/tests/community/api/aicoding/test_token_save.py
@@ -24,6 +24,7 @@ from agentclaw.community.api.baas_service import BaasServiceProtocol
 from agentclaw.community.api.device_service import DeviceServiceProtocol
 from agentclaw.community.core.repository.protocols.bot import BotRepository
 from agentclaw.community.core.repository.protocols.devices import DeviceBindingRepository
+from agentclaw.community.core.repository.protocols.publishing import BotPublishRepositoryProtocol
 from agentclaw.community.core.devices.repository.record import DeviceBindingRecord
 
 
@@ -62,11 +63,13 @@ def _make_client(
     device_repo=None,
     baas_service=None,
     device_service=None,
+    publish_repo=None,
 ) -> TestClient:
     _bot_repo = bot_repo or MagicMock()
     _device_repo = device_repo or MagicMock()
     _baas = baas_service or MagicMock()
     _device_svc = device_service or MagicMock()
+    _publish_repo = publish_repo or MagicMock()
 
     class _TestModule(Module):
         @provider
@@ -88,6 +91,11 @@ def _make_client(
         @singleton
         def provide_device_service(self) -> DeviceServiceProtocol:
             return _device_svc
+
+        @provider
+        @singleton
+        def provide_publish_repo(self) -> BotPublishRepositoryProtocol:
+            return _publish_repo
 
     app = FastAPI()
     app.include_router(router)
@@ -451,3 +459,195 @@ class TestCodefuseTokenCommon:
 
         assert resp.status_code == 400
         assert "auth_code" in resp.json()["detail"].lower()
+
+# ── Service bot: multi-binding fan-out (draft + verify + online) ────────
+
+
+def _pub_record(status, ext_binding, publish_id=1):
+    rec = MagicMock()
+    rec.id = publish_id
+    rec.status = status
+    rec.ext = {"binding": ext_binding}
+    return rec
+
+
+def _publish_repo_with_records(*records):
+    """publish_repo whose list_by_source_bot returns the given records
+    (newest-first), matching resolve_stage_bind_id's contract."""
+    publish_repo = MagicMock()
+    publish_repo.list_by_source_bot.return_value = list(records)
+    return publish_repo
+
+
+class TestCodefuseTokenServiceBot:
+    """PUT .../codefuse/auth — service bot must fan out to every live runtime."""
+
+    def test_fan_out_writes_draft_verify_online(self):
+        bot_repo = MagicMock()
+        bot_repo.get_by_id_and_owner.return_value = {
+            "id": 100,
+            "bot_id": "svc1",
+            "owner_id": "u001",
+            "binding_id": 1,
+            "bot_type": "service",
+        }
+
+        draft = dataclass_replace(_binding_record("baas", "BOT-DRAFT"), id=1)
+        verify = dataclass_replace(_binding_record("baas", "BOT-VERIFY"), id=2)
+        online = dataclass_replace(_binding_record("baas", "BOT-ONLINE"), id=3)
+        device_repo = MagicMock()
+        device_repo.get_by_id.side_effect = lambda bid: {1: draft, 2: verify, 3: online}.get(int(bid))
+
+        baas = MagicMock()
+        baas.exec_command_on_bot.return_value = {"exit_code": 0, "stdout": "", "stderr": ""}
+
+        publish_repo = _publish_repo_with_records(
+            _pub_record("validating", {"verify": 2}),
+            _pub_record("success", {"online": 3}),
+        )
+
+        client = _make_client(
+            bot_repo=bot_repo, device_repo=device_repo, baas_service=baas,
+            publish_repo=publish_repo,
+        )
+        resp = client.put(
+            "/api/aicoding/bots/svc1/codefuse/auth",
+            json={"token": _encode_auth_code("a" * 32, "u001")},
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["success"] is True
+        assert data["bot_id"] == "svc1"
+        assert data["targets"] == 3
+        # every live runtime container received the write
+        assert baas.exec_command_on_bot.call_count == 3
+        written = {c.kwargs["bot_uuid"] for c in baas.exec_command_on_bot.call_args_list}
+        assert written == {"BOT-DRAFT", "BOT-VERIFY", "BOT-ONLINE"}
+
+    def test_partial_success_still_200(self):
+        """draft exec fails but verify succeeds → 200 (serving runtime covered)."""
+        bot_repo = MagicMock()
+        bot_repo.get_by_id_and_owner.return_value = {
+            "id": 100, "bot_id": "svc2", "owner_id": "u001",
+            "binding_id": 1, "bot_type": "service",
+        }
+        draft = dataclass_replace(_binding_record("baas", "BOT-DRAFT"), id=1)
+        verify = dataclass_replace(_binding_record("baas", "BOT-VERIFY"), id=2)
+        device_repo = MagicMock()
+        device_repo.get_by_id.side_effect = lambda bid: {1: draft, 2: verify}.get(int(bid))
+
+        baas = MagicMock()
+        baas.exec_command_on_bot.side_effect = [
+            {"exit_code": 1, "stderr": "err"},
+            {"exit_code": 0, "stdout": "", "stderr": ""},
+        ]
+
+        publish_repo = _publish_repo_with_records(_pub_record("validating", {"verify": 2}))
+
+        client = _make_client(
+            bot_repo=bot_repo, device_repo=device_repo, baas_service=baas,
+            publish_repo=publish_repo,
+        )
+        resp = client.put(
+            "/api/aicoding/bots/svc2/codefuse/auth",
+            json={"token": _encode_auth_code("a" * 32, "u001")},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["success"] is True
+        assert baas.exec_command_on_bot.call_count == 2
+
+    def test_all_fail_returns_502(self):
+        bot_repo = MagicMock()
+        bot_repo.get_by_id_and_owner.return_value = {
+            "id": 100, "bot_id": "svc3", "owner_id": "u001",
+            "binding_id": 1, "bot_type": "service",
+        }
+        draft = dataclass_replace(_binding_record("baas", "BOT-DRAFT"), id=1)
+        verify = dataclass_replace(_binding_record("baas", "BOT-VERIFY"), id=2)
+        device_repo = MagicMock()
+        device_repo.get_by_id.side_effect = lambda bid: {1: draft, 2: verify}.get(int(bid))
+
+        baas = MagicMock()
+        baas.exec_command_on_bot.return_value = {"exit_code": 1, "stderr": "err"}
+
+        publish_repo = _publish_repo_with_records(_pub_record("validating", {"verify": 2}))
+
+        client = _make_client(
+            bot_repo=bot_repo, device_repo=device_repo, baas_service=baas,
+            publish_repo=publish_repo,
+        )
+        resp = client.put(
+            "/api/aicoding/bots/svc3/codefuse/auth",
+            json={"token": _encode_auth_code("a" * 32, "u001")},
+        )
+        assert resp.status_code == 502
+
+    def test_service_no_runtime_bindings_returns_400(self):
+        """service bot 但 draft/verify/online 全空 → 400。"""
+        bot_repo = MagicMock()
+        bot_repo.get_by_id_and_owner.return_value = {
+            "id": 100, "bot_id": "svc4", "owner_id": "u001",
+            "binding_id": None, "bot_type": "service",
+        }
+        publish_repo = _publish_repo_with_records()  # 空发布记录
+        client = _make_client(
+            bot_repo=bot_repo, publish_repo=publish_repo,
+        )
+        resp = client.put(
+            "/api/aicoding/bots/svc4/codefuse/auth",
+            json={"token": _encode_auth_code("a" * 32, "u001")},
+        )
+        assert resp.status_code == 400
+
+    def test_service_missing_binding_skipped_but_succeeds(self):
+        """service bot：某 binding_id 在 device_repo 查不到 → 跳过；其余成功仍 200。"""
+        bot_repo = MagicMock()
+        bot_repo.get_by_id_and_owner.return_value = {
+            "id": 100, "bot_id": "svc5", "owner_id": "u001",
+            "binding_id": 1, "bot_type": "service",
+        }
+        draft = dataclass_replace(_binding_record("baas", "BOT-DRAFT"), id=1)
+        device_repo = MagicMock()
+        # draft binding=1 找到；verify binding=2 查不到返回 None
+        device_repo.get_by_id.side_effect = lambda bid: {1: draft}.get(int(bid))
+
+        baas = MagicMock()
+        baas.exec_command_on_bot.return_value = {"exit_code": 0, "stdout": "", "stderr": ""}
+
+        publish_repo = _publish_repo_with_records(_pub_record("validating", {"verify": 2}))
+
+        client = _make_client(
+            bot_repo=bot_repo, device_repo=device_repo, baas_service=baas,
+            publish_repo=publish_repo,
+        )
+        resp = client.put(
+            "/api/aicoding/bots/svc5/codefuse/auth",
+            json={"token": _encode_auth_code("a" * 32, "u001")},
+        )
+        # draft 成功即 200（verify binding 查不到被 skip）
+        assert resp.status_code == 200
+        assert resp.json()["success"] is True
+        assert baas.exec_command_on_bot.call_count == 1
+
+    def test_service_all_bindings_not_found_returns_404(self):
+        """service bot：解析出的 binding 全部在 device_repo 缺失 → 404。"""
+        bot_repo = MagicMock()
+        bot_repo.get_by_id_and_owner.return_value = {
+            "id": 100, "bot_id": "svc6", "owner_id": "u001",
+            "binding_id": 1, "bot_type": "service",
+        }
+        device_repo = MagicMock()
+        device_repo.get_by_id.return_value = None  # 全查不到
+
+        publish_repo = _publish_repo_with_records(_pub_record("validating", {"verify": 2}))
+
+        client = _make_client(
+            bot_repo=bot_repo, device_repo=device_repo,
+            publish_repo=publish_repo,
+        )
+        resp = client.put(
+            "/api/aicoding/bots/svc6/codefuse/auth",
+            json={"token": _encode_auth_code("a" * 32, "u001")},
+        )
+        assert resp.status_code == 404

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_update_codefuse_token.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_update_codefuse_token.py
@@ -598,7 +598,12 @@ class TestRefreshCodefuseServiceBotFanOut:
         # arca exec_shell 抛异常
         exec_device_service.exec_shell.side_effect = RuntimeError("arca exec boom")
 
+        # build_codefuse_write_cmd_from_auth_code 会对非法 auth_code 抛 ValueError，
+        # 这里只需隔离 arca exec_shell 失败，故把命令构建 stub 掉，确保 exec_shell 真正被调到。
         with patch(
+            "agentclaw.community.core.bot_management.codefuse_token.build_codefuse_write_cmd_from_auth_code",
+            return_value="echo write codefuse",
+        ), patch(
             "agentclaw.community.core.devices.services.baas_codefuse_writer.write_codefuse_token_baas",
         ) as mock_write:
             # 不应抛出：arca 失败被隔离，baas 仍写入

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_update_codefuse_token.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_update_codefuse_token.py
@@ -84,6 +84,16 @@ class TestUpdateBotCodefuseTokenDispatch:
         yield
         _FakeThread.instances.clear()
 
+    @pytest.fixture(autouse=True)
+    def _pin_env(self, monkeypatch):
+        # Finding 2：env 由 _maybe_refresh 在请求边界解析（get_current_env），
+        # 这里固定为 "dev" 使 dispatch 断言的 env 确定化。
+        monkeypatch.setattr(
+            "agentclaw.community.core.bot_management.services.bot_service.get_current_env",
+            lambda: "dev",
+        )
+        yield
+
     @pytest.fixture
     def repo(self):
         repo = Mock()
@@ -145,6 +155,7 @@ class TestUpdateBotCodefuseTokenDispatch:
                     bot_id="bot-1",
                     user_id="user1",
                     plaintext_token="new-plaintext-auth-code",
+                    env="dev",
                 )
 
     def test_no_dispatch_when_token_unchanged(self, repo, template_svc):
@@ -221,6 +232,7 @@ class TestUpdateBotCodefuseTokenDispatch:
                     bot_id="bot-1",
                     user_id="user1",
                     plaintext_token="new-plaintext-auth-code",
+                    env="dev",
                 )
 
     def test_no_dispatch_when_normal_template(self, repo, template_svc):
@@ -308,7 +320,7 @@ class TestRefreshCodefuseTokenOnDevice:
             "agentclaw.community.core.devices.services.baas_codefuse_writer.write_codefuse_token_baas"
         ) as mock_write:
             service._refresh_codefuse_token_on_device(
-                bot_id="bot-1", user_id="user1", plaintext_token="plain-tok"
+                bot_id="bot-1", user_id="user1", plaintext_token="plain-tok", env="dev"
             )
             mock_write.assert_called_once()
             device_service.exec_shell.assert_not_called()
@@ -331,7 +343,7 @@ class TestRefreshCodefuseTokenOnDevice:
                 "agentclaw.community.core.devices.services.baas_codefuse_writer.write_codefuse_token_baas"
             ) as mock_write:
                 service._refresh_codefuse_token_on_device(
-                    bot_id="bot-1", user_id="user1", plaintext_token="plain-tok"
+                    bot_id="bot-1", user_id="user1", plaintext_token="plain-tok", env="dev"
                 )
                 mock_write.assert_not_called()
                 device_service.exec_shell.assert_called_once_with(
@@ -347,7 +359,7 @@ class TestRefreshCodefuseTokenOnDevice:
             "agentclaw.community.core.devices.services.baas_codefuse_writer.write_codefuse_token_baas"
         ) as mock_write:
             service._refresh_codefuse_token_on_device(
-                bot_id="bot-1", user_id="user1", plaintext_token="plain-tok"
+                bot_id="bot-1", user_id="user1", plaintext_token="plain-tok", env="dev"
             )
             mock_write.assert_not_called()
             device_service.exec_shell.assert_not_called()
@@ -362,7 +374,7 @@ class TestRefreshCodefuseTokenOnDevice:
             "agentclaw.community.core.devices.services.baas_codefuse_writer.write_codefuse_token_baas"
         ) as mock_write:
             service._refresh_codefuse_token_on_device(
-                bot_id="bot-1", user_id="user1", plaintext_token="plain-tok"
+                bot_id="bot-1", user_id="user1", plaintext_token="plain-tok", env="dev"
             )
             mock_write.assert_not_called()
             device_service.exec_shell.assert_not_called()
@@ -378,7 +390,7 @@ class TestRefreshCodefuseTokenOnDevice:
             "agentclaw.community.core.devices.services.baas_codefuse_writer.write_codefuse_token_baas"
         ) as mock_write:
             service._refresh_codefuse_token_on_device(
-                bot_id="bot-1", user_id="user1", plaintext_token="plain-tok"
+                bot_id="bot-1", user_id="user1", plaintext_token="plain-tok", env="dev"
             )
             mock_write.assert_not_called()
             device_service.exec_shell.assert_not_called()
@@ -397,7 +409,7 @@ class TestRefreshCodefuseTokenOnDevice:
             "agentclaw.community.core.devices.services.baas_codefuse_writer.write_codefuse_token_baas"
         ) as mock_write:
             service._refresh_codefuse_token_on_device(
-                bot_id="bot-1", user_id="user1", plaintext_token="plain-tok"
+                bot_id="bot-1", user_id="user1", plaintext_token="plain-tok", env="dev"
             )
             mock_write.assert_not_called()
             device_service.exec_shell.assert_not_called()
@@ -420,7 +432,7 @@ class TestRefreshCodefuseTokenOnDevice:
                 side_effect=_fake_cmd,
             ):
                 service._refresh_codefuse_token_on_device(
-                    bot_id="bot-1", user_id="user1", plaintext_token="plain-tok"
+                    bot_id="bot-1", user_id="user1", plaintext_token="plain-tok", env="dev"
                 )
                 mock_write.assert_not_called()
                 device_service.exec_shell.assert_not_called()
@@ -434,7 +446,7 @@ class TestRefreshCodefuseTokenOnDevice:
         ) as mock_write:
             # 不应抛出
             service._refresh_codefuse_token_on_device(
-                bot_id="bot-1", user_id="user1", plaintext_token="plain-tok"
+                bot_id="bot-1", user_id="user1", plaintext_token="plain-tok", env="dev"
             )
             mock_write.assert_not_called()
 
@@ -560,7 +572,7 @@ class TestRefreshCodefuseServiceBotFanOut:
         ) as mock_write:
             # 不应抛出：draft 失败被隔离，verify 仍写入
             service._refresh_codefuse_token_on_device(
-                bot_id="bot-1", user_id="user1", plaintext_token="plain-tok",
+                bot_id="bot-1", user_id="user1", plaintext_token="plain-tok", env="dev",
             )
             # 两条 runtime 都被尝试写入
             assert mock_write.call_count == 2
@@ -608,7 +620,7 @@ class TestRefreshCodefuseServiceBotFanOut:
         ) as mock_write:
             # 不应抛出：arca 失败被隔离，baas 仍写入
             service._refresh_codefuse_token_on_device(
-                bot_id="bot-1", user_id="user1", plaintext_token="plain-tok",
+                bot_id="bot-1", user_id="user1", plaintext_token="plain-tok", env="dev",
             )
             baas_cmd_uuids = [c.args[1] for c in mock_write.call_args_list]
             assert baas_cmd_uuids == ["BOT-VERIFY"]

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_update_codefuse_token.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_update_codefuse_token.py
@@ -523,3 +523,89 @@ class TestMaybeRefreshPrepareFailure:
                 cookie="c",
             )
             mock_thread.assert_not_called()
+
+
+class TestRefreshCodefuseServiceBotFanOut:
+    """service bot：异步刷新发到所有在运行行时；单 runtime 写入失败不中断其它。"""
+
+    def test_one_runtime_failure_does_not_abort_others(self):
+        service = _make_bot_service()
+        service._baas_service_provider = lambda: MagicMock(name="baas_service")
+        service._device_service_provider = lambda: MagicMock()
+
+        # service bot：draft binding=100；发布记录 VALIDATING → verify binding=200
+        service._repository.get_by_id_and_owner.return_value = _bot_record(
+            bot_type="service", binding_id=100,
+        )
+        rec = MagicMock()
+        rec.status = "validating"
+        rec.ext = {"binding": {"verify": 200}}
+        service._bot_publish_repo.list_by_source_bot.return_value = [rec]
+
+        draft_binding = MagicMock()
+        draft_binding.device_provider = "baas"
+        draft_binding.device_props = {"bot_uuid": "BOT-DRAFT"}
+        draft_binding.id = 100
+        verify_binding = MagicMock()
+        verify_binding.device_provider = "baas"
+        verify_binding.device_props = {"bot_uuid": "BOT-VERIFY"}
+        verify_binding.id = 200
+        service._device_binding_repo.get_by_id.side_effect = lambda bid: (
+            {100: draft_binding, 200: verify_binding}.get(int(bid))
+        )
+
+        with patch(
+            "agentclaw.community.core.devices.services.baas_codefuse_writer.write_codefuse_token_baas",
+            side_effect=[RuntimeError("draft write boom"), None],
+        ) as mock_write:
+            # 不应抛出：draft 失败被隔离，verify 仍写入
+            service._refresh_codefuse_token_on_device(
+                bot_id="bot-1", user_id="user1", plaintext_token="plain-tok",
+            )
+            # 两条 runtime 都被尝试写入
+            assert mock_write.call_count == 2
+            written = [c.args[1] for c in mock_write.call_args_list]
+            assert written == ["BOT-DRAFT", "BOT-VERIFY"]
+
+    def test_arca_runtime_failure_does_not_abort_baas_runtime(self):
+        """draft(arca) exec_shell 抛异常 → 隔离跳过；verify(baas) 仍写入。"""
+        service = _make_bot_service()
+        service._baas_service_provider = lambda: MagicMock(name="baas_service")
+        exec_device_service = MagicMock()
+        service._device_service_provider = lambda: exec_device_service
+
+        # service bot：draft binding=100(arca) ；verify binding=200(baas)
+        service._repository.get_by_id_and_owner.return_value = _bot_record(
+            bot_type="service", binding_id=100,
+        )
+        rec = MagicMock()
+        rec.status = "validating"
+        rec.ext = {"binding": {"verify": 200}}
+        service._bot_publish_repo.list_by_source_bot.return_value = [rec]
+
+        draft_binding = MagicMock()
+        draft_binding.device_provider = "arca"
+        draft_binding.device_id = "dev-draft"
+        draft_binding.id = 100
+        verify_binding = MagicMock()
+        verify_binding.device_provider = "baas"
+        verify_binding.device_props = {"bot_uuid": "BOT-VERIFY"}
+        verify_binding.id = 200
+        service._device_binding_repo.get_by_id.side_effect = lambda bid: (
+            {100: draft_binding, 200: verify_binding}.get(int(bid))
+        )
+
+        # arca exec_shell 抛异常
+        exec_device_service.exec_shell.side_effect = RuntimeError("arca exec boom")
+
+        with patch(
+            "agentclaw.community.core.devices.services.baas_codefuse_writer.write_codefuse_token_baas",
+        ) as mock_write:
+            # 不应抛出：arca 失败被隔离，baas 仍写入
+            service._refresh_codefuse_token_on_device(
+                bot_id="bot-1", user_id="user1", plaintext_token="plain-tok",
+            )
+            baas_cmd_uuids = [c.args[1] for c in mock_write.call_args_list]
+            assert baas_cmd_uuids == ["BOT-VERIFY"]
+        # arca exec_shell 被尝试过（失败）
+        exec_device_service.exec_shell.assert_called_once()

--- a/src/backend/tests/community/core/bot_management/test_codefuse_token.py
+++ b/src/backend/tests/community/core/bot_management/test_codefuse_token.py
@@ -99,3 +99,162 @@ class TestBuildFromAuthCode:
     def test_invalid_auth_code_raises(self):
         with pytest.raises(ValueError):
             cft.build_codefuse_write_cmd_from_auth_code("!!!bad!!!")
+
+
+# ── resolve_codefuse_runtime_binding_ids ──────────────────────────────
+
+from unittest.mock import MagicMock, patch  # noqa: E402
+
+from agentclaw.community.core.bot_management.codefuse_runtime_targets import (  # noqa: E402
+    resolve_codefuse_runtime_binding_ids,
+)
+
+
+def _pub_record(status, ext_binding, publish_id=1):
+    rec = MagicMock()
+    rec.id = publish_id
+    rec.status = status
+    rec.ext = {"binding": ext_binding}
+    return rec
+
+
+def _active_binding(binding_id):
+    b = MagicMock()
+    b.id = binding_id
+    b.status = "ACTIVE"
+    return b
+
+
+class TestResolveCodefuseRuntimeBindingIds:
+    """服务 bot 三运行时拓扑解析；verify/online 复用 resolve_stage_bind_id。"""
+
+    def test_personal_returns_draft_only_and_skips_publish(self):
+        publish_repo = MagicMock()
+        binding_repo = MagicMock()
+        ids = resolve_codefuse_runtime_binding_ids(
+            bot={"id": 1, "bot_id": "p1", "owner_id": "u", "binding_id": 10, "bot_type": "personal"},
+            publish_repo=publish_repo, binding_repo=binding_repo,
+        )
+        assert ids == [10]
+        publish_repo.list_by_source_bot.assert_not_called()
+
+    def test_personal_default_when_bot_type_missing(self):
+        publish_repo = MagicMock()
+        ids = resolve_codefuse_runtime_binding_ids(
+            bot={"id": 1, "bot_id": "p2", "owner_id": "u", "binding_id": 7},
+            publish_repo=MagicMock(), binding_repo=MagicMock(),
+        )
+        assert ids == [7]
+
+    def test_service_fans_out_draft_verify_online(self):
+        # 一条 VALIDATING(verify=2) + 一条 SUCCESS(online=3)
+        publish_repo = MagicMock()
+        publish_repo.list_by_source_bot.return_value = [
+            _pub_record("validating", {"verify": 2}),
+            _pub_record("success", {"online": 3}),
+        ]
+        ids = resolve_codefuse_runtime_binding_ids(
+            bot={"id": 100, "bot_id": "s1", "owner_id": "u", "binding_id": 1, "bot_type": "service"},
+            publish_repo=publish_repo, binding_repo=MagicMock(),
+        )
+        # draft(1) + verify(2) + online(3)
+        assert ids == [1, 2, 3]
+
+    def test_service_retained_verify_after_promotion(self):
+        """已全量上线（只有 SUCCESS、无 VALIDATING）但 verify runtime 仍 ACTIVE：
+        resolve_stage_bind_id(verify) 回退到 SUCCESS 记录的 verify binding ——
+        旧实现（照搬 passport）会漏掉这个 retained verify 容器。"""
+        publish_repo = MagicMock()
+        publish_repo.list_by_source_bot.return_value = [
+            _pub_record("success", {"online": 9, "verify": 8}),
+        ]
+        binding_repo = MagicMock()
+        binding_repo.get_by_id.return_value = _active_binding(8)  # retained verify 仍 ACTIVE
+
+        ids = resolve_codefuse_runtime_binding_ids(
+            bot={"id": 100, "bot_id": "s2", "owner_id": "u", "binding_id": None, "bot_type": "service"},
+            publish_repo=publish_repo, binding_repo=binding_repo,
+        )
+        assert ids == [8, 9]  # retained verify(8) + online(9)
+
+    def test_service_no_records_returns_empty(self):
+        publish_repo = MagicMock()
+        publish_repo.list_by_source_bot.return_value = []
+        ids = resolve_codefuse_runtime_binding_ids(
+            bot={"id": 100, "bot_id": "s3", "owner_id": "u", "binding_id": None, "bot_type": "service"},
+            publish_repo=publish_repo, binding_repo=MagicMock(),
+        )
+        assert ids == []
+
+    def test_service_dedups_draft_and_online(self):
+        publish_repo = MagicMock()
+        publish_repo.list_by_source_bot.return_value = [
+            _pub_record("success", {"online": 1}),
+        ]
+        ids = resolve_codefuse_runtime_binding_ids(
+            bot={"id": 100, "bot_id": "s4", "owner_id": "u", "binding_id": 1, "bot_type": "service"},
+            publish_repo=publish_repo, binding_repo=MagicMock(),
+        )
+        assert ids == [1]
+
+    def test_service_publish_lookup_error_skipped(self):
+        publish_repo = MagicMock()
+        publish_repo.list_by_source_bot.side_effect = RuntimeError("boom")
+        ids = resolve_codefuse_runtime_binding_ids(
+            bot={"id": 100, "bot_id": "s5", "owner_id": "u", "binding_id": 1, "bot_type": "service"},
+            publish_repo=publish_repo, binding_repo=MagicMock(),
+        )
+        # draft 仍返回；发布态查询失败被吞
+        assert ids == [1]
+
+    # ── 防御性 guard：非法 binding_id 不阻塞其它 runtime ──────────────────
+
+    def test_non_int_draft_binding_id_skipped(self):
+        """draft binding_id 非 int（脏数据）→ 告警跳过，其余 runtime 仍解析。"""
+        with patch(
+            "agentclaw.community.core.engine_runtime.stage.resolve_stage_bind_id",
+            return_value=5,
+        ):
+            ids = resolve_codefuse_runtime_binding_ids(
+                bot={"id": 100, "bot_id": "s6", "owner_id": "u",
+                     "binding_id": "not-int", "bot_type": "service"},
+                publish_repo=MagicMock(), binding_repo=MagicMock(),
+            )
+        # 脏 draft 被吞；verify/online 返回 5
+        assert ids == [5]
+
+    def test_empty_resolved_bid_skipped(self):
+        """resolve_stage_bind_id 返回空值 → 跳过该 stage（不 NPE）。"""
+        with patch(
+            "agentclaw.community.core.engine_runtime.stage.resolve_stage_bind_id",
+            return_value="",
+        ):
+            ids = resolve_codefuse_runtime_binding_ids(
+                bot={"id": 100, "bot_id": "s7", "owner_id": "u",
+                     "binding_id": 1, "bot_type": "service"},
+                publish_repo=MagicMock(), binding_repo=MagicMock(),
+            )
+        # 仅 draft；verify/online 返回空被跳过
+        assert ids == [1]
+
+    def test_non_int_resolved_bid_skipped(self):
+        """resolve_stage_bind_id 返回非 int → 告警跳过。"""
+        with patch(
+            "agentclaw.community.core.engine_runtime.stage.resolve_stage_bind_id",
+            return_value="abc-not-number",
+        ):
+            ids = resolve_codefuse_runtime_binding_ids(
+                bot={"id": 100, "bot_id": "s8", "owner_id": "u",
+                     "binding_id": None, "bot_type": "service"},
+                publish_repo=MagicMock(), binding_repo=MagicMock(),
+            )
+        # draft 无；verify/online 非 int 被跳过
+        assert ids == []
+
+    def test_non_dict_bot_returns_empty(self):
+        """bot 非 dict（类型错误防御）→ 返回空列表。"""
+        ids = resolve_codefuse_runtime_binding_ids(
+            bot=None,
+            publish_repo=MagicMock(), binding_repo=MagicMock(),
+        )
+        assert ids == []

--- a/src/backend/tests/community/core/bot_management/test_codefuse_token.py
+++ b/src/backend/tests/community/core/bot_management/test_codefuse_token.py
@@ -106,6 +106,7 @@ class TestBuildFromAuthCode:
 from unittest.mock import MagicMock, patch  # noqa: E402
 
 from agentclaw.community.core.bot_management.codefuse_runtime_targets import (  # noqa: E402
+    SERVICE_BOT_TYPE,
     resolve_codefuse_runtime_binding_ids,
 )
 
@@ -133,7 +134,7 @@ class TestResolveCodefuseRuntimeBindingIds:
         binding_repo = MagicMock()
         ids = resolve_codefuse_runtime_binding_ids(
             bot={"id": 1, "bot_id": "p1", "owner_id": "u", "binding_id": 10, "bot_type": "personal"},
-            publish_repo=publish_repo, binding_repo=binding_repo,
+            publish_repo=publish_repo, binding_repo=binding_repo, env="dev",
         )
         assert ids == [10]
         publish_repo.list_by_source_bot.assert_not_called()
@@ -142,7 +143,7 @@ class TestResolveCodefuseRuntimeBindingIds:
         publish_repo = MagicMock()
         ids = resolve_codefuse_runtime_binding_ids(
             bot={"id": 1, "bot_id": "p2", "owner_id": "u", "binding_id": 7},
-            publish_repo=MagicMock(), binding_repo=MagicMock(),
+            publish_repo=MagicMock(), binding_repo=MagicMock(), env="dev",
         )
         assert ids == [7]
 
@@ -155,7 +156,7 @@ class TestResolveCodefuseRuntimeBindingIds:
         ]
         ids = resolve_codefuse_runtime_binding_ids(
             bot={"id": 100, "bot_id": "s1", "owner_id": "u", "binding_id": 1, "bot_type": "service"},
-            publish_repo=publish_repo, binding_repo=MagicMock(),
+            publish_repo=publish_repo, binding_repo=MagicMock(), env="dev",
         )
         # draft(1) + verify(2) + online(3)
         assert ids == [1, 2, 3]
@@ -173,7 +174,7 @@ class TestResolveCodefuseRuntimeBindingIds:
 
         ids = resolve_codefuse_runtime_binding_ids(
             bot={"id": 100, "bot_id": "s2", "owner_id": "u", "binding_id": None, "bot_type": "service"},
-            publish_repo=publish_repo, binding_repo=binding_repo,
+            publish_repo=publish_repo, binding_repo=binding_repo, env="dev",
         )
         assert ids == [8, 9]  # retained verify(8) + online(9)
 
@@ -182,7 +183,7 @@ class TestResolveCodefuseRuntimeBindingIds:
         publish_repo.list_by_source_bot.return_value = []
         ids = resolve_codefuse_runtime_binding_ids(
             bot={"id": 100, "bot_id": "s3", "owner_id": "u", "binding_id": None, "bot_type": "service"},
-            publish_repo=publish_repo, binding_repo=MagicMock(),
+            publish_repo=publish_repo, binding_repo=MagicMock(), env="dev",
         )
         assert ids == []
 
@@ -193,7 +194,7 @@ class TestResolveCodefuseRuntimeBindingIds:
         ]
         ids = resolve_codefuse_runtime_binding_ids(
             bot={"id": 100, "bot_id": "s4", "owner_id": "u", "binding_id": 1, "bot_type": "service"},
-            publish_repo=publish_repo, binding_repo=MagicMock(),
+            publish_repo=publish_repo, binding_repo=MagicMock(), env="dev",
         )
         assert ids == [1]
 
@@ -202,7 +203,7 @@ class TestResolveCodefuseRuntimeBindingIds:
         publish_repo.list_by_source_bot.side_effect = RuntimeError("boom")
         ids = resolve_codefuse_runtime_binding_ids(
             bot={"id": 100, "bot_id": "s5", "owner_id": "u", "binding_id": 1, "bot_type": "service"},
-            publish_repo=publish_repo, binding_repo=MagicMock(),
+            publish_repo=publish_repo, binding_repo=MagicMock(), env="dev",
         )
         # draft 仍返回；发布态查询失败被吞
         assert ids == [1]
@@ -218,7 +219,7 @@ class TestResolveCodefuseRuntimeBindingIds:
             ids = resolve_codefuse_runtime_binding_ids(
                 bot={"id": 100, "bot_id": "s6", "owner_id": "u",
                      "binding_id": "not-int", "bot_type": "service"},
-                publish_repo=MagicMock(), binding_repo=MagicMock(),
+                publish_repo=MagicMock(), binding_repo=MagicMock(), env="dev",
             )
         # 脏 draft 被吞；verify/online 返回 5
         assert ids == [5]
@@ -232,7 +233,7 @@ class TestResolveCodefuseRuntimeBindingIds:
             ids = resolve_codefuse_runtime_binding_ids(
                 bot={"id": 100, "bot_id": "s7", "owner_id": "u",
                      "binding_id": 1, "bot_type": "service"},
-                publish_repo=MagicMock(), binding_repo=MagicMock(),
+                publish_repo=MagicMock(), binding_repo=MagicMock(), env="dev",
             )
         # 仅 draft；verify/online 返回空被跳过
         assert ids == [1]
@@ -246,7 +247,7 @@ class TestResolveCodefuseRuntimeBindingIds:
             ids = resolve_codefuse_runtime_binding_ids(
                 bot={"id": 100, "bot_id": "s8", "owner_id": "u",
                      "binding_id": None, "bot_type": "service"},
-                publish_repo=MagicMock(), binding_repo=MagicMock(),
+                publish_repo=MagicMock(), binding_repo=MagicMock(), env="dev",
             )
         # draft 无；verify/online 非 int 被跳过
         assert ids == []
@@ -255,6 +256,15 @@ class TestResolveCodefuseRuntimeBindingIds:
         """bot 非 dict（类型错误防御）→ 返回空列表。"""
         ids = resolve_codefuse_runtime_binding_ids(
             bot=None,
-            publish_repo=MagicMock(), binding_repo=MagicMock(),
+            publish_repo=MagicMock(), binding_repo=MagicMock(), env="dev",
         )
         assert ids == []
+
+    def test_service_bot_type_matches_canonical_engine_stage(self):
+        """``SERVICE_BOT_TYPE`` 是 ``engine_runtime.stage`` 的 gate 副本（保持 personal
+        路径惰性 import、不在生产模块顶部 import engine_runtime），两者不得漂移
+        （arch.rules.md Rule 2 单一来源）。"""
+        from agentclaw.community.core.engine_runtime.stage import (
+            SERVICE_BOT_TYPE as CANONICAL_SERVICE_BOT_TYPE,
+        )
+        assert SERVICE_BOT_TYPE == CANONICAL_SERVICE_BOT_TYPE


### PR DESCRIPTION
## 背景

CodeFuse 重授权 (PUT /aicoding/bots/{bot_id}/codefuse/auth) 与 token 异步刷新 (BotService._refresh_codefuse_token_on_device) 此前只写 draft runtime，导致 verify/online 容器一直缺 token（真正承接对话的容器缺 codefuse.json）。

## 改动
- 新增 core/bot_management/codefuse_runtime_targets.py：复用 resolve_stage_bind_id 解析 draft/verify/online 三条 live runtime 的 binding_id。
- core/bot_management/services/bot_service.py：_refresh_codefuse_token_on_device 改为对每条 live runtime 逐个 exec 写入 codefuse.json。
- adapters/http/aicoding/router.py：aicoding 路由接入 token 写入与 runtime targets 链路。
- 补充 test_token_save / test_bot_service_update_codefuse_token / test_codefuse_token 单测。

## 备注
基于 dev (e3014f1e4) 新建分支；bot_service.py 与 dev 的 #1836 / #1860 / #1904 / #1930 改动已通过 3-way 合并整合，无冲突，dev 既有改动保留。