### PR TITLE
test(bot-config-manifest): walk the user manual as an e2e flow

### DIFF
--- a/src/backend/tests/community/_flows/bot_config_manifest/api_lifecycle.py
+++ b/src/backend/tests/community/_flows/bot_config_manifest/api_lifecycle.py
@@ -1,0 +1,463 @@
+"""The bot-config-manifest user manual, walked as a business flow.
+
+``docs/bot-config-manifest/user-manual.zh-CN.md`` is what a business caller
+reads before writing their first manifest. It makes claims a caller will build
+against — "an absent manifest reads as an empty document, not a 404", "``PUT``
+starts an apply and the report's trigger is ``put``", "applying the same
+document twice is ``unchanged``", "a dry run mints no id and never enters
+``last-apply``". Each flow below walks one of those journeys end to end and
+**cites the manual section it is asserting**, so a claim that stops being true
+fails here by name rather than drifting into prose nobody re-reads.
+
+Deliberately *not* a second copy of the per-endpoint suites in
+``tests/community/endpoints/test_openapi_config_manifest*.py``: those pin each
+route's own shape in isolation. What only a flow can catch is the seam between
+them — an ``apply_id`` handed out by one route and polled through another, a
+second ``PUT`` converging against what the first one materialised, a dry run
+that must leave the previous report standing.
+
+**Two things the runner owns, not these cases.**
+
+1. *Draining.* ``POST …/apply`` and the apply that follows a ``PUT`` enqueue a
+   ``config_manifest.apply`` task; the endpoint-test app registers no handler,
+   so a worker never runs it (see ``_await_the_background_apply`` in
+   ``tests/community/endpoints/test_openapi_config_manifest_apply.py``). A flow
+   that starts an apply therefore ends where the apply is enqueued, and the
+   flow that reads its report is a separate case — the seam is named in the
+   case names rather than hidden inside one. ``tests/community/e2e/`` drains
+   between them and threads one ``FlowContext`` through, so ``{apply_id}``
+   still chains across the boundary.
+
+2. *Emptiness.* ``FlowStep.expect`` is a **subset** match, so an expected ``[]``
+   matches any list at all. Every "this array is empty" claim in the manual is
+   therefore ``extract``-ed here and asserted exactly by the runner.
+
+**Route A only.** Every route in this group is ``/openapi/v1`` and needs a
+gateway-signed principal, which singlebox cannot mint — the reason
+``bot_config_manifest`` sits in ``SINGLEBOX_E2E_EXEMPT``. These cases mint one
+themselves, which the in-process app accepts and a live backend would not, so
+``covers`` is left empty: this suite does not drain that exemption and must not
+claim to.
+"""
+from __future__ import annotations
+
+import time
+
+import jwt
+
+from agentclaw.community.adapters.http.openapi_v1.dependencies import PRINCIPAL_HEADER
+from tests.community.framework.flow import FlowCase, FlowStep
+
+
+#: The owner every flow acts as, and the bot they all address. The runner seeds
+#: both before the first step.
+OWNER = "manifest-manual-owner"
+BOT_ID = "manifest-manual-bot"
+
+#: Signing key for the minted principal. The runner installs the matching
+#: verifier config; nothing outside the test process ever sees it.
+PRINCIPAL_SIGNING_KEY = "manifest-manual-flow-signing-key-at-least-32-bytes"
+
+#: An ``apply_id`` that was never minted. §B.2.3: polling it answers an *empty
+#: report*, not a 404 — the id is a polling handle, not an access credential.
+UNKNOWN_APPLY_ID = "ffffffffffffffffffffffffffffffff"
+
+
+def _principal(user_id: str = OWNER) -> str:
+    now = int(time.time())
+    return jwt.encode(
+        {
+            "iss": "gateway",
+            "aud": "backend",
+            "iat": now,
+            "exp": now + 24 * 3600,
+            "principals": [
+                {
+                    "type": "user",
+                    "subject": {"id": user_id, "username": f"{user_id}@example.test"},
+                }
+            ],
+        },
+        PRINCIPAL_SIGNING_KEY,
+        algorithm="HS256",
+    )
+
+
+HEADERS = {PRINCIPAL_HEADER: _principal()}
+
+#: §B.0.1: ``user_id`` is a **required** query parameter on every bot-scoped
+#: route. Omitting it is a 422, not a default identity.
+QUERY = {"user_id": OWNER}
+
+
+#: The document the journey declares. ``script`` is the one category whose
+#: materialiser needs neither a container nor a network fetch, so the whole
+#: create → converge → report arc runs offline and the assertions are about the
+#: manual's semantics rather than about a stubbed device.
+SCRIPT_DOCUMENT = (
+    "schema_version: 1\n"
+    "script:\n"
+    "  body: |\n"
+    "    #!/bin/bash\n"
+    "    echo 'manual walkthrough'\n"
+)
+
+#: Two violations from two different places at once. §B.1.2 promises one
+#: validation pass reports **every** rule it can run, so a caller fixes the
+#: document in one round rather than learning one rule per submission.
+#: ``engine_config`` is Appendix C's headline refusal: expressible in the schema,
+#: no materialiser, so refused at ``PUT`` rather than silently ignored.
+INVALID_DOCUMENT = (
+    "schema_version: 1\n"
+    "manifest:\n"
+    "  engine_config:\n"
+    "    config:\n"
+    "      model: m\n"
+    "  identity:\n"
+    "    - type: MEMORY.md\n"
+    '      content: "hi"\n'
+)
+
+
+def _step(method: str, path: str, **kwargs) -> FlowStep:
+    """A FlowStep carrying the principal and ``user_id`` every route demands."""
+    query = {**QUERY, **kwargs.pop("query", {})}
+    return FlowStep(method=method, path=path, query=query, headers=HEADERS, **kwargs)
+
+
+_MANIFEST = "/openapi/v1/bots/{bot_id}/config-manifest"
+
+
+MANIFEST_MANUAL_FLOWS: list[FlowCase] = [
+    # ── §2.1 / §B.1.1 / §B.1.4 / §B.2.4: what a bot answers before anyone has
+    # written anything. Every one of these is "absent is not an error".
+    FlowCase(
+        name="manifest-absent-reads-as-empty",
+        covers=[],
+        steps=[
+            # §B.1.1: an unwritten manifest is an empty document. A 404 here
+            # would make "has none" indistinguishable from "no such bot".
+            _step(
+                "GET",
+                _MANIFEST,
+                expect={
+                    "code": 200000,
+                    "data": {
+                        "bot_id": BOT_ID,
+                        "document": "",
+                        "size_bytes": 0,
+                        "schema_version": None,
+                        "updated_by": "",
+                        "updated_at": None,
+                        "apply": None,
+                    },
+                },
+                extract={"absent_warnings": "data.warnings"},
+            ),
+            # §B.2.4 + §B.2.5: never-applied reads an *empty report* — result
+            # and trigger are "", not any enum value. Judge emptiness by
+            # ``result == ""``.
+            _step(
+                "GET",
+                _MANIFEST + "/last-apply",
+                expect={
+                    "data": {
+                        "apply_id": "",
+                        "result": "",
+                        "trigger": "",
+                        "started_at": None,
+                        "finished_at": None,
+                    }
+                },
+                extract={
+                    "empty_sources": "data.sources",
+                    "empty_categories": "data.categories",
+                    "empty_entries": "data.entries",
+                    "empty_notes": "data.notes",
+                },
+            ),
+            # §B.2.3: an id that is not this bot's answers the same empty
+            # report — "no such record", never "there is one, but not for you".
+            _step(
+                "GET",
+                _MANIFEST + f"/applies/{UNKNOWN_APPLY_ID}",
+                expect={"data": {"apply_id": "", "result": "", "trigger": ""}},
+            ),
+            # §2.1 + §B.1.4: capability is decided by engine × bot type alone —
+            # no container is consulted, so this answers before a bot has one.
+            _step(
+                "GET",
+                _MANIFEST + "/capabilities",
+                expect={
+                    "data": {
+                        "bot_id": BOT_ID,
+                        "engine_type": "openclaw",
+                        "bot_type": "personal",
+                        "schema_versions": [1],
+                    }
+                },
+                extract={"constructs": "data.constructs"},
+            ),
+        ],
+    ),
+    # ── §B.1.2 + 附录 C: a refused document names every reason and stores
+    # nothing. The manifest is still absent afterwards.
+    FlowCase(
+        name="manifest-refused-put-stores-nothing",
+        covers=[],
+        steps=[
+            _step(
+                "PUT",
+                _MANIFEST,
+                body={"document": INVALID_DOCUMENT},
+                expect_status=422,
+                expect={
+                    # §B.0: 422109 is the manifest-validation subcode. Branch on
+                    # ``code``, never on ``message``.
+                    "code": 422109,
+                    "data": {
+                        "violations": [
+                            {
+                                "location": "manifest.engine_config",
+                                "code": "unsupported_category",
+                            },
+                            {
+                                "location": "manifest.identity[0].type",
+                                "code": "reserved_identity_type",
+                            },
+                        ]
+                    },
+                },
+                extract={"violations": "data.violations"},
+            ),
+            # A rejected write is not a partial write.
+            _step("GET", _MANIFEST, expect={"data": {"document": "", "size_bytes": 0}}),
+        ],
+    ),
+    # ── §B.0.1's most-stepped-on rule, as its own case: a missing ``user_id``
+    # is a 422, not "handled as some default identity".
+    FlowCase(
+        name="manifest-requires-a-user-id",
+        covers=[],
+        steps=[
+            FlowStep(
+                method="GET",
+                path=_MANIFEST,
+                headers=HEADERS,
+                expect_status=422,
+            ),
+        ],
+    ),
+    # ── §4.6 step 2 + §B.1.2: an accepted document is stored byte-for-byte and
+    # an apply follows it immediately, handed back as a pollable id.
+    FlowCase(
+        name="manifest-put-stores-and-starts-an-apply",
+        covers=[],
+        steps=[
+            _step(
+                "PUT",
+                _MANIFEST,
+                body={"document": SCRIPT_DOCUMENT},
+                expect={
+                    "code": 200000,
+                    "data": {
+                        "document": SCRIPT_DOCUMENT,
+                        "size_bytes": len(SCRIPT_DOCUMENT.encode("utf-8")),
+                        "schema_version": 1,
+                        # §B.1.2: stamped from the principal, never from the body.
+                        "updated_by": OWNER,
+                        # §B.1.2: the *start result*, not a report. ``reason`` is
+                        # populated only when nothing started.
+                        "apply": {"result": "RUNNING", "reason": None},
+                    },
+                },
+                extract={
+                    "apply_id": "data.apply.apply_id",
+                    "put_warnings": "data.warnings",
+                },
+            ),
+            # §B.1.1: a read never carries a start result — that field belongs
+            # to the write that started one.
+            _step(
+                "GET",
+                _MANIFEST,
+                expect={"data": {"document": SCRIPT_DOCUMENT, "apply": None}},
+                extract={"read_warnings": "data.warnings"},
+            ),
+        ],
+    ),
+    # ── §4.7 + §B.2.5: the report the caller reads to answer "did my manifest
+    # take effect". Runs after the runner drains the enqueued task.
+    FlowCase(
+        name="manifest-report-after-put",
+        covers=[],
+        steps=[
+            _step(
+                "GET",
+                _MANIFEST + "/applies/{apply_id}",
+                expect={
+                    "data": {
+                        "bot_id": BOT_ID,
+                        # §B.7: the auto-apply that follows a PUT is ``put``.
+                        "trigger": "put",
+                        "result": "SUCCEEDED",
+                        "entries": [
+                            {
+                                "category": "script",
+                                "name": "script",
+                                # First time the area is written.
+                                "action": "created",
+                                "error": None,
+                            }
+                        ],
+                    }
+                },
+                extract={
+                    # ``expect`` is matched verbatim — only paths and request
+                    # bodies are interpolated — so ids that must equal an
+                    # earlier step's are chained through the runner instead.
+                    "report_apply_id": "data.apply_id",
+                    "report_entries": "data.entries",
+                    "report_categories": "data.categories",
+                    # §B.2.5: ARCA-family applies leave ``notes`` empty; it
+                    # carries teclaw's whole-artifact redelivery failure only.
+                    "report_notes": "data.notes",
+                    "report_finished_at": "data.finished_at",
+                },
+            ),
+            # §B.2.4: ``last-apply`` is the authoritative "did it land" answer,
+            # and it is the same record the handle names.
+            _step(
+                "GET",
+                _MANIFEST + "/last-apply",
+                expect={"data": {"trigger": "put", "result": "SUCCEEDED"}},
+                extract={"last_apply_id": "data.apply_id"},
+            ),
+        ],
+    ),
+    # ── §3.2 + §4.8: applying the same declaration again converges. This is the
+    # feature's central promise — "already correct" must be zero action, not a
+    # rewrite that reports success.
+    FlowCase(
+        name="manifest-second-put-converges",
+        covers=[],
+        steps=[
+            _step(
+                "PUT",
+                _MANIFEST,
+                body={"document": SCRIPT_DOCUMENT},
+                expect={"data": {"apply": {"result": "RUNNING", "reason": None}}},
+                extract={"apply_id_2": "data.apply.apply_id"},
+            ),
+        ],
+    ),
+    FlowCase(
+        name="manifest-convergence-report",
+        covers=[],
+        steps=[
+            _step(
+                "GET",
+                _MANIFEST + "/applies/{apply_id_2}",
+                expect={
+                    "data": {
+                        "trigger": "put",
+                        "result": "SUCCEEDED",
+                        # §B.7: "already the declared shape, zero action —
+                        # this is normal."
+                        "entries": [{"category": "script", "action": "unchanged"}],
+                    }
+                },
+                extract={"converged_entries": "data.entries"},
+            ),
+        ],
+    ),
+    # ── §B.2.1: an explicit apply takes no body — the document to apply is the
+    # one already stored — and answers 202 with a handle.
+    FlowCase(
+        name="manifest-explicit-apply",
+        covers=[],
+        steps=[
+            _step(
+                "POST",
+                _MANIFEST + "/apply",
+                expect_status=202,
+                expect={"code": 200000, "data": {"result": "RUNNING"}},
+                extract={"apply_id_3": "data.apply_id"},
+            ),
+        ],
+    ),
+    FlowCase(
+        name="manifest-explicit-apply-report",
+        covers=[],
+        steps=[
+            _step(
+                "GET",
+                _MANIFEST + "/applies/{apply_id_3}",
+                # §B.7: ``POST …/apply`` records itself as ``explicit``.
+                expect={"data": {"trigger": "explicit", "result": "SUCCEEDED"}},
+            ),
+        ],
+    ),
+    # ── §4.4 + §B.2.2: a dry run is synchronous (200, not 202), mints no id,
+    # and must not disturb the standing report.
+    FlowCase(
+        name="manifest-dry-run-plans-without-recording",
+        covers=[],
+        steps=[
+            _step(
+                "POST",
+                _MANIFEST + "/apply",
+                query={"dry_run": "true"},
+                expect_status=200,
+                expect={
+                    "data": {
+                        # A preview mints no handle.
+                        "apply_id": "",
+                        # §B.7: the preview report's own trigger value.
+                        "trigger": "dry_run",
+                        "entries": [{"category": "script", "action": "unchanged"}],
+                    }
+                },
+                extract={"dry_run_entries": "data.entries"},
+            ),
+            # §B.2.2: it writes no apply record, so the last real apply still
+            # stands.
+            _step(
+                "GET",
+                _MANIFEST + "/last-apply",
+                expect={"data": {"trigger": "explicit"}},
+                extract={"last_apply_id_after_dry_run": "data.apply_id"},
+            ),
+        ],
+    ),
+    # ── §B.1.3 + §3.3: DELETE clears the *declaration* and nothing else. It is
+    # idempotent, and it applies nothing.
+    FlowCase(
+        name="manifest-delete-clears-the-declaration",
+        covers=[],
+        steps=[
+            _step("DELETE", _MANIFEST, expect={"data": {"deleted": True}}),
+            _step(
+                "GET",
+                _MANIFEST,
+                expect={
+                    "data": {
+                        "document": "",
+                        "size_bytes": 0,
+                        "schema_version": None,
+                    }
+                },
+            ),
+            # Idempotent: deleting an absent declaration still answers deleted.
+            _step("DELETE", _MANIFEST, expect={"data": {"deleted": True}}),
+            # §B.1.3: it removed no entity and started no apply, so the standing
+            # report is untouched.
+            _step(
+                "GET",
+                _MANIFEST + "/last-apply",
+                expect={"data": {"trigger": "explicit"}},
+                extract={"last_apply_id_after_delete": "data.apply_id"},
+            ),
+        ],
+    ),
+]

--- a/src/backend/tests/community/e2e/test_bot_config_manifest_flows.py
+++ b/src/backend/tests/community/e2e/test_bot_config_manifest_flows.py
@@ -1,0 +1,288 @@
+"""Walks the bot-config-manifest user manual against the assembled app.
+
+``tests/community/_flows/bot_config_manifest/api_lifecycle.py`` holds the
+journey as data — one FlowCase per manual section, each step carrying the claim
+it asserts. This module is the executor: it seeds the bot the journey addresses,
+runs the cases **in order through one shared FlowContext** (so an ``apply_id``
+minted in one case is polled in the next), drains the apply queue between them,
+and adds the assertions ``FlowStep.expect`` structurally cannot make.
+
+Why the drain lives here: applying is a ``config_manifest.apply`` task, and this
+app never runs lifecycle ``bootstrap()``, so no handler is registered and its
+worker retires anything enqueued. Running the enqueued payload is exactly what a
+worker with the handler would do, and doing it inline keeps the walk
+deterministic — no lease, no poll interval, no thread racing the per-test
+engine disposal. Same reasoning as ``_await_the_background_apply`` in
+``tests/community/endpoints/test_openapi_config_manifest_apply.py``.
+
+Why the extra assertions live here: ``expect`` is a subset match, so an expected
+``[]`` matches *any* list and an expected ``""`` cannot say "non-empty". Every
+manual claim of that shape — "``warnings`` is always an empty array on a read",
+"``notes`` is empty on ARCA", "the capability table lists exactly these
+constructs" — is asserted below against values the flow extracted.
+"""
+from __future__ import annotations
+
+import pytest
+
+from agentclaw.community.api.bot_config_manifest_apply_service import (
+    BotConfigManifestApplyServiceProtocol,
+)
+from agentclaw.community.core.bot_config_manifest.apply.apply_task import (
+    APPLY_TASK_TYPE,
+)
+from agentclaw.community.core.repository.protocols.bot import BotRepository
+from agentclaw.community.core.repository.protocols.platform import (
+    TaskQueueRepositoryProtocol,
+)
+from agentclaw.community.core.task_queue.types import DEFAULT_APP, TaskStatus
+from agentclaw.community.utils.env_utils import get_current_env
+from agentclaw.community.utils.gateway_principal_config import (
+    init_principal_verifier_config,
+)
+from tests.community._flows.bot_config_manifest.api_lifecycle import (
+    BOT_ID,
+    MANIFEST_MANUAL_FLOWS,
+    OWNER,
+    PRINCIPAL_SIGNING_KEY,
+)
+from tests.community.framework.flow import FlowContext
+from tests.community.framework.flow_runner import run_flow
+
+
+class _Secret:
+    secret_user = "test"
+    secret_value = PRINCIPAL_SIGNING_KEY
+
+
+class _Resolver:
+    """Hands the verifier the key the flows signed their principal with."""
+
+    def get_secret(self, _secret_name: str) -> _Secret:
+        return _Secret()
+
+
+def _seed(world) -> None:
+    """One ACTIVE personal bot on an ARCA-family engine, owned by the caller.
+
+    ``openclaw`` rather than ``teclaw`` because the journey declares ``script``:
+    §2.1's capability table refuses it on teclaw and desktop outright, and the
+    manual's create → converge arc is the ARCA one.
+    """
+    init_principal_verifier_config(_Resolver(), "test-key", strict=False)
+    world.get(BotRepository).insert(
+        {
+            "bot_id": BOT_ID,
+            "bot_name": "Manifest Manual Bot",
+            "owner_id": OWNER,
+            "owner_name": OWNER,
+            "entity_id": OWNER,
+            "entity_type": "staff",
+            "creator_id": OWNER,
+            "status": "ACTIVE",
+            "active_engine": "openclaw",
+            "bot_type": "personal",
+        }
+    )
+
+
+def _drain_applies(world, already_run: set[int]) -> None:
+    """Run every apply task enqueued since the last drain, once each.
+
+    Tracking ids matters here in a way it does not for a single-case test: the
+    walk starts several applies against one bot, and re-running a spent payload
+    would materialise it a second time and hand ``last-apply`` the wrong record.
+    """
+    repo = world.get(TaskQueueRepositoryProtocol)
+    apply_service = world.get(BotConfigManifestApplyServiceProtocol)
+    for status in TaskStatus:
+        for task in repo.list_by_status(
+            status=status, env=get_current_env(), app=DEFAULT_APP
+        ):
+            if task.task_type != APPLY_TASK_TYPE or task.id in already_run:
+                continue
+            already_run.add(task.id)
+            apply_service.run_apply_task(task.payload)
+
+
+# ── The assertions ``expect``'s subset match cannot make ───────────────────
+
+
+def _absent_reads_as_empty(ctx: FlowContext) -> None:
+    # §B.1.1: on a read, ``warnings`` is *always* an empty array — it is the
+    # write's field. An expected [] in ``expect`` would have matched anything.
+    assert ctx["absent_warnings"] == [], (
+        "§B.1.1: warnings must be empty on a read, "
+        f"got {ctx['absent_warnings']!r}"
+    )
+    # §B.2.5: an empty report's four arrays are all empty.
+    for key in ("empty_sources", "empty_categories", "empty_entries", "empty_notes"):
+        assert ctx[key] == [], f"§B.2.5: empty report's {key} must be [], got {ctx[key]!r}"
+
+    # §B.7 + §B.1.4: the capability table lists every construct, supported and
+    # unsupported alike, so a client can decide what to write before writing it.
+    by_kind: dict[str, set[str]] = {}
+    for construct in ctx["constructs"]:
+        assert set(construct) >= {"kind", "name", "supported", "reason"}, (
+            f"§B.1.4: a construct row is missing fields: {construct!r}"
+        )
+        if construct["supported"]:
+            assert construct["reason"] == "", (
+                "§B.1.4: reason is the empty string when supported, "
+                f"got {construct!r}"
+            )
+        by_kind.setdefault(construct["kind"], set()).add(construct["name"])
+
+    assert by_kind == {
+        "category": {
+            "mcp",
+            "resources",
+            "skills",
+            "engine_config",
+            "identity",
+            "cli_tools",
+        },
+        "section": {"script"},
+        "source": {"url", "git", "named", "content"},
+    }, f"§B.7's construct table and the capability endpoint disagree: {by_kind!r}"
+
+
+def _refused_put_names_every_reason(ctx: FlowContext) -> None:
+    # §B.1.2: one pass reports every rule it could run — not one per submission.
+    assert len(ctx["violations"]) == 2, (
+        "§B.1.2: both reasons must arrive together, "
+        f"got {ctx['violations']!r}"
+    )
+    for violation in ctx["violations"]:
+        assert set(violation) == {"location", "code", "message"}, (
+            f"§B.1.2: violation shape is public contract, got {violation!r}"
+        )
+        assert violation["message"], "§B.1.2: message must explain the rule"
+
+
+def _put_starts_an_apply(ctx: FlowContext) -> None:
+    # §B.1.2: RUNNING carries a real handle; only NOT_STARTED has an empty id.
+    assert ctx["apply_id"], "§B.1.2: a RUNNING apply must carry an apply_id"
+    # §B.1.2 warning class 2: a declared ``script`` is written now and executed
+    # at next start, and the response says so rather than leaving it inferred.
+    assert ctx["put_warnings"], (
+        "§B.1.2: declaring a script must warn that it takes effect at next start"
+    )
+    # §B.1.1 again, now that a document exists: reads still never carry warnings.
+    assert ctx["read_warnings"] == [], (
+        f"§B.1.1: a read carries no warnings, got {ctx['read_warnings']!r}"
+    )
+
+
+def _report_is_complete(ctx: FlowContext) -> None:
+    # §B.2.1 + §B.2.4: the handle names the record, and ``last-apply`` — the
+    # authoritative "did it land" answer — names the same one.
+    assert ctx["report_apply_id"] == ctx["apply_id"], (
+        "§B.2.3: polling the handle must return the apply it was minted for"
+    )
+    assert ctx["last_apply_id"] == ctx["apply_id"], (
+        "§B.2.4: last-apply must be the apply the PUT started"
+    )
+    # §B.2.5: one row per *declared* entry, and one per *declared* category —
+    # a category the document never mentions is never touched, so never listed.
+    assert len(ctx["report_entries"]) == 1, (
+        f"§B.2.5: only declared entries are reported, got {ctx['report_entries']!r}"
+    )
+    assert len(ctx["report_categories"]) == 1, (
+        f"§B.2.5: only declared categories are reported, "
+        f"got {ctx['report_categories']!r}"
+    )
+    category = ctx["report_categories"][0]
+    assert category["category"] == "script"
+    # §B.2.5: a converged category aborted nothing and half-wrote nothing.
+    assert category["aborted"] is False and category["partially_written"] is False, (
+        f"§B.2.5: a SUCCEEDED category is neither aborted nor half-written: {category!r}"
+    )
+    # §3.3: overwrite removes what the declared area no longer names. A first
+    # apply into an empty area removes nothing.
+    assert category["removed"] == [], (
+        f"§B.2.5: nothing was displaced, got removed={category['removed']!r}"
+    )
+    # §B.2.5: ``notes`` carries teclaw's whole-artifact redelivery failure and
+    # nothing else — always empty on ARCA.
+    assert ctx["report_notes"] == [], (
+        f"§B.2.5: notes is empty on ARCA, got {ctx['report_notes']!r}"
+    )
+    # §B.2.5: finished_at is null only while RUNNING or on an empty report.
+    assert ctx["report_finished_at"] is not None, (
+        "§B.2.5: a terminal report carries finished_at"
+    )
+
+
+def _second_apply_changed_nothing(ctx: FlowContext) -> None:
+    # §3.2 / §4.8 / §B.7: "already the declared shape" is zero action. If this
+    # reports ``updated``, convergence is rewriting on every apply.
+    assert [e["action"] for e in ctx["converged_entries"]] == ["unchanged"], (
+        "§B.7: re-applying an unchanged declaration must be `unchanged`, "
+        f"got {ctx['converged_entries']!r}"
+    )
+
+
+def _dry_run_planned_the_same_thing(ctx: FlowContext) -> None:
+    # §4.4: the preview reports what *would* happen against current state —
+    # which, on a converged bot, is nothing.
+    assert [e["action"] for e in ctx["dry_run_entries"]] == ["unchanged"], (
+        f"§4.4: the plan must match reality, got {ctx['dry_run_entries']!r}"
+    )
+    # §B.2.2: it writes no apply record, so the explicit apply still stands as
+    # the last one. A dry run that displaced it would make "did my manifest
+    # land" unanswerable.
+    assert ctx["last_apply_id_after_dry_run"] == ctx["apply_id_3"], (
+        "§B.2.2: a dry run must not enter last-apply"
+    )
+
+
+def _delete_cleared_only_the_declaration(ctx: FlowContext) -> None:
+    # §B.1.3 + §3.3: DELETE removes the declaration, not the entities it
+    # materialised — and starts no apply, so the standing report is untouched.
+    assert ctx["last_apply_id_after_delete"] == ctx["apply_id_3"], (
+        "§B.1.3: DELETE must not apply anything"
+    )
+
+
+#: Post-conditions per flow, keyed by the FlowCase name they follow.
+_POSTCONDITIONS = {
+    "manifest-absent-reads-as-empty": _absent_reads_as_empty,
+    "manifest-refused-put-stores-nothing": _refused_put_names_every_reason,
+    "manifest-put-stores-and-starts-an-apply": _put_starts_an_apply,
+    "manifest-report-after-put": _report_is_complete,
+    "manifest-convergence-report": _second_apply_changed_nothing,
+    "manifest-dry-run-plans-without-recording": _dry_run_planned_the_same_thing,
+    "manifest-delete-clears-the-declaration": _delete_cleared_only_the_declaration,
+}
+
+
+@pytest.mark.usefixtures("app_with_testing_modules")
+def test_user_manual_walkthrough(app_with_testing_modules, world):
+    """The manual's §4 workflow, start to finish, on one bot.
+
+    Declare nothing → read empty · refuse a bad document → store nothing ·
+    ``PUT`` → apply → read the report · ``PUT`` again → converge ·
+    explicit apply · dry run → plan without recording · ``DELETE`` → clear the
+    declaration and nothing else.
+
+    One test rather than one per flow because it *is* one journey: each case
+    reads state the previous case wrote. ``run_flow`` names the failing case and
+    step, so a break still points at the manual section that broke.
+    """
+    _seed(world)
+
+    ctx = FlowContext()
+    # ``run_flow`` interpolates the path before substituting path_params, so the
+    # addressed bot travels in the context like any other chained value.
+    ctx["bot_id"] = BOT_ID
+
+    already_run: set[int] = set()
+    for case in MANIFEST_MANUAL_FLOWS:
+        ctx = run_flow(case, app_with_testing_modules, world, initial_context=ctx)
+        postcondition = _POSTCONDITIONS.get(case.name)
+        if postcondition is not None:
+            postcondition(ctx)
+        # Whatever this case enqueued, a worker would have run before the next
+        # case polled for its report.
+        _drain_applies(world, already_run)


### PR DESCRIPTION
## Problem

`src/backend/docs/bot-config-manifest/user-manual.zh-CN.md` is the contract business callers build against — "an absent manifest reads as an empty document, not a 404", "`PUT` starts an apply whose report trigger is `put`", "applying the same document twice is `unchanged`", "a dry run mints no id and never enters `last-apply`". None of those claims executed anywhere.

The per-endpoint suites (`tests/community/endpoints/test_openapi_config_manifest*.py`) pin each route's own shape in isolation, which leaves the seams between routes uncovered: an `apply_id` handed out by one route and polled through another, a second `PUT` converging against what the first materialised, a dry run that must leave the standing report alone.

## Solution

The journey as data — one `FlowCase` per manual section in `tests/community/_flows/bot_config_manifest/api_lifecycle.py`, each step carrying the section it asserts — plus an executor in `tests/community/e2e/test_bot_config_manifest_flows.py`.

Two things the executor owns rather than the cases:

- **Draining.** Applying is a `config_manifest.apply` task and the endpoint-test app registers no handler, so a worker never runs it. A flow that starts an apply ends where the apply is enqueued; the flow that reads its report is a separate case, and the seam is named in the case names rather than hidden inside one. The executor runs the enqueued payload between cases — exactly what a worker with the handler registered would do — and threads one `FlowContext` through so `{apply_id}` still chains. Same reasoning as `_await_the_background_apply` in the endpoint suite.
- **Emptiness.** `FlowStep.expect` is a subset match, so an expected `[]` matches any list and an expected `""` cannot say "non-empty". Every claim of that shape — `warnings` is always empty on a read, `notes` is empty on ARCA, the capability table lists exactly these constructs — is extracted and compared exactly.

`covers` is left empty deliberately. Every route in this group is `/openapi/v1` and needs a gateway-signed principal; these cases mint one themselves, which the in-process app accepts and singlebox cannot produce. That is precisely why `bot_config_manifest` sits in `SINGLEBOX_E2E_EXEMPT`, so this suite does not drain that exemption and must not claim to.

The walked document declares only `script` — the one category whose materialiser needs neither a container nor a network fetch — so the create → converge → report arc runs offline and the assertions are about the manual's semantics rather than about a stubbed device.

## Validation

```
uv run pytest tests/community/e2e/test_bot_config_manifest_flows.py \
              tests/community/architecture/test_e2e_module_coverage.py \
              tests/community/framework -q
128 passed
```

Also green, unchanged by this PR: `tests/community/core/bot_config_manifest` (865 passed) and the manifest/cli-tool/credential endpoint cases (79 passed).

Not run: the route-B acceptance lane (`RUN_ACCEPTANCE=1`), which needs baas/mosn/sofa-registry this environment cannot spawn — and which could not run these cases anyway, for the principal-minting reason above.

Two findings surfaced while writing this, both left for a separate change rather than fixed here:

- §10's limits table omits `MAX_SOURCE_URL_CHARS = 2048`, which is enforced at `PUT` (violation code `source_url_too_long`) and is documented in `manifest-schema.zh-CN.md` §5. §10 enumerates the write-time checks as only three.
- §B.2.5 defines `categories[].aborted` as "at least one declared entry failed to materialise", but the orchestrator only sets it when it abandons a category in `resolve`/`plan`/`write`. A materialiser reporting per-entry failure from `write` (cli_tools does, deliberately) leaves `aborted: false` on an apply whose entry failed and whose result is `FAILED`.

## Compatibility and risk

Test-only. No production code, no contract, schema, config, or migration impact.

## Spec

`src/backend/docs/bot-config-manifest/user-manual.zh-CN.md` — the sections each case cites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019dzBBLChdsLffbjx71e2zM

---
_Generated by [Claude Code](https://claude.ai/code/session_019dzBBLChdsLffbjx71e2zM)_