### PR TITLE
fix(backend): retry transient MCP device delivery

### DIFF
--- a/src/backend/src/agentclaw/community/core/devices/services/mcp_device_payload.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/mcp_device_payload.py
@@ -12,11 +12,6 @@ from agentclaw.community.log import get_logger
 
 logger = get_logger()
 
-# 重试配置
-MAX_RETRY_ATTEMPTS = 3  # 最大重试次数
-RETRY_BACKOFF_BASE = 1  # 退避基数（1s, 2s, 4s）
-
-
 class DeviceMCPConfig:
     """MCP Server 配置（符合远端设备接口）"""
 

--- a/src/backend/src/agentclaw/community/core/devices/services/mcp_device_transport.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/mcp_device_transport.py
@@ -6,6 +6,7 @@ share payload, retry, and result behavior.
 """
 from __future__ import annotations
 
+from collections.abc import Callable
 import time
 from typing import Any, Dict, List, Optional
 
@@ -14,8 +15,6 @@ from agentclaw.community.plugin_api.http_client import (
     HttpClientRequestError,
 )
 from agentclaw.community.core.devices.services.mcp_device_payload import (
-    MAX_RETRY_ATTEMPTS,
-    RETRY_BACKOFF_BASE,
     DeviceMCPConfig,
     convert_to_device_format,
     is_already_exists_error,
@@ -52,6 +51,67 @@ def mcp_base_url_from_conn_info(conn_info: Dict[str, Any]) -> str:
 
 
 _MCP_PATH = "/api/mcp"
+_MCP_RETRY_DELAYS_SECONDS = (1, 2, 4)
+_RETRYABLE_MCP_STATUS_CODES = frozenset({500, 502, 503, 504})
+
+
+def _request_with_transient_retry(
+        request: Callable[[], Any],
+        *,
+        operation: str,
+        server_code: str,
+        stop_on_already_exists: bool = False,
+) -> Any:
+    """Execute one MCP device request across the bounded startup window.
+
+    BaaS can expose a Bot before its engine Device is selectable, returning
+    ``503 NO_ACTIVE_DEVICES`` for the first few seconds.  Retry only transport
+    failures and retryable server responses; permanent 4xx responses are
+    returned immediately for the operation-specific caller to handle.
+    """
+    for attempt, delay_seconds in enumerate(
+        (*_MCP_RETRY_DELAYS_SECONDS, None), start=1
+    ):
+        try:
+            response = request()
+        except HttpClientRequestError as error:
+            if delay_seconds is None:
+                raise Exception(
+                    f"{operation} MCP failed after {attempt} attempts: {error}"
+                ) from error
+            error_detail = f"request_error={error}"
+        else:
+            response_error = Exception(
+                f"{operation} failed: {response.status_code}, {response.text}"
+            )
+            if stop_on_already_exists and is_already_exists_error(response_error):
+                return response
+            if response.status_code not in _RETRYABLE_MCP_STATUS_CODES:
+                return response
+            if delay_seconds is None:
+                raise Exception(
+                    f"{operation} MCP failed after {attempt} attempts: "
+                    f"{response_error}"
+                ) from response_error
+            reason = (
+                "NO_ACTIVE_DEVICES"
+                if "NO_ACTIVE_DEVICES" in response.text
+                else f"HTTP_{response.status_code}"
+            )
+            error_detail = f"reason={reason} response={response.text}"
+
+        logger.warning(
+            "[mcp_transport] transient MCP delivery failure; retrying "
+            "operation=%s server_code=%s attempt=%d delay_seconds=%d error=%s",
+            operation.lower(),
+            server_code,
+            attempt,
+            delay_seconds,
+            error_detail,
+        )
+        time.sleep(delay_seconds)
+
+    raise AssertionError("MCP retry loop must return or raise")
 
 
 def probe_mcp(
@@ -78,23 +138,14 @@ def filter_servers(
 
         server_codes = [get_server_code(s) for s in mcp_servers if get_server_code(s)]
 
-        response = None
-        for attempt in range(MAX_RETRY_ATTEMPTS):
-            try:
-                response = transport.post(
+        response = _request_with_transient_retry(
+            lambda: transport.post(
                     f"{_MCP_PATH}/filter-servers",
                     json={"server_codes": server_codes},
-                )
-                if response.status_code < 500:
-                    break
-                # 带容器 detail，便于定位（如 mcporter cwd deleted）。
-                raise Exception(f"Server error: {response.status_code}, {response.text}")
-            except Exception as e:
-                if attempt == MAX_RETRY_ATTEMPTS - 1:
-                    raise
-                wait = RETRY_BACKOFF_BASE * (2 ** attempt)
-                logger.warning("[filter_servers] Retry filter-servers in %ss: %s", wait, e)
-                time.sleep(wait)
+            ),
+            operation="Declare",
+            server_code=f"scope:{len(server_codes)}",
+        )
 
         if response.status_code == 200:
             result = response.json()
@@ -170,56 +221,41 @@ def remove_mcp(
 
 def _create_mcp(transport: Any, config: DeviceMCPConfig):
     """Create MCP with retry (409 不重试，直接抛出)."""
-    for attempt in range(MAX_RETRY_ATTEMPTS):
-        try:
-            response = transport.post(_MCP_PATH, json=config.to_dict())
-            if response.status_code in [200, 201]:
-                return
-            if response.status_code == 409:
-                raise Exception(f"Create failed: 409, {response.text}")
-            raise Exception(f"Create failed: {response.status_code}, {response.text}")
-        except Exception as e:
-            if is_already_exists_error(e):
-                raise
-            if attempt == MAX_RETRY_ATTEMPTS - 1:
-                raise Exception(f"Create MCP failed after {MAX_RETRY_ATTEMPTS} attempts: {e}")
-            wait = RETRY_BACKOFF_BASE * (2 ** attempt)
-            logger.warning("[_create_mcp] Retry in %ss for %s: %s", wait, config.server_code, e)
-            time.sleep(wait)
+    response = _request_with_transient_retry(
+        lambda: transport.post(_MCP_PATH, json=config.to_dict()),
+        operation="Create",
+        server_code=config.server_code,
+        stop_on_already_exists=True,
+    )
+    if response.status_code in [200, 201]:
+        return
+    raise Exception(f"Create failed: {response.status_code}, {response.text}")
 
 
 def _update_mcp(transport: Any, config: DeviceMCPConfig):
     """Update MCP with retry."""
     path = f"{_MCP_PATH}/{config.server_code}"
-    for attempt in range(MAX_RETRY_ATTEMPTS):
-        try:
-            response = transport.put(path, json=config.to_dict())
-            if response.status_code in [200, 201]:
-                return
-            raise Exception(f"Update failed: {response.status_code}, {response.text}")
-        except Exception as e:
-            if attempt == MAX_RETRY_ATTEMPTS - 1:
-                raise Exception(f"Update MCP failed after {MAX_RETRY_ATTEMPTS} attempts: {e}")
-            wait = RETRY_BACKOFF_BASE * (2 ** attempt)
-            logger.warning("[_update_mcp] Retry in %ss for %s: %s", wait, config.server_code, e)
-            time.sleep(wait)
+    response = _request_with_transient_retry(
+        lambda: transport.put(path, json=config.to_dict()),
+        operation="Update",
+        server_code=config.server_code,
+    )
+    if response.status_code in [200, 201]:
+        return
+    raise Exception(f"Update failed: {response.status_code}, {response.text}")
 
 
 def _delete_mcp(transport: Any, server_code: str):
     """Delete MCP with retry."""
     path = f"{_MCP_PATH}/{server_code}"
-    for attempt in range(MAX_RETRY_ATTEMPTS):
-        try:
-            response = transport.delete(path)
-            if response.status_code in [200, 204]:
-                return
-            if response.status_code == 404:
-                return
-            raise Exception(f"Delete failed: {response.status_code}, {response.text}")
-        except Exception as e:
-            if attempt == MAX_RETRY_ATTEMPTS - 1:
-                logger.error("[_delete_mcp] Failed after %s attempts: %s", MAX_RETRY_ATTEMPTS, e)
-                return
-            wait = RETRY_BACKOFF_BASE * (2 ** attempt)
-            logger.warning("[_delete_mcp] Retry in %ss for %s: %s", wait, server_code, e)
-            time.sleep(wait)
+    try:
+        response = _request_with_transient_retry(
+            lambda: transport.delete(path),
+            operation="Delete",
+            server_code=server_code,
+        )
+        if response.status_code in [200, 204, 404]:
+            return
+        raise Exception(f"Delete failed: {response.status_code}, {response.text}")
+    except Exception as error:
+        logger.error("[_delete_mcp] Failed: %s", error)

--- a/src/backend/tests/community/core/devices/test_mcp_device_transport.py
+++ b/src/backend/tests/community/core/devices/test_mcp_device_transport.py
@@ -2,7 +2,7 @@
 
 收编后 MCP 5 函数走注入的 ``transport``(post/get/put/delete + 相对 path），
 不再裸 httpx。用 FakeTransport 断言走了 transport，业务包装(409-as-update /
-retry / listPolicy)不变。
+bounded transient retry / listPolicy)保持一致。
 
 The transport-agnostic helpers are shared Core code; concrete HTTP transports
 remain in profile-specific composition roots. The moved Core
@@ -159,11 +159,62 @@ class TestCreateMcpNoRetryOnAlreadyExists:
 
     def test_retry_on_other_500_errors(self):
         t = FakeTransport(_resp(500, '{"detail":"Internal Server Error"}'))
-        with patch("time.sleep"):
-            with pytest.raises(Exception, match="Create MCP failed after 3 attempts"):
+        with patch("time.sleep") as sleep:
+            with pytest.raises(Exception, match="Create MCP failed after 4 attempts"):
                 mcp_transport._create_mcp(t, _make_config())
-        assert len(t.calls) == 3
+        assert len(t.calls) == 4
+        assert [call.args[0] for call in sleep.call_args_list] == [1, 2, 4]
         assert t.calls[0] == ("POST", "/api/mcp")
+
+    def test_retry_no_active_devices_then_success(self):
+        t = FakeTransport([
+            _resp(
+                503,
+                '{"detail":{"error":"NO_ACTIVE_DEVICES",'
+                '"message":"No active devices found for bot"}}',
+            ),
+            _resp(201),
+        ])
+
+        with patch("time.sleep") as sleep:
+            mcp_transport._create_mcp(t, _make_config())
+
+        assert len(t.calls) == 2
+        sleep.assert_called_once_with(1)
+
+    def test_no_active_devices_exhausts_initial_plus_three_retries(self):
+        t = FakeTransport(
+            _resp(503, '{"detail":{"error":"NO_ACTIVE_DEVICES"}}')
+        )
+
+        with patch("time.sleep") as sleep:
+            with pytest.raises(
+                Exception,
+                match="Create MCP failed after 4 attempts:.*NO_ACTIVE_DEVICES",
+            ):
+                mcp_transport._create_mcp(t, _make_config())
+
+        assert len(t.calls) == 4
+        assert [call.args[0] for call in sleep.call_args_list] == [1, 2, 4]
+
+    def test_request_error_recovers_within_bounded_retry_window(self):
+        t = FakeTransport([HttpClientRequestError("not ready"), _resp(201)])
+
+        with patch("time.sleep") as sleep:
+            mcp_transport._create_mcp(t, _make_config())
+
+        assert len(t.calls) == 2
+        sleep.assert_called_once_with(1)
+
+    def test_non_retryable_400_fails_immediately(self):
+        t = FakeTransport(_resp(400, '{"detail":"invalid config"}'))
+
+        with patch("time.sleep") as sleep:
+            with pytest.raises(Exception, match="Create failed: 400"):
+                mcp_transport._create_mcp(t, _make_config())
+
+        assert len(t.calls) == 1
+        sleep.assert_not_called()
 
 
 class TestProbeMcp:
@@ -187,12 +238,28 @@ class TestFilterServers:
         assert mcp_transport.filter_servers(t, []) is False
 
     def test_non_200(self):
-        assert mcp_transport.filter_servers(FakeTransport(_resp(400, text="bad")), []) is False
+        t = FakeTransport(_resp(400, text="bad"))
+        with patch("time.sleep") as sleep:
+            assert mcp_transport.filter_servers(t, []) is False
+        assert len(t.calls) == 1
+        sleep.assert_not_called()
 
     def test_retry_then_success(self):
         t = FakeTransport([_resp(500), _resp(200, json_body={"success": True})])
-        with patch("time.sleep"):
+        with patch("time.sleep") as sleep:
             assert mcp_transport.filter_servers(t, [{"server_code": "a"}]) is True
+        sleep.assert_called_once_with(1)
+
+    def test_no_active_devices_exhausts_initial_plus_three_retries(self):
+        t = FakeTransport(
+            _resp(503, text='{"detail":{"error":"NO_ACTIVE_DEVICES"}}')
+        )
+
+        with patch("time.sleep") as sleep:
+            assert mcp_transport.filter_servers(t, [{"server_code": "a"}]) is False
+
+        assert len(t.calls) == 4
+        assert [call.args[0] for call in sleep.call_args_list] == [1, 2, 4]
 
     def test_request_error_returns_false(self):
         with patch("time.sleep"):
@@ -223,9 +290,22 @@ class TestUpdateMcp:
         mcp_transport._update_mcp(FakeTransport(_resp(200)), _make_config())  # no raise
 
     def test_retry_exhausted_raises(self):
-        with patch("time.sleep"):
-            with pytest.raises(Exception, match="Update MCP failed after 3 attempts"):
-                mcp_transport._update_mcp(FakeTransport(_resp(500, text="err")), _make_config())
+        t = FakeTransport(_resp(500, text="err"))
+        with patch("time.sleep") as sleep:
+            with pytest.raises(Exception, match="Update MCP failed after 4 attempts"):
+                mcp_transport._update_mcp(t, _make_config())
+
+        assert len(t.calls) == 4
+        assert [call.args[0] for call in sleep.call_args_list] == [1, 2, 4]
+
+    def test_non_retryable_400_fails_immediately(self):
+        t = FakeTransport(_resp(400, text="bad request"))
+        with patch("time.sleep") as sleep:
+            with pytest.raises(Exception, match="Update failed: 400"):
+                mcp_transport._update_mcp(t, _make_config())
+
+        assert len(t.calls) == 1
+        sleep.assert_not_called()
 
 
 class TestDeleteMcp:
@@ -236,7 +316,9 @@ class TestDeleteMcp:
         mcp_transport._delete_mcp(FakeTransport(_resp(404)), "x")
 
     def test_retry_exhausted_swallows(self):
-        with patch("time.sleep"):
-            mcp_transport._delete_mcp(FakeTransport(_resp(500, text="err")), "x")  # logs + returns
+        t = FakeTransport(_resp(500, text="err"))
+        with patch("time.sleep") as sleep:
+            mcp_transport._delete_mcp(t, "x")  # logs + returns
 
-
+        assert len(t.calls) == 4
+        assert [call.args[0] for call in sleep.call_args_list] == [1, 2, 4]


### PR DESCRIPTION
## Problem

MCP device delivery can race BaaS/Desktop device startup. A Bot may resolve successfully and then return `503 NO_ACTIVE_DEVICES` when the MCP create request is sent. The existing retry loop made only three total attempts over roughly three seconds, so short readiness gaps caused the user configuration flow to fail and roll back.

The same helpers are used for allow-list declaration, create, update, and delete delivery, but their retry handling was duplicated and retried permanent errors inconsistently.

## Solution

- Centralize MCP device mutation retry handling behind one transport-neutral helper.
- Use an initial attempt plus three bounded retries at 1, 2, and 4 seconds.
- Retry request failures and server-side `500/502/503/504` responses, including explicit `NO_ACTIVE_DEVICES`.
- Fail permanent 4xx responses immediately.
- Preserve the existing create-conflict fallback to update and the existing configuration rollback semantics after retry exhaustion.
- Keep the existing `DeviceActivatedEvent` full MCP projection as the recovery path for already committed configuration; no lifecycle or public contract changes are introduced.

## Validation

- Targeted Device/MCP regression: 198 passed.
- Relevant architecture gates: 11 passed.
- Backend full suite: 17,804 passed, 60 skipped.
- Ruff on changed files: passed.
- Targeted Backend SAST on changed files: passed.
- `git diff --check`: passed.

## Compatibility and risk

No Service API, Plugin API, HTTP contract, database schema, or configuration changes. The existing rule remains unchanged: when every applicable runtime delivery fails, the user MCP configuration write is rolled back. Transient failures may now keep the synchronous request open for up to seven seconds before that rollback. OCB's ARCA and BaaS adapters consume the unchanged DeviceSync interface and require only a later ocb-public gitlink update after merge.