### PR TITLE
fix(bcs): allow private outbound callbacks by default

### DIFF
--- a/src/bcs/README.md
+++ b/src/bcs/README.md
@@ -298,6 +298,16 @@ Anthropic supports `json_schema` and `tool_call` for judge output.
 does not send `temperature`, because current Messages API models may reject
 non-default sampling parameters.
 
+### Outbound URL policy
+
+`security.outbound_url.block_private_networks` defaults to `false`, allowing
+Provider webhooks on private networks. Explicitly set it to `true` to reject
+non-public targets. `allow_loopback` still defaults to `false`.
+Existing configurations that explicitly set `block_private_networks = true`
+retain that policy; change the loaded configuration and restart BCS to allow
+private targets. Deployments enabling production Eventing must explicitly set
+this option to `true` because it requires strict outbound protection.
+
 ### Test organization admin-run callbacks locally
 
 Start the dependency-free callback receiver:

--- a/src/bcs/configs/bcs-config-example.toml
+++ b/src/bcs/configs/bcs-config-example.toml
@@ -317,7 +317,7 @@ provider = "noop"
 dry_run = true
 
 [security.outbound_url]
-block_private_networks = true
+block_private_networks = false
 allow_loopback = false
 
 [invite]

--- a/src/bcs/configs/bcs-config-local.toml
+++ b/src/bcs/configs/bcs-config-local.toml
@@ -229,7 +229,7 @@ max_page_limit = 100000000
 provider = "noop"
 
 [security.outbound_url]
-block_private_networks = true
+block_private_networks = false
 allow_loopback = false
 
 [invite]

--- a/src/bcs/crates/bootstrap/bcs/src/config.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/config.rs
@@ -1782,7 +1782,7 @@ botchat_url = "${BCS_TEST_FROM_FILE_MISSING}"
         assert_eq!(config.max_history_per_session, 1000);
         assert_eq!(config.provider_chat_run_timeout_ms, 10_800_000);
         assert_eq!(config.async_chat_run_timeout_ms, 7_500_000);
-        assert!(config.security.outbound_url.block_private_networks);
+        assert!(!config.security.outbound_url.block_private_networks);
         assert!(!config.security.outbound_url.allow_loopback);
         assert_eq!(
             config.group_session_ws.signing_key_secret,

--- a/src/bcs/crates/service-api/bcs-config-api/src/lib.rs
+++ b/src/bcs/crates/service-api/bcs-config-api/src/lib.rs
@@ -583,8 +583,9 @@ fn default_max_filters_per_subscription() -> u32 {
 #[serde(deny_unknown_fields)]
 pub struct OutboundUrlSecurityConfig {
     /// Reject RFC1918, link-local, loopback, unspecified, multicast,
-    /// documentation, and otherwise non-public addresses.
-    #[serde(default = "default_true")]
+    /// documentation, and otherwise non-public addresses. Disabled by default
+    /// to support providers on private networks.
+    #[serde(default)]
     pub block_private_networks: bool,
 
     /// Allow loopback hosts and loopback-resolved addresses.
@@ -595,7 +596,7 @@ pub struct OutboundUrlSecurityConfig {
 impl Default for OutboundUrlSecurityConfig {
     fn default() -> Self {
         Self {
-            block_private_networks: true,
+            block_private_networks: false,
             allow_loopback: false,
         }
     }
@@ -1586,6 +1587,23 @@ impl Default for SqliteConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn outbound_url_security_defaults_allow_private_networks() {
+        let default = OutboundUrlSecurityConfig::default();
+        assert!(!default.block_private_networks);
+        assert!(!default.allow_loopback);
+
+        for input in ["", "allow_loopback = true"] {
+            let parsed: OutboundUrlSecurityConfig = toml::from_str(input).unwrap();
+            assert!(!parsed.block_private_networks);
+        }
+
+        let strict: OutboundUrlSecurityConfig =
+            toml::from_str("block_private_networks = true").unwrap();
+        assert!(strict.block_private_networks);
+        assert!(!strict.allow_loopback);
+    }
 
     #[test]
     fn channel_config_accepts_nested_dingtalk_switch() {


### PR DESCRIPTION
## Problem

BCS rejects Provider downlink callbacks to private-network addresses when `security.outbound_url.block_private_networks` is omitted, because both the Rust default and the deserialization default are `true`. Providers deployed on an internal network therefore fail before an HTTP request is sent, with `provider webhook_url is not allowed`.

## Solution

- Default `block_private_networks` to `false` in both Rust construction and configuration deserialization.
- Align the example and local configuration templates with the new default.
- Document that production Eventing still requires an explicit `true` override. Preserve upstream's removal of the tracked production configuration file.
- Document how existing deployments adopt the new policy and add regression coverage for omitted values and an explicit `true` override.

## Validation

- Confirmed the new default regression test failed before the implementation change.
- `cargo test -p bcs-config-api --offline`: all 59 tests passed after the change.
- `git diff --check` on the changed files passed.
- Updated the bootstrap default-configuration assertion. The bootstrap test suite and full BCS/singlebox gates were not run; validation was limited to the configuration crate for this focused default change.
- The test results above precede the rebase. Rebased onto upstream `dev` at `4fecbb141`, retaining the production configuration file deletion from #1954 and updating the README accordingly. Tests were not rerun after the rebase, and Git hooks were skipped at the user's request.

## Compatibility and risk

This changes the configuration default without adding or removing configuration fields, Service API methods, or Plugin API methods. Consumers using the shared outbound policy now permit private-network targets when the option is omitted; this affects Provider webhooks and other callbacks using that policy. `allow_loopback` remains `false` by default.

Existing configurations explicitly setting `block_private_networks = true` retain their behavior. Deployments must update their loaded configuration and restart BCS to change that explicit policy. Production Eventing still requires strict outbound protection; deployments enabling it must explicitly set this option to `true`.

Rollback: explicitly set `security.outbound_url.block_private_networks = true` and restart BCS. No persistence migration or architecture-boundary waiver is required.
