### PR TITLE
fix(bcs): isolate Eventing SSRF policy and harden public config

### DIFF
--- a/src/bcs/configs/bcs-config-example.toml
+++ b/src/bcs/configs/bcs-config-example.toml
@@ -340,7 +340,7 @@ max_file_size = 5368709120
 
 [session_files.backend]
 # local:
-data_dir = "/var/bcs/session-files"
+data_dir = "/var/lib/bcs/session-files"
 # baas (when storage_backend = "baas"):
 # endpoint = "https://storage.example.com"
 # tenant = "teamclaw"

--- a/src/bcs/configs/bcs-config-example.toml
+++ b/src/bcs/configs/bcs-config-example.toml
@@ -245,12 +245,11 @@ provider = "dummy"
 
 [human_notify.providers.dummy]
 enabled = true
-# DingTalk backend options (internal builds), for illustration:
-# [human_notify.providers.dingtalk]
+# A linked notification backend can provide its own options, for example:
+# [human_notify.providers.example]
 # enabled = true
-# robot_code = "ding..."
-# client_id = "ding..."
-# client_secret = "${DINGTALK_NOTIFY_CLIENT_SECRET}"
+# endpoint = "https://notify.example.com"
+# api_key = "${NOTIFY_API_KEY}"
 
 [auth]
 chain = ["oauth_session"]
@@ -343,7 +342,7 @@ max_file_size = 5368709120
 # local:
 data_dir = "/var/bcs/session-files"
 # baas (when storage_backend = "baas"):
-# endpoint = "http://baas.xxx.xxx:8080"
+# endpoint = "https://storage.example.com"
 # tenant = "teamclaw"
 # health_probe_path = ""
 # [session_files.backend.headers]
@@ -359,5 +358,5 @@ schema_version = 1
 
 [[manifest.bundles]]
 name = "bcsPanel"
-type = "file"
-file = "assets/panel/dist/index.umd.js"
+type = "url"
+url = "https://gw.alipayobjects.com/render/p/hitu_npm/@avernet-assets/bcs-panel/1.3.0/dist/index.umd.js"

--- a/src/bcs/configs/bcs-config-example.toml
+++ b/src/bcs/configs/bcs-config-example.toml
@@ -128,6 +128,8 @@ request_timeout_ms = 10000
 max_request_timeout_ms = 30000
 max_event_body_bytes = 262144
 max_response_body_bytes = 4096
+# Eventing owns this policy independently from [security.outbound_url].
+block_private_networks = true
 allow_http_loopback = false
 allow_non_standard_ports = false
 

--- a/src/bcs/configs/bcs-config-example.toml
+++ b/src/bcs/configs/bcs-config-example.toml
@@ -359,4 +359,4 @@ schema_version = 1
 [[manifest.bundles]]
 name = "bcsPanel"
 type = "url"
-url = "https://gw.alipayobjects.com/render/p/hitu_npm/@avernet-assets/bcs-panel/1.3.0/dist/index.umd.js"
+url = "https://cdn.jsdelivr.net/npm/@avernet-assets/bcs-panel@1.3.0/dist/index.umd.js"

--- a/src/bcs/configs/bcs-config-local.toml
+++ b/src/bcs/configs/bcs-config-local.toml
@@ -110,6 +110,8 @@ request_timeout_ms = 10000
 max_request_timeout_ms = 30000
 max_event_body_bytes = 262144
 max_response_body_bytes = 4096
+# Set false only when local Eventing must reach non-loopback private targets.
+block_private_networks = true
 allow_http_loopback = true
 allow_non_standard_ports = true
 

--- a/src/bcs/crates/bootstrap/bcs/src/eventing_wiring.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/eventing_wiring.rs
@@ -82,7 +82,6 @@ pub(crate) async fn build_eventing_runtime(
     sessions: Arc<dyn SessionManagementService>,
     collaboration_runtime: Arc<dyn CollaborationRuntimeService>,
     registry: Arc<dyn BotRegistryCoreService>,
-    outbound_url_guard: OutboundUrlGuard,
     allow_local_test_endpoints: bool,
 ) -> Result<EventingRuntime> {
     config
@@ -99,11 +98,8 @@ pub(crate) async fn build_eventing_runtime(
     } else {
         WebhookEndpointPolicy::production()
     };
-    let outbound_url_guard = eventing_outbound_url_guard(
-        config,
-        outbound_url_guard,
-        allow_local_test_endpoints,
-    )?;
+    let outbound_url_guard =
+        eventing_outbound_url_guard(config, allow_local_test_endpoints)?;
     let delivery: Arc<dyn EventDeliveryPort> = Arc::new(
         WebhookClient::new(outbound_url_guard, endpoint_policy)
             .with_connect_timeout(Duration::from_millis(
@@ -209,14 +205,12 @@ pub(crate) async fn build_eventing_runtime(
 
 fn eventing_outbound_url_guard(
     config: &BcsConfig,
-    fallback: OutboundUrlGuard,
     allow_local_test_endpoints: bool,
 ) -> Result<OutboundUrlGuard> {
-    let guard = if allow_local_test_endpoints && config.eventing.webhook.allow_http_loopback {
-        OutboundUrlGuard::new(config.security.outbound_url.block_private_networks, true)
-    } else {
-        fallback
-    };
+    let guard = OutboundUrlGuard::new(
+        config.eventing.webhook.block_private_networks,
+        allow_local_test_endpoints && config.eventing.webhook.allow_http_loopback,
+    );
     guard
         .with_private_endpoint_allowlist(
             &config.eventing.webhook.private_endpoint_allowlist,
@@ -231,8 +225,7 @@ fn validate_production_security(
     if !config.eventing.enabled || allow_local_test_endpoints {
         return Ok(());
     }
-    if !config.security.outbound_url.block_private_networks
-        || config.security.outbound_url.allow_loopback
+    if !config.eventing.webhook.block_private_networks
         || config.eventing.webhook.allow_http_loopback
         || config.eventing.webhook.allow_non_standard_ports
     {
@@ -323,7 +316,7 @@ mod tests {
     fn production_eventing_rejects_weakened_outbound_security() {
         let mut config = BcsConfig::default();
         config.eventing.enabled = true;
-        config.security.outbound_url.block_private_networks = false;
+        config.eventing.webhook.block_private_networks = false;
 
         assert!(matches!(
             validate_production_security(&config, false),
@@ -333,11 +326,28 @@ mod tests {
     }
 
     #[test]
+    fn production_eventing_does_not_depend_on_shared_outbound_security() {
+        let mut config = BcsConfig::default();
+        config.eventing.enabled = true;
+        config.security.outbound_url.block_private_networks = false;
+        config.security.outbound_url.allow_loopback = true;
+
+        assert!(validate_production_security(&config, false).is_ok());
+        let guard = eventing_outbound_url_guard(&config, false)
+            .expect("Eventing guard should use its own strict policy");
+        assert!(
+            guard
+                .validate_configured_http_url("https://10.0.0.8/events")
+                .is_err()
+        );
+    }
+
+    #[test]
     fn local_eventing_guard_allows_only_loopback_from_private_address_space() {
         let mut config = BcsConfig::default();
         config.eventing.webhook.allow_http_loopback = true;
-        config.security.outbound_url.block_private_networks = true;
-        let guard = eventing_outbound_url_guard(&config, OutboundUrlGuard::strict(), true)
+        config.eventing.webhook.block_private_networks = true;
+        let guard = eventing_outbound_url_guard(&config, true)
             .expect("valid local Eventing guard");
 
         assert!(
@@ -362,7 +372,7 @@ mod tests {
                 ports: vec![443, 8443],
             },
         ];
-        let guard = eventing_outbound_url_guard(&config, OutboundUrlGuard::strict(), false)
+        let guard = eventing_outbound_url_guard(&config, false)
             .expect("valid private endpoint allowlist");
 
         assert!(guard.allows_allowlisted_host_port(

--- a/src/bcs/crates/bootstrap/bcs/src/server.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/server.rs
@@ -313,7 +313,6 @@ fn build_eventing_runtime_blocking(
     sessions: Arc<dyn SessionManagementService>,
     collaboration_runtime: Arc<dyn bcs_service_api::CollaborationRuntimeService>,
     registry: Arc<dyn BotRegistryCoreService>,
-    outbound_url_guard: OutboundUrlGuard,
     allow_local_test_endpoints: bool,
 ) -> crate::Result<crate::eventing_wiring::EventingRuntime> {
     std::thread::scope(|scope| {
@@ -328,7 +327,6 @@ fn build_eventing_runtime_blocking(
                         sessions,
                         collaboration_runtime,
                         registry,
-                        outbound_url_guard,
                         allow_local_test_endpoints,
                     ))
             })
@@ -2242,7 +2240,6 @@ let collaboration_templates = build_standalone_collaboration_template_service(&c
             session_management.clone(),
             collaboration_runtime.clone(),
             bot_registry.clone(),
-            outbound_url_guard.clone(),
             false,
         )
         .expect("default Eventing configuration must initialize");
@@ -3786,7 +3783,6 @@ let collaboration_templates = build_standalone_collaboration_template_service(&c
             session_management.clone(),
             collaboration_runtime.clone(),
             bot_registry.clone(),
-            callback_url_guard.clone(),
             allow_local_eventing_endpoints,
         )
         .expect("Eventing configuration must initialize");
@@ -4646,7 +4642,6 @@ let collaboration_templates = build_collaboration_template_service_with_storage(
             session_management.clone(),
             collaboration_runtime.clone(),
             bot_registry.clone(),
-            outbound_url_guard.clone(),
             local_eventing_endpoints_allowed(),
         )
         .await?;

--- a/src/bcs/crates/service-api/bcs-config-api/src/lib.rs
+++ b/src/bcs/crates/service-api/bcs-config-api/src/lib.rs
@@ -251,6 +251,10 @@ pub struct EventingWebhookConfig {
     pub max_event_body_bytes: usize,
     #[serde(default = "default_eventing_max_response_body_bytes")]
     pub max_response_body_bytes: usize,
+    /// Reject private and otherwise non-public webhook target addresses.
+    /// Eventing owns this policy independently from the shared outbound URL policy.
+    #[serde(default = "default_true")]
+    pub block_private_networks: bool,
     #[serde(default)]
     pub allow_http_loopback: bool,
     #[serde(default)]
@@ -267,6 +271,7 @@ impl Default for EventingWebhookConfig {
             max_request_timeout_ms: default_eventing_max_request_timeout_ms(),
             max_event_body_bytes: default_eventing_max_event_body_bytes(),
             max_response_body_bytes: default_eventing_max_response_body_bytes(),
+            block_private_networks: true,
             allow_http_loopback: false,
             allow_non_standard_ports: false,
             private_endpoint_allowlist: Vec::new(),
@@ -1849,6 +1854,7 @@ mod tests {
         assert!(!config.dispatcher_enabled);
         assert_eq!(config.worker_concurrency, 64);
         assert_eq!(config.webhook.request_timeout_ms, 10_000);
+        assert!(config.webhook.block_private_networks);
         assert_eq!(config.limits.max_filters_per_subscription, 64);
         config.validate().expect("default Eventing config is valid");
     }
@@ -1880,6 +1886,21 @@ mod tests {
         let unknown = toml::from_str::<EventingConfig>("unknown_field = true")
             .expect_err("unknown Eventing field rejected");
         assert!(unknown.to_string().contains("unknown_field"));
+    }
+
+    #[test]
+    fn eventing_webhook_private_network_policy_defaults_strict_and_can_be_configured() {
+        let default = EventingConfig::default();
+        assert!(default.webhook.block_private_networks);
+
+        let configured = toml::from_str::<EventingConfig>(
+            r#"
+            [webhook]
+            block_private_networks = false
+            "#,
+        )
+        .expect("Eventing webhook private network policy should deserialize");
+        assert!(!configured.webhook.block_private_networks);
     }
 
     #[test]

--- a/src/bcs/docs/superpowers/plans/2026-08-20-bcs-event-subscription-webhook-manual-verification.md
+++ b/src/bcs/docs/superpowers/plans/2026-08-20-bcs-event-subscription-webhook-manual-verification.md
@@ -134,6 +134,7 @@ request_timeout_ms = 2000
 max_request_timeout_ms = 30000
 max_event_body_bytes = 262144
 max_response_body_bytes = 4096
+block_private_networks = true
 allow_http_loopback = true
 allow_non_standard_ports = true
 ```
@@ -585,7 +586,8 @@ loopback/private/link-local/metadata/组播/保留 IPv4 与 IPv6。
 - local 只有显式开启时才接受 loopback HTTP 和非标准端口；
 - query、fragment、userinfo 始终拒绝；
 - 拒绝返回 400 `invalid_webhook_url`，不向目标发请求；
-- production 配置若试图弱化私网阻断、loopback 或端口策略，进程启动失败。
+- production 配置若试图通过 `eventing.webhook` 弱化私网阻断、loopback 或端口策略，进程启动失败；
+- `security.outbound_url` 的取值不改变 Eventing 的 SSRF 策略。
 
 ### MV-24 每次 Attempt 的 DNS/SSRF 校验（P0，Staging）
 

--- a/src/bcs/docs/superpowers/specs/2026-08-18-bcs-event-subscription-webhook-design.md
+++ b/src/bcs/docs/superpowers/specs/2026-08-18-bcs-event-subscription-webhook-design.md
@@ -22,7 +22,8 @@ BCS 需要在群、会话、任务、消息和状态机等业务状态发生变�
 5. 事件使用稳定 `event_id` 去重，并在确定的事件流中使用单调递增 `sequence` 表达顺序。
 6. 状态机事件默认并强制按 `run_id` 严格有序投递；前一个事件未成功时，后续事件不得越过。
 7. 聊天消息只有在逻辑消息成功持久化后才产生 `message.created`。当前静默吞掉消息写失败的行为必须改造。
-8. Webhook 投递复用现有出站 URL 安全能力，每次尝试都重新执行 SSRF 防护且不跟随重定向。MVP 面向内部服务，
+8. Webhook 投递复用现有 Outbound URL Guard 实现，但使用 Eventing 自己的安全策略配置；每次尝试都重新执行
+   SSRF 防护且不跟随重定向。MVP 面向内部服务，
    不提供 Subscription 级鉴权或签名字段。
 9. 现有 ManagerWorker Task Ledger 是否持久化不属于本设计范围；事件 Contract 不依赖其未来存储形态。
 
@@ -1515,6 +1516,7 @@ request_timeout_ms = 10000
 max_request_timeout_ms = 30000
 max_event_body_bytes = 262144
 max_response_body_bytes = 4096
+block_private_networks = true
 allow_http_loopback = false
 allow_non_standard_ports = false
 
@@ -1542,6 +1544,7 @@ max_filters_per_subscription = 64
   接受后丢 Event；
 - `enabled = false` 时普通业务 use case 仍可执行，Event Recorder 必须显式返回 `Disabled` 而不是伪装成
   `Recorded`；只有 `Recorded` 模式适用本文的 Event 完整性承诺；
+- Eventing 的 SSRF 策略只读取 `eventing.webhook`，不继承 `security.outbound_url`；
 - production 禁止通过配置关闭 SSRF guard 或 TLS 校验。
 
 Singlebox/local 模式使用 Memory Event Store 和 Recording/Localhost Webhook adapter，不需要访问外部网络。


### PR DESCRIPTION
## Problem

Eventing 的生产安全校验和 Webhook URL Guard 复用了全局
`security.outbound_url` 配置。当其他出站调用需要关闭全局私网拦截时，
即使 Eventing 配置了精确的私网 endpoint allowlist，生产 Eventing 仍会
因为全局策略被弱化而启动失败。

同时，公开的 BCS 示例配置仍包含内部通知服务示例、不适合容器卷布局的
session-file 路径，以及依赖本地文件或内部 CDN 的 Panel 资源配置，
不利于公开环境直接使用。

## Solution

- 在 `eventing.webhook` 下新增独立的 `block_private_networks` 配置：
  - 默认值为 `true`；
  - 生产环境仍禁止显式关闭；
  - Eventing 的生产校验和 Webhook URL Guard 不再读取
    `security.outbound_url`；
  - 私网 endpoint allowlist 继续按 host、CIDR 和 port 精确放行。
- 移除 Eventing bootstrap 对共享 Outbound URL Guard 参数的依赖。
- 增加回归测试，确认全局出站策略被弱化时 Eventing 仍保持严格 SSRF
  防护。
- 同步更新 Eventing 设计文档、手工验证文档以及 local/example 配置。
- 清理公开示例配置：
  - 将通知服务示例替换为通用占位配置；
  - 将 session-file 数据目录调整为 `/var/lib/bcs/session-files`；
  - 将存储 endpoint 替换为公开示例域名；
  - 通过 jsDelivr 加载 `@avernet-assets/bcs-panel@1.3.0`。

## Validation

- `cargo test -p bcs-config-api eventing_ --lib`
  - 5 passed
- `cargo test -p bcs eventing_wiring --lib`
  - 5 passed
- `cargo test -p bcs checked_in_configs_parse_without_obsolete_eventing_auth_config --lib`
  - 1 passed
- `git diff --check`
  - passed

未运行完整的 `cargo test --workspace`；本次验证聚焦于变更涉及的配置契约、
Eventing bootstrap 和仓库内配置解析路径。

## Compatibility and risk

- 配置 schema 为向后兼容的增量变更。未配置
  `eventing.webhook.block_private_networks` 时默认使用 `true`，现有生产
  配置不会因为缺少新字段而启动失败。
- `security.outbound_url` 继续控制其他出站调用，但不再影响 Eventing。
- 如果 local/dev 环境此前通过
  `security.outbound_url.block_private_networks = false` 允许 Eventing
  访问非 loopback 私网目标，现在需要显式配置：

  ```toml
  [eventing.webhook]
  block_private_networks = false
  ```

- 生产环境显式设置
  `eventing.webhook.block_private_networks = false` 仍会启动失败。
- 不涉及数据库迁移或 HTTP API Contract 变更。
- 回滚时可恢复 Eventing 对共享 Outbound URL Guard 的装配，并删除新增配置项。

## Spec

- `src/bcs/docs/superpowers/specs/2026-08-18-bcs-event-subscription-webhook-design.md`
- `src/bcs/docs/superpowers/plans/2026-08-20-bcs-event-subscription-webhook-manual-verification.md`