### PR TITLE
fix(engine): activate Claude Code skills through local symlinks

### DIFF
--- a/docs/superpowers/specs/2026-09-07-claude-code-skill-activation-spec.md
+++ b/docs/superpowers/specs/2026-09-07-claude-code-skill-activation-spec.md
@@ -19,7 +19,10 @@ Docker startup, GitHub workflows and Corp-specific path conversion unchanged.
 - Validate paths, source availability and target conflicts before mutating links.
   Do not overwrite ordinary files/directories or delete uploaded sources.
 - Forward relative sync and cleanup payloads across the same private port seam.
-  Retain the existing public HTTP DTOs and response fields.
+  Retain the existing public HTTP DTOs and response fields. Full reconciliation
+  cleans active links outside real Skill packages; links inside directories
+  containing `SKILL.md` are package content and must be preserved, including
+  packages not selected in the request and empty-set cleanup.
 - Missing active directories are empty inventories for mapping verification.
   Verification stays read-only; publishing initializes directories after validation,
   in STRICT and BEST_EFFORT modes. Preserve existing external-entry conflict rules.

--- a/docs/superpowers/specs/2026-09-07-claude-code-skill-activation-spec.md
+++ b/docs/superpowers/specs/2026-09-07-claude-code-skill-activation-spec.md
@@ -1,0 +1,40 @@
+# Claude Code local Skill activation repair
+
+## Problem and scope
+
+On community Claude Code, a successfully uploaded local Skill remains absent from
+`.claude/skills`: the bulk symlink adapter drops the request payload and the port
+calls unsupported Relay methods. The error envelope becomes a successful empty
+result. Separately, mapping verify/publish assumes the active directory exists.
+
+Repair Engine activation only. Keep Backend mapping policy, cwd, Bot creation,
+Docker startup, GitHub workflows and Corp-specific path conversion unchanged.
+
+## Required behavior
+
+- HTTP bindpath forwards source/target mappings and `clean_target_dir` to local
+  filesystem operations; no Relay is required for activation or cleanup.
+- First activation creates the target directory and readable Skill symlink.
+  Retry is idempotent; replacement, cleanup and errors report actual outcomes.
+- Validate paths, source availability and target conflicts before mutating links.
+  Do not overwrite ordinary files/directories or delete uploaded sources.
+- Forward relative sync and cleanup payloads across the same private port seam.
+  Retain the existing public HTTP DTOs and response fields.
+- Missing active directories are empty inventories for mapping verification.
+  Verification stays read-only; publishing initializes directories after validation,
+  in STRICT and BEST_EFFORT modes. Preserve existing external-entry conflict rules.
+- Tests exercise real HTTP -> adapter -> local filesystem, rather than only DTO
+  construction from a fake successful Relay response.
+
+## Compatibility and proof boundary
+
+Avernet baseline: `15484b260fc7f7a655ddbc8070b152b70a3b15dc` (github/dev).
+OCB inspected ref: `642358c13e3ca387b9eca227afdc9e5023c039a6` (origin/dev), with
+`ocb-public` gitlink `8aaec59ee33d93d54c2b08e379fa9ae18e4d696d`.
+Corp assembles its own ClaudeCodeSkillsService, not the changed community port.
+It shares mapping filesystem helpers, whose existing regression suite must pass.
+An Avernet PR does not itself update the OCB gitlink or deploy either environment.
+
+The existing Backend empty-set cleanup hardcodes an OpenClaw directory; that is
+an independent caller defect and is not silently remapped by this Engine repair.
+Model auto-invocation policy (`disable-model-invocation`) is unchanged.

--- a/docs/superpowers/specs/2026-09-07-claude-code-skill-activation-spec.md
+++ b/docs/superpowers/specs/2026-09-07-claude-code-skill-activation-spec.md
@@ -17,7 +17,9 @@ Docker startup, GitHub workflows and Corp-specific path conversion unchanged.
 - First activation creates the target directory and readable Skill symlink.
   Retry is idempotent; replacement, cleanup and errors report actual outcomes.
 - Validate paths, source availability and target conflicts before mutating links.
-  Do not overwrite ordinary files/directories or delete uploaded sources.
+  Target parent chains must not traverse existing symlinks; check this before
+  resolving paths, including links created by previous requests. Do not
+  overwrite ordinary files/directories or delete uploaded sources.
 - Forward relative sync and cleanup payloads across the same private port seam.
   Retain the existing public HTTP DTOs and response fields. Full reconciliation
   cleans active links outside real Skill packages; links inside directories

--- a/docs/superpowers/specs/2026-09-07-claude-code-skill-activation-spec.md
+++ b/docs/superpowers/specs/2026-09-07-claude-code-skill-activation-spec.md
@@ -19,7 +19,8 @@ Docker startup, GitHub workflows and Corp-specific path conversion unchanged.
 - Validate paths, source availability and target conflicts before mutating links.
   Target parent chains must not traverse existing symlinks; check this before
   resolving paths, including links created by previous requests. Do not
-  overwrite ordinary files/directories or delete uploaded sources.
+  overwrite ordinary files/directories or delete uploaded sources. Cleanup
+  directories must also be real directories with no symlink ancestors.
 - Forward relative sync and cleanup payloads across the same private port seam.
   Retain the existing public HTTP DTOs and response fields. Full reconciliation
   cleans active links outside real Skill packages; links inside directories

--- a/src/engine/src/engine/community/api/tests/test_claude_code_skill_activation.py
+++ b/src/engine/src/engine/community/api/tests/test_claude_code_skill_activation.py
@@ -191,3 +191,31 @@ def test_nested_batch_targets_do_not_write_into_uploaded_source(runtime, existin
     assert response.status_code == 400
     assert target.exists() is existing
     assert not (source / "nested").exists()
+
+
+def test_relative_reconcile_preserves_all_skill_package_symlinks(runtime):
+    client, source, target = runtime
+    base = target.parent
+    internal = []
+    for name in ("selected", "unselected"):
+        package = base / "sources" / name
+        (package / "assets").mkdir(parents=True)
+        (package / "SKILL.md").write_text(name)
+        (package / "assets/data").write_text("keep")
+        link = package / "assets/shared"
+        link.symlink_to("data")
+        internal.append(link)
+    active = base / "active"
+    active.mkdir()
+    old = active / "old"
+    old.symlink_to(base / "sources/unselected")
+    response = client.post("/api/skills/symlink", json={"symlinks": [
+        {"source": "sources/selected", "target": "active/selected"}
+    ]})
+    assert response.status_code == 200, response.text
+    assert not old.is_symlink()
+    assert all(link.is_symlink() and link.read_text() == "keep" for link in internal)
+    cleared = client.post("/api/skills/symlink", json={"symlinks": []})
+    assert cleared.status_code == 200
+    assert cleared.json()["data"]["removed"] == ["active/selected"]
+    assert all(link.is_symlink() and link.read_text() == "keep" for link in internal)

--- a/src/engine/src/engine/community/api/tests/test_claude_code_skill_activation.py
+++ b/src/engine/src/engine/community/api/tests/test_claude_code_skill_activation.py
@@ -178,12 +178,16 @@ def test_replace_existing_mapping_and_cleanup_paths(runtime):
     assert client.post("/api/skills/symlink", json={"symlinks": [{"source": "../escape", "target": "retro"}]}).status_code == 400
 
 
-def test_nested_batch_targets_do_not_write_into_uploaded_source(runtime):
+@pytest.mark.parametrize("existing", [False, True])
+def test_nested_batch_targets_do_not_write_into_uploaded_source(runtime, existing):
     client, source, target = runtime
+    if existing:
+        target.parent.mkdir(parents=True)
+        target.symlink_to(source)
     response = client.post("/api/skills/symlink/bindpath", json={"symlinks": [
         {"source": str(source), "target": str(target)},
         {"source": str(source), "target": str(target / "nested")},
     ]})
     assert response.status_code == 400
-    assert not target.exists()
+    assert target.exists() is existing
     assert not (source / "nested").exists()

--- a/src/engine/src/engine/community/api/tests/test_claude_code_skill_activation.py
+++ b/src/engine/src/engine/community/api/tests/test_claude_code_skill_activation.py
@@ -219,3 +219,24 @@ def test_relative_reconcile_preserves_all_skill_package_symlinks(runtime):
     assert cleared.status_code == 200
     assert cleared.json()["data"]["removed"] == ["active/selected"]
     assert all(link.is_symlink() and link.read_text() == "keep" for link in internal)
+
+
+@pytest.mark.parametrize("relative", [False, True])
+def test_separate_request_cannot_write_through_existing_skill_link(runtime, relative):
+    client, source, target = runtime
+    if relative:
+        source = target.parent / "sources/retro"
+        source.mkdir(parents=True)
+        (source / "SKILL.md").write_text("retro")
+        def activate(name):
+            return client.post("/api/skills/symlink", json={"symlinks": [
+                {"source": "sources/retro", "target": name}
+            ]})
+        assert activate("retro").status_code == 200
+        response = activate("retro/nested")
+    else:
+        assert bind(client, source, target).status_code == 200
+        response = bind(client, source, target / "nested")
+    assert response.status_code == 400, response.text
+    assert target.resolve() == source
+    assert not (source / "nested").exists()

--- a/src/engine/src/engine/community/api/tests/test_claude_code_skill_activation.py
+++ b/src/engine/src/engine/community/api/tests/test_claude_code_skill_activation.py
@@ -240,3 +240,14 @@ def test_separate_request_cannot_write_through_existing_skill_link(runtime, rela
     assert response.status_code == 400, response.text
     assert target.resolve() == source
     assert not (source / "nested").exists()
+
+
+def test_cleanup_cannot_follow_active_link_into_source(runtime):
+    client, source, target = runtime
+    resource = source / "shared"
+    resource.symlink_to("SKILL.md")
+    assert bind(client, source, target).status_code == 200
+    response = client.post("/api/skills/symlink/clean", json={"directories": [str(target)]})
+    assert response.status_code == 400, response.text
+    assert target.is_symlink()
+    assert resource.is_symlink()

--- a/src/engine/src/engine/community/api/tests/test_claude_code_skill_activation.py
+++ b/src/engine/src/engine/community/api/tests/test_claude_code_skill_activation.py
@@ -176,3 +176,14 @@ def test_replace_existing_mapping_and_cleanup_paths(runtime):
     assert client.post("/api/skills/symlink/clean", json={"directories": [str(source / "absent")]}).json()["data"]["directories_scanned"] == 0
     assert client.post("/api/skills/symlink/clean", json={"directories": [str(source / "SKILL.md")]}).status_code == 400
     assert client.post("/api/skills/symlink", json={"symlinks": [{"source": "../escape", "target": "retro"}]}).status_code == 400
+
+
+def test_nested_batch_targets_do_not_write_into_uploaded_source(runtime):
+    client, source, target = runtime
+    response = client.post("/api/skills/symlink/bindpath", json={"symlinks": [
+        {"source": str(source), "target": str(target)},
+        {"source": str(source), "target": str(target / "nested")},
+    ]})
+    assert response.status_code == 400
+    assert not target.exists()
+    assert not (source / "nested").exists()

--- a/src/engine/src/engine/community/api/tests/test_claude_code_skill_activation.py
+++ b/src/engine/src/engine/community/api/tests/test_claude_code_skill_activation.py
@@ -1,0 +1,178 @@
+"""HTTP regression: uploaded skills must become readable active links without Relay."""
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from engine.community.api.skills.router import router
+from engine.community.engines.claude_code.engine import ClaudeCodeCommunityEngine
+from engine.community.manager import EngineManager
+from engine.community.plugins.claude_code._base import ClaudeCodePortBase
+
+
+@pytest.fixture
+def runtime(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    async def no_relay(self):
+        raise AssertionError("Skill filesystem activation must not call Relay")
+    monkeypatch.setattr(ClaudeCodePortBase, "_relay", no_relay)
+    manager = EngineManager("claude_code")
+    manager._active_engine = ClaudeCodeCommunityEngine()
+    monkeypatch.setattr(EngineManager, "_instance", manager)
+    app = FastAPI()
+    app.include_router(router)
+    source = tmp_path / ".claude_code/workspace/skills/skills-local/retro"
+    source.mkdir(parents=True)
+    (source / "SKILL.md").write_text("---\nname: retro\n---\nRetrospective")
+    target = tmp_path / ".claude/skills/retro"
+    with TestClient(app) as client:
+        yield client, source, target
+
+
+def bind(client, source, target, clean=True):
+    return client.post("/api/skills/symlink/bindpath", json={
+        "symlinks": [{"source": str(source), "target": str(target)}],
+        "clean_target_dir": clean,
+    })
+
+
+def test_first_activation_and_idempotent_retry(runtime):
+    client, source, target = runtime
+    assert not target.parent.exists()
+    response = bind(client, source, target)
+    assert response.status_code == 200, response.text
+    assert response.json()["data"]["created"] == [str(target)]
+    assert target.is_symlink()
+    assert target.resolve() == source
+    assert (target / "SKILL.md").read_text() == (source / "SKILL.md").read_text()
+    assert bind(client, source, target).json()["data"]["kept"] == [str(target)]
+
+
+def test_cleanup_option_and_disable_preserve_source(runtime):
+    client, source, target = runtime
+    target.parent.mkdir(parents=True)
+    old = target.parent / "old"
+    old.symlink_to(source)
+    ordinary = target.parent / "user-file"
+    ordinary.write_text("keep")
+    assert bind(client, source, target, clean=False).status_code == 200
+    assert old.is_symlink()
+    assert bind(client, source, target).json()["data"]["removed"] == [str(old)]
+    response = client.post("/api/skills/symlink/clean", json={"directories": [str(target.parent)]})
+    assert response.status_code == 200
+    assert not target.is_symlink()
+    assert (source / "SKILL.md").exists()
+    assert ordinary.read_text() == "keep"
+
+
+def test_invalid_source_does_not_create_or_remove_links(runtime):
+    client, source, target = runtime
+    target.parent.mkdir(parents=True)
+    old = target.parent / "old"
+    old.symlink_to(source)
+    response = bind(client, source / "absent", target)
+    assert response.status_code == 409, response.text
+    assert old.is_symlink()
+    assert not target.exists()
+
+
+def test_occupied_target_is_not_overwritten(runtime):
+    client, source, target = runtime
+    target.mkdir(parents=True)
+    (target / "keep").write_text("keep")
+    assert bind(client, source, target).status_code == 409
+    assert (target / "keep").read_text() == "keep"
+
+
+def test_outside_root_rejected(runtime, tmp_path):
+    client, source, target = runtime
+    outside = tmp_path.parent / "unowned-skill"
+    assert bind(client, source, outside).status_code == 400
+    assert not outside.exists()
+
+
+def test_replacement_failure_preserves_previous_mapping(runtime, monkeypatch):
+    client, source, target = runtime
+    target.parent.mkdir(parents=True)
+    old_source = source.parent / "previous"
+    old_source.mkdir()
+    target.symlink_to(old_source)
+    def fail(*args, **kwargs):
+        raise PermissionError("read-only")
+    monkeypatch.setattr(Path, "symlink_to", fail)
+    with pytest.raises(PermissionError):
+        bind(client, source, target)
+    assert target.resolve() == old_source
+
+
+def test_relative_sync_and_empty_cleanup(runtime):
+    client, source, target = runtime
+    nested = target.parent / "sources/retro"
+    nested.mkdir(parents=True)
+    (nested / "SKILL.md").write_text("retro")
+    response = client.post("/api/skills/symlink", json={"symlinks": [
+        {"source": "sources/retro", "target": "nested/retro"}
+    ]})
+    assert response.status_code == 200, response.text
+    assert response.json()["data"]["created"] == ["nested/retro"]
+    link = target.parent / "nested/retro"
+    assert link.resolve() == nested
+    assert client.post("/api/skills/symlink", json={"symlinks": []}).json()["data"]["removed"] == ["nested/retro"]
+    assert (nested / "SKILL.md").exists()
+
+
+def test_batch_parent_conflict_has_no_partial_changes(runtime):
+    client, source, target = runtime
+    target.parent.mkdir(parents=True)
+    blocked = target.parent / "blocked"
+    blocked.write_text("keep")
+    response = client.post("/api/skills/symlink/bindpath", json={"symlinks": [
+        {"source": str(source), "target": str(target)},
+        {"source": str(source), "target": str(blocked / "second")},
+    ]})
+    assert response.status_code == 409
+    assert not target.is_symlink()
+    assert blocked.read_text() == "keep"
+
+
+def test_unreadable_source_has_no_partial_changes(runtime, monkeypatch):
+    client, source, target = runtime
+    original = Path.open
+    def denied(path, *args, **kwargs):
+        if path == source / "SKILL.md":
+            raise PermissionError("unreadable")
+        return original(path, *args, **kwargs)
+    monkeypatch.setattr(Path, "open", denied)
+    assert bind(client, source, target).status_code == 409
+    assert not target.parent.exists()
+
+
+@pytest.mark.parametrize("bad", ["relative", "", "/tmp/../escape"])
+def test_invalid_absolute_paths(runtime, bad):
+    client, source, target = runtime
+    assert bind(client, source, bad).status_code == 400
+    assert not target.parent.exists()
+
+
+def test_duplicate_root_and_self_targets(runtime):
+    client, source, target = runtime
+    for bad in (source, target.parent):
+        assert bind(client, source, bad).status_code == 400
+    response = client.post("/api/skills/symlink/bindpath", json={"symlinks": [
+        {"source": str(source), "target": str(target)},
+        {"source": str(source), "target": str(target)},
+    ]})
+    assert response.status_code == 400
+    assert not target.exists()
+
+
+def test_replace_existing_mapping_and_cleanup_paths(runtime):
+    client, source, target = runtime
+    target.parent.mkdir(parents=True)
+    target.symlink_to(source.parent / "missing")
+    assert bind(client, source, target).json()["data"]["updated"] == [str(target)]
+    assert target.resolve() == source
+    assert client.post("/api/skills/symlink/clean", json={"directories": [str(source / "absent")]}).json()["data"]["directories_scanned"] == 0
+    assert client.post("/api/skills/symlink/clean", json={"directories": [str(source / "SKILL.md")]}).status_code == 400
+    assert client.post("/api/skills/symlink", json={"symlinks": [{"source": "../escape", "target": "retro"}]}).status_code == 400

--- a/src/engine/src/engine/community/config.py
+++ b/src/engine/src/engine/community/config.py
@@ -506,3 +506,8 @@ def load_claude_code_file_roots() -> tuple[Path, ...]:
         layout.active_root,
         load_claude_code_workspace(),
     )
+
+
+def load_claude_code_skills_root() -> Path:
+    """Active Skill discovery directory from the existing Engine layout."""
+    return _claude_code_file_layout(Path.home()).active_root

--- a/src/engine/src/engine/community/core/adapters/claude_code/skills.py
+++ b/src/engine/src/engine/community/core/adapters/claude_code/skills.py
@@ -282,23 +282,16 @@ class ClaudeCodeSkillsAdapter(SkillsService):
         return [_skill_from_payload(s) for s in raw if isinstance(s, dict)]
 
     # ── Bulk symlink reconciliation ───────────────────────────────────────────
-    #
-    # The port method signatures take only ``token`` — no symlinks payload.
-    # The corp impl performed the FS reconciliation locally; the OSS port
-    # routes the same-named relay RPCs (``skills.sync_symlinks`` etc.). The
-    # adapter forwards the token and builds the DTO from the returned dict.
-    # (GAP NOTE: the port does not accept the ``symlinks`` / ``directories``
-    # payload from the request DTO. See report — the port signature may need
-    # widening, or the impl reads them from server-side config. This adapter
-    # calls the port as-is; tests only verify the DTO build.)
-
     async def sync_symlinks(
         self,
         request: SyncSymlinksRequest,
         auth: AuthContext | None = None,
     ) -> SyncSymlinksResult:
         token = auth.token if auth is not None else None
-        raw = await self._port.skills_sync_symlinks(token=token)
+        raw = await self._port.skills_sync_symlinks(
+            params={"symlinks": [_serialize_pool_mapping(item) for item in request.symlinks]},
+            token=token,
+        )
         return SyncSymlinksResult(
             total=raw.get("total", 0),
             created=raw.get("created", []),
@@ -314,7 +307,13 @@ class ClaudeCodeSkillsAdapter(SkillsService):
         auth: AuthContext | None = None,
     ) -> SyncSymlinksResult:
         token = auth.token if auth is not None else None
-        raw = await self._port.skills_sync_bindpaths(token=token)
+        raw = await self._port.skills_sync_bindpaths(
+            params={
+                "symlinks": [_serialize_pool_mapping(item) for item in request.symlinks],
+                "clean_target_dir": request.clean_target_dir,
+            },
+            token=token,
+        )
         return SyncSymlinksResult(
             total=raw.get("total", 0),
             created=raw.get("created", []),
@@ -330,7 +329,9 @@ class ClaudeCodeSkillsAdapter(SkillsService):
         auth: AuthContext | None = None,
     ) -> CleanSymlinksResult:
         token = auth.token if auth is not None else None
-        raw = await self._port.skills_clean_symlinks(token=token)
+        raw = await self._port.skills_clean_symlinks(
+            params={"directories": list(request.directories)}, token=token,
+        )
         return CleanSymlinksResult(
             directories_scanned=raw.get("directories_scanned", 0),
             removed=raw.get("removed", []),

--- a/src/engine/src/engine/community/core/adapters/claude_code/tests/test_adapters.py
+++ b/src/engine/src/engine/community/core/adapters/claude_code/tests/test_adapters.py
@@ -651,13 +651,13 @@ class _FakeSkillsPort:
     async def skills_discover(self, source, token=None) -> list[dict]:
         return [{"skillId": "new", "name": "New", "description": ""}]
 
-    async def skills_sync_symlinks(self, token=None) -> dict:
+    async def skills_sync_symlinks(self, params, token=None) -> dict:
         return {"total": 2, "created": ["a"], "kept": ["b"]}
 
-    async def skills_sync_bindpaths(self, token=None) -> dict:
+    async def skills_sync_bindpaths(self, params, token=None) -> dict:
         return {"total": 1, "created": ["c"]}
 
-    async def skills_clean_symlinks(self, token=None) -> dict:
+    async def skills_clean_symlinks(self, params, token=None) -> dict:
         return {"directories_scanned": 2, "removed": ["x"]}
 
     async def skills_ensure_center(self, token=None) -> dict:

--- a/src/engine/src/engine/community/core/adapters/claude_code/tests/test_adapters_coverage.py
+++ b/src/engine/src/engine/community/core/adapters/claude_code/tests/test_adapters_coverage.py
@@ -1466,13 +1466,13 @@ class _SkillsPort:
     async def skills_discover(self, source, token=None) -> list[dict]:
         return [{"skillId": "new", "name": "New", "description": ""}]
 
-    async def skills_sync_symlinks(self, token=None) -> dict:
+    async def skills_sync_symlinks(self, params, token=None) -> dict:
         return {"total": 2, "created": ["a"], "kept": ["b"]}
 
-    async def skills_sync_bindpaths(self, token=None) -> dict:
+    async def skills_sync_bindpaths(self, params, token=None) -> dict:
         return {"total": 1, "created": ["c"]}
 
-    async def skills_clean_symlinks(self, token=None) -> dict:
+    async def skills_clean_symlinks(self, params, token=None) -> dict:
         return {"directories_scanned": 2, "removed": ["x"]}
 
     async def skills_ensure_center(self, token=None) -> dict:
@@ -1560,7 +1560,7 @@ class TestSkillsAdapterCoverage:
     async def test_sync_symlinks_with_all_fields(self):
         port = _SkillsPort()
 
-        async def sync(token=None):
+        async def sync(params, token=None):
             return {"total": 5, "created": ["a"], "updated": ["b"],
                     "kept": ["c"], "removed": ["d"], "base_dir": "/base"}
         port.skills_sync_symlinks = sync  # type: ignore[assignment]
@@ -1574,7 +1574,7 @@ class TestSkillsAdapterCoverage:
     async def test_clean_symlinks_with_defaults(self):
         port = _SkillsPort()
 
-        async def clean(token=None):
+        async def clean(params, token=None):
             return {}  # empty → defaults
         port.skills_clean_symlinks = clean  # type: ignore[assignment]
         adapter = ClaudeCodeSkillsAdapter(port)

--- a/src/engine/src/engine/community/engines/claude_code/engine.py
+++ b/src/engine/src/engine/community/engines/claude_code/engine.py
@@ -39,6 +39,7 @@ from engine.community.core.engine.base import BaseEngine
 from engine.community.core.engine.capability import Capability, EngineCapabilities
 from engine.community.config import (
     load_claude_code_file_roots,
+    load_claude_code_skills_root,
 )
 from engine.community.plugins.claude_code._base import ClaudeCodeRelayClient
 from engine.community.plugins.claude_code.plugin_impl import ClaudeCodePluginImpl
@@ -146,7 +147,7 @@ class ClaudeCodeCommunityEngine(BaseEngine):
         self._injected_client = client  # None in production; set only by tests
 
         # The single community transport impl shared by every adapter.
-        self._port = ClaudeCodePluginImpl(client=client, file_roots=load_claude_code_file_roots())
+        self._port = ClaudeCodePluginImpl(client=client, file_roots=load_claude_code_file_roots(), skills_root=load_claude_code_skills_root())
 
         # ACL adapters implementing the core *Service protocols.
         self._chat = ClaudeCodeChatAdapter(self._port)

--- a/src/engine/src/engine/community/local/claude_code/plugin_impl.py
+++ b/src/engine/src/engine/community/local/claude_code/plugin_impl.py
@@ -516,6 +516,8 @@ class LocalClaudeCodePluginImpl(ClaudeCodePlugin):
             ):
                 raise RuntimeError("Skill target is occupied")
             desired[target] = source
+        if any(PurePosixPath(other) in PurePosixPath(target).parents for target in desired for other in desired):
+            raise ValueError("Skill targets cannot contain another requested target")
         result: dict[str, Any] = {"ok": True, "total": len(desired), "created": [], "updated": [], "kept": [], "removed": []}
         for target, source in desired.items():
             key = "kept" if self._skill_links.get(target) == source else "updated" if target in self._skill_links else "created"

--- a/src/engine/src/engine/community/local/claude_code/plugin_impl.py
+++ b/src/engine/src/engine/community/local/claude_code/plugin_impl.py
@@ -67,6 +67,7 @@ class LocalClaudeCodePluginImpl(ClaudeCodePlugin):
         self._cron: dict[str, dict[str, Any]] = {}
         self._files: dict[str, bytes] = {}
         self._file_dirs: set[str] = {"/"}
+        self._skill_links: dict[str, str] = {}
 
     # ----------------------------------------------------------------- chat
 
@@ -479,23 +480,66 @@ class LocalClaudeCodePluginImpl(ClaudeCodePlugin):
     ) -> list[dict]:
         return [{"id": "demo", "source": source}]
 
-    async def skills_sync_symlinks(
-        self,
-        token: str | None = None,
-    ) -> dict:
-        return {"ok": True, "total": 0, "created": [], "updated": [], "removed": []}
+    async def skills_sync_symlinks(self, params: dict, token: str | None = None) -> dict:
+        base = PurePosixPath("/home/admin/.claude/skills")
+        def absolute(raw: str) -> str:
+            path = PurePosixPath(raw)
+            if not raw.strip() or path.is_absolute() or ".." in path.parts or path == PurePosixPath("."):
+                raise ValueError("Invalid relative Skill path")
+            return str(base / path)
+        mappings = [{"source": absolute(item["source"]), "target": absolute(item["target"])}
+                    for item in params.get("symlinks", [])]
+        result = await self.skills_sync_bindpaths({"symlinks": mappings, "clean_target_dir": False})
+        desired = {item["target"] for item in mappings}
+        for target in list(self._skill_links):
+            if PurePosixPath(target).is_relative_to(base) and target not in desired:
+                del self._skill_links[target]
+                result["removed"].append(target)
+        for key in ("created", "updated", "kept", "removed"):
+            result[key] = [str(PurePosixPath(path).relative_to(base)) for path in result[key]]
+        result["base_dir"] = str(base)
+        return result
 
-    async def skills_sync_bindpaths(
-        self,
-        token: str | None = None,
-    ) -> dict:
-        return {"ok": True, "total": 0, "created": [], "updated": [], "removed": []}
+    async def skills_sync_bindpaths(self, params: dict, token: str | None = None) -> dict:
+        desired: dict[str, str] = {}
+        for item in params.get("symlinks", []):
+            source, target = item["source"], item["target"]
+            for path in (source, target):
+                if not PurePosixPath(path).is_absolute() or ".." in PurePosixPath(path).parts:
+                    raise ValueError("Invalid absolute Skill path")
+            if target in desired or target == source:
+                raise ValueError("Duplicate or self-referencing Skill target")
+            if str(PurePosixPath(source) / "SKILL.md") not in self._files:
+                raise RuntimeError("Skill source is missing")
+            if target in self._files or target in self._file_dirs or any(
+                str(parent) in self._files for parent in PurePosixPath(target).parents
+            ):
+                raise RuntimeError("Skill target is occupied")
+            desired[target] = source
+        result: dict[str, Any] = {"ok": True, "total": len(desired), "created": [], "updated": [], "kept": [], "removed": []}
+        for target, source in desired.items():
+            key = "kept" if self._skill_links.get(target) == source else "updated" if target in self._skill_links else "created"
+            self._skill_links[target] = source
+            self._file_dirs.update(str(parent) for parent in PurePosixPath(target).parents)
+            result[key].append(target)
+        if params.get("clean_target_dir", True):
+            parents = {PurePosixPath(target).parent for target in desired}
+            for target in list(self._skill_links):
+                if PurePosixPath(target).parent in parents and target not in desired:
+                    del self._skill_links[target]
+                    result["removed"].append(target)
+        return result
 
-    async def skills_clean_symlinks(
-        self,
-        token: str | None = None,
-    ) -> dict:
-        return {"ok": True, "removed": [], "scanned": 0}
+    async def skills_clean_symlinks(self, params: dict, token: str | None = None) -> dict:
+        directories = {PurePosixPath(path) for path in params.get("directories", [])}
+        if any(not path.is_absolute() or ".." in path.parts for path in directories):
+            raise ValueError("Invalid Skill cleanup path")
+        if any(str(path) in self._files for path in directories):
+            raise ValueError("Skill cleanup path is not a directory")
+        removed = [target for target in self._skill_links if PurePosixPath(target).parent in directories]
+        for target in removed:
+            del self._skill_links[target]
+        return {"ok": True, "removed": removed, "directories_scanned": sum(str(path) in self._file_dirs for path in directories)}
 
     async def skills_ensure_center(
         self,

--- a/src/engine/src/engine/community/local/claude_code/plugin_impl.py
+++ b/src/engine/src/engine/community/local/claude_code/plugin_impl.py
@@ -507,6 +507,8 @@ class LocalClaudeCodePluginImpl(ClaudeCodePlugin):
             for path in (source, target):
                 if not PurePosixPath(path).is_absolute() or ".." in PurePosixPath(path).parts:
                     raise ValueError("Invalid absolute Skill path")
+            if any(str(parent) in self._skill_links for parent in PurePosixPath(target).parents):
+                raise ValueError("Skill target parent must not traverse a symlink")
             if target in desired or target == source:
                 raise ValueError("Duplicate or self-referencing Skill target")
             if str(PurePosixPath(source) / "SKILL.md") not in self._files:

--- a/src/engine/src/engine/community/local/claude_code/plugin_impl.py
+++ b/src/engine/src/engine/community/local/claude_code/plugin_impl.py
@@ -538,6 +538,8 @@ class LocalClaudeCodePluginImpl(ClaudeCodePlugin):
         directories = {PurePosixPath(path) for path in params.get("directories", [])}
         if any(not path.is_absolute() or ".." in path.parts for path in directories):
             raise ValueError("Invalid Skill cleanup path")
+        if any(str(part) in self._skill_links for path in directories for part in (path, *path.parents)):
+            raise ValueError("Skill cleanup directory must not traverse a symlink")
         if any(str(path) in self._files for path in directories):
             raise ValueError("Skill cleanup path is not a directory")
         removed = [target for target in self._skill_links if PurePosixPath(target).parent in directories]

--- a/src/engine/src/engine/community/plugin_api/claude_code/skills.py
+++ b/src/engine/src/engine/community/plugin_api/claude_code/skills.py
@@ -1,7 +1,7 @@
 """ClaudeCodeSkillsPort — native port for skill lifecycle management.
 
-Skills are pooled (client + relay), so port methods take
-``token: str | None = None`` for per-token routing. Returns raw
+Relay-backed operations accept
+``token: str | None = None`` for routing; bulk symlink methods act locally. Returns raw
 dicts / list[dict] / bool — the adapter builds the core DTOs.
 
 Relay RPC mapping (teamclaw-aicoding-relay v3 protocol):
@@ -19,9 +19,9 @@ Port method                 Relay RPC (method name on the wire)
 ``skills_execute``          ``skills.execute``
 ``skills_validate``         ``skills.validate``
 ``skills_discover``         ``skills.discover``
-``skills_sync_symlinks``    ``skills.sync_symlinks``
-``skills_sync_bindpaths``   ``skills.sync_bindpaths``
-``skills_clean_symlinks``   ``skills.clean_symlinks``
+``skills_sync_symlinks``    Local filesystem
+``skills_sync_bindpaths``   Local filesystem
+``skills_clean_symlinks``   Local filesystem
 ``skills_ensure_center``    ``skills.ensure_center``
 ==========================  ================================================
 """
@@ -32,7 +32,11 @@ from typing import Protocol
 
 
 class ClaudeCodeSkillsPort(Protocol):
-    """Native skill lifecycle operations over the claude_code gateway (vendored Node relay)."""
+    """Relay lifecycle and local filesystem activation operations.
+
+    Bulk methods require the full params payload and raise on invalid paths,
+    conflicts or I/O failure. They never encode failure as an empty success.
+    """
 
     async def skills_list(
         self,
@@ -182,9 +186,10 @@ class ClaudeCodeSkillsPort(Protocol):
 
     async def skills_sync_symlinks(
         self,
+        params: dict,
         token: str | None = None,
     ) -> dict:
-        """Call ``skills.sync_symlinks`` to synchronize skill symlinks.
+        """Reconcile relative symlinks locally; params contains symlinks.
 
         Args:
             token: MCP token for per-token pool routing; None -> default client.
@@ -193,9 +198,10 @@ class ClaudeCodeSkillsPort(Protocol):
 
     async def skills_sync_bindpaths(
         self,
+        params: dict,
         token: str | None = None,
     ) -> dict:
-        """Call ``skills.sync_bindpaths`` to synchronize skill bindpaths.
+        """Reconcile absolute symlinks locally; params contains symlinks and clean_target_dir.
 
         Args:
             token: MCP token for per-token pool routing; None -> default client.
@@ -204,9 +210,10 @@ class ClaudeCodeSkillsPort(Protocol):
 
     async def skills_clean_symlinks(
         self,
+        params: dict,
         token: str | None = None,
     ) -> dict:
-        """Call ``skills.clean_symlinks`` to remove stale skill symlinks.
+        """Remove local symlinks in params directories without deleting sources.
 
         Args:
             token: MCP token for per-token pool routing; None -> default client.

--- a/src/engine/src/engine/community/plugins/claude_code/_skills.py
+++ b/src/engine/src/engine/community/plugins/claude_code/_skills.py
@@ -1,17 +1,15 @@
-"""_SkillsPortMixin — skill lifecycle + sync (relay RPC).
+"""Skill discovery/lifecycle via Relay; bulk symlink mutations on local disk.
 
-All skill ops are forwarded to the relay (``skills.*``). The corp
-``engines/claude_code/skills.py`` also performs local filesystem rsync/symlink
-work for ``sync_symlinks`` / ``ensure_center``; that local-OS work moves into
-the adapter (or a local plugin) in the ACL split, and the community port only
-owns the relay RPC shape. Returning the raw ``{success, payload|error}`` /
-dict / list / bool shapes the adapter consumes.
+The adapter carries complete request payloads to the filesystem implementation.
+Filesystem failures propagate instead of becoming empty successful DTOs.
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
+
+from engine.community.plugins.claude_code.symlinks import LocalSkillSymlinks
 from pathlib import Path
 from typing import Any
 
@@ -54,6 +52,8 @@ class _SkillsPortMixin:
     """Domain mixin: skills.{list,get,install,uninstall,update,enable,disable,
     execute,validate,discover,sync_symlinks,sync_bindpaths,clean_symlinks,
     ensure_center}."""
+
+    _local_symlinks: LocalSkillSymlinks
 
     @staticmethod
     def _pool_mappings(
@@ -303,14 +303,14 @@ class _SkillsPortMixin:
             return resp.payload if isinstance(resp.payload, dict) else {"success": True}
         return _resp_dict(resp)
 
-    async def skills_sync_symlinks(self, token: str | None = None) -> dict:
-        return await self._skills_passthrough("skills.sync_symlinks", {})
+    async def skills_sync_symlinks(self, params: dict, token: str | None = None) -> dict:
+        return await asyncio.to_thread(self._local_symlinks.sync_relative, params)
 
-    async def skills_sync_bindpaths(self, token: str | None = None) -> dict:
-        return await self._skills_passthrough("skills.sync_bindpaths", {})
+    async def skills_sync_bindpaths(self, params: dict, token: str | None = None) -> dict:
+        return await asyncio.to_thread(self._local_symlinks.sync, params)
 
-    async def skills_clean_symlinks(self, token: str | None = None) -> dict:
-        return await self._skills_passthrough("skills.clean_symlinks", {})
+    async def skills_clean_symlinks(self, params: dict, token: str | None = None) -> dict:
+        return await asyncio.to_thread(self._local_symlinks.clean, params)
 
     async def skills_ensure_center(self, token: str | None = None) -> dict:
         return await self._skills_passthrough("skills.ensure_center", {})

--- a/src/engine/src/engine/community/plugins/claude_code/plugin_impl.py
+++ b/src/engine/src/engine/community/plugins/claude_code/plugin_impl.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from engine.community.plugins.claude_code.symlinks import LocalSkillSymlinks
+
 from engine.community.plugin_api.claude_code.plugin import ClaudeCodePlugin
 from engine.community.plugins.claude_code._base import ClaudeCodePortBase, ClaudeCodeRelayClient
 from engine.community.plugins.claude_code._chat import _ChatPortMixin
@@ -51,9 +53,10 @@ class ClaudeCodePluginImpl(
     fresh ``ClaudeCodeRelayClient`` on first use.
     """
 
-    def __init__(self, client: ClaudeCodeRelayClient | None = None, *, file_roots: tuple[Path, ...] = ()) -> None:
+    def __init__(self, client: ClaudeCodeRelayClient | None = None, *, file_roots: tuple[Path, ...] = (), skills_root: Path = Path("/home/admin/.claude/skills")) -> None:
         super().__init__(client=client)
         self._file_roots = tuple(root.resolve() for root in file_roots)
+        self._local_symlinks = LocalSkillSymlinks(self._file_roots, skills_root)
 
 
 __all__ = ["ClaudeCodePluginImpl"]

--- a/src/engine/src/engine/community/plugins/claude_code/symlinks.py
+++ b/src/engine/src/engine/community/plugins/claude_code/symlinks.py
@@ -73,7 +73,9 @@ class LocalSkillSymlinks:
         return result
 
     def clean(self, params: dict) -> dict:
-        directories = [self._path(raw) for raw in params.get("directories", [])]
+        directories = [self._path(raw, link=True) for raw in params.get("directories", [])]
+        if any(directory.is_symlink() for directory in directories):
+            raise ValueError("Skill cleanup directory must not be a symlink")
         removed: list[str] = []
         scanned = 0
         for directory in directories:

--- a/src/engine/src/engine/community/plugins/claude_code/symlinks.py
+++ b/src/engine/src/engine/community/plugins/claude_code/symlinks.py
@@ -14,6 +14,8 @@ class LocalSkillSymlinks:
         path = Path(raw)
         if not raw.strip() or not path.is_absolute() or ".." in path.parts:
             raise ValueError("Skill path must be absolute without parent traversal")
+        if link and any(parent.is_symlink() for parent in path.parents):
+            raise ValueError("Skill target parent must not traverse a symlink")
         resolved = path.parent.resolve() / path.name if link else path.resolve()
         if not any(resolved.is_relative_to(root) for root in self.roots):
             raise ValueError("Skill path is outside the configured engine roots")

--- a/src/engine/src/engine/community/plugins/claude_code/symlinks.py
+++ b/src/engine/src/engine/community/plugins/claude_code/symlinks.py
@@ -1,4 +1,5 @@
 """Local filesystem implementation of the existing bulk Skill symlink contract."""
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 from uuid import uuid4
@@ -99,8 +100,18 @@ class LocalSkillSymlinks:
             for item in params.get("symlinks", [])
         ]
         desired = {self._path(item["target"], link=True) for item in mappings}
-        stale = [entry for entry in sorted(base.rglob("*"))
-                 if entry.is_symlink() and entry not in desired]
+        def active_links(directory: Path) -> Iterator[Path]:
+            # A real Skill directory owns its contents, including symlinks.
+            # Never traverse packages, even when absent from this request.
+            if (directory / "SKILL.md").is_file():
+                return
+            for entry in sorted(directory.iterdir()):
+                if entry.is_symlink():
+                    yield entry
+                elif entry.is_dir():
+                    yield from active_links(entry)
+
+        stale = [entry for entry in active_links(base) if entry not in desired] if base.exists() else []
         result = self.sync({"symlinks": mappings, "clean_target_dir": False})
         for entry in stale:
             entry.unlink()

--- a/src/engine/src/engine/community/plugins/claude_code/symlinks.py
+++ b/src/engine/src/engine/community/plugins/claude_code/symlinks.py
@@ -41,6 +41,8 @@ class LocalSkillSymlinks:
             if target.exists() and not target.is_symlink():
                 raise RuntimeError(f"Skill target is occupied: {target}")
             desired[target] = source
+        if any(other in target.parents for target in desired for other in desired):
+            raise ValueError("Skill targets cannot contain another requested target")
         result: dict[str, Any] = {"total": len(desired), "created": [], "updated": [], "kept": [], "removed": []}
         for target, source in desired.items():
             target.parent.mkdir(parents=True, exist_ok=True)

--- a/src/engine/src/engine/community/plugins/claude_code/symlinks.py
+++ b/src/engine/src/engine/community/plugins/claude_code/symlinks.py
@@ -1,0 +1,105 @@
+"""Local filesystem implementation of the existing bulk Skill symlink contract."""
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+
+class LocalSkillSymlinks:
+    def __init__(self, roots: tuple[Path, ...], base_dir: Path) -> None:
+        self.roots = roots
+        self.base_dir = base_dir
+
+    def _path(self, raw: str, *, link: bool = False) -> Path:
+        path = Path(raw)
+        if not raw.strip() or not path.is_absolute() or ".." in path.parts:
+            raise ValueError("Skill path must be absolute without parent traversal")
+        resolved = path.parent.resolve() / path.name if link else path.resolve()
+        if not any(resolved.is_relative_to(root) for root in self.roots):
+            raise ValueError("Skill path is outside the configured engine roots")
+        return resolved
+
+    def sync(self, params: dict) -> dict:
+        desired: dict[Path, Path] = {}
+        # Validate the whole request before changing any existing links.
+        for item in params.get("symlinks", []):
+            source = self._path(item["source"])
+            target = self._path(item["target"], link=True)
+            if target in self.roots or target == source:
+                raise ValueError("Skill target cannot replace a root or its source")
+            if target in desired:
+                raise ValueError(f"Duplicate Skill target: {target}")
+            if not source.is_dir() or not (source / "SKILL.md").is_file():
+                raise RuntimeError(f"Skill source is missing or unreadable: {source}")
+            try:
+                with (source / "SKILL.md").open("rb") as skill_file:
+                    skill_file.read(1)
+            except OSError as error:
+                raise RuntimeError(f"Skill source is unreadable: {source}") from error
+            for parent in target.parents:
+                if parent.exists() and not parent.is_dir():
+                    raise RuntimeError(f"Skill target parent is occupied: {parent}")
+            if target.exists() and not target.is_symlink():
+                raise RuntimeError(f"Skill target is occupied: {target}")
+            desired[target] = source
+        result: dict[str, Any] = {"total": len(desired), "created": [], "updated": [], "kept": [], "removed": []}
+        for target, source in desired.items():
+            target.parent.mkdir(parents=True, exist_ok=True)
+            if target.is_symlink() and target.resolve() == source:
+                result["kept"].append(str(target))
+                continue
+            key = "updated" if target.is_symlink() else "created"
+            temporary = target.with_name(f".{target.name}.{uuid4().hex}.tmp")
+            try:
+                temporary.symlink_to(source, target_is_directory=True)
+                temporary.replace(target)
+            finally:
+                temporary.unlink(missing_ok=True)
+            result[key].append(str(target))
+        if params.get("clean_target_dir", True):
+            for directory in sorted({target.parent for target in desired}):
+                for entry in sorted(directory.iterdir()):
+                    if entry.is_symlink() and entry not in desired:
+                        entry.unlink()
+                        result["removed"].append(str(entry))
+        return result
+
+    def clean(self, params: dict) -> dict:
+        directories = [self._path(raw) for raw in params.get("directories", [])]
+        removed: list[str] = []
+        scanned = 0
+        for directory in directories:
+            if not directory.exists():
+                continue
+            if not directory.is_dir():
+                raise ValueError(f"Skill cleanup path is not a directory: {directory}")
+            scanned += 1
+            for entry in sorted(directory.iterdir()):
+                if entry.is_symlink():
+                    entry.unlink()
+                    removed.append(str(entry))
+        return {"directories_scanned": scanned, "removed": removed}
+
+    def sync_relative(self, params: dict) -> dict:
+        base = self._path(str(self.base_dir))
+
+        def absolute(raw: str) -> str:
+            path = Path(raw)
+            if not raw.strip() or path.is_absolute() or ".." in path.parts or path == Path("."):
+                raise ValueError("Skill path must be a non-empty relative path without traversal")
+            return str(base / path)
+
+        mappings = [
+            {"source": absolute(item["source"]), "target": absolute(item["target"])}
+            for item in params.get("symlinks", [])
+        ]
+        desired = {self._path(item["target"], link=True) for item in mappings}
+        stale = [entry for entry in sorted(base.rglob("*"))
+                 if entry.is_symlink() and entry not in desired]
+        result = self.sync({"symlinks": mappings, "clean_target_dir": False})
+        for entry in stale:
+            entry.unlink()
+            result["removed"].append(str(entry))
+        result["base_dir"] = str(base)
+        for key in ("created", "updated", "kept", "removed"):
+            result[key] = [str(Path(path).relative_to(base)) for path in result[key]]
+        return result

--- a/src/engine/src/engine/community/plugins/claude_code/symlinks.py
+++ b/src/engine/src/engine/community/plugins/claude_code/symlinks.py
@@ -20,6 +20,10 @@ class LocalSkillSymlinks:
 
     def sync(self, params: dict) -> dict:
         desired: dict[Path, Path] = {}
+        # Check lexical targets before resolving existing parent symlinks.
+        requested_targets = [Path(item["target"]) for item in params.get("symlinks", [])]
+        if any(other in target.parents for target in requested_targets for other in requested_targets):
+            raise ValueError("Skill targets cannot contain another requested target")
         # Validate the whole request before changing any existing links.
         for item in params.get("symlinks", []):
             source = self._path(item["source"])

--- a/src/engine/src/engine/community/plugins/claude_code/tests/test_community_transport.py
+++ b/src/engine/src/engine/community/plugins/claude_code/tests/test_community_transport.py
@@ -425,8 +425,7 @@ async def test_send_request_on_unconnected_client_raises_connectionerror():
 
 
 def test_skills_sync_signatures_match_port_protocol():
-    """Community skills sync_* must match the port Protocol (token-only, no
-    out-of-contract ``params`` positional)."""
+    """Community skills sync_* must match the port Protocol including the filesystem request payload."""
     import inspect
 
     from engine.community.plugin_api.claude_code.skills import ClaudeCodeSkillsPort

--- a/src/engine/src/engine/community/plugins/claude_code/tests/test_mixins_coverage.py
+++ b/src/engine/src/engine/community/plugins/claude_code/tests/test_mixins_coverage.py
@@ -801,37 +801,6 @@ class TestSkillsMixin:
         impl, _ = _impl(c)
         assert await impl.skills_discover(source="market") == []
 
-    async def test_sync_symlinks_success_payload(self):
-        c = _FakeRelayClient()
-        c.set_response("skills.sync_symlinks", _ok({"synced": 3}))
-        impl, _ = _impl(c)
-        assert await impl.skills_sync_symlinks() == {"synced": 3}
-
-    async def test_sync_symlinks_success_non_dict(self):
-        c = _FakeRelayClient()
-        c.set_response("skills.sync_symlinks", _ok("raw"))
-        impl, _ = _impl(c)
-        assert await impl.skills_sync_symlinks() == {"success": True}
-
-    async def test_sync_symlinks_error(self):
-        c = _FakeRelayClient()
-        c.set_response("skills.sync_symlinks", _err("SYNC_FAIL", "nope"))
-        impl, _ = _impl(c)
-        out = await impl.skills_sync_symlinks()
-        assert out == {"success": False, "error": {"code": "SYNC_FAIL", "message": "nope"}}
-
-    async def test_sync_bindpaths_success(self):
-        c = _FakeRelayClient()
-        c.set_response("skills.sync_bindpaths", _ok({"ok": True}))
-        impl, _ = _impl(c)
-        assert await impl.skills_sync_bindpaths() == {"ok": True}
-
-    async def test_clean_symlinks_success(self):
-        c = _FakeRelayClient()
-        c.set_response("skills.clean_symlinks", _ok({"cleaned": 1}))
-        impl, _ = _impl(c)
-        assert await impl.skills_clean_symlinks() == {"cleaned": 1}
-
     async def test_ensure_center_success(self):
         c = _FakeRelayClient()
         c.set_response("skills.ensure_center", _ok({"ensured": True}))

--- a/src/engine/src/engine/community/plugins/claude_code/tests/test_pool_layout.py
+++ b/src/engine/src/engine/community/plugins/claude_code/tests/test_pool_layout.py
@@ -435,3 +435,23 @@ async def test_claude_code_port_forwards_best_effort_apply_mode(
         "BEST_EFFORT",
         "BEST_EFFORT",
     ]
+
+
+@pytest.mark.parametrize("apply_mode", ["STRICT", "BEST_EFFORT"])
+def test_first_legacy_mapping_without_active_directory(tmp_path, apply_mode):
+    from engine.community.plugins.skills_pool.layout_activation import MappingApplyMode
+    source = tmp_path / ".claude_code/workspace/skills/skills-local/retro"
+    source.mkdir(parents=True)
+    (source / "SKILL.md").write_text("---\nname: retro\n---\nretrospective")
+    target = tmp_path / ".claude/skills/retro"
+    mappings = [SkillMapping(source=str(source), target=str(target))]
+    options = dict(home=tmp_path, mappings=mappings,
+                   source_layout=MappingSourceLayout.LEGACY,
+                   apply_mode=MappingApplyMode(apply_mode))
+    verification = verify_claude_code_pool_mappings(**options)
+    assert not verification.valid
+    assert not target.parent.exists(), "verification must remain read-only"
+    result = publish_claude_code_pool_mappings(**options)
+    assert result.published, result
+    assert target.resolve() == source
+    assert verify_claude_code_pool_mappings(**options).valid

--- a/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
@@ -886,7 +886,13 @@ def _active_entry_inventory(
     external: list[Path] = []
     occupied: list[Path] = []
     reserved = {layout.local_bridge, layout.repo_bridge}
-    for entry in sorted(layout.active_root.iterdir(), key=lambda path: path.name):
+    try:
+        entries = sorted(layout.active_root.iterdir(), key=lambda path: path.name)
+    except FileNotFoundError:
+        if layout.active_root.is_symlink():
+            raise
+        return managed, tuple(external), tuple(occupied)
+    for entry in entries:
         if entry in reserved or entry.name.startswith(".skills-local.pool-cutover-"):
             continue
         if not entry.is_symlink():
@@ -1437,6 +1443,7 @@ def _best_effort_mapping_results(
                 )
             continue
         try:
+            target.parent.mkdir(parents=True, exist_ok=True)
             if target.is_symlink():
                 if _lexical_target(target) == source:
                     kept.append(str(target))
@@ -3023,6 +3030,7 @@ def publish_pool_mappings(
             target.unlink()
             removed.append(str(target))
         for target, source in plan.managed.items():
+            target.parent.mkdir(parents=True, exist_ok=True)
             if target.is_symlink():
                 if _lexical_target(target) == Path(os.path.abspath(source)):
                     kept.append(str(target))

--- a/src/engine/src/engine/community/tests/contracts/test_claude_code_local_plugin.py
+++ b/src/engine/src/engine/community/tests/contracts/test_claude_code_local_plugin.py
@@ -224,9 +224,9 @@ async def test_local_claude_code_plugin_stateful_ports_and_error_branches():
     assert (await plugin.skills_execute("sk1", {"x": 1}))["success"] is True
     assert (await plugin.skills_validate({"id": "sk1"}))["valid"] is True
     assert (await plugin.skills_discover("registry"))[0]["source"] == "registry"
-    assert (await plugin.skills_sync_symlinks())["ok"] is True
-    assert (await plugin.skills_sync_bindpaths())["ok"] is True
-    assert (await plugin.skills_clean_symlinks())["ok"] is True
+    assert (await plugin.skills_sync_symlinks({}))["ok"] is True
+    assert (await plugin.skills_sync_bindpaths({}))["ok"] is True
+    assert (await plugin.skills_clean_symlinks({}))["ok"] is True
     assert (await plugin.skills_ensure_center())["ok"] is True
     assert await plugin.skills_uninstall("sk1") is True
     assert await plugin.skills_uninstall("sk1") is False
@@ -289,3 +289,54 @@ async def test_file_adapter_distinguishes_missing_and_empty_directories(tmp_path
     await adapter.rmtree(project)
     with pytest.raises(FileNotFoundError):
         await adapter.list_dir(project)
+
+
+async def test_adapter_local_skill_activation_contract():
+    from engine.community.core.adapters.claude_code.skills import ClaudeCodeSkillsAdapter
+    from engine.community.core.skills.models import SyncBindPathsRequest, SymlinkItem, CleanSymlinksRequest
+    plugin = LocalClaudeCodePluginImpl()
+    adapter = ClaudeCodeSkillsAdapter(plugin)
+    source, target = "/source/retro", "/active/retro"
+    await plugin.file_upload(source + "/SKILL.md", b"retro")
+    request = SyncBindPathsRequest(symlinks=[SymlinkItem(source=source, target=target)])
+    assert (await adapter.sync_bindpaths(request)).created == [target]
+    assert plugin._skill_links == {target: source}
+    assert (await adapter.sync_bindpaths(request)).kept == [target]
+    with pytest.raises(RuntimeError):
+        await adapter.sync_bindpaths(SyncBindPathsRequest(symlinks=[SymlinkItem(source="/absent", target=target)]))
+    assert plugin._skill_links == {target: source}
+    assert (await adapter.clean_symlinks(CleanSymlinksRequest(directories=["/active"]))).removed == [target]
+    assert (await plugin.file_read(source + "/SKILL.md"))["content"] == b"retro"
+
+
+async def test_local_activation_replacement_and_relative_cleanup():
+    plugin = LocalClaudeCodePluginImpl()
+    base = "/home/admin/.claude/skills"
+    for name in ("one", "two"):
+        await plugin.file_upload(f"{base}/sources/{name}/SKILL.md", b"skill")
+    def relative(source, target):
+        return {"symlinks": [{"source": f"sources/{source}", "target": target}]}
+    assert (await plugin.skills_sync_symlinks(relative("one", "nested/active")))["created"] == ["nested/active"]
+    assert (await plugin.skills_sync_symlinks(relative("two", "nested/active")))["updated"] == ["nested/active"]
+    assert (await plugin.skills_sync_symlinks({"symlinks": []}))["removed"] == ["nested/active"]
+    for name in ("old", "new"):
+        await plugin.skills_sync_bindpaths({"symlinks": [{"source": f"{base}/sources/one", "target": f"{base}/{name}"}], "clean_target_dir": False})
+    result = await plugin.skills_sync_bindpaths({"symlinks": [{"source": f"{base}/sources/one", "target": f"{base}/new"}]})
+    assert result["kept"] == [f"{base}/new"]
+    assert result["removed"] == [f"{base}/old"]
+
+
+@pytest.mark.parametrize("method,params,error", [
+    ("skills_sync_symlinks", {"symlinks": [{"source": "../escape", "target": "x"}]}, ValueError),
+    ("skills_sync_bindpaths", {"symlinks": [{"source": "relative", "target": "/x"}]}, ValueError),
+    ("skills_sync_bindpaths", {"symlinks": [{"source": "/source", "target": "/source"}]}, ValueError),
+    ("skills_sync_bindpaths", {"symlinks": [{"source": "/source", "target": "/source/SKILL.md"}]}, RuntimeError),
+    ("skills_clean_symlinks", {"directories": ["relative"]}, ValueError),
+    ("skills_clean_symlinks", {"directories": ["/source/SKILL.md"]}, ValueError),
+])
+async def test_local_activation_rejects_invalid_payload(method, params, error):
+    plugin = LocalClaudeCodePluginImpl()
+    await plugin.file_upload("/source/SKILL.md", b"skill")
+    with pytest.raises(error):
+        await getattr(plugin, method)(params)
+    assert plugin._skill_links == {}

--- a/src/engine/src/engine/community/tests/contracts/test_claude_code_local_plugin.py
+++ b/src/engine/src/engine/community/tests/contracts/test_claude_code_local_plugin.py
@@ -360,3 +360,12 @@ async def test_local_activation_rejects_parent_link_from_previous_request():
     with pytest.raises(ValueError):
         await plugin.skills_sync_bindpaths({"symlinks": [{"source": "/source", "target": "/active/retro/nested"}]})
     assert plugin._skill_links == {"/active/retro": "/source"}
+
+
+async def test_local_cleanup_rejects_active_link_directory():
+    plugin = LocalClaudeCodePluginImpl()
+    await plugin.file_upload("/source/SKILL.md", b"skill")
+    await plugin.skills_sync_bindpaths({"symlinks": [{"source": "/source", "target": "/active/retro"}]})
+    with pytest.raises(ValueError):
+        await plugin.skills_clean_symlinks({"directories": ["/active/retro"]})
+    assert plugin._skill_links == {"/active/retro": "/source"}

--- a/src/engine/src/engine/community/tests/contracts/test_claude_code_local_plugin.py
+++ b/src/engine/src/engine/community/tests/contracts/test_claude_code_local_plugin.py
@@ -340,3 +340,14 @@ async def test_local_activation_rejects_invalid_payload(method, params, error):
     with pytest.raises(error):
         await getattr(plugin, method)(params)
     assert plugin._skill_links == {}
+
+
+async def test_local_activation_rejects_nested_batch_targets():
+    plugin = LocalClaudeCodePluginImpl()
+    await plugin.file_upload("/source/SKILL.md", b"skill")
+    with pytest.raises(ValueError):
+        await plugin.skills_sync_bindpaths({"symlinks": [
+            {"source": "/source", "target": "/active/retro"},
+            {"source": "/source", "target": "/active/retro/nested"},
+        ]})
+    assert plugin._skill_links == {}

--- a/src/engine/src/engine/community/tests/contracts/test_claude_code_local_plugin.py
+++ b/src/engine/src/engine/community/tests/contracts/test_claude_code_local_plugin.py
@@ -351,3 +351,12 @@ async def test_local_activation_rejects_nested_batch_targets():
             {"source": "/source", "target": "/active/retro/nested"},
         ]})
     assert plugin._skill_links == {}
+
+
+async def test_local_activation_rejects_parent_link_from_previous_request():
+    plugin = LocalClaudeCodePluginImpl()
+    await plugin.file_upload("/source/SKILL.md", b"skill")
+    await plugin.skills_sync_bindpaths({"symlinks": [{"source": "/source", "target": "/active/retro"}]})
+    with pytest.raises(ValueError):
+        await plugin.skills_sync_bindpaths({"symlinks": [{"source": "/source", "target": "/active/retro/nested"}]})
+    assert plugin._skill_links == {"/active/retro": "/source"}


### PR DESCRIPTION
## Problem

Community Claude Code can upload a local Skill successfully while leaving it undiscoverable: the bulk Skill adapter drops mappings/cleanup options, calls unsupported Relay RPCs, and turns the returned error into an empty successful result. The mapping API also raises FileNotFoundError when `.claude/skills` has not been created yet.

## Solution

- Carry complete bulk requests through the private Claude Code port and reconcile symlinks in the Engine filesystem, within configured roots. Initialize directories on activation; report actual created/updated/kept/removed results. Validate sources and conflicts before mutation, preserve ordinary files, and retain the previous link if replacement fails.
- Treat a missing active directory as an empty read-only inventory; initialize it during valid STRICT/BEST_EFFORT mapping publication.
- Replace fake Relay-success tests with HTTP/filesystem regression tests and stateful local-plugin conformance tests.

This change is limited to Engine activation. It does not change Backend policy, cwd, Bot creation, Docker/startup, or GitHub workflows. The separate Backend empty-set cleanup that hardcodes the OpenClaw directory remains outside this repair.

## Validation

- Engine full suite: 2,565 passed, 5 intentionally deselected by the existing community CI script.
- Final activation/conformance regression suite: 41 passed, including additional boundary cases added after the full run began.
- Combined coverage gate: 93.42% overall, 99.37% changed lines (473/476).
- OCB Corp Claude Code Skill/Pool tests: 10 passed against OCB origin/dev `642358c13`, using the changed public helpers.
- Standards and Spec reviews: findings fixed; both re-reviews passed.
- Review follow-ups: preserve selected/unselected package-internal symlinks; reject target and cleanup symlink ancestors before resolution (including across requests).
- GitHub CI: pending on latest commit.

## Compatibility and risk

Public HTTP request/response DTOs are unchanged. The community-only ClaudeCodeSkillsPort bulk signatures now require the request payload; its production/local implementations and adapter callers are updated together. OCB assembles its own ClaudeCodeSkillsService and does not consume this private port. Shared mapping helpers are covered by regression and Corp tests. OCB inspected gitlink: `8aaec59ee33d93d54c2b08e379fa9ae18e4d696d`; no gitlink bump or deployment is included. No architecture waiver is needed.

## Spec

`docs/superpowers/specs/2026-09-07-claude-code-skill-activation-spec.md`
