### PR TITLE
feat(backend): fix connection bcn flag

### DIFF
--- a/src/backend/src/agentclaw/community/core/expert_chat/services/expert_chat_service.py
+++ b/src/backend/src/agentclaw/community/core/expert_chat/services/expert_chat_service.py
@@ -601,7 +601,11 @@ class ExpertChatService(ExpertChatOwnedSessionMixin, ExpertChatSessionRuntimeMix
             raise BotNotFoundError("Session不存在或不属于当前用户")
 
         connection, need_poll = await self._prepare_chat_connection(
-            bot, user_id, owner_id, iam_token
+            bot,
+            user_id,
+            owner_id,
+            iam_token,
+            bcn_friend_authorized=bcn_friend_authorized,
         )
         if not need_poll:
             self._repo.save_session(user_id, bot_id, owner_id, session_key)

--- a/src/backend/tests/community/core/expert_chat/services/test_expert_chat_owned_session.py
+++ b/src/backend/tests/community/core/expert_chat/services/test_expert_chat_owned_session.py
@@ -94,3 +94,38 @@ async def test_empty_or_invalid_runtime_session_payload_is_rejected():
     service._transport.invoke.return_value = {"data": None}
     with pytest.raises(BotNotFoundError):
         await service.update_owned_chat_session("u", "b", "o", "s/1", {})
+
+
+@pytest.mark.asyncio
+async def test_all_owned_session_operations_propagate_bcn_authorization():
+    service = Harness()
+
+    await service.get_owned_chat_session(
+        "u", "b", "o", "s/1", bcn_friend_authorized=True
+    )
+
+    service._transport.invoke.return_value = {"data": [], "total": 0}
+    await service.list_owned_chat_session_messages(
+        "u", "b", "o", "s/1", 20, bcn_friend_authorized=True
+    )
+
+    service._transport.invoke.return_value = {"data": {"id": "s/1"}}
+    await service.update_owned_chat_session(
+        "u", "b", "o", "s/1", {}, bcn_friend_authorized=True
+    )
+    await service.clear_owned_chat_session_messages(
+        "u", "b", "o", "s/1", bcn_friend_authorized=True
+    )
+    await service.set_owned_chat_session_favorite(
+        "u", "b", "o", "s/1", True, bcn_friend_authorized=True
+    )
+
+    assert service.list_chat_sessions.await_args.kwargs["bcn_friend_authorized"] is True
+    assert all(
+        call.kwargs["bcn_friend_authorized"] is True
+        for call in service._get_authorized_chat_bot.call_args_list
+    )
+    assert all(
+        call.kwargs["bcn_friend_authorized"] is True
+        for call in service._prepare_chat_connection.await_args_list
+    )

--- a/src/backend/tests/community/core/expert_chat/services/test_expert_chat_permission.py
+++ b/src/backend/tests/community/core/expert_chat/services/test_expert_chat_permission.py
@@ -229,3 +229,85 @@ class TestExpertChatPermissionCheck:
         resolver.resolve_for_binding.assert_called_once_with(
             123, "friend1", bot_id="bot1"
         )
+
+    @pytest.mark.asyncio
+    async def test_connect_session_propagates_bcn_authorization_to_connection(self):
+        repository = MagicMock()
+        repository.list_chat_bots.return_value = [
+            {"bot_id": "bot1", "owner_id": "owner1"}
+        ]
+        repository.get_owned_session.return_value = {"session_key": "session-1"}
+        bot_repo = MagicMock()
+        bot = {
+            "bot_id": "bot1",
+            "owner_id": "owner1",
+            "public": "0",
+            "status": "ACTIVE",
+        }
+        bot_repo.get_by_id_and_owner.return_value = bot
+        service = _make_service(repository=repository, bot_repo=bot_repo)
+        service._prepare_chat_connection = AsyncMock(return_value=({"url": "ws://bot"}, False))
+
+        result = await service.connect_chat_session(
+            "friend1",
+            "bot1",
+            "owner1",
+            "session-1",
+            bcn_friend_authorized=True,
+        )
+
+        assert result["connection"] == {"url": "ws://bot"}
+        service._prepare_chat_connection.assert_awaited_once_with(
+            bot,
+            "friend1",
+            "owner1",
+            None,
+            bcn_friend_authorized=True,
+        )
+
+    @pytest.mark.asyncio
+    async def test_session_lifecycle_propagates_bcn_authorization_to_connection(self):
+        repository = MagicMock()
+        repository.list_chat_bots.return_value = [
+            {"bot_id": "bot1", "owner_id": "owner1"}
+        ]
+        repository.list_owned_sessions.return_value = [
+            {
+                "session_key": "session-1",
+                "user_id": "friend1",
+                "bot_id": "bot1",
+                "gmt_create": "2026-09-07T00:00:00Z",
+            }
+        ]
+        repository.get_owned_session.return_value = {"session_key": "session-1"}
+        bot_repo = MagicMock()
+        bot = {
+            "bot_id": "bot1",
+            "owner_id": "owner1",
+            "public": "0",
+            "status": "ACTIVE",
+        }
+        bot_repo.get_by_id_and_owner.return_value = bot
+        service = _make_service(repository=repository, bot_repo=bot_repo)
+        service._prepare_chat_connection = AsyncMock(return_value=({"url": "ws://bot"}, False))
+        service._list_owned_adapter_sessions = AsyncMock(return_value={})
+        service._create_session = AsyncMock(return_value="session-2")
+        service._delete_adapter_session = AsyncMock()
+        service._remove_session_favorite = AsyncMock()
+
+        await service.list_chat_sessions(
+            "friend1", "bot1", "owner1", bcn_friend_authorized=True
+        )
+        await service.create_chat_session(
+            "friend1", "bot1", "owner1", bcn_friend_authorized=True
+        )
+        await service.delete_owned_chat_session(
+            "friend1", "bot1", "owner1", "session-1",
+            bcn_friend_authorized=True,
+        )
+
+        assert len(service._prepare_chat_connection.await_args_list) == 3
+        assert all(
+            call.kwargs["bcn_friend_authorized"] is True
+            for call in service._prepare_chat_connection.await_args_list
+        )


### PR DESCRIPTION
Problem
OpenAPI 好友聊天接口已通过 BCN 完成好友关系鉴权，但 ExpertChat 在获取 Bot Runtime 连接时仍会重复执行旧的 owner/public/collaborator 权限校验。
其中 GET /openapi/v1/bots/{bot_id}/connection 的调用链还存在授权状态透传遗漏：
OpenAPI Router
→ connect_chat_session
→ _prepare_chat_connection
→ _get_connection
bcn_friend_authorized=True 没有从 connect_chat_session 继续传递到 _prepare_chat_connection，最终恢复为默认值 False。因此，合法 BCN 好友访问私有 Bot 时会抛出 ChatPermissionError，并对外返回 500 Internal Server Error。
Solution
- 在 connect_chat_session 调用 _prepare_chat_connection 时继续传递 bcn_friend_authorized。
- 检查所有支持 f_user_id 的好友聊天 Session 和 Connection 接口，确认授权状态在 Router、ExpertChat Service、Owned Session helper 和 Runtime Connection 之间完整传递。
- 增加 Session 生命周期和 Owned Session 操作的参数透传回归测试，覆盖：
  - Session 列表、创建、连接和删除
  - Session 详情、更新和收藏
  - 消息查询和消息清理
- 保留 Bot 存在性、状态、聊天列表及 Session 归属校验，仅跳过 BCN 已完成的重复旧权限校验。
Validation
- 好友 Session、Connection 和 ExpertChat 调用链测试：132 passed
- 完整 ExpertChat 服务相关回归：200 passed
- Gateway WebSocket 路由、鉴权、路径重写及双向通信测试：237 passed
- Ruff：通过
- git diff --check：通过
- git diff --check：通过
- 未执行完整 Backend 测试套件；已运行本次变更直接涉及的 ExpertChat 和 OpenAPI 回归测试。
Compatibility and risk
- bcn_friend_authorized 默认为 False，未传 f_user_id 的原有调用仍执行 owner/public/collaborator 权限校验。
- 只有 OpenAPI 在 BCN 好友关系验证成功后才会传入 True，客户端不能直接控制该内部授权状态。
- 不改变既有 Session ID、请求参数、响应结构或 WebSocket 消息协议。
- 未修改前端、Gateway、BCS、Engine 或其他模块。
- 回滚时可撤销授权状态的中间透传及对应测试；旧业务路径不需要数据迁移。