### PR TITLE
fix(backend): configure installation read mode through typed YAML

### DIFF
--- a/src/backend/src/agentclaw/community/core/skill_center/AGENTS.md
+++ b/src/backend/src/agentclaw/community/core/skill_center/AGENTS.md
@@ -70,7 +70,7 @@ Bot 定位必须携带 `owner_id + bot_id`，并保持 Repository 的 tenant/env
 - `CapabilityDesiredStateRepository` 是 Set state、membership、Default exclusion 与 Skill/MCP Installation 的事务写入入口；表级 SQL owner 使用同一个事务 Session。
 - 普通 Set 新建默认 `is_active=True`。active Set 增删成员同步维护 Installation；inactive Set 编辑不要求 Runtime 投影。
 - `services/bot_capability_state_reader.py` 在读有效态前同步 Installation，然后只从 Installation 读取有效身份。Center 资产在返回前由 `SkillVersionResolver` 解析到精确 PUBLISHED Version。
-- `SC_INSTALLATION_DEFAULT_SYNC_ONLY=false` 时执行完整 `flush_installations`；验收历史 backfill 后可启用 Default-only 同步模式。该模式仍同步 Default/exclusion，不等于完全取消 DB 补齐。新 Bot 的 `initialize_installations` 始终完整初始化。
+- Reader 的 `InstallationReadConfig` 由 `ConfigModule` 从 YAML `user_config.skill_installation.default_sync_only` 按规范化环境选择，`pre`、`prod` 缺省均为 `false`；旧 `SC_INSTALLATION_DEFAULT_SYNC_ONLY` 环境变量不再生效。验收某个环境的完整 backfill 后，才可单独将该环境置为 `true` 并重新部署 Backend。该模式仍同步 Default/exclusion，不等于完全取消 DB 补齐。运维 backfill 和新 Bot 的 `initialize_installations` 始终完整执行，不受此读侧配置影响。
 - 普通 Asset、Draft、Version 查询不应为方便而触发 Bot flush。需要回答“Bot 当前应有哪些有效能力”时才使用 Reader。
 - `policies/capability_ownership.py` 统一判定：Set 成员（含 inactive Set 和 excluded Default member）由 Set 控制；Direct-active 能力加入 Set 前先停用；同一 Bot 下只能属于一个 reaching Set（含 Default）。`RESOURCE_DIRECT_ACTIVE` 优先于另一个 Set 冲突。
 - Default member 被 exclusion 后仍属于 Default；重新启用走 un-exclude。Default 选择统一使用 `policies/default_skill_set_selection.py`，保留全局 Default 与 engine/template 兼容规则。

--- a/src/backend/src/agentclaw/community/core/skill_center/feature_flags.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/feature_flags.py
@@ -15,9 +15,6 @@ class SkillCenterFlags:
     symlink_verify_auto_fix: bool
     write_skill_uuid: bool  # 双写控制，不关
     space_skill_enabled: bool = False
-    # Migration gate for Installation backfill.  It remains false until the
-    # operator has completed and accepted the environment backfill.
-    installation_default_sync_only: bool = False
 
     @classmethod
     def from_env(cls) -> "SkillCenterFlags":
@@ -29,10 +26,6 @@ class SkillCenterFlags:
             symlink_verify_auto_fix=os.environ.get("SC_SYMLINK_AUTO_FIX", "false").lower() == "true",
             write_skill_uuid=os.environ.get("SC_WRITE_SKILL_UUID", "true").lower() == "true",
             space_skill_enabled=os.environ.get("SC_SPACE_SKILL_ENABLED", "false").lower() == "true",
-            installation_default_sync_only=(
-                os.environ.get("SC_INSTALLATION_DEFAULT_SYNC_ONLY", "false").lower()
-                == "true"
-            ),
         )
 
     def any_blocking_enabled(self) -> bool:

--- a/src/backend/src/agentclaw/community/core/skill_center/installation_read_config.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/installation_read_config.py
@@ -1,0 +1,10 @@
+"""Resolved Installation read mode; deployment parsing belongs to DI."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class InstallationReadConfig:
+    """False retains full repair until this environment's backfill is accepted."""
+
+    default_sync_only: bool = False

--- a/src/backend/src/agentclaw/community/core/skill_center/services/bot_capability_state_reader.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/bot_capability_state_reader.py
@@ -21,7 +21,7 @@ from agentclaw.community.core.skill_center.bot_engine_scope import (
     bot_default_engine_types,
     bot_engine_type,
 )
-from agentclaw.community.core.skill_center.feature_flags import get_skill_center_flags
+from agentclaw.community.core.skill_center.installation_read_config import InstallationReadConfig
 from agentclaw.community.core.skill_center.errors import LocalSkillNotFoundError
 from agentclaw.community.core.skill_center.version_resolution_contract import (
     SkillVersionResolverProtocol,
@@ -47,11 +47,13 @@ class BotCapabilityStateReader(BotCapabilityStateReaderProtocol):
         bot_repo: BotRepository,
         pool_skills: SkillsPoolSkillRepositoryProtocol,
         version_resolver: SkillVersionResolverProtocol,
+        read_config: InstallationReadConfig = InstallationReadConfig(),
     ) -> None:
         self._repository = repository
         self._bot_repo = bot_repo
         self._pool_skills = pool_skills
         self._version_resolver = version_resolver
+        self._read_config = read_config
 
     def member_skill_ids(self, *, bot: Mapping[str, Any]) -> frozenset[int]:
         return self._repository.list_member_skill_ids(
@@ -152,7 +154,7 @@ class BotCapabilityStateReader(BotCapabilityStateReaderProtocol):
     ) -> InstallationFlushPlan:
         sync = (
             self._repository.sync_default_installations
-            if get_skill_center_flags().installation_default_sync_only
+            if self._read_config.default_sync_only
             else self._repository.flush_installations
         )
         return sync(

--- a/src/backend/src/agentclaw/community/di/container.py
+++ b/src/backend/src/agentclaw/community/di/container.py
@@ -49,6 +49,9 @@ from agentclaw.community.di.modules.grt_chat_module import GrtChatModule
 from agentclaw.community.di.modules.harness_module import HarnessModule
 from agentclaw.community.di.modules.http_client_module import HttpClientModule
 from agentclaw.community.di.modules.identity_module import IdentityModule
+from agentclaw.community.di.modules.installation_read_config_module import (
+    InstallationReadConfigModule,
+)
 from agentclaw.community.di.modules.mcp_module import McpModule
 from agentclaw.community.di.modules.quality_module import QualityModule
 from agentclaw.community.di.modules.resources_module import ResourcesModule
@@ -110,6 +113,7 @@ def build_injector(
     """
     modules: list[Module] = [
         ConfigModule(),
+        InstallationReadConfigModule(),
         SkillCenterModule(),
         SkillCenterGroup4Module(),
         SkillVersionModule(),

--- a/src/backend/src/agentclaw/community/di/modules/config_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/config_module.py
@@ -19,6 +19,7 @@ from dataclasses import fields
 from typing import Any
 from injector import Module, inject, provider, singleton
 from agentclaw.community.core.skill_center import draft_content
+from agentclaw.community.core.skill_center.installation_read_config import InstallationReadConfig
 from agentclaw.community.core.task_queue.types import MAX_APP_LEN
 from agentclaw.community.core.skill_center.canonical_center_store import CanonicalCenterStoreConfig
 from agentclaw.community.di import config as cfg
@@ -232,6 +233,24 @@ def _pool_policy(
 
 class ConfigModule(Module):
     """Bind every typed config dataclass."""
+
+    @singleton
+    @provider
+    def installation_read(self) -> InstallationReadConfig:
+        """Resolve the migration gate independently for pre and prod."""
+        block = _user_config().get("skill_installation", {})
+        if not isinstance(block, dict) or set(block) - {"default_sync_only"}:
+            raise ValueError("skill_installation must contain only default_sync_only")
+        modes = block.get("default_sync_only", {})
+        if not isinstance(modes, dict) or set(modes) - {"pre", "prod"}:
+            raise ValueError("skill_installation.default_sync_only must map pre/prod")
+        if any(type(value) is not bool for value in modes.values()):
+            raise ValueError("skill_installation.default_sync_only values must be booleans")
+        env = get_current_env()
+        default = InstallationReadConfig().default_sync_only
+        config = InstallationReadConfig(default_sync_only=modes.get(env, default))
+        logger.info("[installation_read_config] env=%s default_sync_only=%s", env, config.default_sync_only)
+        return config
 
     # ── Workspace ───────────────────────────────────────────────────
 

--- a/src/backend/src/agentclaw/community/di/modules/config_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/config_module.py
@@ -19,7 +19,6 @@ from dataclasses import fields
 from typing import Any
 from injector import Module, inject, provider, singleton
 from agentclaw.community.core.skill_center import draft_content
-from agentclaw.community.core.skill_center.installation_read_config import InstallationReadConfig
 from agentclaw.community.core.task_queue.types import MAX_APP_LEN
 from agentclaw.community.core.skill_center.canonical_center_store import CanonicalCenterStoreConfig
 from agentclaw.community.di import config as cfg
@@ -233,24 +232,6 @@ def _pool_policy(
 
 class ConfigModule(Module):
     """Bind every typed config dataclass."""
-
-    @singleton
-    @provider
-    def installation_read(self) -> InstallationReadConfig:
-        """Resolve the migration gate independently for pre and prod."""
-        block = _user_config().get("skill_installation", {})
-        if not isinstance(block, dict) or set(block) - {"default_sync_only"}:
-            raise ValueError("skill_installation must contain only default_sync_only")
-        modes = block.get("default_sync_only", {})
-        if not isinstance(modes, dict) or set(modes) - {"pre", "prod"}:
-            raise ValueError("skill_installation.default_sync_only must map pre/prod")
-        if any(type(value) is not bool for value in modes.values()):
-            raise ValueError("skill_installation.default_sync_only values must be booleans")
-        env = get_current_env()
-        default = InstallationReadConfig().default_sync_only
-        config = InstallationReadConfig(default_sync_only=modes.get(env, default))
-        logger.info("[installation_read_config] env=%s default_sync_only=%s", env, config.default_sync_only)
-        return config
 
     # ── Workspace ───────────────────────────────────────────────────
 

--- a/src/backend/src/agentclaw/community/di/modules/installation_read_config_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/installation_read_config_module.py
@@ -1,0 +1,40 @@
+"""InstallationReadConfig binding for the completed-backfill migration gate."""
+
+from __future__ import annotations
+
+from injector import Module, provider, singleton
+
+from agentclaw.community.core.skill_center.installation_read_config import (
+    InstallationReadConfig,
+)
+from agentclaw.community.di.modules import config_module
+from agentclaw.community.log import get_logger
+from agentclaw.community.utils.env_utils import get_current_env
+
+
+logger = get_logger()
+
+
+class InstallationReadConfigModule(Module):
+    """Bind the environment-specific Installation Reader mode."""
+
+    @singleton
+    @provider
+    def installation_read(self) -> InstallationReadConfig:
+        """Choose Default-only sync only for an explicitly accepted environment."""
+        block = config_module.read_user_config().get("skill_installation", {})
+        if not isinstance(block, dict) or set(block) - {"default_sync_only"}:
+            raise ValueError("skill_installation must contain only default_sync_only")
+        modes = block.get("default_sync_only", {})
+        if not isinstance(modes, dict) or set(modes) - {"pre", "prod"}:
+            raise ValueError("skill_installation.default_sync_only must map pre/prod")
+        if any(type(value) is not bool for value in modes.values()):
+            raise ValueError("skill_installation.default_sync_only values must be booleans")
+        env = get_current_env()
+        config = InstallationReadConfig(default_sync_only=modes.get(env, False))
+        logger.info(
+            "[installation_read_config] env=%s default_sync_only=%s",
+            env,
+            config.default_sync_only,
+        )
+        return config

--- a/src/backend/tests/community/core/skill_center/test_bot_capability_state_reader.py
+++ b/src/backend/tests/community/core/skill_center/test_bot_capability_state_reader.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import pytest
-from types import SimpleNamespace
+from agentclaw.community.core.skill_center.installation_read_config import InstallationReadConfig
 
 from agentclaw.community.api.bot_capability_state_reader import (
     BotCapabilityStateReaderProtocol,
@@ -70,7 +70,7 @@ class _Repository:
 
     def list_installed_mcps(self, **kwargs) -> set[str]:
         # A read that beats the flush would answer from unflushed rows.
-        assert self.flush_calls, "read reached Installation before the flush"
+        assert self.flush_calls or self.default_sync_calls, "read reached Installation before the flush"
         self.mcp_reads.append(kwargs)
         return {"mcp.weather"}
 
@@ -113,7 +113,7 @@ class _Versions:
 
 
 def _reader(
-    *, bots: _Bots | None = None
+    *, bots: _Bots | None = None, default_sync_only: bool = False
 ) -> tuple[BotCapabilityStateReader, _Repository, _PoolSkills, _Bots, _Versions]:
     repository = _Repository()
     pool_skills = _PoolSkills().bind(repository)
@@ -125,6 +125,7 @@ def _reader(
             bot_repo=bots,
             pool_skills=pool_skills,
             version_resolver=versions,
+            read_config=InstallationReadConfig(default_sync_only=default_sync_only),
         ),
         repository,
         pool_skills,
@@ -215,14 +216,8 @@ def test_member_skill_ids_reads_the_set_membership_without_materializing():
     assert ids == frozenset({1})
 
 
-def test_reader_uses_default_only_sync_after_the_explicit_migration_switch(
-    monkeypatch: pytest.MonkeyPatch,
-):
-    reader, repository, pool_skills, _bots, _versions = _reader()
-    monkeypatch.setattr(
-        "agentclaw.community.core.skill_center.services.bot_capability_state_reader.get_skill_center_flags",
-        lambda: SimpleNamespace(installation_default_sync_only=True),
-    )
+def test_reader_uses_default_only_sync_after_the_explicit_migration_switch():
+    reader, repository, pool_skills, _bots, _versions = _reader(default_sync_only=True)
 
     reader.active_skill_assets(bot_id="bot-1", owner_id="owner")
 
@@ -231,17 +226,18 @@ def test_reader_uses_default_only_sync_after_the_explicit_migration_switch(
     assert pool_skills.reads
 
 
-def test_new_bot_initialization_always_uses_the_complete_resolver(
-    monkeypatch: pytest.MonkeyPatch,
-):
-    reader, repository, _pool, _bots, _versions = _reader()
-    monkeypatch.setattr(
-        "agentclaw.community.core.skill_center.services.bot_capability_state_reader.get_skill_center_flags",
-        lambda: SimpleNamespace(installation_default_sync_only=True),
-    )
+def test_new_bot_initialization_always_uses_the_complete_resolver():
+    reader, repository, _pool, _bots, _versions = _reader(default_sync_only=True)
 
     reader.initialize_installations(bot_id="bot-1", owner_id="owner")
 
     assert repository.initialization_calls == [_EXPECTED_FLUSH]
     assert repository.flush_calls == []
     assert repository.default_sync_calls == []
+
+
+def test_default_only_mode_also_synchronizes_before_mcp_read():
+    reader, repository, _pool, _bots, _versions = _reader(default_sync_only=True)
+    assert reader.active_mcp_server_codes(bot_id="bot-1", owner_id="owner") == frozenset({"mcp.weather"})
+    assert repository.default_sync_calls == [_EXPECTED_FLUSH]
+    assert repository.flush_calls == []

--- a/src/backend/tests/community/core/skill_center/test_feature_flags.py
+++ b/src/backend/tests/community/core/skill_center/test_feature_flags.py
@@ -19,18 +19,15 @@ class TestSkillCenterFlags:
     def test_from_env_reads_env_vars(self):
         os.environ["SC_NAS_SYNC_ENABLED"] = "true"
         os.environ["SC_PROPAGATION_ENABLED"] = "true"
-        os.environ["SC_INSTALLATION_DEFAULT_SYNC_ONLY"] = "true"
         try:
             flags = SkillCenterFlags.from_env()
             assert flags.nas_sync_enabled is True
             assert flags.propagation_enabled is True
             assert flags.center_uri_enabled is False
             assert flags.space_skill_enabled is False
-            assert flags.installation_default_sync_only is True
         finally:
             del os.environ["SC_NAS_SYNC_ENABLED"]
             del os.environ["SC_PROPAGATION_ENABLED"]
-            del os.environ["SC_INSTALLATION_DEFAULT_SYNC_ONLY"]
 
     def test_any_blocking_enabled_true_when_any_flag_on(self):
         flags = SkillCenterFlags(

--- a/src/backend/tests/community/di/modules/test_installation_read_config.py
+++ b/src/backend/tests/community/di/modules/test_installation_read_config.py
@@ -1,0 +1,62 @@
+"""Installation migration mode is YAML-owned and environment-isolated."""
+
+from unittest.mock import Mock
+
+import pytest
+from injector import Injector, InstanceProvider
+
+from agentclaw.community.core.repository.protocols.bot import BotRepository
+from agentclaw.community.core.repository.protocols.capability_desired_state import CapabilityDesiredStateRepositoryProtocol
+from agentclaw.community.core.repository.protocols.skills_pool import SkillsPoolSkillRepositoryProtocol
+from agentclaw.community.core.skill_center.installation_read_config import InstallationReadConfig
+from agentclaw.community.core.skill_center.services.bot_capability_state_reader import BotCapabilityStateReader
+from agentclaw.community.core.skill_center.version_resolution_contract import SkillVersionResolverProtocol
+from agentclaw.community.di.modules import config_module
+
+
+@pytest.mark.parametrize("environment,expected", [("pre", True), ("prepub", True), ("prod", False), ("gray", False), ("dev", False)])
+def test_environment_selection_and_reader_injection(monkeypatch, environment, expected):
+    monkeypatch.setenv("SERVER_ENV", environment)
+    monkeypatch.setenv("SC_INSTALLATION_DEFAULT_SYNC_ONLY", "true")
+    monkeypatch.setattr(config_module, "_user_config", lambda: {
+        "skill_installation": {"default_sync_only": {"pre": True, "prod": False}}
+    })
+    injector = Injector([config_module.ConfigModule()])
+    repository = Mock()
+    for protocol, value in [(CapabilityDesiredStateRepositoryProtocol, repository),
+                            (BotRepository, Mock()), (SkillsPoolSkillRepositoryProtocol, Mock()),
+                            (SkillVersionResolverProtocol, Mock())]:
+        injector.binder.bind(protocol, to=InstanceProvider(value))
+    reader = injector.get(BotCapabilityStateReader)
+    reader.synchronize_installations(bot_id="default", owner_id="owner", bot={
+        "bot_id": "default", "owner_id": "owner", "env": "pre" if expected else "prod",
+        "active_engine": "openclaw",
+    })
+    assert repository.sync_default_installations.called is expected
+    assert repository.flush_installations.called is not expected
+    assert injector.get(InstallationReadConfig).default_sync_only is expected
+
+
+@pytest.mark.parametrize("user_config", [{}, {"skill_installation": {}}, {"skill_installation": {"default_sync_only": {}}}])
+def test_missing_settings_are_disabled(monkeypatch, user_config):
+    monkeypatch.setenv("SC_INSTALLATION_DEFAULT_SYNC_ONLY", "true")
+    monkeypatch.setattr(config_module, "_user_config", lambda: user_config)
+    assert config_module.ConfigModule().installation_read() == InstallationReadConfig()
+
+
+@pytest.mark.parametrize("environment,expected", [("pre", False), ("prod", True)])
+def test_production_switch_does_not_enable_pre(monkeypatch, environment, expected):
+    monkeypatch.setenv("SERVER_ENV", environment)
+    monkeypatch.setattr(config_module, "_user_config", lambda: {
+        "skill_installation": {"default_sync_only": {"prod": True}}
+    })
+    assert config_module.ConfigModule().installation_read().default_sync_only is expected
+
+
+@pytest.mark.parametrize("block", [None, True, {"typo": True}, {"default_sync_only": None},
+    {"default_sync_only": True}, {"default_sync_only": {"pre": "false"}},
+    {"default_sync_only": {"prod": 1}}, {"default_sync_only": {"prd": True}}])
+def test_invalid_settings_fail_explicitly(monkeypatch, block):
+    monkeypatch.setattr(config_module, "_user_config", lambda: {"skill_installation": block})
+    with pytest.raises(ValueError, match="skill_installation"):
+        config_module.ConfigModule().installation_read()

--- a/src/backend/tests/community/di/modules/test_installation_read_config.py
+++ b/src/backend/tests/community/di/modules/test_installation_read_config.py
@@ -12,16 +12,19 @@ from agentclaw.community.core.skill_center.installation_read_config import Insta
 from agentclaw.community.core.skill_center.services.bot_capability_state_reader import BotCapabilityStateReader
 from agentclaw.community.core.skill_center.version_resolution_contract import SkillVersionResolverProtocol
 from agentclaw.community.di.modules import config_module
+from agentclaw.community.di.modules.installation_read_config_module import (
+    InstallationReadConfigModule,
+)
 
 
 @pytest.mark.parametrize("environment,expected", [("pre", True), ("prepub", True), ("prod", False), ("gray", False), ("dev", False)])
 def test_environment_selection_and_reader_injection(monkeypatch, environment, expected):
     monkeypatch.setenv("SERVER_ENV", environment)
     monkeypatch.setenv("SC_INSTALLATION_DEFAULT_SYNC_ONLY", "true")
-    monkeypatch.setattr(config_module, "_user_config", lambda: {
+    monkeypatch.setattr(config_module, "read_user_config", lambda: {
         "skill_installation": {"default_sync_only": {"pre": True, "prod": False}}
     })
-    injector = Injector([config_module.ConfigModule()])
+    injector = Injector([config_module.ConfigModule(), InstallationReadConfigModule()])
     repository = Mock()
     for protocol, value in [(CapabilityDesiredStateRepositoryProtocol, repository),
                             (BotRepository, Mock()), (SkillsPoolSkillRepositoryProtocol, Mock()),
@@ -40,23 +43,23 @@ def test_environment_selection_and_reader_injection(monkeypatch, environment, ex
 @pytest.mark.parametrize("user_config", [{}, {"skill_installation": {}}, {"skill_installation": {"default_sync_only": {}}}])
 def test_missing_settings_are_disabled(monkeypatch, user_config):
     monkeypatch.setenv("SC_INSTALLATION_DEFAULT_SYNC_ONLY", "true")
-    monkeypatch.setattr(config_module, "_user_config", lambda: user_config)
-    assert config_module.ConfigModule().installation_read() == InstallationReadConfig()
+    monkeypatch.setattr(config_module, "read_user_config", lambda: user_config)
+    assert InstallationReadConfigModule().installation_read() == InstallationReadConfig()
 
 
 @pytest.mark.parametrize("environment,expected", [("pre", False), ("prod", True)])
 def test_production_switch_does_not_enable_pre(monkeypatch, environment, expected):
     monkeypatch.setenv("SERVER_ENV", environment)
-    monkeypatch.setattr(config_module, "_user_config", lambda: {
+    monkeypatch.setattr(config_module, "read_user_config", lambda: {
         "skill_installation": {"default_sync_only": {"prod": True}}
     })
-    assert config_module.ConfigModule().installation_read().default_sync_only is expected
+    assert InstallationReadConfigModule().installation_read().default_sync_only is expected
 
 
 @pytest.mark.parametrize("block", [None, True, {"typo": True}, {"default_sync_only": None},
     {"default_sync_only": True}, {"default_sync_only": {"pre": "false"}},
     {"default_sync_only": {"prod": 1}}, {"default_sync_only": {"prd": True}}])
 def test_invalid_settings_fail_explicitly(monkeypatch, block):
-    monkeypatch.setattr(config_module, "_user_config", lambda: {"skill_installation": block})
+    monkeypatch.setattr(config_module, "read_user_config", lambda: {"skill_installation": block})
     with pytest.raises(ValueError, match="skill_installation"):
-        config_module.ConfigModule().installation_read()
+        InstallationReadConfigModule().installation_read()


### PR DESCRIPTION
## Problem

The Installation backfill migration gate reads only a process environment variable. OCB YAML configuration does not feed it, so adding deployment YAML alone cannot change Reader behavior safely by environment.

## Solution

Read user_config.skill_installation.default_sync_only via the existing typed ConfigModule and inject InstallationReadConfig into BotCapabilityStateReader. Accept only boolean pre/prod keys, normalize prepub/gray via the existing environment helper, and default to full flush. Remove only the legacy SC_INSTALLATION_DEFAULT_SYNC_ONLY environment setting. Backfill and new Bot initialization remain complete regardless of Reader mode.

## Validation

- Implementation task ran 41 community configuration, Injector/Reader, backfill and architecture tests successfully.
- Paired OCB YAML overlay and typed DI validation: 23 passed.
- Ruff and git diff --check passed in both worktrees.
- No full Backend suite or live configuration switch performed; CI remains pending.

## Compatibility and risk

Target REL20260908. OCB companion PR adds pre:false/prod:false defaults and must carry this public implementation through its gitlink. The old environment flag no longer controls this gate. Restart Backend after changing YAML. Do not enable an environment until its full backfill has been accepted. No schema, runtime projection or public API changes.
