### PR TITLE
fix(backend): make installation read gate DB-configurable

### DIFF
--- a/src/backend/src/agentclaw/community/core/skill_center/AGENTS.md
+++ b/src/backend/src/agentclaw/community/core/skill_center/AGENTS.md
@@ -70,7 +70,7 @@ Bot 定位必须携带 `owner_id + bot_id`，并保持 Repository 的 tenant/env
 - `CapabilityDesiredStateRepository` 是 Set state、membership、Default exclusion 与 Skill/MCP Installation 的事务写入入口；表级 SQL owner 使用同一个事务 Session。
 - 普通 Set 新建默认 `is_active=True`。active Set 增删成员同步维护 Installation；inactive Set 编辑不要求 Runtime 投影。
 - `services/bot_capability_state_reader.py` 在读有效态前同步 Installation，然后只从 Installation 读取有效身份。Center 资产在返回前由 `SkillVersionResolver` 解析到精确 PUBLISHED Version。
-- Reader 的 `InstallationReadConfig` 由 `ConfigModule` 从 YAML `user_config.skill_installation.default_sync_only` 按规范化环境选择，`pre`、`prod` 缺省均为 `false`；旧 `SC_INSTALLATION_DEFAULT_SYNC_ONLY` 环境变量不再生效。验收某个环境的完整 backfill 后，才可单独将该环境置为 `true` 并重新部署 Backend。该模式仍同步 Default/exclusion，不等于完全取消 DB 补齐。运维 backfill 和新 Bot 的 `initialize_installations` 始终完整执行，不受此读侧配置影响。
+- Reader 的 `InstallationReadConfig` 从 `ac_common_config` 按规范化环境读取 `business_code=skill_installation`、`param_code=default_sync_only`。每个环境有独立记录，缺失、禁用、读取失败或非布尔值均 fail-safe 为 `false`（完整同步）；该值在每次 Effective Read 动态读取，因此验收某环境完整 backfill 后可将其单独设为 `true`，也可仅通过 DB 立即回退。旧 YAML 和 `SC_INSTALLATION_DEFAULT_SYNC_ONLY` 环境变量均不生效。该模式仍同步 Default/exclusion，不等于完全取消 DB 补齐。运维 backfill 和新 Bot 的 `initialize_installations` 始终完整执行，不受此读侧配置影响。
 - 普通 Asset、Draft、Version 查询不应为方便而触发 Bot flush。需要回答“Bot 当前应有哪些有效能力”时才使用 Reader。
 - `policies/capability_ownership.py` 统一判定：Set 成员（含 inactive Set 和 excluded Default member）由 Set 控制；Direct-active 能力加入 Set 前先停用；同一 Bot 下只能属于一个 reaching Set（含 Default）。`RESOURCE_DIRECT_ACTIVE` 优先于另一个 Set 冲突。
 - Default member 被 exclusion 后仍属于 Default；重新启用走 un-exclude。Default 选择统一使用 `policies/default_skill_set_selection.py`，保留全局 Default 与 engine/template 兼容规则。

--- a/src/backend/src/agentclaw/community/core/skill_center/README.md
+++ b/src/backend/src/agentclaw/community/core/skill_center/README.md
@@ -140,6 +140,7 @@ internal_dependencies:
   - agentclaw.community.core.access
   - agentclaw.community.core.base
   - agentclaw.community.core.bot_collaborator
+  - agentclaw.community.core.common_config
   - agentclaw.community.core.bot_management
   - agentclaw.community.core.config
   - agentclaw.community.core.config_compose

--- a/src/backend/src/agentclaw/community/core/skill_center/installation_read_config.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/installation_read_config.py
@@ -1,10 +1,73 @@
-"""Resolved Installation read mode; deployment parsing belongs to DI."""
+"""Runtime-configurable Installation Reader migration gate."""
 
-from dataclasses import dataclass
+from __future__ import annotations
+
+from typing import Any
+
+from agentclaw.community.core.common_config.common_config_service_protocol import (
+    CommonConfigServiceProtocol,
+)
+from agentclaw.community.log import get_logger
 
 
-@dataclass(frozen=True)
+logger = get_logger()
+
+INSTALLATION_READ_BUSINESS_CODE = "skill_installation"
+INSTALLATION_READ_PARAM_CODE = "default_sync_only"
+
+
 class InstallationReadConfig:
-    """False retains full repair until this environment's backfill is accepted."""
+    """Resolve the migration mode from ``ac_common_config`` for one environment.
 
-    default_sync_only: bool = False
+    A missing, disabled, unreadable, or malformed record deliberately keeps the
+    complete repair path enabled. The value is read on each effective-capability
+    access so an operator can roll an accepted environment back through DB
+    configuration without waiting for a process restart or release.
+
+    ``default_sync_only`` constructor argument exists only for direct unit-test wiring. The
+    production DI binding always supplies ``common_config_service`` and ``env``.
+    """
+
+    def __init__(
+        self,
+        default_sync_only: bool = False,
+        *,
+        common_config_service: CommonConfigServiceProtocol | None = None,
+        env: str | None = None,
+    ) -> None:
+        self._static_default_sync_only = default_sync_only
+        self._common_config_service = common_config_service
+        self._env = env
+
+    @property
+    def default_sync_only(self) -> bool:
+        """Return the current environment's DB-owned migration switch."""
+        if self._common_config_service is None or self._env is None:
+            return self._static_default_sync_only
+        try:
+            value: Any = self._common_config_service.get_value(
+                business_code=INSTALLATION_READ_BUSINESS_CODE,
+                param_code=INSTALLATION_READ_PARAM_CODE,
+                env=self._env,
+                default=False,
+                only_enabled=True,
+            )
+        except Exception:
+            logger.exception(
+                "[installation_read_config] common config read failed env=%s; "
+                "retaining complete installation repair",
+                self._env,
+            )
+            return False
+        if type(value) is bool:
+            return value
+        if value is not False:
+            logger.warning(
+                "[installation_read_config] invalid common config value env=%s "
+                "business_code=%s param_code=%s value=%r; retaining complete repair",
+                self._env,
+                INSTALLATION_READ_BUSINESS_CODE,
+                INSTALLATION_READ_PARAM_CODE,
+                value,
+            )
+        return False

--- a/src/backend/src/agentclaw/community/di/modules/installation_read_config_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/installation_read_config_module.py
@@ -1,40 +1,24 @@
-"""InstallationReadConfig binding for the completed-backfill migration gate."""
+"""Installation Reader binding for the DB-owned completed-backfill gate."""
 
 from __future__ import annotations
 
 from injector import Module, provider, singleton
 
-from agentclaw.community.core.skill_center.installation_read_config import (
-    InstallationReadConfig,
-)
-from agentclaw.community.di.modules import config_module
-from agentclaw.community.log import get_logger
+from agentclaw.community.api.common_config_service import CommonConfigServiceProtocol
+from agentclaw.community.core.skill_center.installation_read_config import InstallationReadConfig
 from agentclaw.community.utils.env_utils import get_current_env
 
 
-logger = get_logger()
-
-
 class InstallationReadConfigModule(Module):
-    """Bind the environment-specific Installation Reader mode."""
+    """Bind a runtime DB-configured Installation Reader mode."""
 
     @singleton
     @provider
-    def installation_read(self) -> InstallationReadConfig:
-        """Choose Default-only sync only for an explicitly accepted environment."""
-        block = config_module.read_user_config().get("skill_installation", {})
-        if not isinstance(block, dict) or set(block) - {"default_sync_only"}:
-            raise ValueError("skill_installation must contain only default_sync_only")
-        modes = block.get("default_sync_only", {})
-        if not isinstance(modes, dict) or set(modes) - {"pre", "prod"}:
-            raise ValueError("skill_installation.default_sync_only must map pre/prod")
-        if any(type(value) is not bool for value in modes.values()):
-            raise ValueError("skill_installation.default_sync_only values must be booleans")
-        env = get_current_env()
-        config = InstallationReadConfig(default_sync_only=modes.get(env, False))
-        logger.info(
-            "[installation_read_config] env=%s default_sync_only=%s",
-            env,
-            config.default_sync_only,
+    def installation_read(
+        self, common_config_service: CommonConfigServiceProtocol
+    ) -> InstallationReadConfig:
+        """Use the normalized deployment environment's ``ac_common_config`` row."""
+        return InstallationReadConfig(
+            common_config_service=common_config_service,
+            env=get_current_env(),
         )
-        return config

--- a/src/backend/tests/community/di/modules/test_installation_read_config.py
+++ b/src/backend/tests/community/di/modules/test_installation_read_config.py
@@ -1,65 +1,125 @@
-"""Installation migration mode is YAML-owned and environment-isolated."""
+"""Installation migration mode is DB-owned and environment-isolated."""
 
 from unittest.mock import Mock
 
 import pytest
 from injector import Injector, InstanceProvider
 
+from agentclaw.community.api.common_config_service import CommonConfigServiceProtocol
 from agentclaw.community.core.repository.protocols.bot import BotRepository
-from agentclaw.community.core.repository.protocols.capability_desired_state import CapabilityDesiredStateRepositoryProtocol
-from agentclaw.community.core.repository.protocols.skills_pool import SkillsPoolSkillRepositoryProtocol
-from agentclaw.community.core.skill_center.installation_read_config import InstallationReadConfig
-from agentclaw.community.core.skill_center.services.bot_capability_state_reader import BotCapabilityStateReader
-from agentclaw.community.core.skill_center.version_resolution_contract import SkillVersionResolverProtocol
-from agentclaw.community.di.modules import config_module
+from agentclaw.community.core.repository.protocols.capability_desired_state import (
+    CapabilityDesiredStateRepositoryProtocol,
+)
+from agentclaw.community.core.repository.protocols.skills_pool import (
+    SkillsPoolSkillRepositoryProtocol,
+)
+from agentclaw.community.core.skill_center.installation_read_config import (
+    INSTALLATION_READ_BUSINESS_CODE,
+    INSTALLATION_READ_PARAM_CODE,
+    InstallationReadConfig,
+)
+from agentclaw.community.core.skill_center.services.bot_capability_state_reader import (
+    BotCapabilityStateReader,
+)
+from agentclaw.community.core.skill_center.version_resolution_contract import (
+    SkillVersionResolverProtocol,
+)
 from agentclaw.community.di.modules.installation_read_config_module import (
     InstallationReadConfigModule,
 )
 
 
-@pytest.mark.parametrize("environment,expected", [("pre", True), ("prepub", True), ("prod", False), ("gray", False), ("dev", False)])
-def test_environment_selection_and_reader_injection(monkeypatch, environment, expected):
-    monkeypatch.setenv("SERVER_ENV", environment)
-    monkeypatch.setenv("SC_INSTALLATION_DEFAULT_SYNC_ONLY", "true")
-    monkeypatch.setattr(config_module, "read_user_config", lambda: {
-        "skill_installation": {"default_sync_only": {"pre": True, "prod": False}}
-    })
-    injector = Injector([config_module.ConfigModule(), InstallationReadConfigModule()])
+def _injector(*, common_config: Mock) -> Injector:
+    injector = Injector([InstallationReadConfigModule()])
     repository = Mock()
-    for protocol, value in [(CapabilityDesiredStateRepositoryProtocol, repository),
-                            (BotRepository, Mock()), (SkillsPoolSkillRepositoryProtocol, Mock()),
-                            (SkillVersionResolverProtocol, Mock())]:
+    for protocol, value in [
+        (CommonConfigServiceProtocol, common_config),
+        (CapabilityDesiredStateRepositoryProtocol, repository),
+        (BotRepository, Mock()),
+        (SkillsPoolSkillRepositoryProtocol, Mock()),
+        (SkillVersionResolverProtocol, Mock()),
+    ]:
         injector.binder.bind(protocol, to=InstanceProvider(value))
+    return injector
+
+
+@pytest.mark.parametrize(
+    ("environment", "expected"),
+    [
+        ("pre", True),
+        ("prepub", True),
+        ("prod", False),
+        ("gray", False),
+        ("dev", False),
+    ],
+)
+def test_environment_scoped_common_config_drives_reader(monkeypatch, environment, expected):
+    monkeypatch.setenv("SERVER_ENV", environment)
+    common_config = Mock()
+    common_config.get_value.return_value = expected
+    injector = _injector(common_config=common_config)
+    repository = injector.get(CapabilityDesiredStateRepositoryProtocol)
+
     reader = injector.get(BotCapabilityStateReader)
-    reader.synchronize_installations(bot_id="default", owner_id="owner", bot={
-        "bot_id": "default", "owner_id": "owner", "env": "pre" if expected else "prod",
-        "active_engine": "openclaw",
-    })
+    reader.synchronize_installations(
+        bot_id="default",
+        owner_id="owner",
+        bot={
+            "bot_id": "default",
+            "owner_id": "owner",
+            "env": "pre" if expected else "prod",
+            "active_engine": "openclaw",
+        },
+    )
+
     assert repository.sync_default_installations.called is expected
     assert repository.flush_installations.called is not expected
-    assert injector.get(InstallationReadConfig).default_sync_only is expected
+    common_config.get_value.assert_called_with(
+        business_code=INSTALLATION_READ_BUSINESS_CODE,
+        param_code=INSTALLATION_READ_PARAM_CODE,
+        env={"prepub": "pre", "gray": "prod"}.get(environment, environment),
+        default=False,
+        only_enabled=True,
+    )
 
 
-@pytest.mark.parametrize("user_config", [{}, {"skill_installation": {}}, {"skill_installation": {"default_sync_only": {}}}])
-def test_missing_settings_are_disabled(monkeypatch, user_config):
-    monkeypatch.setenv("SC_INSTALLATION_DEFAULT_SYNC_ONLY", "true")
-    monkeypatch.setattr(config_module, "read_user_config", lambda: user_config)
-    assert InstallationReadConfigModule().installation_read() == InstallationReadConfig()
+@pytest.mark.parametrize("value", [None, "true", 1, {}, []])
+def test_missing_disabled_or_invalid_config_retains_complete_repair(value):
+    common_config = Mock()
+    common_config.get_value.return_value = value
+    config = InstallationReadConfig(common_config_service=common_config, env="pre")
+
+    assert config.default_sync_only is False
 
 
-@pytest.mark.parametrize("environment,expected", [("pre", False), ("prod", True)])
-def test_production_switch_does_not_enable_pre(monkeypatch, environment, expected):
-    monkeypatch.setenv("SERVER_ENV", environment)
-    monkeypatch.setattr(config_module, "read_user_config", lambda: {
-        "skill_installation": {"default_sync_only": {"prod": True}}
-    })
-    assert InstallationReadConfigModule().installation_read().default_sync_only is expected
+def test_common_config_read_error_retains_complete_repair():
+    common_config = Mock()
+    common_config.get_value.side_effect = RuntimeError("database unavailable")
+    config = InstallationReadConfig(common_config_service=common_config, env="prod")
+
+    assert config.default_sync_only is False
 
 
-@pytest.mark.parametrize("block", [None, True, {"typo": True}, {"default_sync_only": None},
-    {"default_sync_only": True}, {"default_sync_only": {"pre": "false"}},
-    {"default_sync_only": {"prod": 1}}, {"default_sync_only": {"prd": True}}])
-def test_invalid_settings_fail_explicitly(monkeypatch, block):
-    monkeypatch.setattr(config_module, "read_user_config", lambda: {"skill_installation": block})
-    with pytest.raises(ValueError, match="skill_installation"):
-        InstallationReadConfigModule().installation_read()
+def test_db_value_is_read_dynamically_for_emergency_rollback():
+    common_config = Mock()
+    common_config.get_value.side_effect = [True, False]
+    config = InstallationReadConfig(common_config_service=common_config, env="pre")
+
+    assert config.default_sync_only is True
+    assert config.default_sync_only is False
+    assert common_config.get_value.call_count == 2
+
+
+def test_pre_and_prod_read_independent_common_config_records():
+    common_config = Mock()
+    common_config.get_value.side_effect = lambda **kwargs: {
+        "pre": True,
+        "prod": False,
+    }[kwargs["env"]]
+
+    assert InstallationReadConfig(
+        common_config_service=common_config, env="pre"
+    ).default_sync_only is True
+    assert InstallationReadConfig(
+        common_config_service=common_config, env="prod"
+    ).default_sync_only is False


### PR DESCRIPTION
## Problem
The completed-backfill migration gate was static YAML, so an emergency rollback required a Backend release.

## Solution
Read `skill_installation/default_sync_only` from the environment-scoped `ac_common_config` record on every Effective Read. Missing, disabled, malformed, or unreadable values retain full installation repair.

## Validation
- `pytest tests/community/di/modules/test_installation_read_config.py tests/community/core/skill_center/test_bot_capability_state_reader.py tests/community/architecture/test_architecture_compliance.py -q` (29 passed)
- `ruff check` on changed Python modules
- `git diff --check`

## Compatibility and risk
The default is unchanged: full repair. The new gate becomes active only through an enabled boolean DB record for the deployment environment. Default/exclusion synchronization, new-Bot initialization, and operational backfill remain complete.