### PR TITLE
feat(step-trace): display subagent/collaboration SKILL step traces; fix(clawweb): expose workflow_specs.version & persist workflow_version on flow run insert

### DIFF
--- a/src/evolverun/clawweb/public/modules/workflow/server/repositories/workflow-spec-repository.ts
+++ b/src/evolverun/clawweb/public/modules/workflow/server/repositories/workflow-spec-repository.ts
@@ -74,7 +74,7 @@ export class WorkflowSpecRepository {
 
   async findByWorkflowId(workflowId: string): Promise<WorkflowSpecRow | null> {
     const rows = await this.db.query<WorkflowSpecRow>(
-      "SELECT id, workflow_id, pack_id, spec_json, gmt_create, gmt_modified, title FROM workflow_specs WHERE workflow_id = ?",
+      "SELECT id, workflow_id, pack_id, version, spec_json, gmt_create, gmt_modified, title FROM workflow_specs WHERE workflow_id = ?",
       [workflowId],
     );
     return rows[0] ?? null;

--- a/src/evolverun/clawweb/public/modules/workflow/server/routes/__tests__/workflow-spec-read.test.ts
+++ b/src/evolverun/clawweb/public/modules/workflow/server/routes/__tests__/workflow-spec-read.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import express from "express";
+import { once } from "node:events";
+import type { WorkflowSpecRepository, WorkflowSpecRow } from "../../repositories/workflow-spec-repository.js";
+import { createWorkflowsRouter } from "../workflows.js";
+
+let server: ReturnType<express.Application["listen"]> | null = null;
+
+afterEach(async () => {
+  const active = server;
+  server = null;
+  if (active) await new Promise<void>((resolve) => active.close(() => resolve()));
+});
+
+/** Build a WorkflowSpecRow with a known spec_json containing no version field. */
+function makeRow(version: number | null): WorkflowSpecRow {
+  return {
+    id: 1,
+    workflow_id: "wf-1",
+    pack_id: null,
+    version,
+    spec_json: JSON.stringify({ name: "wf-1", nodes: [] }),
+    gmt_create: 1000,
+    gmt_modified: 2000,
+    title: "wf-1",
+  };
+}
+
+async function start(rows: WorkflowSpecRow[]) {
+  const workflowSpecRepo = {
+    findByWorkflowId: vi.fn(async (_workflowId: string) => rows[0] ?? null),
+  } as unknown as WorkflowSpecRepository;
+
+  const app = express();
+  app.use(express.json());
+  app.use("/api/workflows", createWorkflowsRouter(workflowSpecRepo, null, null, null, null, null));
+  const instance = app.listen(0, "127.0.0.1");
+  await once(instance, "listening");
+  server = instance;
+  const address = instance.address();
+  if (!address || typeof address === "string") throw new Error("test server did not bind");
+  return `http://127.0.0.1:${address.port}`;
+}
+
+describe("GET /api/workflows/:workflowId — version propagation contract", () => {
+  it("attaches the synced deploy version to the returned spec", async () => {
+    const baseUrl = await start([makeRow(3)]);
+    const res = await fetch(`${baseUrl}/api/workflows/wf-1`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    // spec_json itself has no version; the synced version must come from the row.
+    expect(body.version).toBe(3);
+    expect(body.name).toBe("wf-1");
+  });
+
+  it("omits version when the row version is null", async () => {
+    const baseUrl = await start([makeRow(null)]);
+    const res = await fetch(`${baseUrl}/api/workflows/wf-1`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.version).toBeUndefined();
+  });
+
+  it("returns 404 when the workflow is not found", async () => {
+    const baseUrl = await start([]);
+    const res = await fetch(`${baseUrl}/api/workflows/wf-missing`);
+    expect(res.status).toBe(404);
+  });
+});

--- a/src/evolverun/clawweb/public/modules/workflow/server/routes/internal/runs.ts
+++ b/src/evolverun/clawweb/public/modules/workflow/server/routes/internal/runs.ts
@@ -40,7 +40,7 @@ export function createInternalRunsRouter(
       return;
     }
     try {
-      const { flow_id, workflow_id, workflow_title, status, triggered_by, params_json, input_json, node_count, identity_key, started_at, credentials_json, origin_session_key, origin_session_id, origin_bot_id, user_id, plugin_version, engine } = req.body as {
+      const { flow_id, workflow_id, workflow_title, status, triggered_by, params_json, input_json, node_count, identity_key, started_at, credentials_json, origin_session_key, origin_session_id, origin_bot_id, user_id, plugin_version, engine, workflow_version, workflow_deploy_number } = req.body as {
         flow_id?: string;
         workflow_id?: string;
         workflow_title?: string;
@@ -58,6 +58,8 @@ export function createInternalRunsRouter(
         user_id?: string;
         plugin_version?: string;
         engine?: string;
+        workflow_version?: number;
+        workflow_deploy_number?: number;
       };
 
       if (!flow_id || !workflow_id || !status) {
@@ -84,6 +86,8 @@ export function createInternalRunsRouter(
         userId: user_id ?? null,
         pluginVersion: plugin_version ?? null,
         engine: engine ?? null,
+        workflowVersion: workflow_version ?? null,
+        workflowDeployNumber: workflow_deploy_number ?? null,
       });
       if (!ok) {
         apiLog("WRITE", "/runs", { status: 500, error: "Failed to insert flow run", flow_id, workflow_id });

--- a/src/evolverun/clawweb/public/modules/workflow/server/routes/workflows.ts
+++ b/src/evolverun/clawweb/public/modules/workflow/server/routes/workflows.ts
@@ -609,6 +609,12 @@ export function createWorkflowsRouter(
             spec.updatedAt = updatedAtMs;
           }
 
+          // Attach the synced deploy version so API-mode ClawMind can populate
+          // flow_runs.workflow_version when falling back to workflow_specs.
+          if (row.version != null) {
+            spec.version = row.version;
+          }
+
           res.json(spec);
           return;
         }

--- a/src/evolverun/clawweb/public/modules/workflow/web/components/NodeExecutionList.tsx
+++ b/src/evolverun/clawweb/public/modules/workflow/web/components/NodeExecutionList.tsx
@@ -12,6 +12,8 @@ import AnalysisModal from './AnalysisModal'
 
 const EXECUTOR_LABELS: Record<string, string> = {
   'embedded-agent': '代理',
+  subagent: '子代理',
+  collaboration: '协作',
   action: '动作',
   human: '人工',
   'loop-group': '循环',
@@ -483,7 +485,9 @@ function NodeDetailPanel({
 
       {node.token_usage_json && <TokenUsageDisplay json={node.token_usage_json} />}
 
-      {node.executor_type === 'embedded-agent' && (
+      {(node.executor_type === 'embedded-agent' ||
+        node.executor_type === 'subagent' ||
+        node.executor_type === 'collaboration') && (
         <div className="border-t border-gray-100 pt-3">
           <NodeStepTracePanel flowId={flowId} nodeId={node.node_id} attempt={node.attempt} />
         </div>

--- a/src/evolverun/clawweb/public/modules/workflow/web/components/NodeStepTracePanel.tsx
+++ b/src/evolverun/clawweb/public/modules/workflow/web/components/NodeStepTracePanel.tsx
@@ -9,7 +9,8 @@ interface NodeStepTracePanelProps {
 }
 
 /**
- * Displays embedded-agent node execution steps as a timeline.
+ * Displays agent node execution steps as a timeline.
+ * Works for embedded-agent, subagent, and collaboration nodes.
  * Shows tool_call inputs, tool_result outputs, and assistant_text content.
  */
 export default function NodeStepTracePanel({ flowId, nodeId, attempt = 1 }: NodeStepTracePanelProps) {


### PR DESCRIPTION
## 概述

包含 3 个提交：

### 1. feat(step-trace): display subagent/collaboration SKILL step traces
展示 subagent / collaboration 节点的 SKILL 执行步骤 trace。

### 2. fix(clawweb): include version column in WorkflowSpecRepository.findByWorkflowId
`workflow_specs.version` 列（部署版本，从 deploy_history 同步）未被 SQL 查询 SELECT，导致 API 模式解析工作流版本时回退到 `spec_json` 中的语义版本字符串 `"1.0.0"`，无法写入 `flow_runs.workflow_version`（INT 列）。补充 SELECT `version` 列。

### 3. fix(clawweb): persist workflow_version and deploy_number on flow run insert
`POST /runs` 内部路由只解构了请求 body 的 16 个字段，丢弃了 `workflow_version` 和 `workflow_deploy_number`，导致它们到达 `FlowRunRepository.insert` 前就丢失，`flow_runs` 两列始终为 NULL。补充解构并将两个字段透传到 insert。

## 验证

- 引擎解析到明确发布版本（如 v3）时，`workflow_version` / `workflow_deploy_number` 能正确落库。
