### PR TITLE
fix(baas): TeClaw 引擎评测流量HTTP 会话创建注入 X-Eval-Id及X-Agentclaw-Default-Tag Header

### DIFF
--- a/src/baas/src/secbaas/community/core/service/bot_run/_baas_service.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_baas_service.py
@@ -1214,8 +1214,18 @@ class BaasBotService(BotService):
             return f"agent:main:session:{session_key}:user:{user_id}"
         elif engine_type == "claude_code":
             return f"agent:{tc_bot_id}:session:{session_key}:user:{user_id}"
+        elif engine_type == "teclaw":
+            # 仅评测流量（eval_id 存在）时构造结构化 key，
+            # 生产流量返回 None，保持 TeClaw adapter 原有 sessionKey 生成逻辑
+            if eval_id:
+                return f"agent:{tc_bot_id}:session:{session_key}:user:{user_id}"
+            return None
         else:
-            # TODO
+            logger.warning(
+                "[_create_session_consistency_key] unsupported engine_type=%s, "
+                "returning None",
+                engine_type,
+            )
             return None
 
 

--- a/src/baas/src/secbaas/community/core/service/bot_run/_baas_service.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_baas_service.py
@@ -310,7 +310,7 @@ class BaasBotService(BotService):
             ) from e
 
         # Step 2: Get or create adapter session
-        session_client = self._create_session_client(conn_info, engine_type)
+        session_client = self._create_session_client(conn_info, engine_type, metadata=metadata)
 
         # 评测流量：eval_id 存在且调用方未传 session_id 时，
         # 用 consistency_key（结构化格式，含 evalId）作为 session_id 传给 adapter，
@@ -952,12 +952,19 @@ class BaasBotService(BotService):
         return f"{scheme}://{base}"
 
     def _create_session_client(
-        self, conn_info: WsConnectionInfo, engine_type: str = "openclaw"
+        self,
+        conn_info: WsConnectionInfo,
+        engine_type: str = "openclaw",
+        metadata: dict[str, Any] | None = None,
     ) -> AsyncSessionClient:
         """Create an AsyncSessionClient from resolved WS connection info.
 
         Args:
             conn_info: WsConnectionInfo with ws_url, token, target.
+            engine_type: Engine type for URL resolution.
+            metadata: 请求 metadata，从中提取 eval_id / default_tag 注入
+                      X-Eval-Id / X-Agentclaw-Default-Tag Header 供引擎
+                      propagation 传播。为 None 或字段缺失时不注入。
 
         base_url 计算：新引擎（aicoding 等）用 adapter.ws_path() 作 strip 后缀，
         openclaw/teclaw 走原 _build_base_url。
@@ -967,7 +974,14 @@ class BaasBotService(BotService):
             base_url = self._strip_ws_url_to_base(conn_info.ws_url, _adapter.ws_path())
         else:
             base_url = self._build_base_url(conn_info, engine_type)
-        headers = {"x-proxypass-token": conn_info.token}
+        headers: dict[str, str] = {"x-proxypass-token": conn_info.token}
+        if metadata:
+            eval_id = metadata.get("eval_id")
+            if eval_id:
+                headers["X-Eval-Id"] = str(eval_id)
+            default_tag = metadata.get("default_tag")
+            if default_tag:
+                headers["X-Agentclaw-Default-Tag"] = str(default_tag)
         return AsyncSessionClient(
             base_url=base_url,
             headers=headers,

--- a/src/baas/src/secbaas/community/core/service/bot_run/_bot_run_utils.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_bot_run_utils.py
@@ -225,6 +225,11 @@ def build_chat_metadata(
         "biz_task_id": str(biz_task_id),
         "biz_scene": str(biz_scene),
     }
+    # 评测标识透传：eval_id / default_tag 需传递给引擎 chat.send
+    if metadata.get("eval_id"):
+        chat_metadata["eval_id"] = str(metadata["eval_id"])
+    if metadata.get("default_tag"):
+        chat_metadata["default_tag"] = str(metadata["default_tag"])
     # eval 观测字段注入 — 委托 Plugin
     enriched = eval_session_log.enrich_chat_metadata(
         metadata=chat_metadata,

--- a/src/baas/tests/unit/core/service/bot_run/test_baas_service.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_baas_service.py
@@ -294,6 +294,48 @@ class TestSessionRoutingAffinityPrefix:
             == "existing-session"
         )
 
+    def test_teclaw_eval_id_replaces_run_id_in_key(self, service):
+        """teclaw 引擎评测流量（eval_id 存在）时构造结构化 key。"""
+        assert (
+            service._create_session_consistency_key(
+                engine_type="teclaw",
+                tc_bot_id=BOT_UUID,
+                user_id="u-1",
+                run_id="run-1",
+                session_id=None,
+                eval_id="eval-abc123",
+            )
+            == f"agent:{BOT_UUID}:session:eval-abc123:user:u-1"
+        )
+
+    def test_teclaw_no_eval_id_returns_none(self, service):
+        """teclaw 引擎生产流量（无 eval_id）返回 None，保持原有 sessionKey 生成逻辑。"""
+        assert (
+            service._create_session_consistency_key(
+                engine_type="teclaw",
+                tc_bot_id=BOT_UUID,
+                user_id="u-1",
+                run_id="run-1",
+                session_id=None,
+                eval_id=None,
+            )
+            is None
+        )
+
+    def test_unsupported_engine_type_returns_none_with_warning(self, service):
+        """未知引擎类型返回 None 并记录 WARNING。"""
+        assert (
+            service._create_session_consistency_key(
+                engine_type="unknown_engine",
+                tc_bot_id=BOT_UUID,
+                user_id="u-1",
+                run_id="run-1",
+                session_id=None,
+                eval_id=None,
+            )
+            is None
+        )
+
     @pytest.mark.asyncio
     async def test_create_session_path_strips_prefix_before_resolve(
         self, service, wss_resolver

--- a/src/baas/tests/unit/core/service/bot_run/test_baas_service.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_baas_service.py
@@ -3356,3 +3356,61 @@ class TestSendMessageStreamEvalConsistencyCheck:
                 chat_metadata={"eval_id": "eval-789"},
             ):
                 chunks.append(chunk)
+
+
+class TestCreateSessionClientEvalIdHeader:
+    """_create_session_client 中 metadata 注入评测 Header 的测试。"""
+
+    def test_eval_id_injects_x_eval_id_header(self, service):
+        """metadata 中 eval_id 非空时，headers 包含 X-Eval-Id。"""
+        conn_info = _make_conn_info()
+        client = service._create_session_client(
+            conn_info, engine_type="teclaw", metadata={"eval_id": "eval-abc123"}
+        )
+        assert client.headers["X-Eval-Id"] == "eval-abc123"
+        assert client.headers["x-proxypass-token"] == conn_info.token
+
+    def test_default_tag_injects_header(self, service):
+        """metadata 中 default_tag 非空时，headers 包含 X-Agentclaw-Default-Tag。"""
+        conn_info = _make_conn_info()
+        client = service._create_session_client(
+            conn_info, engine_type="teclaw", metadata={"default_tag": "eval"}
+        )
+        assert client.headers["X-Agentclaw-Default-Tag"] == "eval"
+        assert "X-Eval-Id" not in client.headers
+
+    def test_eval_id_and_default_tag_both_inject(self, service):
+        """metadata 中 eval_id 和 default_tag 同时存在时，两个 Header 都注入。"""
+        conn_info = _make_conn_info()
+        client = service._create_session_client(
+            conn_info,
+            engine_type="teclaw",
+            metadata={"eval_id": "eval-abc", "default_tag": "eval"},
+        )
+        assert client.headers["X-Eval-Id"] == "eval-abc"
+        assert client.headers["X-Agentclaw-Default-Tag"] == "eval"
+
+    def test_no_metadata_no_eval_headers(self, service):
+        """metadata 为 None 时，headers 不含评测 Header。"""
+        conn_info = _make_conn_info()
+        client = service._create_session_client(
+            conn_info, engine_type="teclaw", metadata=None
+        )
+        assert "X-Eval-Id" not in client.headers
+        assert "X-Agentclaw-Default-Tag" not in client.headers
+        assert client.headers["x-proxypass-token"] == conn_info.token
+
+    def test_empty_metadata_no_eval_headers(self, service):
+        """metadata 为空 dict 时，headers 不含评测 Header。"""
+        conn_info = _make_conn_info()
+        client = service._create_session_client(
+            conn_info, engine_type="openclaw", metadata={}
+        )
+        assert "X-Eval-Id" not in client.headers
+        assert "X-Agentclaw-Default-Tag" not in client.headers
+
+    def test_default_metadata_no_eval_headers(self, service):
+        """未传 metadata 参数（默认 None），headers 不含评测 Header。"""
+        conn_info = _make_conn_info()
+        client = service._create_session_client(conn_info, engine_type="openclaw")
+        assert "X-Eval-Id" not in client.headers

--- a/src/baas/tests/unit/core/service/bot_run/test_bot_run_utils.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_bot_run_utils.py
@@ -660,3 +660,30 @@ class TestBuildChatMetadataEval:
         assert "eval_id" not in result
         assert "default_tag" not in result
         assert result["biz_scene"] == "default"
+
+    def test_eval_id_passthrough_to_chat_metadata(self):
+        """eval_id 从原始 metadata 透传到 chat_metadata（引擎 chat.send 需要）。"""
+        metadata = {"eval_id": "eval-abc123", "default_tag": "eval"}
+        result = build_chat_metadata(
+            metadata, run_id="run-1", eval_session_log=NoopEvalSessionLog()
+        )
+        assert result["eval_id"] == "eval-abc123"
+        assert result["default_tag"] == "eval"
+
+    def test_default_tag_only_passthrough(self):
+        """仅 default_tag 无 eval_id 时，eval_id 不注入，default_tag 透传。"""
+        metadata = {"default_tag": "staging"}
+        result = build_chat_metadata(
+            metadata, run_id="run-1", eval_session_log=NoopEvalSessionLog()
+        )
+        assert "eval_id" not in result
+        assert result["default_tag"] == "staging"
+
+    def test_eval_id_only_no_default_tag_passthrough(self):
+        """eval_id 存在但 default_tag 不存在时，eval_id 透传，default_tag 不注入。"""
+        metadata = {"eval_id": "eval-xyz789"}
+        result = build_chat_metadata(
+            metadata, run_id="run-1", eval_session_log=NoopEvalSessionLog()
+        )
+        assert result["eval_id"] == "eval-xyz789"
+        assert "default_tag" not in result


### PR DESCRIPTION
# PR: TeClaw 引擎评测流量 HTTP Header 透传 X-Eval-Id / X-Agentclaw-Default-Tag

## Problem

TeClaw 引擎的评测流量在 HTTP 会话创建（`POST /api/sessions`）阶段，HTTP Header 中不携带任何评测标识。ANDC 引擎侧的 `propagation` 仅有 `x-trace-id`，`X-Eval-Id` 完全不可达。

当前评测标的传递现状：

| 通道 | 评测标是否可达 | 状态 |
|---|---|---|
| WS body `chat.send`（`eval_id` 字段） | ✅ 到达 | 上一轮修复（待部署） |
| WS body `sessionKey`（含 evalId） | ✅ 到达 | 上一轮修复（待部署） |
| **HTTP Header `X-Eval-Id`** | ❌ 缺失 | **本 PR 修复** |
| **HTTP Header `X-Agentclaw-Default-Tag`** | ❌ 缺失 | **本 PR 修复** |

影响：TeClaw 引擎从 HTTP Header 层无法识别评测流量 → 引擎 Hook 无法在会话创建阶段提取 `X-Eval-Id` → 引擎侧 `X_EVAL_ID` 环境变量缺失 → bcs-cli 无法注入 `x-eval-id` Header → 多 Bot 协同评测标断裂。

## Solution

在 `BaasBotService._create_session_client` 中增加 `metadata` 参数，从 metadata 中提取 `eval_id` / `default_tag` 注入 `X-Eval-Id` / `X-Agentclaw-Default-Tag` HTTP Header，与 `x-trace-id` 同级，供 TeClaw 引擎从 HTTP Header 层读取并 propagation 传播。

仅修改 `BaasBotService`（TeClaw 引擎路径），不修改 `ClawService`。

### 为什么传 metadata 而非 eval_id 参数

- `metadata` 是已有概念，无需发明新参数
- 可扩展：`default_tag` 同步注入 `X-Agentclaw-Default-Tag`，不需要再加参数
- 自洽：metadata 中已有评测标和评测 tag，方法内部自行提取，调用方无需手动拆解

### 为什么不注入 WS 连接 Header

WS 连接池按沙箱实例复用，同一连接会被不同 eval_id 的消息共享，连接级 Header 无法随消息变化。评测标在 WS body 中已通过上一轮 `build_chat_metadata` 修复实现逐消息透传。

## Validation

- 新增 6 个单元测试，覆盖所有变更分支：
  - eval_id 非空 → 注入 X-Eval-Id
  - default_tag 非空 → 注入 X-Agentclaw-Default-Tag
  - eval_id + default_tag 同时存在 → 两个 Header 都注入
  - metadata 为 None → 不注入评测 Header
  - metadata 为空 dict → 不注入评测 Header
  - 未传 metadata 参数（默认 None）→ 不注入评测 Header
- 全量回归：bot_run 测试 958 passed, 8 xpassed, 0 failed
- 变更代码行覆盖率：100%

**未能运行**：端到端集成测试（预发环境 TeClaw 引擎实际会话创建验证），需要部署后确认 ANDC `propagation` 中出现 `x-eval-id` 字段。

## Compatibility and risk

- **生产流量**：无影响。metadata 中无 `eval_id` / `default_tag` 时不注入任何 Header
- **OpenClaw / claude_code 评测流量**：冗余但无害——sessionKey 已含 evalId，额外注入 `X-Eval-Id` Header 被 adapter 忽略
- **TeClaw 评测流量**：行为变更（HTTP Header 新增评测标识），TeClaw 引擎确认从 HTTP Header 层读取，与 `x-trace-id` 同级
- **ClawService**：未修改，不影响 ARCA 引擎路径
- **HTTP Header 兼容**：新增 `X-Eval-Id` / `X-Agentclaw-Default-Tag` Header，HTTP 协议要求服务端忽略不认识的 Header
- **回滚路径**：回退此 commit 即可恢复原行为

## Spec

系分文档 6.3 评测标全链路透