### PR TITLE
fix(bot-config-manifest): repair mis-provisioned ac_bot_config_manifest_apply

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/repository/apply_models.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/repository/apply_models.py
@@ -119,8 +119,15 @@ class BotConfigManifestApplyModel(Base):
     # The vocabulary is ``apply/triggers.py``: ``explicit`` (W4), W13's two
     # ``create:*`` phases, and ``put`` (W8). Restart and republish were deferred
     # (W8 spec D-1). None of them needed a migration; every value fits.
+    #
+    # The COLUMN is ``apply_trigger``: TRIGGER is a SQL keyword, and the DDL
+    # review standard that gates provisioning refuses keyword column names. The
+    # attribute, the record field and the API field all stay ``trigger``.
     trigger = Column(
-        String(32), nullable=False, comment="What started it: explicit/put/create:pre_container/create:on_container"
+        "apply_trigger",
+        String(32),
+        nullable=False,
+        comment="What started it: explicit/put/create:pre_container/create:on_container",
     )
     # RUNNING on insert, terminal on completion — the two-write lifecycle apply's
     # async shape requires. Denormalised out of ``report`` so "show me failed
@@ -141,6 +148,9 @@ class BotConfigManifestApplyModel(Base):
     # narrower width without anything being malformed.
     actor = Column(String(1024), nullable=False, comment="Audit: who started it")
 
+    # TIMESTAMP on OceanBase (the DDL standard refuses DATETIME); ``DateTime``
+    # here as for gmt_* below. Filled from ``datetime.now()`` and read back
+    # through the same session, so the value written is the value read.
     started_at = Column(DateTime, nullable=False, comment="When the apply began")
     # Null exactly while ``status`` is RUNNING. The two move together.
     finished_at = Column(DateTime, nullable=True, comment="When it ended; null while RUNNING")

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/sql/2026_08_31_bot_config_manifest_apply.sql
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/sql/2026_08_31_bot_config_manifest_apply.sql
@@ -47,23 +47,34 @@
 --     it prevents surfaces as duplicate rows, silently, never as an error.
 --     SQLAlchemy cannot render the modifier, so this file is the only place it
 --     can live.
---   * ``TIMESTAMP`` FOR THE DB-CLOCK COLUMNS, ``DATETIME`` FOR THE REST, and
---     which one a column gets is decided by who fills it, not by taste.
+--   * ``TIMESTAMP`` FOR EVERY TIME COLUMN, because the DDL review standard
+--     (研发规范) that gates provisioning refuses DATETIME outright -- along
+--     with BIT, FLOAT, DOUBLE, ENUM and SET -- and refuses any column whose
+--     name is a SQL keyword. The first draft of this table declared
+--     started_at/finished_at as DATETIME and a column named `trigger`, and
+--     was rejected on exactly those three findings; that is why the record
+--     table never existed in production while the lock table did.
+--
 --     gmt_create and gmt_modified are written by the database itself
 --     (``DEFAULT CURRENT_TIMESTAMP``, and ``func.now()`` from the ORM), so
 --     TIMESTAMP's session-time-zone conversion is a no-op round trip and they
---     match ac_bots and every table added since --
---     skill_center/sql/2026_09_03_align_space_skill_timestamps_with_gmt.sql is
---     the repair that convention exists to avoid repeating.
+--     match ac_bots and every table added since.
 --
---     A column the APPLICATION fills stays DATETIME. TIMESTAMP reads the naive
---     value being bound as session-local wall time and converts it to UTC for
---     storage, so a Python-supplied instant is stored shifted by the session
---     offset -- eight hours under the Asia/Shanghai session assumed here. This
---     was got wrong in the first draft of this change and caught in review; started_at and
---     finished_at are the columns in question here, per their comment below.
+--     started_at and finished_at are filled by the APPLICATION from
+--     datetime.now() (naive). TIMESTAMP binds that as session-local wall time,
+--     stores UTC, and converts back on read through the same session -- so the
+--     value the application wrote is the value it reads back, exactly as with
+--     DATETIME. The one difference is what an out-of-band reader sees when the
+--     process time zone and the session time zone differ (a UTC container
+--     against an Asia/Shanghai session): the stored instant is offset by that
+--     difference. That mismatch existed under DATETIME too, as a wall-clock
+--     disagreement with gmt_create; TIMESTAMP merely makes it visible.
 --
---     The ORM keeps ``DateTime`` for both kinds -- ac_skill_version's
+--     Every TIMESTAMP column carries an explicit DEFAULT (or an explicit NULL)
+--     so the server can never attach an implicit ON UPDATE CURRENT_TIMESTAMP;
+--     test_manifest_ddl_contract.py holds that line.
+--
+--     The ORM keeps ``DateTime`` for all of them -- ac_skill_version's
 --     published_at is the precedent for ``DateTime`` over a TIMESTAMP column.
 --   * NO ``ENGINE`` CLAUSE, and no BLOCK_SIZE / REPLICA_NUM / COMPRESSION /
 --     TABLET_SIZE / PCTFREE / ROW_FORMAT. OceanBase applies its own defaults
@@ -94,7 +105,11 @@ CREATE TABLE `ac_bot_config_manifest_apply` (
   -- 'explicit' is the only value this wave writes: W4's single entry point is
   -- the explicit POST. W8 adds 'republish'/'restart' and W13 adds 'create',
   -- neither of which needs a migration.
-  `trigger`        varchar(32)   NOT NULL COMMENT 'What started it: explicit/create/republish/restart',
+  --
+  -- apply_trigger, not `trigger`: TRIGGER is a SQL keyword and the DDL review
+  -- standard refuses keyword column names (see the header). The ORM attribute
+  -- and the API field are still ``trigger``; only the column is prefixed.
+  `apply_trigger`  varchar(32)   NOT NULL COMMENT 'What started it: explicit/create/republish/restart',
   -- RUNNING on insert, terminal on completion — the two-write lifecycle apply's
   -- async shape requires, since the route answers 202 and the work continues on
   -- a background thread.
@@ -111,16 +126,15 @@ CREATE TABLE `ac_bot_config_manifest_apply` (
   -- ("app:7:on-behalf-of:<...>"), so the composed value can legitimately be
   -- long without anything being malformed.
   `actor`          varchar(1024) NOT NULL COMMENT 'Audit: who started it',
-  -- DATETIME, not TIMESTAMP, for both of these: they are filled by the
-  -- application from datetime.now() (process-local, naive), never by the
-  -- database. TIMESTAMP binds a naive value as session-local, so these would
-  -- be stored correctly only where the process time zone happens to equal the
-  -- database session's -- and a container on UTC against an Asia/Shanghai
-  -- session is exactly where that stops being true. gmt_* below are a
-  -- different case: the database fills those itself.
-  `started_at`     datetime      NOT NULL COMMENT 'When the apply began',
+  -- TIMESTAMP because the DDL review standard refuses DATETIME (header note).
+  -- Both are filled by the application from datetime.now(); the round trip
+  -- through one session is the identity, so the application reads back what
+  -- it wrote. The explicit DEFAULT on started_at is what stops the server
+  -- attaching an implicit ON UPDATE CURRENT_TIMESTAMP to it -- the application
+  -- always supplies a value, so the default itself is never used.
+  `started_at`     timestamp     NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'When the apply began',
   -- NULL exactly while status is RUNNING. The two move together.
-  `finished_at`    datetime      NULL     COMMENT 'When it ended; NULL while RUNNING',
+  `finished_at`    timestamp     NULL     DEFAULT NULL COMMENT 'When it ended; NULL while RUNNING',
   `avernet_tenant` varchar(64)   NOT NULL DEFAULT 'teamclaw' COMMENT 'Tenant, for data isolation',
   `gmt_create`     timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'Row created',
   `gmt_modified`   timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Row last modified',

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/sql/2026_09_07_repair_misprovisioned_bot_config_manifest_apply.sql
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/sql/2026_09_07_repair_misprovisioned_bot_config_manifest_apply.sql
@@ -24,8 +24,11 @@
 --      operator decides when to DROP the quarantined copy.
 --   3. Create ac_bot_config_manifest_apply with the canonical DDL, verbatim
 --      from 2026_08_31_bot_config_manifest_apply.sql (see that file for why
---      every index is GLOBAL, why AUTO_INCREMENT_MODE is pinned to ORDER, and
---      why started_at/finished_at are DATETIME).
+--      every index is GLOBAL, why AUTO_INCREMENT_MODE is pinned to ORDER, why
+--      the column is apply_trigger and not `trigger`, and why
+--      started_at/finished_at are TIMESTAMP -- the DDL review standard that
+--      most likely caused the mis-provisioning refuses keyword column names
+--      and DATETIME).
 --   4. Verify. Save the results with the deployment record.
 --
 -- Conditional DDL goes through PREPARE/EXECUTE, the pattern
@@ -75,12 +78,12 @@ CREATE TABLE IF NOT EXISTS `ac_bot_config_manifest_apply` (
   `env`            varchar(20)   NOT NULL COMMENT 'Environment: prod/pre/dev',
   `entity_id`      varchar(256)  NOT NULL COMMENT 'Entity id: the bot entity_id',
   `bot_id`         varchar(256)  NOT NULL COMMENT 'Bot ID',
-  `trigger`        varchar(32)   NOT NULL COMMENT 'What started it: explicit/create/republish/restart',
+  `apply_trigger`  varchar(32)   NOT NULL COMMENT 'What started it: explicit/create/republish/restart',
   `status`         varchar(16)   NOT NULL COMMENT 'RUNNING, or SUCCEEDED/PARTIAL/FAILED',
   `report`         mediumtext    NOT NULL COMMENT 'The per-entry report (JSON)',
   `actor`          varchar(1024) NOT NULL COMMENT 'Audit: who started it',
-  `started_at`     datetime      NOT NULL COMMENT 'When the apply began',
-  `finished_at`    datetime      NULL     COMMENT 'When it ended; NULL while RUNNING',
+  `started_at`     timestamp     NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'When the apply began',
+  `finished_at`    timestamp     NULL     DEFAULT NULL COMMENT 'When it ended; NULL while RUNNING',
   `avernet_tenant` varchar(64)   NOT NULL DEFAULT 'teamclaw' COMMENT 'Tenant, for data isolation',
   `gmt_create`     timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'Row created',
   `gmt_modified`   timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Row last modified',

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/sql/2026_09_07_repair_misprovisioned_bot_config_manifest_apply.sql
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/sql/2026_09_07_repair_misprovisioned_bot_config_manifest_apply.sql
@@ -1,0 +1,110 @@
+-- Repair for a mis-provisioned ac_bot_config_manifest_apply.
+--
+-- WHAT WENT WRONG. 2026_08_31_bot_config_manifest_apply.sql declares two
+-- tables: the apply RECORD (ac_bot_config_manifest_apply: apply_id, trigger,
+-- status, report, actor, started_at, finished_at) and the apply LOCK
+-- (ac_bot_config_manifest_apply_lock: holder_user_id, lock_token, and the
+-- UNIQUE KEY that *is* the lock). At least one environment was provisioned with
+-- the LOCK's body under the RECORD's name -- SHOW CREATE TABLE
+-- ac_bot_config_manifest_apply came back with holder_user_id / lock_token /
+-- uk_manifest_apply_lock and the lock's COMMENT, and no apply_id at all.
+-- Every read of the record then fails the way GET .../config-manifest/last-apply
+-- did: ``1054 Unknown column 'ac_bot_config_manifest_apply.apply_id'``.
+--
+-- WHAT THIS DOES. Idempotent, and a no-op wherever the schema is already right:
+--
+--   1. Detect the mis-shape: ac_bot_config_manifest_apply exists but has no
+--      apply_id column. Nothing below touches a correctly shaped table.
+--   2. Move the mis-shaped table out of the way. It has exactly the lock's
+--      shape, so when the lock table is missing it is RENAMED INTO PLACE as
+--      ac_bot_config_manifest_apply_lock -- the same DDL, only under the right
+--      name now. When the lock table already exists it is renamed ASIDE to
+--      ac_bot_config_manifest_apply_misprovisioned_20260907 instead. Nothing is
+--      dropped: whatever rows it holds are at most stale lock rows, and the
+--      operator decides when to DROP the quarantined copy.
+--   3. Create ac_bot_config_manifest_apply with the canonical DDL, verbatim
+--      from 2026_08_31_bot_config_manifest_apply.sql (see that file for why
+--      every index is GLOBAL, why AUTO_INCREMENT_MODE is pinned to ORDER, and
+--      why started_at/finished_at are DATETIME).
+--   4. Verify. Save the results with the deployment record.
+--
+-- Conditional DDL goes through PREPARE/EXECUTE, the pattern
+-- skill_center/sql/2026_08_30_finalize_space_skill_group3_publication.sql set,
+-- because MySQL/OceanBase have no IF around a bare statement.
+
+-- 1. Is the record table the mis-shaped one? (1 = yes, 0 = no / absent.)
+SET @apply_is_misshaped = (
+  SELECT COUNT(*) FROM information_schema.TABLES t
+   WHERE t.TABLE_SCHEMA = DATABASE()
+     AND t.TABLE_NAME = 'ac_bot_config_manifest_apply'
+     AND NOT EXISTS (
+       SELECT 1 FROM information_schema.COLUMNS c
+        WHERE c.TABLE_SCHEMA = t.TABLE_SCHEMA
+          AND c.TABLE_NAME = t.TABLE_NAME
+          AND c.COLUMN_NAME = 'apply_id'
+     )
+);
+
+SET @lock_exists = (
+  SELECT COUNT(*) FROM information_schema.TABLES
+   WHERE TABLE_SCHEMA = DATABASE()
+     AND TABLE_NAME = 'ac_bot_config_manifest_apply_lock'
+);
+
+-- 2. Move the mis-shaped table out of the way: into place as the lock when the
+--    lock is missing, aside under a quarantine name when it is not.
+SET @move_misshaped_apply = IF(
+  @apply_is_misshaped = 1,
+  IF(
+    @lock_exists = 0,
+    'RENAME TABLE `ac_bot_config_manifest_apply` TO `ac_bot_config_manifest_apply_lock`',
+    'RENAME TABLE `ac_bot_config_manifest_apply` TO `ac_bot_config_manifest_apply_misprovisioned_20260907`'
+  ),
+  'SELECT 1'
+);
+PREPARE move_misshaped_apply_stmt FROM @move_misshaped_apply;
+EXECUTE move_misshaped_apply_stmt;
+DEALLOCATE PREPARE move_misshaped_apply_stmt;
+
+-- 3. The apply RECORD, as 2026_08_31_bot_config_manifest_apply.sql declares it.
+--    IF NOT EXISTS keeps this a no-op on an environment that was provisioned
+--    correctly in the first place.
+CREATE TABLE IF NOT EXISTS `ac_bot_config_manifest_apply` (
+  `id`             bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT 'Primary key',
+  `apply_id`       varchar(64)   NOT NULL COMMENT 'Public handle for this apply',
+  `env`            varchar(20)   NOT NULL COMMENT 'Environment: prod/pre/dev',
+  `entity_id`      varchar(256)  NOT NULL COMMENT 'Entity id: the bot entity_id',
+  `bot_id`         varchar(256)  NOT NULL COMMENT 'Bot ID',
+  `trigger`        varchar(32)   NOT NULL COMMENT 'What started it: explicit/create/republish/restart',
+  `status`         varchar(16)   NOT NULL COMMENT 'RUNNING, or SUCCEEDED/PARTIAL/FAILED',
+  `report`         mediumtext    NOT NULL COMMENT 'The per-entry report (JSON)',
+  `actor`          varchar(1024) NOT NULL COMMENT 'Audit: who started it',
+  `started_at`     datetime      NOT NULL COMMENT 'When the apply began',
+  `finished_at`    datetime      NULL     COMMENT 'When it ended; NULL while RUNNING',
+  `avernet_tenant` varchar(64)   NOT NULL DEFAULT 'teamclaw' COMMENT 'Tenant, for data isolation',
+  `gmt_create`     timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'Row created',
+  `gmt_modified`   timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Row last modified',
+  PRIMARY KEY (`id`),
+  KEY `idx_manifest_apply_latest`
+    (`avernet_tenant`, `env`, `entity_id`, `bot_id`, `id`) GLOBAL,
+  KEY `idx_manifest_apply_by_id`
+    (`avernet_tenant`, `env`, `entity_id`, `bot_id`, `apply_id`) GLOBAL
+) AUTO_INCREMENT_MODE = 'ORDER' DEFAULT CHARSET = utf8mb4
+  COMMENT = 'Bot config manifest apply record';
+
+-- 4. POST: both tables present, each with its own distinguishing column, and
+--    no quarantined copy unless step 2 had to leave one. Expected:
+--      ac_bot_config_manifest_apply       has_apply_id=1  has_lock_token=0
+--      ac_bot_config_manifest_apply_lock  has_apply_id=0  has_lock_token=1
+SELECT t.TABLE_NAME,
+       SUM(c.COLUMN_NAME = 'apply_id')   AS has_apply_id,
+       SUM(c.COLUMN_NAME = 'lock_token') AS has_lock_token
+  FROM information_schema.TABLES t
+  JOIN information_schema.COLUMNS c
+    ON c.TABLE_SCHEMA = t.TABLE_SCHEMA AND c.TABLE_NAME = t.TABLE_NAME
+ WHERE t.TABLE_SCHEMA = DATABASE()
+   AND t.TABLE_NAME IN ('ac_bot_config_manifest_apply',
+                        'ac_bot_config_manifest_apply_lock',
+                        'ac_bot_config_manifest_apply_misprovisioned_20260907')
+ GROUP BY t.TABLE_NAME
+ ORDER BY t.TABLE_NAME;

--- a/src/backend/tests/community/core/bot_config_manifest/test_manifest_ddl_contract.py
+++ b/src/backend/tests/community/core/bot_config_manifest/test_manifest_ddl_contract.py
@@ -65,7 +65,7 @@ def _tables(path: Path) -> dict[str, dict[str, str]]:
     )
     starts = [
         (match.group(1), match.start())
-        for match in re.finditer(r"CREATE TABLE\s+`(\w+)`", body)
+        for match in re.finditer(r"CREATE TABLE\s+(?:IF NOT EXISTS\s+)?`(\w+)`", body)
     ]
     assert starts, f"{path.name}: no CREATE TABLE found"
 

--- a/src/backend/tests/community/core/bot_config_manifest/test_manifest_ddl_contract.py
+++ b/src/backend/tests/community/core/bot_config_manifest/test_manifest_ddl_contract.py
@@ -30,12 +30,23 @@ _SQL_DIR = (
 
 #: Columns filled by the application, which must stay DATETIME. TIMESTAMP reads
 #: the bound naive value as session-local and converts it, so an instant the
-#: application already normalised to UTC (``fetched_at``) or took from
-#: ``datetime.now()`` (the apply times) is stored shifted by the session offset.
+#: application already normalised to UTC (``fetched_at``) is stored shifted by
+#: the session offset.
+#:
+#: The apply table's started_at/finished_at used to be listed here and are
+#: not any more: the DDL review standard refused them as DATETIME (see
+#: ``_DDL_STANDARD_FORBIDDEN_TYPES``), and their round trip through one
+#: session is the identity, so TIMESTAMP loses nothing the application reads.
 _APPLICATION_SUPPLIED = {
-    "2026_08_31_bot_config_manifest_apply.sql": ("started_at", "finished_at"),
     "2026_08_31_manifest_content.sql": ("fetched_at",),
 }
+
+#: The DDL review standard (研发规范) that gates provisioning on OceanBase.
+#: ac_bot_config_manifest_apply was refused on exactly these two rules -- a
+#: column named `trigger`, and DATETIME started_at/finished_at -- which is why
+#: the record table never existed in production while its lock table did.
+_DDL_STANDARD_FORBIDDEN_TYPES = {"bit", "float", "double", "datetime", "enum", "set"}
+_DDL_STANDARD_FILES = ("2026_08_31_bot_config_manifest_apply.sql",)
 
 #: Filled by the database itself, so TIMESTAMP's conversion is a no-op round
 #: trip and matches ac_bots. Every table here has both.
@@ -157,6 +168,31 @@ def test_every_table_in_every_file_is_parsed() -> None:
         "ac_source_credential",
         "ac_bot_cli_tool",
     }
+
+
+def test_apply_tables_pass_the_ddl_review_standard() -> None:
+    """The two findings the standard raised, held so they cannot come back.
+
+    Scoped to the apply file: ac_manifest_content.fetched_at is still DATETIME
+    and is a separate change with its own UTC-normalisation reasoning.
+    """
+    for filename in _DDL_STANDARD_FILES:
+        tables = _tables(_SQL_DIR / filename)
+        assert tables, f"{filename}: nothing parsed"
+        for table, declarations in tables.items():
+            assert "trigger" not in declarations, (
+                f"{table}: `trigger` is a SQL keyword; the column is apply_trigger"
+            )
+            for column, rest in declarations.items():
+                declared_type = rest.split()[0].lower().split("(")[0]
+                assert declared_type not in _DDL_STANDARD_FORBIDDEN_TYPES, (
+                    f"{table}.{column} is declared {declared_type}, which the DDL "
+                    "review standard refuses"
+                )
+        apply_columns = tables["ac_bot_config_manifest_apply"]
+        assert "apply_trigger" in apply_columns
+        for column in ("started_at", "finished_at"):
+            assert apply_columns[column].split()[0].lower() == "timestamp"
 
 
 def test_no_bare_timestamp_column_can_attach_an_implicit_on_update() -> None:

--- a/src/backend/tests/community/core/bot_config_manifest/test_manifest_ddl_contract.py
+++ b/src/backend/tests/community/core/bot_config_manifest/test_manifest_ddl_contract.py
@@ -46,7 +46,10 @@ _APPLICATION_SUPPLIED = {
 #: column named `trigger`, and DATETIME started_at/finished_at -- which is why
 #: the record table never existed in production while its lock table did.
 _DDL_STANDARD_FORBIDDEN_TYPES = {"bit", "float", "double", "datetime", "enum", "set"}
-_DDL_STANDARD_FILES = ("2026_08_31_bot_config_manifest_apply.sql",)
+_DDL_STANDARD_FILES = (
+    "2026_08_31_bot_config_manifest_apply.sql",
+    "2026_09_07_repair_misprovisioned_bot_config_manifest_apply.sql",
+)
 
 #: Filled by the database itself, so TIMESTAMP's conversion is a no-op round
 #: trip and matches ac_bots. Every table here has both.


### PR DESCRIPTION
## Problem

`GET /openapi/v1/bots/{bot_id}/config-manifest/last-apply` fails with:

```
mysql.connector.errors.ProgrammingError: 1054 (42S22): Unknown column 'ac_bot_config_manifest_apply.apply_id' in 'field list'
```

`SHOW CREATE TABLE ac_bot_config_manifest_apply` in production returns the apply **lock**'s body (`holder_user_id`, `lock_token`, `UNIQUE KEY uk_manifest_apply_lock`) and no `apply_id`, `status`, `report`, `started_at` columns at all. The ORM and the repo DDL agree with each other; the database was provisioned with the lock DDL under the record table's name.

The root cause surfaced when re-provisioning: the DDL review standard (研发规范) that gates OceanBase provisioning refuses the canonical record DDL on three findings:

- `trigger` is a SQL keyword and cannot be a column name.
- `started_at` is DATETIME, which the standard forbids (with BIT, FLOAT, DOUBLE, ENUM, SET).
- `finished_at`, same.

So the record table could never have been created as declared, while the lock table (which has none of those) went through.

## Solution

Two parts, one PR:

**1. Make the record DDL pass the standard**, with the ORM moving in lockstep:

- Column renamed `trigger` → `apply_trigger`. The ORM maps it via `Column("apply_trigger", ...)` so the Python attribute, the pydantic record field and the API field all stay `trigger`. No caller changes.
- `started_at` / `finished_at` → `TIMESTAMP` with explicit `DEFAULT CURRENT_TIMESTAMP` / `NULL DEFAULT NULL`. The application fills both from `datetime.now()` and reads them back through the same session, so the TIMESTAMP round trip is the identity; the explicit defaults are what stop the server attaching an implicit `ON UPDATE CURRENT_TIMESTAMP`. The ORM keeps `DateTime`, as it already does for `gmt_*` over TIMESTAMP.
- Canonical DDL (`2026_08_31_bot_config_manifest_apply.sql`) and its header prose updated to say why.
- `test_manifest_ddl_contract.py`: the apply file leaves `_APPLICATION_SUPPLIED`; a new `test_apply_tables_pass_the_ddl_review_standard` holds both rules for this table. Parser now accepts `CREATE TABLE IF NOT EXISTS`.

**2. Repair migration** `2026_09_07_repair_misprovisioned_bot_config_manifest_apply.sql` for any environment carrying the mis-shaped table: detects it via `information_schema` (record table present, no `apply_id`), renames it into place as the lock when the lock is missing or aside to a quarantine name when not, then `CREATE TABLE IF NOT EXISTS` with the corrected DDL. Idempotent; nothing dropped.

Rejected alternative: keeping DATETIME and arguing with the standard. `skill_center/sql/2026_09_03_align_space_skill_timestamps_with_gmt.sql` already made the same DATETIME→TIMESTAMP move for the same reason.

Out of scope, flagged: `ac_manifest_content.fetched_at` is also DATETIME and will hit the same rule when that table is provisioned. Its value is UTC-normalised by the application, so it needs its own reasoning; left for a separate change.

## Validation

- `test_manifest_ddl_contract.py`: 5 passed locally (stdlib-only, run with `--noconftest`). The three original failures reproduce without the parser change.
- `ruff check` clean on the touched Python files.
- Column-by-column comparison of the production `SHOW CREATE TABLE` output against both bodies in the canonical DDL: it matches the lock table exactly.
- **Not run:** the migration and the corrected DDL against OceanBase. No MySQL/OceanBase in the sandbox. Production is being re-provisioned by hand from the corrected CREATE TABLE statements; the migration is for other environments.

## Compatibility and risk

Schema and ORM change together. The renamed column is only ever addressed through the ORM, so deploying the app without the new DDL (or vice versa) fails loudly on the first apply, not silently. No production rows exist in the record table (it never existed correctly), so there is nothing to backfill. Rollback: revert the PR and recreate the table from the previous DDL, which the standard will refuse.

Note: `REL20260908` rejects direct pushes (repository rule "changes must be made through a pull request"), hence this PR from a working branch into that release branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLdSEfH7LzYhxp3TrKj6qN