### PR TITLE
fix(bcs): preserve request correlation in diagnostic logs

### DIFF
--- a/src/bcs/Cargo.lock
+++ b/src/bcs/Cargo.lock
@@ -1879,12 +1879,15 @@ dependencies = [
  "bcs-domain",
  "bcs-human-notify-api",
  "bcs-llm-api",
+ "bcs-observability",
  "bcs-service-api",
  "bcs-session",
  "bcs-session-file",
  "serde_json",
  "sha2",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/src/bcs/crates/adapters/http/bcs-http/Cargo.toml
+++ b/src/bcs/crates/adapters/http/bcs-http/Cargo.toml
@@ -52,6 +52,7 @@ reqwest         = { workspace = true }
 bcs-test-support = { workspace = true }
 
 [dev-dependencies]
+bcs-test-support = { workspace = true, features = ["diagnostic-logs"] }
 futures = { workspace = true }
 bcs-app-session = { workspace = true }
 bcs-config = { workspace = true }

--- a/src/bcs/crates/adapters/http/bcs-http/src/admin_invocation_terminal.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/admin_invocation_terminal.rs
@@ -65,7 +65,7 @@ impl AdminInvocationTerminalObserver {
                 Ok(url) => url,
                 Err(error) => {
                     warn!(
-                        request_id = %bcs_observability::current_request_id(),
+                        request_id = %bcs_observability::CurrentRequestId,
                         run_id = %run_id,
                         provider_id = %provider_id,
                         callback_url = %callback_url,
@@ -86,7 +86,7 @@ impl AdminInvocationTerminalObserver {
                 Ok(client) => client,
                 Err(error) => {
                     warn!(
-                        request_id = %bcs_observability::current_request_id(),
+                        request_id = %bcs_observability::CurrentRequestId,
                         run_id = %run_id,
                         provider_id = %provider_id,
                         callback_url = %callback_url,
@@ -108,10 +108,10 @@ impl AdminInvocationTerminalObserver {
                     info!(run_id = %run_id, "organization admin terminal callback acknowledged")
                 }
                 Ok(response) => {
-                    warn!(request_id = %bcs_observability::current_request_id(), run_id = %run_id, status = %response.status(), "organization admin terminal callback was not acknowledged")
+                    warn!(request_id = %bcs_observability::CurrentRequestId, run_id = %run_id, status = %response.status(), "organization admin terminal callback was not acknowledged")
                 }
                 Err(error) => {
-                    warn!(request_id = %bcs_observability::current_request_id(), run_id = %run_id, error = %error, "organization admin terminal callback failed")
+                    warn!(request_id = %bcs_observability::CurrentRequestId, run_id = %run_id, error = %error, "organization admin terminal callback failed")
                 }
             }
         }));

--- a/src/bcs/crates/adapters/http/bcs-http/src/admin_invocation_terminal.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/admin_invocation_terminal.rs
@@ -65,6 +65,7 @@ impl AdminInvocationTerminalObserver {
                 Ok(url) => url,
                 Err(error) => {
                     warn!(
+                        request_id = %bcs_observability::current_request_id(),
                         run_id = %run_id,
                         provider_id = %provider_id,
                         callback_url = %callback_url,
@@ -85,6 +86,7 @@ impl AdminInvocationTerminalObserver {
                 Ok(client) => client,
                 Err(error) => {
                     warn!(
+                        request_id = %bcs_observability::current_request_id(),
                         run_id = %run_id,
                         provider_id = %provider_id,
                         callback_url = %callback_url,
@@ -106,10 +108,10 @@ impl AdminInvocationTerminalObserver {
                     info!(run_id = %run_id, "organization admin terminal callback acknowledged")
                 }
                 Ok(response) => {
-                    warn!(run_id = %run_id, status = %response.status(), "organization admin terminal callback was not acknowledged")
+                    warn!(request_id = %bcs_observability::current_request_id(), run_id = %run_id, status = %response.status(), "organization admin terminal callback was not acknowledged")
                 }
                 Err(error) => {
-                    warn!(run_id = %run_id, error = %error, "organization admin terminal callback failed")
+                    warn!(request_id = %bcs_observability::current_request_id(), run_id = %run_id, error = %error, "organization admin terminal callback failed")
                 }
             }
         }));

--- a/src/bcs/crates/adapters/http/bcs-http/src/gateway_trace.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/gateway_trace.rs
@@ -141,7 +141,8 @@ pub async fn observe_request(
     tracing::info!(target: "bcs_http_access", request_id = %observation.request_id,
         route = %observation.route,
         status = response.status().as_u16(), duration_ms = elapsed.as_secs_f64() * 1000.0,
-        outcome = if response.status().is_success() { "success" } else { "http_error" },
+        outcome = if response.status() == axum::http::StatusCode::SWITCHING_PROTOCOLS { "upgraded" }
+            else if response.status().is_success() { "success" } else { "http_error" },
         "http.request.response_ready");
     response
 }

--- a/src/bcs/crates/adapters/http/bcs-http/src/gateway_trace.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/gateway_trace.rs
@@ -138,11 +138,13 @@ pub async fn observe_request(
     let elapsed = observation.started.elapsed();
     response.headers_mut().insert("x-request-id", header);
     observation.completed = true;
+    let outcome = if response.status() == axum::http::StatusCode::SWITCHING_PROTOCOLS {
+        "upgraded"
+    } else if response.status().is_success() { "success" } else { "http_error" };
     tracing::info!(target: "bcs_http_access", request_id = %observation.request_id,
         route = %observation.route,
         status = response.status().as_u16(), duration_ms = elapsed.as_secs_f64() * 1000.0,
-        outcome = if response.status() == axum::http::StatusCode::SWITCHING_PROTOCOLS { "upgraded" }
-            else if response.status().is_success() { "success" } else { "http_error" },
+        outcome,
         "http.request.response_ready");
     response
 }

--- a/src/bcs/crates/adapters/http/bcs-http/src/oauth/diagnostics_test.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/oauth/diagnostics_test.rs
@@ -1,0 +1,366 @@
+use super::*;
+use async_trait::async_trait;
+use axum::body::to_bytes;
+use bcs_auth_api::{AuthError, AuthPlugin, AuthPluginChain, AuthPrincipal, UserIdentityInfo};
+use bcs_test_support::{capture_request_logs, MockFailure, MockOAuthProvider};
+use serde_json::Value;
+use std::sync::Mutex;
+
+const JWT_SECRET: &str = "private-oauth-diagnostic-secret-32-bytes";
+const AUTH_CODE: &str = "private-oauth-diagnostic-code";
+const USER_ID: &str = "oauth-diagnostic-user";
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum Failure {
+    Exchange,
+    UserInfo,
+    Ensure,
+    UpdateToken,
+    LookupToken,
+    LookupUser,
+}
+
+struct FailingIdentity {
+    failure: Failure,
+    calls: Mutex<Vec<&'static str>>,
+    bound_hash: Mutex<Option<String>>,
+    writes: Mutex<Vec<(String, String, u64)>>,
+}
+
+impl FailingIdentity {
+    fn new(failure: Failure) -> Self {
+        Self {
+            failure,
+            calls: Mutex::new(Vec::new()),
+            bound_hash: Mutex::new(None),
+            writes: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn record(&self, call: &'static str, failure: Failure) -> Result<(), AuthError> {
+        self.calls.lock().unwrap().push(call);
+        if self.failure == failure {
+            Err(AuthError::LookupFailed("identity store unavailable".into()))
+        } else {
+            Ok(())
+        }
+    }
+
+    fn info() -> UserIdentityInfo {
+        UserIdentityInfo {
+            user_id: USER_ID.into(),
+            auth_source: "google".into(),
+            user_name: Some("Current Name".into()),
+            external_user_name: None,
+            avatar: None,
+        }
+    }
+}
+
+#[async_trait]
+impl UserIdentityPort for FailingIdentity {
+    async fn ensure_identity(
+        &self, source: &str, external_id: &str, name: Option<&str>,
+        avatar: Option<&str>, env: &str,
+    ) -> Result<String, AuthError> {
+        assert_eq!((source, external_id, name, avatar, env),
+            ("google", "external-42", Some("Mock User"), None, "test"));
+        self.record("ensure", Failure::Ensure)?;
+        Ok(USER_ID.into())
+    }
+
+    async fn lookup_by_user_id(&self, _: &str, _: &str) -> Result<Option<String>, AuthError> {
+        panic!("OAuth flows must use the full identity lookup contract")
+    }
+
+    async fn get_identity_by_token(&self, token_hash: &str) -> Result<Option<UserIdentityInfo>, AuthError> {
+        assert_eq!(self.bound_hash.lock().unwrap().as_deref(), Some(token_hash));
+        self.record("lookup_token", Failure::LookupToken)?;
+        Ok(Some(Self::info()))
+    }
+
+    async fn get_identity_by_user_id(&self, user_id: &str) -> Result<Option<UserIdentityInfo>, AuthError> {
+        assert_eq!(user_id, USER_ID);
+        self.record("lookup_user", Failure::LookupUser)?;
+        Ok(Some(Self::info()))
+    }
+
+    async fn update_token(&self, user_id: &str, hash: &str, expires: u64) -> Result<(), AuthError> {
+        assert_eq!(user_id, USER_ID);
+        self.writes.lock().unwrap().push((user_id.into(), hash.into(), expires));
+        self.record("update_token", Failure::UpdateToken)?;
+        *self.bound_hash.lock().unwrap() = Some(hash.into());
+        Ok(())
+    }
+}
+
+fn state(failure: Failure) -> (Arc<OAuthRouteState>, Arc<FailingIdentity>) {
+    let port = Arc::new(FailingIdentity::new(failure));
+    let provider = MockOAuthProvider::new("google", "external-42").with_failure(match failure {
+        Failure::Exchange => MockFailure::Exchange,
+        Failure::UserInfo => MockFailure::UserInfo,
+        _ => MockFailure::None,
+    });
+    let providers: HashMap<String, Arc<dyn OAuthProvider>> = HashMap::from([
+        ("google".into(), Arc::new(provider) as Arc<dyn OAuthProvider>),
+    ]);
+    let state = OAuthRouteState::new(JWT_SECRET, port.clone(), providers, OAuthConfig {
+        jwt_secret: JWT_SECRET.into(),
+        idle_timeout_minutes: 30,
+        base_url: "https://bcs.example.com".into(),
+        cookie_secure: true,
+        env: "test".into(),
+        success_redirect_path: "/".into(),
+    }, None);
+    (Arc::new(state), port)
+}
+
+fn warning<'a>(events: &'a [Value], request_id: &str, message: &str) -> &'a Value {
+    let matching: Vec<_> = events.iter().filter(|event| event["fields"]["message"] == message).collect();
+    assert_eq!(matching.len(), 1, "expected one {message}: {events:?}");
+    let event = matching[0];
+    assert_eq!(event["level"], "WARN");
+    assert_eq!(event["fields"]["request_id"], request_id);
+    event
+}
+
+fn assert_no_credentials(events: &[Value], secrets: &[&str]) {
+    let logs = serde_json::to_string(events).unwrap();
+    for secret in secrets {
+        assert!(!logs.contains(secret), "OAuth credentials must not appear in diagnostic logs");
+    }
+}
+
+async fn assert_failure_response(response: axum::response::Response, status: StatusCode, body: &str) {
+    assert_eq!(response.status(), status);
+    assert!(!response.headers().contains_key("set-cookie"), "failed authentication must not issue a session");
+    assert!(!response.headers().contains_key("location"), "failed authentication must not redirect as success");
+    let bytes = to_bytes(response.into_body(), 4096).await.unwrap();
+    assert_eq!(std::str::from_utf8(&bytes).unwrap(), body);
+}
+
+fn expected_calls(failure: Failure) -> Vec<&'static str> {
+    match failure {
+        Failure::Exchange | Failure::UserInfo => vec![],
+        Failure::Ensure => vec!["ensure"],
+        Failure::UpdateToken => vec!["ensure", "update_token"],
+        _ => panic!("expected login failure"),
+    }
+}
+
+const LOGIN_FAILURES: [(Failure, &str, &str, &str); 4] = [
+    (Failure::Exchange, "OAuth token exchange failed", "token_exchange_failed", "token exchange failed"),
+    (Failure::UserInfo, "OAuth userinfo failed", "userinfo_request_failed", "userinfo request failed"),
+    (Failure::Ensure, "ensure_identity failed", "internal_error", "identity creation failed"),
+    (Failure::UpdateToken, "update_token failed; aborting login", "internal_error", "session creation failed"),
+];
+
+#[tokio::test]
+async fn service_login_failures_keep_request_id_and_preserve_application_errors() {
+    for (failure, message, code, public_message) in LOGIN_FAILURES {
+        let (state, port) = state(failure);
+        let csrf = state.state_store.generate("google").await;
+        let request_id = format!("oauth-service-login-{failure:?}");
+        let request = CompleteOAuthLogin {
+            provider: "google".into(), code: Some(AUTH_CODE.into()), auth_code: None,
+            state: csrf.clone(), callback_base_url: "https://bcs.example.com/openapi/v1/auth/callback".into(),
+        };
+        let (result, logs) = capture_request_logs(&request_id, state.complete_login(request.clone())).await;
+        let error = result.unwrap_err();
+        assert_eq!(error.code(), code);
+        match error {
+            ApplicationError::BadGateway { message, .. } | ApplicationError::Internal(message) => {
+                assert_eq!(message, public_message);
+            }
+            other => panic!("unexpected application error: {other}"),
+        }
+        let event = warning(&logs, &request_id, message);
+        assert!(event["fields"]["error"].as_str().is_some_and(|value| !value.is_empty()));
+        if matches!(failure, Failure::Exchange | Failure::UserInfo) {
+            assert_eq!(event["fields"]["provider"], "google");
+        }
+        assert_eq!(*port.calls.lock().unwrap(), expected_calls(failure));
+        assert!(port.bound_hash.lock().unwrap().is_none());
+        assert_no_credentials(&logs, &[AUTH_CODE, JWT_SECRET, &csrf]);
+        assert_eq!(state.complete_login(request).await.unwrap_err().code(), "invalid_state",
+            "a failed login must still consume the one-use CSRF state");
+    }
+}
+
+#[tokio::test]
+async fn callback_dependency_failures_keep_request_id_and_do_not_issue_cookies() {
+    for (failure, message, _, body) in LOGIN_FAILURES {
+        let (state, port) = state(failure);
+        let csrf = state.state_store.generate("google").await;
+        let request_id = format!("oauth-callback-{failure:?}");
+        let (response, logs) = capture_request_logs(&request_id, callback_handler(
+            State(state), Path("google".into()), axum::extract::Query(CallbackParams {
+                code: Some(AUTH_CODE.into()), auth_code: None, state: csrf.clone(),
+            }),
+        )).await;
+        assert_failure_response(response.into_response(), StatusCode::INTERNAL_SERVER_ERROR, body).await;
+        let event = warning(&logs, &request_id, message);
+        assert!(event["fields"]["error"].as_str().is_some_and(|value| !value.is_empty()));
+        assert_eq!(*port.calls.lock().unwrap(), expected_calls(failure));
+        assert!(port.bound_hash.lock().unwrap().is_none());
+        assert_no_credentials(&logs, &[AUTH_CODE, JWT_SECRET, &csrf]);
+    }
+}
+
+#[tokio::test]
+async fn callback_validation_failures_identify_the_request_before_any_identity_write() {
+    for (case, message, body) in [
+        ("state", "OAuth callback: invalid state", "invalid state"),
+        ("provider", "OAuth callback: provider mismatch", "provider mismatch"),
+        ("code", "OAuth callback: missing code or auth_code", "missing code or auth_code"),
+    ] {
+        let (state, port) = state(Failure::Ensure);
+        let csrf = match case {
+            "state" => "private-invalid-csrf-state".to_string(),
+            "provider" => state.state_store.generate("github").await,
+            _ => state.state_store.generate("google").await,
+        };
+        let request_id = format!("oauth-callback-invalid-{case}");
+        let (response, logs) = capture_request_logs(&request_id, callback_handler(
+            State(state), Path("google".into()), axum::extract::Query(CallbackParams {
+                code: (case != "code").then(|| AUTH_CODE.into()), auth_code: None, state: csrf.clone(),
+            }),
+        )).await;
+        assert_failure_response(response.into_response(), StatusCode::BAD_REQUEST, body).await;
+        let event = warning(&logs, &request_id, message);
+        if case == "provider" {
+            assert_eq!(event["fields"]["expected"], "github");
+            assert_eq!(event["fields"]["got"], "google");
+        }
+        assert!(port.calls.lock().unwrap().is_empty());
+        assert_no_credentials(&logs, &[AUTH_CODE, JWT_SECRET, &csrf]);
+    }
+}
+
+fn session(state: &OAuthRouteState, port: &FailingIdentity) -> (String, HeaderMap, RequestAuthHeaders) {
+    let now = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_secs();
+    let jwt = state.jwt_service.sign(&Claims {
+        sub: USER_ID.into(), src: "google".into(), iat: now - 300, exp: now + 3600,
+        name: Some("Previous Name".into()),
+    }).unwrap();
+    *port.bound_hash.lock().unwrap() = Some(bcs_jwt::token_hash(&jwt));
+    let cookie = format!("bcs_session={jwt}");
+    let mut headers = HeaderMap::new();
+    headers.insert(axum::http::header::COOKIE, cookie.parse().unwrap());
+    let auth = RequestAuthHeaders { authorization: None, cookie: Some(cookie), forwarded_headers: vec![] };
+    (jwt, headers, auth)
+}
+
+#[tokio::test]
+async fn refresh_failures_preserve_the_existing_binding_and_correlate_both_entry_points() {
+    for failure in [Failure::LookupToken, Failure::UpdateToken] {
+        for service in [false, true] {
+            let (state, port) = state(failure);
+            let (jwt, headers, auth) = session(&state, &port);
+            let original_hash = bcs_jwt::token_hash(&jwt);
+            let request_id = format!("oauth-refresh-{failure:?}-service-{service}");
+            let logs = if service {
+                let (result, logs) = capture_request_logs(&request_id, state.refresh_session(RefreshSession { headers: auth })).await;
+                let expected = if failure == Failure::LookupToken { "identity lookup failed" } else { "session renewal failed" };
+                assert!(matches!(result, Err(ApplicationError::Internal(ref message)) if message == expected));
+                logs
+            } else {
+                let (response, logs) = capture_request_logs(&request_id, refresh_handler(State(state), headers)).await;
+                let body = if failure == Failure::LookupToken { "internal error" } else { "session renewal failed" };
+                assert_failure_response(response.into_response(), StatusCode::INTERNAL_SERVER_ERROR, body).await;
+                logs
+            };
+            let message = if failure == Failure::LookupToken { "refresh: identity lookup failed" } else { "refresh: update_token failed" };
+            warning(&logs, &request_id, message);
+            assert_eq!(port.bound_hash.lock().unwrap().as_deref(), Some(original_hash.as_str()));
+            if failure == Failure::LookupToken {
+                assert_eq!(*port.calls.lock().unwrap(), vec!["lookup_token"]);
+                assert!(port.writes.lock().unwrap().is_empty());
+            } else {
+                assert_eq!(*port.calls.lock().unwrap(), vec!["lookup_token", "update_token"]);
+                let writes = port.writes.lock().unwrap();
+                assert_eq!(writes.len(), 1);
+                assert_eq!(writes[0].1.len(), 64, "only a fingerprint may be persisted");
+                assert_ne!(writes[0].1, original_hash, "renewal must generate a new session fingerprint");
+                assert!(writes[0].2 > 0);
+            }
+            assert_no_credentials(&logs, &[&jwt, JWT_SECRET, &original_hash]);
+        }
+    }
+}
+
+#[tokio::test]
+async fn logout_revocation_failure_is_logged_while_both_entry_points_clear_the_cookie() {
+    for service in [false, true] {
+        let (state, port) = state(Failure::UpdateToken);
+        let (jwt, headers, auth) = session(&state, &port);
+        let request_id = format!("oauth-logout-service-{service}");
+        let (cookie, logs) = if service {
+            let (result, logs) = capture_request_logs(&request_id, state.logout(LogoutSession { headers: auth })).await;
+            (result.unwrap().set_cookie, logs)
+        } else {
+            let (response, logs) = capture_request_logs(&request_id, logout_handler(State(state), headers)).await;
+            let response = response.into_response();
+            assert_eq!(response.status(), StatusCode::OK);
+            (response.headers()["set-cookie"].to_str().unwrap().to_owned(), logs)
+        };
+        assert_eq!(cookie, clear_session_cookie(true));
+        assert!(cookie.contains("Max-Age=0"));
+        assert_eq!(*port.writes.lock().unwrap(), vec![(USER_ID.into(), "".into(), 0)]);
+        let event = warning(&logs, &request_id, "logout: token revocation failed");
+        assert_eq!(event["fields"]["user_id"], USER_ID);
+        assert_no_credentials(&logs, &[&jwt, JWT_SECRET]);
+    }
+}
+
+struct FailingAuthPlugin;
+
+#[async_trait]
+impl AuthPlugin for FailingAuthPlugin {
+    fn can_authenticate(&self, _: &HeaderMap) -> bool { true }
+    async fn authenticate(&self, _: &HeaderMap) -> Result<Option<AuthPrincipal>, AuthError> {
+        Err(AuthError::LookupFailed("authentication store unavailable".into()))
+    }
+    fn priority(&self) -> u8 { 1 }
+    fn name(&self) -> &'static str { "diagnostic-failing-auth" }
+}
+
+#[tokio::test]
+async fn current_user_dependency_failure_correlates_chain_and_endpoint_warnings() {
+    for service in [false, true] {
+        let state = Arc::new(OAuthRouteState::new_chain_only(
+            Arc::new(FailingIdentity::new(Failure::LookupUser)),
+            Arc::new(AuthPluginChain::new(vec![Box::new(FailingAuthPlugin)])),
+        ));
+        let request_id = format!("oauth-current-user-service-{service}");
+        let logs = if service {
+            let (result, logs) = capture_request_logs(&request_id, state.current_user(ReadCurrentUser {
+                headers: RequestAuthHeaders { authorization: None, cookie: None, forwarded_headers: vec![] },
+            })).await;
+            assert!(matches!(result, Err(ApplicationError::Internal(ref message)) if message == "auth chain failed"));
+            logs
+        } else {
+            let (response, logs) = capture_request_logs(&request_id, current_user_handler(State(state), HeaderMap::new())).await;
+            assert_failure_response(response.into_response(), StatusCode::INTERNAL_SERVER_ERROR, "internal error").await;
+            logs
+        };
+        let chain = warning(&logs, &request_id, "auth: plugin failed");
+        assert_eq!(chain["fields"]["plugin"], "diagnostic-failing-auth");
+        assert_eq!(chain["fields"]["outcome"], "error");
+        warning(&logs, &request_id, if service { "auth chain failed in OpenAPI auth user" } else { "auth chain failed in /auth/user" });
+    }
+}
+
+#[tokio::test]
+async fn get_user_identity_failure_keeps_request_id_and_returns_a_generic_error() {
+    let (state, port) = state(Failure::LookupUser);
+    let (jwt, headers, _) = session(&state, &port);
+    let request_id = "oauth-get-user-identity-failure";
+    let (response, logs) = capture_request_logs(request_id, get_user_handler(
+        State(state), Path(USER_ID.into()), headers,
+    )).await;
+    assert_failure_response(response.into_response(), StatusCode::INTERNAL_SERVER_ERROR, "internal error").await;
+    warning(&logs, request_id, "get_identity_by_user_id failed");
+    assert_eq!(*port.calls.lock().unwrap(), vec!["lookup_user"]);
+    assert_no_credentials(&logs, &[&jwt, JWT_SECRET]);
+}

--- a/src/bcs/crates/adapters/http/bcs-http/src/oauth/mod.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/oauth/mod.rs
@@ -171,12 +171,12 @@ impl AuthService for OAuthRouteState {
         })?;
         let redirect_uri = format!("{callback_base_url}/{}", request.provider);
         let token = provider.exchange_code(&code, &redirect_uri).await.map_err(|e| {
-            warn!(error = %e, provider = %request.provider, "OAuth token exchange failed");
+            warn!(request_id = %bcs_observability::current_request_id(), error = %e, provider = %request.provider, "OAuth token exchange failed");
             ApplicationError::bad_gateway("token_exchange_failed", "token exchange failed")
         })?;
 
         let user_info = provider.get_user_info(&token).await.map_err(|e| {
-            warn!(error = %e, provider = %request.provider, "OAuth userinfo failed");
+            warn!(request_id = %bcs_observability::current_request_id(), error = %e, provider = %request.provider, "OAuth userinfo failed");
             ApplicationError::bad_gateway("userinfo_request_failed", "userinfo request failed")
         })?;
 
@@ -191,7 +191,7 @@ impl AuthService for OAuthRouteState {
             )
             .await
             .map_err(|e| {
-                warn!(error = %e, "ensure_identity failed");
+                warn!(request_id = %bcs_observability::current_request_id(), error = %e, "ensure_identity failed");
                 ApplicationError::internal("identity creation failed")
             })?;
 
@@ -207,7 +207,7 @@ impl AuthService for OAuthRouteState {
             name: user_info.name.clone(),
         };
         let jwt = self.jwt_service.sign(&claims).map_err(|e| {
-            warn!(error = %e, "JWT signing failed");
+            warn!(request_id = %bcs_observability::current_request_id(), error = %e, "JWT signing failed");
             ApplicationError::internal("session creation failed")
         })?;
 
@@ -215,7 +215,7 @@ impl AuthService for OAuthRouteState {
             .update_token(&claims.sub, &bcs_jwt::token_hash(&jwt), claims.exp)
             .await
             .map_err(|e| {
-                warn!(error = %e, "update_token failed; aborting login");
+                warn!(request_id = %bcs_observability::current_request_id(), error = %e, "update_token failed; aborting login");
                 ApplicationError::internal("session creation failed")
             })?;
 
@@ -249,7 +249,7 @@ impl AuthService for OAuthRouteState {
                 _ => Err(ApplicationError::Unauthenticated),
             },
             Err(e) => {
-                warn!(error = %e, "auth chain failed in OpenAPI auth user");
+                warn!(request_id = %bcs_observability::current_request_id(), error = %e, "auth chain failed in OpenAPI auth user");
                 Err(ApplicationError::internal("auth chain failed"))
             }
         }
@@ -267,7 +267,7 @@ impl AuthService for OAuthRouteState {
             Ok(Some(info)) if info.user_id == claims.sub => info,
             Ok(_) => return Err(ApplicationError::Unauthenticated),
             Err(e) => {
-                warn!(error = %e, "refresh: identity lookup failed");
+                warn!(request_id = %bcs_observability::current_request_id(), error = %e, "refresh: identity lookup failed");
                 return Err(ApplicationError::internal("identity lookup failed"));
             }
         };
@@ -285,14 +285,14 @@ impl AuthService for OAuthRouteState {
             name: info.user_name.or(info.external_user_name),
         };
         let new_jwt = self.jwt_service.sign(&new_claims).map_err(|e| {
-            warn!(error = %e, "refresh: JWT signing failed");
+            warn!(request_id = %bcs_observability::current_request_id(), error = %e, "refresh: JWT signing failed");
             ApplicationError::internal("session renewal failed")
         })?;
         self.user_port
             .update_token(&new_claims.sub, &bcs_jwt::token_hash(&new_jwt), new_claims.exp)
             .await
             .map_err(|e| {
-                warn!(error = %e, "refresh: update_token failed");
+                warn!(request_id = %bcs_observability::current_request_id(), error = %e, "refresh: update_token failed");
                 ApplicationError::internal("session renewal failed")
             })?;
 
@@ -306,7 +306,7 @@ impl AuthService for OAuthRouteState {
         if let Some(jwt) = extract_session_cookie(&headers) {
             if let Ok(claims) = self.jwt_service.verify(&jwt) {
                 if let Err(e) = self.user_port.update_token(&claims.sub, "", 0).await {
-                    warn!(error = %e, user_id = %claims.sub, "logout: token revocation failed");
+                    warn!(request_id = %bcs_observability::current_request_id(), error = %e, user_id = %claims.sub, "logout: token revocation failed");
                 }
             }
         }
@@ -382,14 +382,14 @@ pub async fn callback_handler(
     let provider_key = match state.state_store.consume(&params.state).await {
         Ok(key) => key,
         Err(e) => {
-            warn!(error = %e, "OAuth callback: invalid state");
+            warn!(request_id = %bcs_observability::current_request_id(), error = %e, "OAuth callback: invalid state");
             return (StatusCode::BAD_REQUEST, "invalid state").into_response();
         }
     };
 
     // 2. Verify provider matches state
     if provider_key != provider_name {
-        warn!(expected = %provider_key, got = %provider_name, "OAuth callback: provider mismatch");
+        warn!(request_id = %bcs_observability::current_request_id(), expected = %provider_key, got = %provider_name, "OAuth callback: provider mismatch");
         return (StatusCode::BAD_REQUEST, "provider mismatch").into_response();
     }
 
@@ -405,7 +405,7 @@ pub async fn callback_handler(
     let code = match params.code.or(params.auth_code) {
         Some(c) => c,
         None => {
-            warn!("OAuth callback: missing code or auth_code");
+            warn!(request_id = %bcs_observability::current_request_id(), "OAuth callback: missing code or auth_code");
             return (StatusCode::BAD_REQUEST, "missing code or auth_code").into_response();
         }
     };
@@ -413,7 +413,7 @@ pub async fn callback_handler(
     let token = match provider.exchange_code(&code, &redirect_uri).await {
         Ok(t) => t,
         Err(e) => {
-            warn!(error = %e, provider = %provider_name, "OAuth token exchange failed");
+            warn!(request_id = %bcs_observability::current_request_id(), error = %e, provider = %provider_name, "OAuth token exchange failed");
             return (StatusCode::INTERNAL_SERVER_ERROR, "token exchange failed").into_response();
         }
     };
@@ -422,7 +422,7 @@ pub async fn callback_handler(
     let user_info = match provider.get_user_info(&token).await {
         Ok(u) => u,
         Err(e) => {
-            warn!(error = %e, provider = %provider_name, "OAuth userinfo failed");
+            warn!(request_id = %bcs_observability::current_request_id(), error = %e, provider = %provider_name, "OAuth userinfo failed");
             return (StatusCode::INTERNAL_SERVER_ERROR, "userinfo request failed").into_response();
         }
     };
@@ -441,7 +441,7 @@ pub async fn callback_handler(
     {
         Ok(id) => id,
         Err(e) => {
-            warn!(error = %e, "ensure_identity failed");
+            warn!(request_id = %bcs_observability::current_request_id(), error = %e, "ensure_identity failed");
             return (StatusCode::INTERNAL_SERVER_ERROR, "identity creation failed").into_response();
         }
     };
@@ -461,7 +461,7 @@ pub async fn callback_handler(
     let jwt = match state.jwt_service.sign(&claims) {
         Ok(j) => j,
         Err(e) => {
-            warn!(error = %e, "JWT signing failed");
+            warn!(request_id = %bcs_observability::current_request_id(), error = %e, "JWT signing failed");
             return (StatusCode::INTERNAL_SERVER_ERROR, "session creation failed").into_response();
         }
     };
@@ -475,7 +475,7 @@ pub async fn callback_handler(
         .update_token(&claims.sub, &bcs_jwt::token_hash(&jwt), claims.exp)
         .await
     {
-        warn!(error = %e, "update_token failed; aborting login");
+        warn!(request_id = %bcs_observability::current_request_id(), error = %e, "update_token failed; aborting login");
         return (StatusCode::INTERNAL_SERVER_ERROR, "session creation failed").into_response();
     }
 
@@ -531,7 +531,7 @@ pub async fn logout_handler(
     if let Some(jwt) = extract_session_cookie(&headers) {
         if let Ok(claims) = state.jwt_service.verify(&jwt) {
             if let Err(e) = state.user_port.update_token(&claims.sub, "", 0).await {
-                warn!(error = %e, user_id = %claims.sub, "logout: token revocation failed");
+                warn!(request_id = %bcs_observability::current_request_id(), error = %e, user_id = %claims.sub, "logout: token revocation failed");
             }
         }
     }
@@ -570,7 +570,7 @@ pub async fn refresh_handler(
         Ok(Some(info)) if info.user_id == claims.sub => info,
         Ok(_) => return (StatusCode::UNAUTHORIZED, "not authenticated").into_response(),
         Err(e) => {
-            warn!(error = %e, "refresh: identity lookup failed");
+            warn!(request_id = %bcs_observability::current_request_id(), error = %e, "refresh: identity lookup failed");
             return (StatusCode::INTERNAL_SERVER_ERROR, "internal error").into_response();
         }
     };
@@ -589,7 +589,7 @@ pub async fn refresh_handler(
     let new_jwt = match state.jwt_service.sign(&new_claims) {
         Ok(j) => j,
         Err(e) => {
-            warn!(error = %e, "refresh: JWT signing failed");
+            warn!(request_id = %bcs_observability::current_request_id(), error = %e, "refresh: JWT signing failed");
             return (StatusCode::INTERNAL_SERVER_ERROR, "session renewal failed").into_response();
         }
     };
@@ -600,7 +600,7 @@ pub async fn refresh_handler(
         .update_token(&new_claims.sub, &bcs_jwt::token_hash(&new_jwt), new_claims.exp)
         .await
     {
-        warn!(error = %e, "refresh: update_token failed");
+        warn!(request_id = %bcs_observability::current_request_id(), error = %e, "refresh: update_token failed");
         return (StatusCode::INTERNAL_SERVER_ERROR, "session renewal failed").into_response();
     }
 
@@ -670,7 +670,7 @@ pub async fn current_user_handler(
                 .into_response(),
         },
         Err(e) => {
-            warn!(error = %e, "auth chain failed in /auth/user");
+            warn!(request_id = %bcs_observability::current_request_id(), error = %e, "auth chain failed in /auth/user");
             (StatusCode::INTERNAL_SERVER_ERROR, "internal error").into_response()
         }
     }
@@ -711,7 +711,7 @@ pub async fn get_user_handler(
         })).into_response(),
         Ok(None) => (StatusCode::NOT_FOUND, Json(serde_json::json!({"error": "not found"}))).into_response(),
         Err(e) => {
-            warn!(error = %e, "get_identity_by_user_id failed");
+            warn!(request_id = %bcs_observability::current_request_id(), error = %e, "get_identity_by_user_id failed");
             (StatusCode::INTERNAL_SERVER_ERROR, "internal error").into_response()
         }
     }

--- a/src/bcs/crates/adapters/http/bcs-http/src/oauth/mod.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/oauth/mod.rs
@@ -171,12 +171,12 @@ impl AuthService for OAuthRouteState {
         })?;
         let redirect_uri = format!("{callback_base_url}/{}", request.provider);
         let token = provider.exchange_code(&code, &redirect_uri).await.map_err(|e| {
-            warn!(request_id = %bcs_observability::current_request_id(), error = %e, provider = %request.provider, "OAuth token exchange failed");
+            warn!(request_id = %bcs_observability::CurrentRequestId, error = %e, provider = %request.provider, "OAuth token exchange failed");
             ApplicationError::bad_gateway("token_exchange_failed", "token exchange failed")
         })?;
 
         let user_info = provider.get_user_info(&token).await.map_err(|e| {
-            warn!(request_id = %bcs_observability::current_request_id(), error = %e, provider = %request.provider, "OAuth userinfo failed");
+            warn!(request_id = %bcs_observability::CurrentRequestId, error = %e, provider = %request.provider, "OAuth userinfo failed");
             ApplicationError::bad_gateway("userinfo_request_failed", "userinfo request failed")
         })?;
 
@@ -191,7 +191,7 @@ impl AuthService for OAuthRouteState {
             )
             .await
             .map_err(|e| {
-                warn!(request_id = %bcs_observability::current_request_id(), error = %e, "ensure_identity failed");
+                warn!(request_id = %bcs_observability::CurrentRequestId, error = %e, "ensure_identity failed");
                 ApplicationError::internal("identity creation failed")
             })?;
 
@@ -207,7 +207,7 @@ impl AuthService for OAuthRouteState {
             name: user_info.name.clone(),
         };
         let jwt = self.jwt_service.sign(&claims).map_err(|e| {
-            warn!(request_id = %bcs_observability::current_request_id(), error = %e, "JWT signing failed");
+            warn!(request_id = %bcs_observability::CurrentRequestId, error = %e, "JWT signing failed");
             ApplicationError::internal("session creation failed")
         })?;
 
@@ -215,7 +215,7 @@ impl AuthService for OAuthRouteState {
             .update_token(&claims.sub, &bcs_jwt::token_hash(&jwt), claims.exp)
             .await
             .map_err(|e| {
-                warn!(request_id = %bcs_observability::current_request_id(), error = %e, "update_token failed; aborting login");
+                warn!(request_id = %bcs_observability::CurrentRequestId, error = %e, "update_token failed; aborting login");
                 ApplicationError::internal("session creation failed")
             })?;
 
@@ -249,7 +249,7 @@ impl AuthService for OAuthRouteState {
                 _ => Err(ApplicationError::Unauthenticated),
             },
             Err(e) => {
-                warn!(request_id = %bcs_observability::current_request_id(), error = %e, "auth chain failed in OpenAPI auth user");
+                warn!(request_id = %bcs_observability::CurrentRequestId, error = %e, "auth chain failed in OpenAPI auth user");
                 Err(ApplicationError::internal("auth chain failed"))
             }
         }
@@ -267,7 +267,7 @@ impl AuthService for OAuthRouteState {
             Ok(Some(info)) if info.user_id == claims.sub => info,
             Ok(_) => return Err(ApplicationError::Unauthenticated),
             Err(e) => {
-                warn!(request_id = %bcs_observability::current_request_id(), error = %e, "refresh: identity lookup failed");
+                warn!(request_id = %bcs_observability::CurrentRequestId, error = %e, "refresh: identity lookup failed");
                 return Err(ApplicationError::internal("identity lookup failed"));
             }
         };
@@ -285,14 +285,14 @@ impl AuthService for OAuthRouteState {
             name: info.user_name.or(info.external_user_name),
         };
         let new_jwt = self.jwt_service.sign(&new_claims).map_err(|e| {
-            warn!(request_id = %bcs_observability::current_request_id(), error = %e, "refresh: JWT signing failed");
+            warn!(request_id = %bcs_observability::CurrentRequestId, error = %e, "refresh: JWT signing failed");
             ApplicationError::internal("session renewal failed")
         })?;
         self.user_port
             .update_token(&new_claims.sub, &bcs_jwt::token_hash(&new_jwt), new_claims.exp)
             .await
             .map_err(|e| {
-                warn!(request_id = %bcs_observability::current_request_id(), error = %e, "refresh: update_token failed");
+                warn!(request_id = %bcs_observability::CurrentRequestId, error = %e, "refresh: update_token failed");
                 ApplicationError::internal("session renewal failed")
             })?;
 
@@ -306,7 +306,7 @@ impl AuthService for OAuthRouteState {
         if let Some(jwt) = extract_session_cookie(&headers) {
             if let Ok(claims) = self.jwt_service.verify(&jwt) {
                 if let Err(e) = self.user_port.update_token(&claims.sub, "", 0).await {
-                    warn!(request_id = %bcs_observability::current_request_id(), error = %e, user_id = %claims.sub, "logout: token revocation failed");
+                    warn!(request_id = %bcs_observability::CurrentRequestId, error = %e, user_id = %claims.sub, "logout: token revocation failed");
                 }
             }
         }
@@ -382,14 +382,14 @@ pub async fn callback_handler(
     let provider_key = match state.state_store.consume(&params.state).await {
         Ok(key) => key,
         Err(e) => {
-            warn!(request_id = %bcs_observability::current_request_id(), error = %e, "OAuth callback: invalid state");
+            warn!(request_id = %bcs_observability::CurrentRequestId, error = %e, "OAuth callback: invalid state");
             return (StatusCode::BAD_REQUEST, "invalid state").into_response();
         }
     };
 
     // 2. Verify provider matches state
     if provider_key != provider_name {
-        warn!(request_id = %bcs_observability::current_request_id(), expected = %provider_key, got = %provider_name, "OAuth callback: provider mismatch");
+        warn!(request_id = %bcs_observability::CurrentRequestId, expected = %provider_key, got = %provider_name, "OAuth callback: provider mismatch");
         return (StatusCode::BAD_REQUEST, "provider mismatch").into_response();
     }
 
@@ -405,7 +405,7 @@ pub async fn callback_handler(
     let code = match params.code.or(params.auth_code) {
         Some(c) => c,
         None => {
-            warn!(request_id = %bcs_observability::current_request_id(), "OAuth callback: missing code or auth_code");
+            warn!(request_id = %bcs_observability::CurrentRequestId, "OAuth callback: missing code or auth_code");
             return (StatusCode::BAD_REQUEST, "missing code or auth_code").into_response();
         }
     };
@@ -413,7 +413,7 @@ pub async fn callback_handler(
     let token = match provider.exchange_code(&code, &redirect_uri).await {
         Ok(t) => t,
         Err(e) => {
-            warn!(request_id = %bcs_observability::current_request_id(), error = %e, provider = %provider_name, "OAuth token exchange failed");
+            warn!(request_id = %bcs_observability::CurrentRequestId, error = %e, provider = %provider_name, "OAuth token exchange failed");
             return (StatusCode::INTERNAL_SERVER_ERROR, "token exchange failed").into_response();
         }
     };
@@ -422,7 +422,7 @@ pub async fn callback_handler(
     let user_info = match provider.get_user_info(&token).await {
         Ok(u) => u,
         Err(e) => {
-            warn!(request_id = %bcs_observability::current_request_id(), error = %e, provider = %provider_name, "OAuth userinfo failed");
+            warn!(request_id = %bcs_observability::CurrentRequestId, error = %e, provider = %provider_name, "OAuth userinfo failed");
             return (StatusCode::INTERNAL_SERVER_ERROR, "userinfo request failed").into_response();
         }
     };
@@ -441,7 +441,7 @@ pub async fn callback_handler(
     {
         Ok(id) => id,
         Err(e) => {
-            warn!(request_id = %bcs_observability::current_request_id(), error = %e, "ensure_identity failed");
+            warn!(request_id = %bcs_observability::CurrentRequestId, error = %e, "ensure_identity failed");
             return (StatusCode::INTERNAL_SERVER_ERROR, "identity creation failed").into_response();
         }
     };
@@ -461,7 +461,7 @@ pub async fn callback_handler(
     let jwt = match state.jwt_service.sign(&claims) {
         Ok(j) => j,
         Err(e) => {
-            warn!(request_id = %bcs_observability::current_request_id(), error = %e, "JWT signing failed");
+            warn!(request_id = %bcs_observability::CurrentRequestId, error = %e, "JWT signing failed");
             return (StatusCode::INTERNAL_SERVER_ERROR, "session creation failed").into_response();
         }
     };
@@ -475,7 +475,7 @@ pub async fn callback_handler(
         .update_token(&claims.sub, &bcs_jwt::token_hash(&jwt), claims.exp)
         .await
     {
-        warn!(request_id = %bcs_observability::current_request_id(), error = %e, "update_token failed; aborting login");
+        warn!(request_id = %bcs_observability::CurrentRequestId, error = %e, "update_token failed; aborting login");
         return (StatusCode::INTERNAL_SERVER_ERROR, "session creation failed").into_response();
     }
 
@@ -531,7 +531,7 @@ pub async fn logout_handler(
     if let Some(jwt) = extract_session_cookie(&headers) {
         if let Ok(claims) = state.jwt_service.verify(&jwt) {
             if let Err(e) = state.user_port.update_token(&claims.sub, "", 0).await {
-                warn!(request_id = %bcs_observability::current_request_id(), error = %e, user_id = %claims.sub, "logout: token revocation failed");
+                warn!(request_id = %bcs_observability::CurrentRequestId, error = %e, user_id = %claims.sub, "logout: token revocation failed");
             }
         }
     }
@@ -570,7 +570,7 @@ pub async fn refresh_handler(
         Ok(Some(info)) if info.user_id == claims.sub => info,
         Ok(_) => return (StatusCode::UNAUTHORIZED, "not authenticated").into_response(),
         Err(e) => {
-            warn!(request_id = %bcs_observability::current_request_id(), error = %e, "refresh: identity lookup failed");
+            warn!(request_id = %bcs_observability::CurrentRequestId, error = %e, "refresh: identity lookup failed");
             return (StatusCode::INTERNAL_SERVER_ERROR, "internal error").into_response();
         }
     };
@@ -589,7 +589,7 @@ pub async fn refresh_handler(
     let new_jwt = match state.jwt_service.sign(&new_claims) {
         Ok(j) => j,
         Err(e) => {
-            warn!(request_id = %bcs_observability::current_request_id(), error = %e, "refresh: JWT signing failed");
+            warn!(request_id = %bcs_observability::CurrentRequestId, error = %e, "refresh: JWT signing failed");
             return (StatusCode::INTERNAL_SERVER_ERROR, "session renewal failed").into_response();
         }
     };
@@ -600,7 +600,7 @@ pub async fn refresh_handler(
         .update_token(&new_claims.sub, &bcs_jwt::token_hash(&new_jwt), new_claims.exp)
         .await
     {
-        warn!(request_id = %bcs_observability::current_request_id(), error = %e, "refresh: update_token failed");
+        warn!(request_id = %bcs_observability::CurrentRequestId, error = %e, "refresh: update_token failed");
         return (StatusCode::INTERNAL_SERVER_ERROR, "session renewal failed").into_response();
     }
 
@@ -670,7 +670,7 @@ pub async fn current_user_handler(
                 .into_response(),
         },
         Err(e) => {
-            warn!(request_id = %bcs_observability::current_request_id(), error = %e, "auth chain failed in /auth/user");
+            warn!(request_id = %bcs_observability::CurrentRequestId, error = %e, "auth chain failed in /auth/user");
             (StatusCode::INTERNAL_SERVER_ERROR, "internal error").into_response()
         }
     }
@@ -711,7 +711,7 @@ pub async fn get_user_handler(
         })).into_response(),
         Ok(None) => (StatusCode::NOT_FOUND, Json(serde_json::json!({"error": "not found"}))).into_response(),
         Err(e) => {
-            warn!(request_id = %bcs_observability::current_request_id(), error = %e, "get_identity_by_user_id failed");
+            warn!(request_id = %bcs_observability::CurrentRequestId, error = %e, "get_identity_by_user_id failed");
             (StatusCode::INTERNAL_SERVER_ERROR, "internal error").into_response()
         }
     }

--- a/src/bcs/crates/adapters/http/bcs-http/src/oauth/mod.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/oauth/mod.rs
@@ -1109,3 +1109,6 @@ mod tests {
         );
     }
 }
+
+#[cfg(test)]
+mod diagnostics_test;

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/actors.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/actors.rs
@@ -160,7 +160,7 @@ fn actor_service_error_response(error: ServiceError) -> Response {
         ServiceError::Forbidden(message) => (StatusCode::FORBIDDEN, message),
         other => {
             tracing::warn!(
-                request_id = %bcs_observability::current_request_id(),
+                request_id = %bcs_observability::CurrentRequestId,
                 error = %other,
                 "actor route service error"
             );

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/actors.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/actors.rs
@@ -160,6 +160,7 @@ fn actor_service_error_response(error: ServiceError) -> Response {
         ServiceError::Forbidden(message) => (StatusCode::FORBIDDEN, message),
         other => {
             tracing::warn!(
+                request_id = %bcs_observability::current_request_id(),
                 error = %other,
                 "actor route service error"
             );

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/bot_events.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/bot_events.rs
@@ -75,6 +75,7 @@ where
             let status = StatusCode::UNSUPPORTED_MEDIA_TYPE;
             let body_text = "Expected request with `Content-Type: application/json`";
             warn!(
+                request_id = %bcs_observability::current_request_id(),
                 provider_id = %provider_id,
                 status = %status.as_u16(),
                 error = %body_text,
@@ -89,6 +90,7 @@ where
                 let status = StatusCode::BAD_REQUEST;
                 let body_text = format!("Failed to read request body: {error}");
                 warn!(
+                    request_id = %bcs_observability::current_request_id(),
                     provider_id = %provider_id,
                     status = %status.as_u16(),
                     error = %body_text,
@@ -105,6 +107,7 @@ where
                 let body_text = rejection.body_text();
                 let request_body = String::from_utf8_lossy(&body_bytes);
                 warn!(
+                    request_id = %bcs_observability::current_request_id(),
                     provider_id = %provider_id,
                     status = %status.as_u16(),
                     error = %body_text,
@@ -290,6 +293,7 @@ pub async fn post_bot_event(
         Ok(outcome) => outcome,
         Err(error) => {
             warn!(
+                request_id = %bcs_observability::current_request_id(),
                 provider_id = %provider_id,
                 error = %error,
                 "provider callback: bot event rejected"

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/bot_events.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/bot_events.rs
@@ -75,7 +75,7 @@ where
             let status = StatusCode::UNSUPPORTED_MEDIA_TYPE;
             let body_text = "Expected request with `Content-Type: application/json`";
             warn!(
-                request_id = %bcs_observability::current_request_id(),
+                request_id = %bcs_observability::CurrentRequestId,
                 provider_id = %provider_id,
                 status = %status.as_u16(),
                 error = %body_text,
@@ -90,7 +90,7 @@ where
                 let status = StatusCode::BAD_REQUEST;
                 let body_text = format!("Failed to read request body: {error}");
                 warn!(
-                    request_id = %bcs_observability::current_request_id(),
+                    request_id = %bcs_observability::CurrentRequestId,
                     provider_id = %provider_id,
                     status = %status.as_u16(),
                     error = %body_text,
@@ -107,7 +107,7 @@ where
                 let body_text = rejection.body_text();
                 let request_body = String::from_utf8_lossy(&body_bytes);
                 warn!(
-                    request_id = %bcs_observability::current_request_id(),
+                    request_id = %bcs_observability::CurrentRequestId,
                     provider_id = %provider_id,
                     status = %status.as_u16(),
                     error = %body_text,
@@ -293,7 +293,7 @@ pub async fn post_bot_event(
         Ok(outcome) => outcome,
         Err(error) => {
             warn!(
-                request_id = %bcs_observability::current_request_id(),
+                request_id = %bcs_observability::CurrentRequestId,
                 provider_id = %provider_id,
                 error = %error,
                 "provider callback: bot event rejected"

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/groups.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/groups.rs
@@ -491,7 +491,7 @@ async fn create_group_with_inline_subscriptions(
                 Ok(sessions) => sessions.into_iter().next().map(|session| session.id),
                 Err(error) => {
                     tracing::warn!(
-                        request_id = %bcs_observability::current_request_id(),
+                        request_id = %bcs_observability::CurrentRequestId,
                         group_id = %group_id,
                         error = %error,
                         "failed to load initial Session for legacy Group create response"
@@ -852,7 +852,7 @@ async fn start_initial_state_machine_run_for_group(
         })?;
     let Some(session) = session else {
         tracing::warn!(
-            request_id = %bcs_observability::current_request_id(),
+            request_id = %bcs_observability::CurrentRequestId,
             group_id = %group.group_id,
             session_id = %session_id,
             "default state-machine session not found after group creation"
@@ -1052,7 +1052,7 @@ fn group_application_error_response(error: ApplicationError) -> Response {
         }
         // COSEC: keep persistence and infrastructure details out of the legacy response.
         ApplicationError::Internal(error) => {
-            tracing::error!(request_id = %bcs_observability::current_request_id(), error = %error, "legacy Group application request failed");
+            tracing::error!(request_id = %bcs_observability::CurrentRequestId, error = %error, "legacy Group application request failed");
             legacy_group_error_response(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "internal_error",

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/groups.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/groups.rs
@@ -491,6 +491,7 @@ async fn create_group_with_inline_subscriptions(
                 Ok(sessions) => sessions.into_iter().next().map(|session| session.id),
                 Err(error) => {
                     tracing::warn!(
+                        request_id = %bcs_observability::current_request_id(),
                         group_id = %group_id,
                         error = %error,
                         "failed to load initial Session for legacy Group create response"
@@ -851,6 +852,7 @@ async fn start_initial_state_machine_run_for_group(
         })?;
     let Some(session) = session else {
         tracing::warn!(
+            request_id = %bcs_observability::current_request_id(),
             group_id = %group.group_id,
             session_id = %session_id,
             "default state-machine session not found after group creation"
@@ -1050,7 +1052,7 @@ fn group_application_error_response(error: ApplicationError) -> Response {
         }
         // COSEC: keep persistence and infrastructure details out of the legacy response.
         ApplicationError::Internal(error) => {
-            tracing::error!(error = %error, "legacy Group application request failed");
+            tracing::error!(request_id = %bcs_observability::current_request_id(), error = %error, "legacy Group application request failed");
             legacy_group_error_response(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "internal_error",

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/providers.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/providers.rs
@@ -231,6 +231,7 @@ pub async fn register_provider_bot(
             }
             None => {
                 warn!(
+                    request_id = %bcs_observability::current_request_id(),
                     provider_id = %outcome.provider_id,
                     bot_uuid = %outcome.bot_uuid,
                     "register_provider_bot: allowlisted provider but capabilities missing; \
@@ -356,6 +357,7 @@ pub async fn patch_provider_bot_attributes(
     require_provider_bot_attributes_access(&state, &provider_id, &bot_uuid, &headers).await?;
     let Json(body) = body.map_err(|_| {
         warn!(
+            request_id = %bcs_observability::current_request_id(),
             provider_id,
             bot_uuid,
             failure = "invalid_json_body",
@@ -659,6 +661,7 @@ async fn require_provider_bot_attributes_access(
         .any(|configured_id| configured_id == provider_id)
     {
         warn!(
+            request_id = %bcs_observability::current_request_id(),
             provider_id,
             bot_uuid,
             failure = "provider_not_allowed",

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/providers.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/providers.rs
@@ -231,7 +231,7 @@ pub async fn register_provider_bot(
             }
             None => {
                 warn!(
-                    request_id = %bcs_observability::current_request_id(),
+                    request_id = %bcs_observability::CurrentRequestId,
                     provider_id = %outcome.provider_id,
                     bot_uuid = %outcome.bot_uuid,
                     "register_provider_bot: allowlisted provider but capabilities missing; \
@@ -357,7 +357,7 @@ pub async fn patch_provider_bot_attributes(
     require_provider_bot_attributes_access(&state, &provider_id, &bot_uuid, &headers).await?;
     let Json(body) = body.map_err(|_| {
         warn!(
-            request_id = %bcs_observability::current_request_id(),
+            request_id = %bcs_observability::CurrentRequestId,
             provider_id,
             bot_uuid,
             failure = "invalid_json_body",
@@ -661,7 +661,7 @@ async fn require_provider_bot_attributes_access(
         .any(|configured_id| configured_id == provider_id)
     {
         warn!(
-            request_id = %bcs_observability::current_request_id(),
+            request_id = %bcs_observability::CurrentRequestId,
             provider_id,
             bot_uuid,
             failure = "provider_not_allowed",

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/register.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/register.rs
@@ -172,6 +172,7 @@ pub async fn register_bot(
 
     if let Err(e) = onboard_result {
         tracing::warn!(
+            request_id = %bcs_observability::current_request_id(),
             bot_uuid = %connect_result.bot_uuid,
             error = %e,
             "register: admin_onboard_bot failed after connect"

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/register.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/register.rs
@@ -172,7 +172,7 @@ pub async fn register_bot(
 
     if let Err(e) = onboard_result {
         tracing::warn!(
-            request_id = %bcs_observability::current_request_id(),
+            request_id = %bcs_observability::CurrentRequestId,
             bot_uuid = %connect_result.bot_uuid,
             error = %e,
             "register: admin_onboard_bot failed after connect"

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/secret.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/secret.rs
@@ -27,7 +27,7 @@ pub async fn pull_secret(
 ) -> Response {
     let ip = addr.ip();
     if !ip.is_loopback() {
-        tracing::warn!(remote = %ip, "rejecting /admin/secret request from non-loopback");
+        tracing::warn!(request_id = %bcs_observability::current_request_id(), remote = %ip, "rejecting /admin/secret request from non-loopback");
         return (
             StatusCode::FORBIDDEN,
             Json(json!({ "error": "loopback_only" })),
@@ -51,7 +51,7 @@ pub async fn pull_secret(
                 SecretServiceError::Unavailable(_) => (StatusCode::SERVICE_UNAVAILABLE, "unavailable"),
                 SecretServiceError::InvalidInput(_) => (StatusCode::BAD_REQUEST, "invalid_input"),
             };
-            tracing::warn!(secret = %name, error = %err, "SecretService.get_secret failed");
+            tracing::warn!(request_id = %bcs_observability::current_request_id(), secret = %name, error = %err, "SecretService.get_secret failed");
             (
                 code,
                 Json(json!({ "error": kind, "message": err.to_string() })),

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/secret.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/secret.rs
@@ -27,7 +27,7 @@ pub async fn pull_secret(
 ) -> Response {
     let ip = addr.ip();
     if !ip.is_loopback() {
-        tracing::warn!(request_id = %bcs_observability::current_request_id(), remote = %ip, "rejecting /admin/secret request from non-loopback");
+        tracing::warn!(request_id = %bcs_observability::CurrentRequestId, remote = %ip, "rejecting /admin/secret request from non-loopback");
         return (
             StatusCode::FORBIDDEN,
             Json(json!({ "error": "loopback_only" })),
@@ -51,7 +51,7 @@ pub async fn pull_secret(
                 SecretServiceError::Unavailable(_) => (StatusCode::SERVICE_UNAVAILABLE, "unavailable"),
                 SecretServiceError::InvalidInput(_) => (StatusCode::BAD_REQUEST, "invalid_input"),
             };
-            tracing::warn!(request_id = %bcs_observability::current_request_id(), secret = %name, error = %err, "SecretService.get_secret failed");
+            tracing::warn!(request_id = %bcs_observability::CurrentRequestId, secret = %name, error = %err, "SecretService.get_secret failed");
             (
                 code,
                 Json(json!({ "error": kind, "message": err.to_string() })),

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/sessions.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/sessions.rs
@@ -575,7 +575,7 @@ pub async fn list_sessions_for_group(
                     }
                     Err(e) => {
                         tracing::warn!(
-                            request_id = %bcs_observability::current_request_id(),
+                            request_id = %bcs_observability::CurrentRequestId,
                             group_id = %group_id,
                             error = %e,
                             "auto-create legacy session failed"
@@ -1217,7 +1217,7 @@ pub async fn update_session_participant_mode(
                     .await
                 {
                     tracing::warn!(
-                        request_id = %bcs_observability::current_request_id(),
+                        request_id = %bcs_observability::CurrentRequestId,
                         session_id = %sid,
                         error = %e,
                         "notify participant mode changed failed"
@@ -1271,7 +1271,7 @@ pub async fn update_session_participant_mode(
                                         .await
                                     {
                                         tracing::warn!(
-                                            request_id = %bcs_observability::current_request_id(),
+                                            request_id = %bcs_observability::CurrentRequestId,
                                             session_id = %sid,
                                             error = %e,
                                             "notify participant mode changed failed"
@@ -1462,7 +1462,7 @@ pub async fn session_chat(
             };
             if code.is_server_error() {
                 tracing::error!(
-                    request_id = %bcs_observability::current_request_id(),
+                    request_id = %bcs_observability::CurrentRequestId,
                     route = "/sessions/{sid}/chat",
                     session_id = %sid,
                     group_id = %sess.group_id,
@@ -1761,7 +1761,7 @@ pub async fn delete_session(
                     "cleaned up session files after session delete"
                 ),
                 Err(e) => tracing::warn!(
-                    request_id = %bcs_observability::current_request_id(),
+                    request_id = %bcs_observability::CurrentRequestId,
                     error = ?e,
                     session_id = %sid,
                     "session file cleanup partial failure (orphan sweep will reconcile)"

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/sessions.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/sessions.rs
@@ -575,6 +575,7 @@ pub async fn list_sessions_for_group(
                     }
                     Err(e) => {
                         tracing::warn!(
+                            request_id = %bcs_observability::current_request_id(),
                             group_id = %group_id,
                             error = %e,
                             "auto-create legacy session failed"
@@ -1216,6 +1217,7 @@ pub async fn update_session_participant_mode(
                     .await
                 {
                     tracing::warn!(
+                        request_id = %bcs_observability::current_request_id(),
                         session_id = %sid,
                         error = %e,
                         "notify participant mode changed failed"
@@ -1269,6 +1271,7 @@ pub async fn update_session_participant_mode(
                                         .await
                                     {
                                         tracing::warn!(
+                                            request_id = %bcs_observability::current_request_id(),
                                             session_id = %sid,
                                             error = %e,
                                             "notify participant mode changed failed"
@@ -1459,6 +1462,7 @@ pub async fn session_chat(
             };
             if code.is_server_error() {
                 tracing::error!(
+                    request_id = %bcs_observability::current_request_id(),
                     route = "/sessions/{sid}/chat",
                     session_id = %sid,
                     group_id = %sess.group_id,
@@ -1757,6 +1761,7 @@ pub async fn delete_session(
                     "cleaned up session files after session delete"
                 ),
                 Err(e) => tracing::warn!(
+                    request_id = %bcs_observability::current_request_id(),
                     error = ?e,
                     session_id = %sid,
                     "session file cleanup partial failure (orphan sweep will reconcile)"

--- a/src/bcs/crates/adapters/http/bcs-http/tests/bot_events_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/bot_events_contract.rs
@@ -245,6 +245,7 @@ fn test_app_with_collaboration_runtime(
 struct BlockingCollaborationRuntime {
     correlations: RwLock<HashMap<String, StateMachineDeliveryCorrelation>>,
     terminal_calls: Mutex<Vec<HandleBotTerminalEventCommand>>,
+    terminal_request_ids: Mutex<Vec<String>>,
     terminal_started: Semaphore,
     terminal_release: Semaphore,
     terminal_completed: Semaphore,
@@ -255,6 +256,7 @@ impl Default for BlockingCollaborationRuntime {
         Self {
             correlations: RwLock::new(HashMap::new()),
             terminal_calls: Mutex::new(Vec::new()),
+            terminal_request_ids: Mutex::new(Vec::new()),
             terminal_started: Semaphore::new(0),
             terminal_release: Semaphore::new(0),
             terminal_completed: Semaphore::new(0),
@@ -364,6 +366,7 @@ impl CollaborationRuntimeService for BlockingCollaborationRuntime {
             .await
             .expect("terminal release semaphore should remain open")
             .forget();
+        self.terminal_request_ids.lock().await.push(bcs_observability::current_request_id());
         self.terminal_completed.add_permits(1);
         Ok(HandleBotTerminalEventOutcome {
             consumed: true,
@@ -443,13 +446,12 @@ async fn bot_events_returns_200_before_state_machine_final_processing_completes(
         .insert_correlation("provider-run-async", &registered.bot_uuid)
         .await;
 
+    let app = app.layer(axum::middleware::from_fn(bcs_http::gateway_trace::observe_request));
+    let mut request = state_machine_final_request(&registered.provider_id, &token, "provider-run-async");
+    request.headers_mut().insert("x-request-id", "async-final-42".parse().unwrap());
     let response = tokio::time::timeout(
         Duration::from_secs(1),
-        app.oneshot(state_machine_final_request(
-            &registered.provider_id,
-            &token,
-            "provider-run-async",
-        )),
+        app.oneshot(request),
     )
     .await
     .expect("state-machine final callback should not wait for background processing")
@@ -463,6 +465,7 @@ async fn bot_events_returns_200_before_state_machine_final_processing_completes(
     collaboration_runtime.wait_for_terminal_start().await;
     collaboration_runtime.release_terminal();
     collaboration_runtime.wait_for_terminal_completion().await;
+    assert_eq!(collaboration_runtime.terminal_request_ids.lock().await.as_slice(), ["async-final-42"]);
 }
 
 #[tokio::test]
@@ -606,6 +609,7 @@ async fn bot_events_accepts_empty_state_machine_final_for_runtime_failure_handli
 #[tokio::test]
 async fn bot_events_logs_json_rejections_before_handler() {
     let TestApp { app, .. } = test_app(Arc::new(StaticAgentpassResolver::default()));
+    let app = app.layer(axum::middleware::from_fn(bcs_http::gateway_trace::observe_request));
 
     let logs = capture_tracing_logs(async {
         let response = app
@@ -615,6 +619,7 @@ async fn bot_events_logs_json_rejections_before_handler() {
                     .uri("/bot/events")
                     .header("content-type", "application/json")
                     .header("X-BCN-Provider-Id", "prv-log")
+                    .header("x-request-id", "rejected-callback-42")
                     .header("authorization", "Bearer runtime-token")
                     .body(Body::from(
                         json!({
@@ -646,6 +651,8 @@ async fn bot_events_logs_json_rejections_before_handler() {
         logs.contains("provider callback: invalid bot event request"),
         "expected invalid request log, got:\n{logs}"
     );
+    let rejection = logs.lines().find(|line| line.contains("provider callback: invalid bot event request")).unwrap();
+    assert!(rejection.contains("request_id=rejected-callback-42"), "request ID missing from business error: {rejection}");
     assert!(
         logs.contains("provider_id=prv-log"),
         "expected provider id in log, got:\n{logs}"

--- a/src/bcs/crates/adapters/http/bcs-http/tests/request_observations.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/request_observations.rs
@@ -252,3 +252,29 @@ async fn detached_logging_does_not_extend_existing_a2a_spans() {
         assert!(background["fields"].get("trace_id").is_none());
     }
 }
+
+#[tokio::test]
+async fn protocol_upgrade_is_not_reported_as_an_http_error() {
+    let buffer = Buffer::default();
+    let writer = buffer.clone();
+    let subscriber = tracing_subscriber::fmt().json().with_writer(move || writer.clone()).finish();
+    async {
+        for status in [StatusCode::SWITCHING_PROTOCOLS, StatusCode::OK, StatusCode::UNAUTHORIZED] {
+            let app = Router::new().route("/ws/bot", post(move || async move { status }))
+                .layer(middleware::from_fn(bcs_http::gateway_trace::observe_request));
+            let request_id = format!("status-{}", status.as_u16());
+            let request = Request::builder().method("POST").uri("/ws/bot")
+                .header("x-request-id", &request_id).body(Body::empty()).unwrap();
+            let response = app.oneshot(request).await.unwrap();
+            assert_eq!(response.status(), status);
+            assert_eq!(response.headers()["x-request-id"], request_id);
+        }
+    }.with_subscriber(subscriber).await;
+    let logs = String::from_utf8(buffer.0.lock().unwrap().clone()).unwrap();
+    let events: Vec<serde_json::Value> = logs.lines().map(|line| serde_json::from_str(line).unwrap()).collect();
+    for (status, outcome) in [(101, "upgraded"), (200, "success"), (401, "http_error")] {
+        let event = events.iter().find(|event| event["fields"]["message"] == "http.request.response_ready"
+            && event["fields"]["status"] == status).unwrap();
+        assert_eq!(event["fields"]["outcome"], outcome);
+    }
+}

--- a/src/bcs/crates/adapters/http/bcs-http/tests/secret_diagnostics.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/secret_diagnostics.rs
@@ -1,0 +1,49 @@
+use std::{net::SocketAddr, sync::{Arc, atomic::{AtomicUsize, Ordering}}};
+
+use axum::{body::{Body, to_bytes}, extract::ConnectInfo, http::{Request, StatusCode}};
+use bcs_http::{gateway_trace::observe_request, router::build_router, state::HttpAppState};
+use bcs_service_api::application::{SecretService, SecretServiceError, SecretView};
+use bcs_services_container::Services;
+use bcs_test_support::capture_request_logs;
+use tower::ServiceExt;
+
+struct UnavailableSecret(AtomicUsize);
+
+#[async_trait::async_trait]
+impl SecretService for UnavailableSecret {
+    async fn get_secret(&self, name: &str) -> Result<SecretView, SecretServiceError> {
+        assert_eq!(name, "diagnostic-key");
+        self.0.fetch_add(1, Ordering::SeqCst);
+        Err(SecretServiceError::Unavailable("secret backend offline".into()))
+    }
+}
+
+#[tokio::test]
+async fn secret_rejections_and_dependency_failures_keep_the_http_request_id() {
+    let service = Arc::new(UnavailableSecret(AtomicUsize::new(0)));
+    let state = HttpAppState::new(Services::builder().secret(service.clone()).build_for_test());
+    let app = build_router(state).layer(axum::middleware::from_fn(observe_request));
+    for (peer, id, status, kind, message, calls) in [
+        ("192.0.2.1:10001", "secret-remote", StatusCode::FORBIDDEN, "loopback_only",
+            "rejecting /admin/secret request from non-loopback", 0),
+        ("127.0.0.1:10002", "secret-unavailable", StatusCode::SERVICE_UNAVAILABLE, "unavailable",
+            "SecretService.get_secret failed", 1),
+    ] {
+        let request = Request::builder().uri("/admin/secret/diagnostic-key")
+            .header("x-request-id", id)
+            .extension(ConnectInfo(peer.parse::<SocketAddr>().unwrap()))
+            .body(Body::empty()).unwrap();
+        let (response, events) = capture_request_logs("outer-test-context", app.clone().oneshot(request)).await;
+        let response = response.expect("HTTP response");
+        assert_eq!(response.status(), status);
+        assert_eq!(response.headers()["x-request-id"], id);
+        let body: serde_json::Value = serde_json::from_slice(&to_bytes(response.into_body(), usize::MAX).await.unwrap()).unwrap();
+        assert_eq!(body["error"], kind);
+        assert_eq!(service.0.load(Ordering::SeqCst), calls);
+        let warning = events.iter().find(|event| event["fields"]["message"] == message)
+            .unwrap_or_else(|| panic!("missing diagnostic: {events:?}"));
+        assert_eq!(warning["level"], "WARN");
+        assert_eq!(warning["fields"]["request_id"], id);
+        assert!(events.iter().all(|event| event["fields"].get("trace_id").is_none()));
+    }
+}

--- a/src/bcs/crates/adapters/ws/bcs-ws/Cargo.toml
+++ b/src/bcs/crates/adapters/ws/bcs-ws/Cargo.toml
@@ -39,7 +39,7 @@ bcs-route-security = { workspace = true }
 tokio-test  = "0.4"
 tokio-tungstenite = "0.26"
 bcs-session = { workspace = true }
-bcs-test-support = { workspace = true }
+bcs-test-support = { workspace = true, features = ["diagnostic-logs"] }
 bcs-services-container = { workspace = true, features = ["test-support"] }
 bcs-interaction = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/src/bcs/crates/adapters/ws/bcs-ws/src/bot/connection_registry.rs
+++ b/src/bcs/crates/adapters/ws/bcs-ws/src/bot/connection_registry.rs
@@ -94,7 +94,7 @@ impl BotConnectionRegistry {
         };
 
         tx.send(frame_json).await.map_err(|err| {
-            warn!(request_id = %bcs_observability::current_request_id(), bot_id = %bot_id, error = %err, "bot delivery failed");
+            warn!(request_id = %bcs_observability::CurrentRequestId, bot_id = %bot_id, error = %err, "bot delivery failed");
         })
     }
 
@@ -320,7 +320,7 @@ impl BotConnectionControlPort for BotConnectionRegistry {
         let frame_str = match serde_json::to_string(&frame) {
             Ok(s) => s,
             Err(err) => {
-                warn!(request_id = %bcs_observability::current_request_id(), bot_id = %bot_id, error = %err, "kick: failed to serialize event frame");
+                warn!(request_id = %bcs_observability::CurrentRequestId, bot_id = %bot_id, error = %err, "kick: failed to serialize event frame");
                 return true;
             }
         };

--- a/src/bcs/crates/adapters/ws/bcs-ws/src/bot/connection_registry.rs
+++ b/src/bcs/crates/adapters/ws/bcs-ws/src/bot/connection_registry.rs
@@ -94,7 +94,7 @@ impl BotConnectionRegistry {
         };
 
         tx.send(frame_json).await.map_err(|err| {
-            warn!(bot_id = %bot_id, error = %err, "bot delivery failed");
+            warn!(request_id = %bcs_observability::current_request_id(), bot_id = %bot_id, error = %err, "bot delivery failed");
         })
     }
 
@@ -320,7 +320,7 @@ impl BotConnectionControlPort for BotConnectionRegistry {
         let frame_str = match serde_json::to_string(&frame) {
             Ok(s) => s,
             Err(err) => {
-                warn!(bot_id = %bot_id, error = %err, "kick: failed to serialize event frame");
+                warn!(request_id = %bcs_observability::current_request_id(), bot_id = %bot_id, error = %err, "kick: failed to serialize event frame");
                 return true;
             }
         };

--- a/src/bcs/crates/adapters/ws/bcs-ws/src/bot/dispatcher.rs
+++ b/src/bcs/crates/adapters/ws/bcs-ws/src/bot/dispatcher.rs
@@ -438,7 +438,7 @@ async fn reject_provider_delivery_websocket(
         Ok(false) | Err(ServiceError::BotNotFound(_)) => Ok(false),
         Err(err) => {
             warn!(
-                request_id = %bcs_observability::current_request_id(),
+                request_id = %bcs_observability::CurrentRequestId,
                 bot_id = %bot_id,
                 error = %err,
                 "provider delivery guard failed; allowing WebSocket connect"
@@ -514,7 +514,7 @@ async fn handle_bot_status(
         .map_err(map_bot_use_case_error)?;
 
     if !outcome.updated {
-        warn!(request_id = %bcs_observability::current_request_id(), bot_id = %bot_id, "Failed to update status - bot not found in registry");
+        warn!(request_id = %bcs_observability::CurrentRequestId, bot_id = %bot_id, "Failed to update status - bot not found in registry");
         send_error(tx, req_id, "not_registered", "Bot not found in registry").await?;
         return Ok(());
     }
@@ -621,7 +621,7 @@ async fn handle_response_frame(
         if is_known_run {
             // Forward error to client and clean up
             warn!(
-                request_id = %bcs_observability::current_request_id(),
+                request_id = %bcs_observability::CurrentRequestId,
                 run_id = %run_id,
                 error = %error,
                 "Bot rejected request, cleaning up run channel"
@@ -650,7 +650,7 @@ async fn handle_response_frame(
             state.run_channels.unregister(run_id).await;
         } else {
             warn!(
-                request_id = %bcs_observability::current_request_id(),
+                request_id = %bcs_observability::CurrentRequestId,
                 run_id = %run_id,
                 error = %error,
                 "Received error ResponseFrame for unknown run"
@@ -791,7 +791,7 @@ async fn log_bot_response_frame(
     } else {
         warn!(
             target: MSG_LOG_TARGET,
-            request_id = %bcs_observability::current_request_id(),
+            request_id = %bcs_observability::CurrentRequestId,
             schema_version = MESSAGE_LOG_SCHEMA_VERSION,
             event_type = event_type.as_str(),
             status = status.as_str(),
@@ -833,7 +833,7 @@ async fn handle_event_frame(
         Some(id) => id.clone(),
         None => {
             log_bot_event("unknown", event);
-            warn!(request_id = %bcs_observability::current_request_id(), event = %event.event, "Received EventFrame from unregistered bot");
+            warn!(request_id = %bcs_observability::CurrentRequestId, event = %event.event, "Received EventFrame from unregistered bot");
             return Ok(());
         }
     };
@@ -848,7 +848,7 @@ async fn handle_event_frame(
                 (run_id, group_id, is_final)
             }
             None => {
-                warn!(request_id = %bcs_observability::current_request_id(), bot_id = %bot_id, "Failed to parse agent event payload");
+                warn!(request_id = %bcs_observability::CurrentRequestId, bot_id = %bot_id, "Failed to parse agent event payload");
                 return Ok(());
             }
         },
@@ -861,12 +861,12 @@ async fn handle_event_frame(
                 (run_id, group_id, is_final)
             }
             None => {
-                warn!(request_id = %bcs_observability::current_request_id(), bot_id = %bot_id, "Failed to parse chat event payload");
+                warn!(request_id = %bcs_observability::CurrentRequestId, bot_id = %bot_id, "Failed to parse chat event payload");
                 return Ok(());
             }
         },
         _ => {
-            warn!(request_id = %bcs_observability::current_request_id(), bot_id = %bot_id, event = %event.event, "Unknown event type");
+            warn!(request_id = %bcs_observability::CurrentRequestId, bot_id = %bot_id, event = %event.event, "Unknown event type");
             return Ok(());
         }
     };
@@ -1241,7 +1241,7 @@ async fn handle_accepted_run_id_response(
                 .await
             {
                 warn!(
-                    request_id = %bcs_observability::current_request_id(),
+                    request_id = %bcs_observability::CurrentRequestId,
                     canonical_run_id = %run_id,
                     downstream_run_id = %sub_run_id,
                     error = %error,
@@ -1256,7 +1256,7 @@ async fn handle_accepted_run_id_response(
                 Ok(rebound) => rebound,
                 Err(error) => {
                     warn!(
-                        request_id = %bcs_observability::current_request_id(),
+                        request_id = %bcs_observability::CurrentRequestId,
                         source_run_id = %run_id,
                         accepted_run_id = %sub_run_id,
                         error = %error,
@@ -1274,7 +1274,7 @@ async fn handle_accepted_run_id_response(
                     Ok(registration) => registration,
                     Err(error) => {
                         warn!(
-                            request_id = %bcs_observability::current_request_id(),
+                            request_id = %bcs_observability::CurrentRequestId,
                             task_id = %run_id,
                             sub_bot_run_id = %sub_run_id,
                             bot_id = %bot_id,
@@ -1395,7 +1395,7 @@ async fn handle_state_machine_response(
         Ok(None) => return,
         Err(error) => {
             warn!(
-                request_id = %bcs_observability::current_request_id(),
+                request_id = %bcs_observability::CurrentRequestId,
                 run_id = %run_id,
                 error = %error,
                 "state_machine: failed to lookup delivery correlation for response"
@@ -1422,7 +1422,7 @@ async fn handle_state_machine_response(
         .await
     {
         warn!(
-            request_id = %bcs_observability::current_request_id(),
+            request_id = %bcs_observability::CurrentRequestId,
             delivery_request_id = %correlation.delivery_request_id,
             bot_delivery_run_id = %bot_delivery_run_id,
             error = %error,

--- a/src/bcs/crates/adapters/ws/bcs-ws/src/bot/dispatcher.rs
+++ b/src/bcs/crates/adapters/ws/bcs-ws/src/bot/dispatcher.rs
@@ -438,6 +438,7 @@ async fn reject_provider_delivery_websocket(
         Ok(false) | Err(ServiceError::BotNotFound(_)) => Ok(false),
         Err(err) => {
             warn!(
+                request_id = %bcs_observability::current_request_id(),
                 bot_id = %bot_id,
                 error = %err,
                 "provider delivery guard failed; allowing WebSocket connect"
@@ -513,7 +514,7 @@ async fn handle_bot_status(
         .map_err(map_bot_use_case_error)?;
 
     if !outcome.updated {
-        warn!(bot_id = %bot_id, "Failed to update status - bot not found in registry");
+        warn!(request_id = %bcs_observability::current_request_id(), bot_id = %bot_id, "Failed to update status - bot not found in registry");
         send_error(tx, req_id, "not_registered", "Bot not found in registry").await?;
         return Ok(());
     }
@@ -620,6 +621,7 @@ async fn handle_response_frame(
         if is_known_run {
             // Forward error to client and clean up
             warn!(
+                request_id = %bcs_observability::current_request_id(),
                 run_id = %run_id,
                 error = %error,
                 "Bot rejected request, cleaning up run channel"
@@ -648,6 +650,7 @@ async fn handle_response_frame(
             state.run_channels.unregister(run_id).await;
         } else {
             warn!(
+                request_id = %bcs_observability::current_request_id(),
                 run_id = %run_id,
                 error = %error,
                 "Received error ResponseFrame for unknown run"
@@ -788,6 +791,7 @@ async fn log_bot_response_frame(
     } else {
         warn!(
             target: MSG_LOG_TARGET,
+            request_id = %bcs_observability::current_request_id(),
             schema_version = MESSAGE_LOG_SCHEMA_VERSION,
             event_type = event_type.as_str(),
             status = status.as_str(),
@@ -829,7 +833,7 @@ async fn handle_event_frame(
         Some(id) => id.clone(),
         None => {
             log_bot_event("unknown", event);
-            warn!(event = %event.event, "Received EventFrame from unregistered bot");
+            warn!(request_id = %bcs_observability::current_request_id(), event = %event.event, "Received EventFrame from unregistered bot");
             return Ok(());
         }
     };
@@ -844,7 +848,7 @@ async fn handle_event_frame(
                 (run_id, group_id, is_final)
             }
             None => {
-                warn!(bot_id = %bot_id, "Failed to parse agent event payload");
+                warn!(request_id = %bcs_observability::current_request_id(), bot_id = %bot_id, "Failed to parse agent event payload");
                 return Ok(());
             }
         },
@@ -857,12 +861,12 @@ async fn handle_event_frame(
                 (run_id, group_id, is_final)
             }
             None => {
-                warn!(bot_id = %bot_id, "Failed to parse chat event payload");
+                warn!(request_id = %bcs_observability::current_request_id(), bot_id = %bot_id, "Failed to parse chat event payload");
                 return Ok(());
             }
         },
         _ => {
-            warn!(bot_id = %bot_id, event = %event.event, "Unknown event type");
+            warn!(request_id = %bcs_observability::current_request_id(), bot_id = %bot_id, event = %event.event, "Unknown event type");
             return Ok(());
         }
     };
@@ -1237,6 +1241,7 @@ async fn handle_accepted_run_id_response(
                 .await
             {
                 warn!(
+                    request_id = %bcs_observability::current_request_id(),
                     canonical_run_id = %run_id,
                     downstream_run_id = %sub_run_id,
                     error = %error,
@@ -1251,6 +1256,7 @@ async fn handle_accepted_run_id_response(
                 Ok(rebound) => rebound,
                 Err(error) => {
                     warn!(
+                        request_id = %bcs_observability::current_request_id(),
                         source_run_id = %run_id,
                         accepted_run_id = %sub_run_id,
                         error = %error,
@@ -1268,6 +1274,7 @@ async fn handle_accepted_run_id_response(
                     Ok(registration) => registration,
                     Err(error) => {
                         warn!(
+                            request_id = %bcs_observability::current_request_id(),
                             task_id = %run_id,
                             sub_bot_run_id = %sub_run_id,
                             bot_id = %bot_id,
@@ -1388,6 +1395,7 @@ async fn handle_state_machine_response(
         Ok(None) => return,
         Err(error) => {
             warn!(
+                request_id = %bcs_observability::current_request_id(),
                 run_id = %run_id,
                 error = %error,
                 "state_machine: failed to lookup delivery correlation for response"
@@ -1414,6 +1422,7 @@ async fn handle_state_machine_response(
         .await
     {
         warn!(
+            request_id = %bcs_observability::current_request_id(),
             delivery_request_id = %correlation.delivery_request_id,
             bot_delivery_run_id = %bot_delivery_run_id,
             error = %error,

--- a/src/bcs/crates/adapters/ws/bcs-ws/src/bot/handler.rs
+++ b/src/bcs/crates/adapters/ws/bcs-ws/src/bot/handler.rs
@@ -102,9 +102,9 @@ pub async fn handle_connection(
                                     let bot_uuid = bot_uuid.clone();
                                     let at = agent_token.clone();
                                     let ac = agent_code_header.clone();
-                                    tokio::spawn(async move {
+                                    tokio::spawn(bcs_observability::in_current_context(async move {
                                         backfill.backfill(&bot_uuid, at, ac).await;
-                                    });
+                                    }));
                                 }
                             } else {
                                 metrics_hook
@@ -118,7 +118,7 @@ pub async fn handle_connection(
                         }
                     }
                     Err(e) => {
-                        warn!(error = %e, "Frame dispatch error");
+                        warn!(request_id = %bcs_observability::current_request_id(), error = %e, "Frame dispatch error");
                         let error_kind =
                             if let BotWsDispatchError::BotConnectError { bot_uuid, .. } = &e {
                                 if observed_bot_uuid.is_none() {
@@ -150,7 +150,7 @@ pub async fn handle_connection(
                 }
             }
             Ok(Message::Binary(data)) => {
-                warn!(len = data.len(), "Received unexpected binary frame");
+                warn!(request_id = %bcs_observability::current_request_id(), len = data.len(), "Received unexpected binary frame");
             }
             Ok(Message::Ping(_data)) => {
                 debug!("Received ping, sending pong");
@@ -218,7 +218,7 @@ pub async fn handle_connection(
             })
             .await
         {
-            warn!(bot_id = %bot_id, error = %err, "Failed to record bot streaming disconnect");
+            warn!(request_id = %bcs_observability::current_request_id(), bot_id = %bot_id, error = %err, "Failed to record bot streaming disconnect");
         }
         state.bot_connections.disconnect(bot_id).await;
 
@@ -250,6 +250,7 @@ pub async fn handle_connection(
 
 fn log_websocket_error(error: &impl std::fmt::Display, bot_uuid: Option<&str>, registered: bool) {
     error!(
+        request_id = %bcs_observability::current_request_id(),
         bot_uuid = bot_uuid.unwrap_or("unknown"),
         registered,
         error = %error,

--- a/src/bcs/crates/adapters/ws/bcs-ws/src/bot/handler.rs
+++ b/src/bcs/crates/adapters/ws/bcs-ws/src/bot/handler.rs
@@ -118,7 +118,7 @@ pub async fn handle_connection(
                         }
                     }
                     Err(e) => {
-                        warn!(request_id = %bcs_observability::current_request_id(), error = %e, "Frame dispatch error");
+                        warn!(request_id = %bcs_observability::CurrentRequestId, error = %e, "Frame dispatch error");
                         let error_kind =
                             if let BotWsDispatchError::BotConnectError { bot_uuid, .. } = &e {
                                 if observed_bot_uuid.is_none() {
@@ -150,7 +150,7 @@ pub async fn handle_connection(
                 }
             }
             Ok(Message::Binary(data)) => {
-                warn!(request_id = %bcs_observability::current_request_id(), len = data.len(), "Received unexpected binary frame");
+                warn!(request_id = %bcs_observability::CurrentRequestId, len = data.len(), "Received unexpected binary frame");
             }
             Ok(Message::Ping(_data)) => {
                 debug!("Received ping, sending pong");
@@ -218,7 +218,7 @@ pub async fn handle_connection(
             })
             .await
         {
-            warn!(request_id = %bcs_observability::current_request_id(), bot_id = %bot_id, error = %err, "Failed to record bot streaming disconnect");
+            warn!(request_id = %bcs_observability::CurrentRequestId, bot_id = %bot_id, error = %err, "Failed to record bot streaming disconnect");
         }
         state.bot_connections.disconnect(bot_id).await;
 
@@ -250,7 +250,7 @@ pub async fn handle_connection(
 
 fn log_websocket_error(error: &impl std::fmt::Display, bot_uuid: Option<&str>, registered: bool) {
     error!(
-        request_id = %bcs_observability::current_request_id(),
+        request_id = %bcs_observability::CurrentRequestId,
         bot_uuid = bot_uuid.unwrap_or("unknown"),
         registered,
         error = %error,

--- a/src/bcs/crates/adapters/ws/bcs-ws/src/gateway/chat_handler.rs
+++ b/src/bcs/crates/adapters/ws/bcs-ws/src/gateway/chat_handler.rs
@@ -401,6 +401,7 @@ async fn execute_chat_task(
         if !bot_result.success {
             had_error = true;
             warn!(
+                request_id = %bcs_observability::current_request_id(),
                 run_id = %run_id,
                 bot_id = %bot_result.bot_uuid,
                 error = ?bot_result.error,

--- a/src/bcs/crates/adapters/ws/bcs-ws/src/gateway/chat_handler.rs
+++ b/src/bcs/crates/adapters/ws/bcs-ws/src/gateway/chat_handler.rs
@@ -401,7 +401,7 @@ async fn execute_chat_task(
         if !bot_result.success {
             had_error = true;
             warn!(
-                request_id = %bcs_observability::current_request_id(),
+                request_id = %bcs_observability::CurrentRequestId,
                 run_id = %run_id,
                 bot_id = %bot_result.bot_uuid,
                 error = ?bot_result.error,

--- a/src/bcs/crates/adapters/ws/bcs-ws/src/shared/run_channels.rs
+++ b/src/bcs/crates/adapters/ws/bcs-ws/src/shared/run_channels.rs
@@ -91,6 +91,7 @@ impl RunChannelManager {
                 }
                 Err(err) => {
                     warn!(
+                        request_id = %bcs_observability::current_request_id(),
                         run_id = %run_id,
                         resolved_run_id = %resolved_run_id,
                         error = %err,
@@ -250,6 +251,7 @@ impl RunChannelManager {
             Some(session_id) => session_id,
             None => {
                 warn!(
+                    request_id = %bcs_observability::current_request_id(),
                     alias_run_id = %alias_run_id,
                     source_run_id = %source_run_id,
                     resolved_source_run_id = %resolved_source_run_id,
@@ -261,6 +263,7 @@ impl RunChannelManager {
 
         if !self.channels.read().await.contains_key(&resolved_source_run_id) {
             warn!(
+                request_id = %bcs_observability::current_request_id(),
                 alias_run_id = %alias_run_id,
                 source_run_id = %source_run_id,
                 resolved_source_run_id = %resolved_source_run_id,
@@ -342,7 +345,7 @@ impl RunChannelManager {
 
         let removed = before - channels.len();
         if removed > 0 {
-            warn!(removed, "Removed expired run channels");
+            warn!(request_id = %bcs_observability::current_request_id(), removed, "Removed expired run channels");
         }
     }
 }

--- a/src/bcs/crates/adapters/ws/bcs-ws/src/shared/run_channels.rs
+++ b/src/bcs/crates/adapters/ws/bcs-ws/src/shared/run_channels.rs
@@ -91,7 +91,7 @@ impl RunChannelManager {
                 }
                 Err(err) => {
                     warn!(
-                        request_id = %bcs_observability::current_request_id(),
+                        request_id = %bcs_observability::CurrentRequestId,
                         run_id = %run_id,
                         resolved_run_id = %resolved_run_id,
                         error = %err,
@@ -251,7 +251,7 @@ impl RunChannelManager {
             Some(session_id) => session_id,
             None => {
                 warn!(
-                    request_id = %bcs_observability::current_request_id(),
+                    request_id = %bcs_observability::CurrentRequestId,
                     alias_run_id = %alias_run_id,
                     source_run_id = %source_run_id,
                     resolved_source_run_id = %resolved_source_run_id,
@@ -263,7 +263,7 @@ impl RunChannelManager {
 
         if !self.channels.read().await.contains_key(&resolved_source_run_id) {
             warn!(
-                request_id = %bcs_observability::current_request_id(),
+                request_id = %bcs_observability::CurrentRequestId,
                 alias_run_id = %alias_run_id,
                 source_run_id = %source_run_id,
                 resolved_source_run_id = %resolved_source_run_id,
@@ -345,7 +345,7 @@ impl RunChannelManager {
 
         let removed = before - channels.len();
         if removed > 0 {
-            warn!(request_id = %bcs_observability::current_request_id(), removed, "Removed expired run channels");
+            warn!(request_id = %bcs_observability::CurrentRequestId, removed, "Removed expired run channels");
         }
     }
 }

--- a/src/bcs/crates/adapters/ws/bcs-ws/src/web/connection_registry.rs
+++ b/src/bcs/crates/adapters/ws/bcs-ws/src/web/connection_registry.rs
@@ -143,7 +143,7 @@ impl WorkbenchConnectionRegistry {
                 }
                 Err(mpsc::error::TrySendError::Closed(_)) => disconnected.push(conn.conn_id),
                 Err(mpsc::error::TrySendError::Full(_)) => {
-                    warn!(session_id = %session_id, conn_id = conn.conn_id, "frontend channel full");
+                    warn!(request_id = %bcs_observability::current_request_id(), session_id = %session_id, conn_id = conn.conn_id, "frontend channel full");
                 }
             }
         }
@@ -175,6 +175,7 @@ impl WorkbenchConnectionRegistry {
             Ok(actor) => actor.status == ActorStatus::Hidden,
             Err(error) => {
                 warn!(
+                    request_id = %bcs_observability::current_request_id(),
                     user_id = %user_id,
                     %error,
                     "silent-status get_bot failed at subscribe; defaulting to not-silent"

--- a/src/bcs/crates/adapters/ws/bcs-ws/src/web/connection_registry.rs
+++ b/src/bcs/crates/adapters/ws/bcs-ws/src/web/connection_registry.rs
@@ -143,7 +143,7 @@ impl WorkbenchConnectionRegistry {
                 }
                 Err(mpsc::error::TrySendError::Closed(_)) => disconnected.push(conn.conn_id),
                 Err(mpsc::error::TrySendError::Full(_)) => {
-                    warn!(request_id = %bcs_observability::current_request_id(), session_id = %session_id, conn_id = conn.conn_id, "frontend channel full");
+                    warn!(request_id = %bcs_observability::CurrentRequestId, session_id = %session_id, conn_id = conn.conn_id, "frontend channel full");
                 }
             }
         }
@@ -175,7 +175,7 @@ impl WorkbenchConnectionRegistry {
             Ok(actor) => actor.status == ActorStatus::Hidden,
             Err(error) => {
                 warn!(
-                    request_id = %bcs_observability::current_request_id(),
+                    request_id = %bcs_observability::CurrentRequestId,
                     user_id = %user_id,
                     %error,
                     "silent-status get_bot failed at subscribe; defaulting to not-silent"

--- a/src/bcs/crates/adapters/ws/bcs-ws/src/web/dispatcher.rs
+++ b/src/bcs/crates/adapters/ws/bcs-ws/src/web/dispatcher.rs
@@ -130,10 +130,10 @@ pub async fn dispatch_client_frame(
             }
         }
         BcsFrame::Response(res) => {
-            warn!(id = %res.id, ok = res.ok, "Unexpected ResponseFrame from frontend client");
+            warn!(request_id = %bcs_observability::current_request_id(), id = %res.id, ok = res.ok, "Unexpected ResponseFrame from frontend client");
         }
         BcsFrame::Event(event) => {
-            warn!(event = %event.event, "Unexpected EventFrame from frontend client");
+            warn!(request_id = %bcs_observability::current_request_id(), event = %event.event, "Unexpected EventFrame from frontend client");
         }
     }
 
@@ -276,6 +276,7 @@ async fn handle_connect(
             Ok(outcome) => outcome,
             Err(err) => {
                 warn!(
+                    request_id = %bcs_observability::current_request_id(),
                     group_id = %group_id,
                     session_id = ?session_id,
                     bound_actor_id = ?bound_actor_id,
@@ -311,7 +312,7 @@ async fn handle_connect(
                         .await
                 }
                 _ => {
-                    warn!("session-bound connect is missing a valid V1 authorization context");
+                    warn!(request_id = %bcs_observability::current_request_id(), "session-bound connect is missing a valid V1 authorization context");
                     send_session_access_revoked(tx, &req.id, connection_state).await?;
                     return Ok(());
                 }
@@ -332,6 +333,7 @@ async fn handle_connect(
                 },
                 Err(err) => {
                     warn!(
+                        request_id = %bcs_observability::current_request_id(),
                         error = ?err,
                         "connect rejected by V1 group-session authorization"
                     );
@@ -376,7 +378,7 @@ async fn handle_connect(
                 }
             }
             Err(error) => {
-                warn!(session_id, %error, "pending interaction replay failed after connect");
+                warn!(request_id = %bcs_observability::current_request_id(), session_id, %error, "pending interaction replay failed after connect");
             }
         }
     }
@@ -571,7 +573,7 @@ async fn handle_interaction_resolve(
             .await?;
         }
         Err(InteractionServiceError::Internal(message)) => {
-            warn!(%message, "interaction resolve application service failed");
+            warn!(request_id = %bcs_observability::current_request_id(), %message, "interaction resolve application service failed");
             send_error_shape(
                 tx,
                 &req.id,
@@ -701,6 +703,7 @@ async fn handle_chat_send(
         .await
     {
         warn!(
+            request_id = %bcs_observability::current_request_id(),
             from = %from_id,
             group_id = %group_id,
             bound_actor_id = ?bound_actor_id,
@@ -739,6 +742,7 @@ async fn handle_chat_send(
         }
         Err(error) => {
             warn!(
+                request_id = %bcs_observability::current_request_id(),
                 group_id = %group_id,
                 session_id = ?session_id,
                 error = %error,
@@ -1001,6 +1005,7 @@ async fn handle_chat_abort(
         .await
     {
         warn!(
+            request_id = %bcs_observability::current_request_id(),
             actor_id = %bound_actor_id,
             group_id = %group_id,
             session_id = %session_id,
@@ -1046,6 +1051,7 @@ async fn handle_chat_abort(
             // best-effort and must not turn that successful command into a WS
             // failure.
             warn!(
+                request_id = %bcs_observability::current_request_id(),
                 run_id = %aborted_run_id,
                 %error,
                 "failed to invalidate aborted run interactions"

--- a/src/bcs/crates/adapters/ws/bcs-ws/src/web/dispatcher.rs
+++ b/src/bcs/crates/adapters/ws/bcs-ws/src/web/dispatcher.rs
@@ -130,10 +130,10 @@ pub async fn dispatch_client_frame(
             }
         }
         BcsFrame::Response(res) => {
-            warn!(request_id = %bcs_observability::current_request_id(), id = %res.id, ok = res.ok, "Unexpected ResponseFrame from frontend client");
+            warn!(request_id = %bcs_observability::CurrentRequestId, id = %res.id, ok = res.ok, "Unexpected ResponseFrame from frontend client");
         }
         BcsFrame::Event(event) => {
-            warn!(request_id = %bcs_observability::current_request_id(), event = %event.event, "Unexpected EventFrame from frontend client");
+            warn!(request_id = %bcs_observability::CurrentRequestId, event = %event.event, "Unexpected EventFrame from frontend client");
         }
     }
 
@@ -276,7 +276,7 @@ async fn handle_connect(
             Ok(outcome) => outcome,
             Err(err) => {
                 warn!(
-                    request_id = %bcs_observability::current_request_id(),
+                    request_id = %bcs_observability::CurrentRequestId,
                     group_id = %group_id,
                     session_id = ?session_id,
                     bound_actor_id = ?bound_actor_id,
@@ -312,7 +312,7 @@ async fn handle_connect(
                         .await
                 }
                 _ => {
-                    warn!(request_id = %bcs_observability::current_request_id(), "session-bound connect is missing a valid V1 authorization context");
+                    warn!(request_id = %bcs_observability::CurrentRequestId, "session-bound connect is missing a valid V1 authorization context");
                     send_session_access_revoked(tx, &req.id, connection_state).await?;
                     return Ok(());
                 }
@@ -333,7 +333,7 @@ async fn handle_connect(
                 },
                 Err(err) => {
                     warn!(
-                        request_id = %bcs_observability::current_request_id(),
+                        request_id = %bcs_observability::CurrentRequestId,
                         error = ?err,
                         "connect rejected by V1 group-session authorization"
                     );
@@ -378,7 +378,7 @@ async fn handle_connect(
                 }
             }
             Err(error) => {
-                warn!(request_id = %bcs_observability::current_request_id(), session_id, %error, "pending interaction replay failed after connect");
+                warn!(request_id = %bcs_observability::CurrentRequestId, session_id, %error, "pending interaction replay failed after connect");
             }
         }
     }
@@ -573,7 +573,7 @@ async fn handle_interaction_resolve(
             .await?;
         }
         Err(InteractionServiceError::Internal(message)) => {
-            warn!(request_id = %bcs_observability::current_request_id(), %message, "interaction resolve application service failed");
+            warn!(request_id = %bcs_observability::CurrentRequestId, %message, "interaction resolve application service failed");
             send_error_shape(
                 tx,
                 &req.id,
@@ -703,7 +703,7 @@ async fn handle_chat_send(
         .await
     {
         warn!(
-            request_id = %bcs_observability::current_request_id(),
+            request_id = %bcs_observability::CurrentRequestId,
             from = %from_id,
             group_id = %group_id,
             bound_actor_id = ?bound_actor_id,
@@ -742,7 +742,7 @@ async fn handle_chat_send(
         }
         Err(error) => {
             warn!(
-                request_id = %bcs_observability::current_request_id(),
+                request_id = %bcs_observability::CurrentRequestId,
                 group_id = %group_id,
                 session_id = ?session_id,
                 error = %error,
@@ -1005,7 +1005,7 @@ async fn handle_chat_abort(
         .await
     {
         warn!(
-            request_id = %bcs_observability::current_request_id(),
+            request_id = %bcs_observability::CurrentRequestId,
             actor_id = %bound_actor_id,
             group_id = %group_id,
             session_id = %session_id,
@@ -1051,7 +1051,7 @@ async fn handle_chat_abort(
             // best-effort and must not turn that successful command into a WS
             // failure.
             warn!(
-                request_id = %bcs_observability::current_request_id(),
+                request_id = %bcs_observability::CurrentRequestId,
                 run_id = %aborted_run_id,
                 %error,
                 "failed to invalidate aborted run interactions"

--- a/src/bcs/crates/adapters/ws/bcs-ws/src/web/group_session.rs
+++ b/src/bcs/crates/adapters/ws/bcs-ws/src/web/group_session.rs
@@ -73,7 +73,9 @@ async fn upgrade(
     let dispatch = state.dispatch;
     let metrics = state.metrics;
 
-    ws.on_upgrade(move |socket| handle_client_connection(socket, dispatch, auth, metrics))
+    let log_request_id = bcs_observability::current_request_id();
+    ws.on_upgrade(move |socket| bcs_observability::with_request_id(
+        log_request_id, handle_client_connection(socket, dispatch, auth, metrics)))
 }
 
 fn connection_token(raw_query: Option<&str>) -> Option<String> {

--- a/src/bcs/crates/adapters/ws/bcs-ws/src/web/handler.rs
+++ b/src/bcs/crates/adapters/ws/bcs-ws/src/web/handler.rs
@@ -114,7 +114,7 @@ pub async fn handle_client_connection(
                                 }
                             }
                             Err(e) => {
-                                warn!(request_id = %bcs_observability::current_request_id(), client_id = client_id, error = %e, "Frame dispatch error");
+                                warn!(request_id = %bcs_observability::CurrentRequestId, client_id = client_id, error = %e, "Frame dispatch error");
                                 let error_kind = if matches!(&e, WebWsDispatchError::ClientConnectError(_)) {
                                     WsErrorKind::RegisterRejected
                                 } else {
@@ -142,7 +142,7 @@ pub async fn handle_client_connection(
                         }
                     }
                     Ok(Message::Binary(data)) => {
-                        warn!(request_id = %bcs_observability::current_request_id(), client_id = client_id, len = data.len(), "Received unexpected binary frame");
+                        warn!(request_id = %bcs_observability::CurrentRequestId, client_id = client_id, len = data.len(), "Received unexpected binary frame");
                     }
                     Ok(Message::Ping(_data)) => {
                         debug!(client_id = client_id, "Received WebSocket ping");
@@ -162,7 +162,7 @@ pub async fn handle_client_connection(
                     }
                     Err(e) => {
                         close_reason = WsCloseReason::ProtocolError;
-                        error!(request_id = %bcs_observability::current_request_id(), client_id = client_id, error = %e, "WebSocket error");
+                        error!(request_id = %bcs_observability::CurrentRequestId, client_id = client_id, error = %e, "WebSocket error");
                         metrics_hook
                             .error(
                                 WsPeer::Frontend,

--- a/src/bcs/crates/adapters/ws/bcs-ws/src/web/handler.rs
+++ b/src/bcs/crates/adapters/ws/bcs-ws/src/web/handler.rs
@@ -114,7 +114,7 @@ pub async fn handle_client_connection(
                                 }
                             }
                             Err(e) => {
-                                warn!(client_id = client_id, error = %e, "Frame dispatch error");
+                                warn!(request_id = %bcs_observability::current_request_id(), client_id = client_id, error = %e, "Frame dispatch error");
                                 let error_kind = if matches!(&e, WebWsDispatchError::ClientConnectError(_)) {
                                     WsErrorKind::RegisterRejected
                                 } else {
@@ -142,7 +142,7 @@ pub async fn handle_client_connection(
                         }
                     }
                     Ok(Message::Binary(data)) => {
-                        warn!(client_id = client_id, len = data.len(), "Received unexpected binary frame");
+                        warn!(request_id = %bcs_observability::current_request_id(), client_id = client_id, len = data.len(), "Received unexpected binary frame");
                     }
                     Ok(Message::Ping(_data)) => {
                         debug!(client_id = client_id, "Received WebSocket ping");
@@ -162,7 +162,7 @@ pub async fn handle_client_connection(
                     }
                     Err(e) => {
                         close_reason = WsCloseReason::ProtocolError;
-                        error!(client_id = client_id, error = %e, "WebSocket error");
+                        error!(request_id = %bcs_observability::current_request_id(), client_id = client_id, error = %e, "WebSocket error");
                         metrics_hook
                             .error(
                                 WsPeer::Frontend,

--- a/src/bcs/crates/adapters/ws/bcs-ws/tests/diagnostic_registries.rs
+++ b/src/bcs/crates/adapters/ws/bcs-ws/tests/diagnostic_registries.rs
@@ -1,0 +1,78 @@
+use bcs_protocol::{BcsFrame, RequestFrame};
+use bcs_service_api::{BotDeliveryCommand, BotDeliveryKind, BotDeliveryPort, BotDeliveryTarget, ServiceError};
+use bcs_ws::{bot::BotConnectionRegistry, shared::RunChannelManager, web::WorkbenchConnectionRegistry};
+use tokio::sync::mpsc;
+
+#[tokio::test]
+async fn closed_bot_channel_reports_failed_delivery_with_request_id() {
+    let registry = BotConnectionRegistry::new();
+    let (tx, rx) = mpsc::channel(1);
+    registry.connect("disconnected-bot".into(), tx).await;
+    drop(rx);
+    let (result, logs) = bcs_test_support::capture_request_logs("failed-bot-delivery", registry.deliver(BotDeliveryCommand {
+        target: BotDeliveryTarget::WebSocket { bot_id: "disconnected-bot".into() },
+        run_id: "run-delivery".into(),
+        frame: BcsFrame::Request(RequestFrame::new("run-delivery", "chat.send", None)),
+        delivery_kind: BotDeliveryKind::Send,
+        provider_transport: Default::default(),
+        provider_bypass_headers: Vec::new(),
+    })).await;
+    let result = result.unwrap();
+    assert!(!result.delivered);
+    assert_eq!(result.target_bot_id, "disconnected-bot");
+    assert!(matches!(result.error, Some(ServiceError::BotNotConnected(id)) if id == "disconnected-bot"));
+    let warning = logs.iter().find(|event| event["fields"]["message"] == "bot delivery failed").unwrap();
+    assert_eq!(warning["level"], "WARN");
+    assert_eq!(warning["fields"]["request_id"], "failed-bot-delivery");
+    assert_eq!(warning["fields"]["bot_id"], "disconnected-bot");
+}
+
+#[tokio::test]
+async fn expired_run_channel_is_removed_and_no_longer_delivers() {
+    let registry = RunChannelManager::new();
+    let (tx, mut rx) = mpsc::channel(1);
+    registry.register("expired-run".into(), "session-diagnostic".into(), tx, None, None).await;
+    assert!(registry.send_event("expired-run", "before-expiry".into()).await);
+    assert_eq!(rx.recv().await.as_deref(), Some("before-expiry"));
+    let (_, logs) = bcs_test_support::capture_request_logs("expired-run-request", async {
+        // Zero TTL deterministically expires an existing channel without sleeping.
+        registry.cleanup_expired(0).await;
+        assert_eq!(registry.run_count().await, 0);
+        assert!(!registry.send_event("expired-run", "after-expiry".into()).await);
+        assert!(!registry.send_event_by_session("session-diagnostic", "after-expiry".into()).await);
+    }).await;
+    assert!(rx.recv().await.is_none());
+    let warning = logs.iter().find(|event| event["fields"]["message"] == "Removed expired run channels").unwrap();
+    assert_eq!(warning["fields"]["request_id"], "expired-run-request");
+    assert_eq!(warning["fields"]["removed"], 1);
+}
+
+#[tokio::test]
+async fn failed_run_delivery_and_full_frontend_queue_remain_observable_without_false_success() {
+    let runs = RunChannelManager::new();
+    let (tx, rx) = mpsc::channel(1);
+    runs.register("failed-run".into(), "session-diagnostic".into(), tx, None, None).await;
+    drop(rx);
+    let frontends = WorkbenchConnectionRegistry::new();
+    let (tx, mut rx) = mpsc::channel(1);
+    let connection_id = frontends.subscribe("session-diagnostic".into(), tx, None).await;
+    assert_eq!(frontends.broadcast("session-diagnostic", "first-event").await, 1);
+    let (_, logs) = bcs_test_support::capture_request_logs("full-queue-request", async {
+        assert!(!runs.send_event("failed-run", "event".into()).await);
+        let delivered = tokio::time::timeout(std::time::Duration::from_secs(1),
+            frontends.broadcast("session-diagnostic", "overflow-event")).await
+            .expect("a full queue must reject the event without blocking");
+        assert_eq!(delivered, 0);
+    }).await;
+    assert_eq!(rx.recv().await.as_deref(), Some("first-event"));
+    assert!(rx.try_recv().is_err(), "overflow must not overwrite the queued event");
+    assert_eq!(frontends.connection_count("session-diagnostic").await, 1, "a full queue is not a disconnection");
+    assert_eq!(frontends.broadcast("session-diagnostic", "after-drain").await, 1);
+    assert_eq!(rx.recv().await.as_deref(), Some("after-drain"));
+    for message in ["Failed to send event to client channel", "frontend channel full"] {
+        let warning = logs.iter().find(|event| event["fields"]["message"] == message).expect(message);
+        assert_eq!(warning["level"], "WARN");
+        assert_eq!(warning["fields"]["request_id"], "full-queue-request");
+        if message == "frontend channel full" { assert_eq!(warning["fields"]["conn_id"], connection_id); }
+    }
+}

--- a/src/bcs/crates/adapters/ws/bcs-ws/tests/frame_compat.rs
+++ b/src/bcs/crates/adapters/ws/bcs-ws/tests/frame_compat.rs
@@ -50,6 +50,8 @@ struct RecordingBotRuntime {
     statuses: Mutex<HashMap<String, BotDynamicStatus>>,
     connect_count: AtomicUsize,
     delivery_target: Mutex<Option<BotDeliveryTarget>>,
+    reject_status_update: std::sync::atomic::AtomicBool,
+    fail_disconnect: std::sync::atomic::AtomicBool,
 }
 
 #[derive(Default)]
@@ -383,6 +385,13 @@ impl BotRuntimeConnectionService for RecordingBotRuntime {
         &self,
         command: BotRuntimeStatusCommand,
     ) -> Result<BotRuntimeStatusOutcome, BotUseCaseError> {
+        if self.reject_status_update.load(Ordering::Relaxed) {
+            return Ok(BotRuntimeStatusOutcome {
+                updated: false,
+                bot_uuid: command.bot_id,
+                status: command.status,
+            });
+        }
         self.statuses
             .lock()
             .await
@@ -398,6 +407,9 @@ impl BotRuntimeConnectionService for RecordingBotRuntime {
         &self,
         command: BotRuntimeDisconnectCommand,
     ) -> Result<(), BotUseCaseError> {
+        if self.fail_disconnect.load(Ordering::Relaxed) {
+            return Err(ServiceError::InternalError("disconnect persistence unavailable".into()).into());
+        }
         self.statuses.lock().await.remove(&command.bot_id);
         Ok(())
     }
@@ -642,6 +654,103 @@ fn new_state() -> TestState {
         system_message,
         bot_run_context,
         dispatch_state,
+    }
+}
+
+#[tokio::test]
+async fn invalid_bot_events_are_dropped_with_request_correlated_warnings() {
+    let state = new_state();
+    let (tx, mut rx) = mpsc::channel(8);
+    let cases = [
+        (None, "agent", "Received EventFrame from unregistered bot"),
+        (Some("bot-diagnostic".to_string()), "agent", "Failed to parse agent event payload"),
+        (Some("bot-diagnostic".to_string()), "chat.event", "Failed to parse chat event payload"),
+        (Some("bot-diagnostic".to_string()), "future.event", "Unknown event type"),
+    ];
+    for (mut registered, event, message) in cases {
+        let frame = BcsFrame::Event(EventFrame::new(event, Some(serde_json::json!({})), None));
+        let (outcome, logs) = bcs_test_support::capture_request_logs("invalid-bot-event", async {
+            dispatch_frame(&state.dispatch_state, &serde_json::to_string(&frame).unwrap(), &tx, &mut registered).await
+        }).await;
+        assert!(matches!(outcome.unwrap(), BotDispatchOutcome::Dispatched));
+        assert!(rx.try_recv().is_err(), "ignored events must not produce a protocol response");
+        assert!(state.message_flow.bot_events.lock().await.is_empty(), "invalid events must not reach message flow");
+        let warning = logs.iter().find(|event| event["fields"]["message"] == message).expect(message);
+        assert_eq!(warning["level"], "WARN");
+        assert_eq!(warning["fields"]["request_id"], "invalid-bot-event");
+    }
+}
+
+#[tokio::test]
+async fn status_for_removed_bot_returns_not_registered_and_correlates_warning() {
+    let state = new_state();
+    state.bot_runtime.reject_status_update.store(true, Ordering::Relaxed);
+    let (tx, mut rx) = mpsc::channel(8);
+    let mut registered = Some("removed-bot".to_string());
+    let frame = BcsFrame::Request(RequestFrame::new("status-removed", "bot.status", Some(serde_json::json!({"status":"idle"}))));
+    let (_, logs) = bcs_test_support::capture_request_logs("removed-bot-request", async {
+        dispatch_frame(&state.dispatch_state, &serde_json::to_string(&frame).unwrap(), &tx, &mut registered).await.unwrap();
+    }).await;
+    let response = recv_response(&mut rx).await;
+    assert_eq!(response.id, "status-removed");
+    assert!(!response.ok);
+    assert_eq!(response.error.unwrap().code, "not_registered");
+    assert!(state.bot_runtime.statuses.lock().await.is_empty());
+    let warning = logs.iter().find(|event| event["fields"]["message"] == "Failed to update status - bot not found in registry").unwrap();
+    assert_eq!(warning["fields"]["request_id"], "removed-bot-request");
+    assert_eq!(warning["fields"]["bot_id"], "removed-bot");
+}
+
+#[tokio::test]
+async fn bot_socket_errors_keep_request_identity_and_cleanup_after_disconnect_failure() {
+    use futures::{SinkExt, StreamExt};
+    use tokio_tungstenite::tungstenite::Message;
+    let state = new_state();
+    state.bot_runtime.fail_disconnect.store(true, Ordering::Relaxed);
+    let registry = state.dispatch_state.bot_connections.clone();
+    let (_, logs) = bcs_test_support::capture_request_logs("bot-socket-diagnostic", async {
+        let dispatch = tracing::dispatcher::get_default(Clone::clone);
+        let request_id = bcs_observability::current_request_id();
+        let (finished_tx, finished_rx) = tokio::sync::oneshot::channel();
+        let finished_tx = Arc::new(Mutex::new(Some(finished_tx)));
+        let app = axum::Router::new().route("/ws/bot", axum::routing::get(move |ws: axum::extract::ws::WebSocketUpgrade| {
+            let state = state.dispatch_state.clone();
+            let dispatch = dispatch.clone();
+            let request_id = request_id.clone();
+            let finished_tx = finished_tx.clone();
+            async move {
+                ws.on_upgrade(move |socket| bcs_observability::with_request_id(request_id, async move {
+                    bcs_ws::bot::handle_connection(socket, state, Arc::new(bcs_test_support::NoopWsLifecycleInstrumentationHook), None, None).await;
+                    finished_tx.lock().await.take().unwrap().send(()).unwrap();
+                }).with_subscriber(dispatch))
+            }
+        }));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap(); });
+        let (mut socket, _) = tokio_tungstenite::connect_async(format!("ws://{addr}/ws/bot")).await.unwrap();
+        socket.send(Message::Binary(vec![1, 2, 3].into())).await.unwrap();
+        socket.send(Message::Text("{".into())).await.unwrap();
+        let response = tokio::time::timeout(std::time::Duration::from_secs(2), socket.next()).await.unwrap().unwrap().unwrap();
+        let response: serde_json::Value = serde_json::from_str(response.to_text().unwrap()).unwrap();
+        assert_eq!(response["ok"], false);
+        assert_eq!(response["error"]["code"], "dispatch_error");
+        let connect = BcsFrame::Request(RequestFrame::new("connect-diagnostic", "bot.connect", Some(serde_json::json!({"bot_id":"bot-diagnostic","protocol_version":1}))));
+        socket.send(Message::Text(serde_json::to_string(&connect).unwrap().into())).await.unwrap();
+        let response = tokio::time::timeout(std::time::Duration::from_secs(2), socket.next()).await.unwrap().unwrap().unwrap();
+        let response: serde_json::Value = serde_json::from_str(response.to_text().unwrap()).unwrap();
+        assert_eq!(response["ok"], true);
+        assert!(registry.is_connected("bot-diagnostic").await);
+        socket.close(None).await.unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(2), finished_rx).await.unwrap().unwrap();
+        assert!(!registry.is_connected("bot-diagnostic").await, "adapter cleanup must still run when persistence fails");
+        server.abort();
+        let _ = server.await;
+    }).await;
+    for message in ["Received unexpected binary frame", "Frame dispatch error", "Failed to record bot streaming disconnect"] {
+        let warning = logs.iter().find(|event| event["fields"]["message"] == message).expect(message);
+        assert_eq!(warning["level"], "WARN");
+        assert_eq!(warning["fields"]["request_id"], "bot-socket-diagnostic");
     }
 }
 

--- a/src/bcs/crates/adapters/ws/bcs-ws/tests/group_session_ws.rs
+++ b/src/bcs/crates/adapters/ws/bcs-ws/tests/group_session_ws.rs
@@ -32,6 +32,7 @@ struct RecordingConnectionService {
     mode: VerifyMode,
     verified_tokens: Mutex<Vec<String>>,
     authorizations: Mutex<Vec<AuthorizeGroupSessionConnection>>,
+    authorization_request_ids: Mutex<Vec<String>>,
 }
 
 impl RecordingConnectionService {
@@ -40,6 +41,7 @@ impl RecordingConnectionService {
             mode,
             verified_tokens: Mutex::new(Vec::new()),
             authorizations: Mutex::new(Vec::new()),
+            authorization_request_ids: Mutex::new(Vec::new()),
         }
     }
 }
@@ -75,6 +77,7 @@ impl GroupSessionConnectionService for RecordingConnectionService {
         command: AuthorizeGroupSessionConnection,
     ) -> Result<AuthorizedGroupSessionConnection, GroupSessionConnectionError> {
         self.authorizations.lock().await.push(command);
+        self.authorization_request_ids.lock().await.push(bcs_observability::current_request_id());
         Ok(AuthorizedGroupSessionConnection {
             participants: Vec::new(),
         })
@@ -107,7 +110,12 @@ async fn start(
         .expect("bind test server");
     let addr = listener.local_addr().expect("test server address");
     let handle = tokio::spawn(async move {
-        axum::serve(listener, app(service))
+        let app = app(service).layer(axum::middleware::from_fn(
+            |request: axum::extract::Request, next: axum::middleware::Next| async move {
+                bcs_observability::with_request_context("group-ws-handshake-42".into(), next.run(request)).await
+            },
+        ));
+        axum::serve(listener, app)
             .await
             .expect("serve test app");
     });
@@ -197,6 +205,10 @@ async fn valid_token_upgrades_and_connect_uses_the_immutable_verified_binding() 
     };
     let response: BcsFrame = serde_json::from_str(&response).expect("BCS response frame");
     assert!(matches!(response, BcsFrame::Response(response) if response.ok));
+
+    // This authorization runs on a real post-upgrade Axum task, after the HTTP
+    // middleware has returned. The production upgrade boundary must carry its ID.
+    assert_eq!(service.authorization_request_ids.lock().await.as_slice(), ["group-ws-handshake-42"]);
 
     assert_eq!(
         service.verified_tokens.lock().await.as_slice(),

--- a/src/bcs/crates/adapters/ws/bcs-ws/tests/web_frame_compat.rs
+++ b/src/bcs/crates/adapters/ws/bcs-ws/tests/web_frame_compat.rs
@@ -378,6 +378,7 @@ struct RecordingInteractions {
     resolves: Mutex<Vec<ResolveInteractionCommand>>,
     next_result: Mutex<Option<Result<ResolveInteractionResult, InteractionServiceError>>>,
     pending: Mutex<Vec<InteractionFrontendEvent>>,
+    pending_error: Mutex<Option<bcs_service_api::ServiceError>>,
     invalidations: Mutex<Vec<(String, String)>>,
 }
 
@@ -416,6 +417,9 @@ impl InteractionService for RecordingInteractions {
         &self,
         _bcs_session_id: &str,
     ) -> ServiceResult<Vec<InteractionFrontendEvent>> {
+        if let Some(error) = self.pending_error.lock().await.take() {
+            return Err(error);
+        }
         Ok(self.pending.lock().await.clone())
     }
 
@@ -473,6 +477,134 @@ async fn recv_response(rx: &mut mpsc::Receiver<String>) -> ResponseFrame {
     match serde_json::from_str::<BcsFrame>(&raw).unwrap() {
         BcsFrame::Response(res) => res,
         other => panic!("expected response frame, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn unexpected_frontend_frames_are_ignored_with_correlated_warnings() {
+    let state = new_state();
+    let (tx, mut rx) = mpsc::channel(8);
+    let mut connection = WebClientConnectionState::default();
+    let frames = [
+        (BcsFrame::Response(ResponseFrame::ok("unexpected-response", serde_json::json!({}))), "Unexpected ResponseFrame from frontend client"),
+        (BcsFrame::Event(bcs_protocol::EventFrame::new("unexpected.event", None, None)), "Unexpected EventFrame from frontend client"),
+    ];
+    for (frame, message) in frames {
+        let (result, logs) = bcs_test_support::capture_request_logs("unexpected-web-frame", async {
+            dispatch_client_frame(&state.dispatch_state, &serde_json::to_string(&frame).unwrap(), &tx,
+                &mut connection, &WorkbenchConnectionAuth::UserBound { actor_id: None }).await
+        }).await;
+        assert!(matches!(result.unwrap(), WebDispatchOutcome::Dispatched));
+        assert!(rx.try_recv().is_err(), "unexpected client frames must not produce responses");
+        assert!(connection.subscribed_sessions.is_empty());
+        let warning = logs.iter().find(|event| event["fields"]["message"] == message).expect(message);
+        assert_eq!(warning["level"], "WARN");
+        assert_eq!(warning["fields"]["request_id"], "unexpected-web-frame");
+    }
+}
+
+#[tokio::test]
+async fn invalid_session_authorization_context_closes_and_logs_request_id() {
+    let state = new_state();
+    let (tx, mut rx) = mpsc::channel(8);
+    let mut connection = WebClientConnectionState::default();
+    let auth = WorkbenchConnectionAuth::SessionBound {
+        tenant: None, actor_id: "bot-not-a-human".into(), group_id: "group-web-1".into(), session_id: "session-bound-1".into(),
+    };
+    let frame = BcsFrame::Request(RequestFrame::new("invalid-binding", "connect", Some(serde_json::json!({
+        "group_id":"group-web-1", "session_id":"session-bound-1"
+    }))));
+    let (result, logs) = bcs_test_support::capture_request_logs("invalid-session-context", async {
+        dispatch_client_frame(&state.dispatch_state, &serde_json::to_string(&frame).unwrap(), &tx, &mut connection, &auth).await
+    }).await;
+    assert!(matches!(result.unwrap(), WebDispatchOutcome::Close));
+    let response = recv_response(&mut rx).await;
+    assert_eq!(response.id, "invalid-binding");
+    assert_eq!(response.error.unwrap().code, "session_access_revoked");
+    assert!(connection.subscribed_sessions.is_empty());
+    let warning = logs.iter().find(|event| event["fields"]["message"] == "session-bound connect is missing a valid V1 authorization context").unwrap();
+    assert_eq!(warning["fields"]["request_id"], "invalid-session-context");
+}
+
+#[tokio::test]
+async fn interaction_service_failures_preserve_connect_ack_and_retryable_resolution_error() {
+    let state = new_state();
+    *state.interactions.pending_error.lock().await = Some(bcs_service_api::ServiceError::InternalError("pending store unavailable".into()));
+    let (tx, mut rx) = mpsc::channel(8);
+    let mut connection = WebClientConnectionState::default();
+    let (_, logs) = bcs_test_support::capture_request_logs("interaction-failure-request", async {
+        connect_session_bound(&state, &tx, &mut rx, &mut connection).await;
+        assert!(rx.try_recv().is_err(), "failed replay must not fabricate an interaction event");
+        *state.interactions.next_result.lock().await = Some(Err(InteractionServiceError::Internal("internal resolution store unavailable".into())));
+        let frame = BcsFrame::Request(RequestFrame::new("resolve-unavailable", "interaction.resolve", Some(serde_json::json!({
+            "bcsRunId":"run-diagnostic", "interactionId":"interaction-diagnostic", "idempotencyKey":"diagnostic-key", "decision":"allow_once"
+        }))));
+        dispatch_client_frame(&state.dispatch_state, &serde_json::to_string(&frame).unwrap(), &tx, &mut connection, &session_bound_auth()).await.unwrap();
+        let response = recv_response(&mut rx).await;
+        assert_eq!(response.id, "resolve-unavailable");
+        assert!(!response.ok);
+        let error = response.error.unwrap();
+        assert_eq!(error.code, "interaction_resolve_failed");
+        assert_eq!(error.message, "Interaction resolution could not be processed");
+        assert!(error.retryable);
+        assert_eq!(error.details.unwrap()["interactionStatus"], "pending");
+        assert_eq!(state.interactions.resolves.lock().await.len(), 1);
+        assert_eq!(connection.subscribed_sessions.len(), 1, "service failure must preserve subscription");
+    }).await;
+    // The resolution logger explicitly records `%message`; JSON retains that
+    // application error under `message`, while the protocol response stays generic.
+    for message in ["pending interaction replay failed after connect", "internal resolution store unavailable"] {
+        let warning = logs.iter().find(|event| event["fields"]["message"] == message)
+            .unwrap_or_else(|| panic!("missing warning {message}: {logs:?}"));
+        assert_eq!(warning["level"], "WARN");
+        assert_eq!(warning["fields"]["request_id"], "interaction-failure-request");
+    }
+}
+
+#[tokio::test]
+async fn frontend_socket_malformed_binary_and_abrupt_close_logs_keep_request_id() {
+    use futures::{SinkExt, StreamExt};
+    use tracing::instrument::WithSubscriber;
+    use tokio_tungstenite::tungstenite::Message;
+    let state = new_state();
+    let (_, logs) = bcs_test_support::capture_request_logs("web-socket-diagnostic", async {
+        let dispatch = tracing::dispatcher::get_default(Clone::clone);
+        let request_id = bcs_observability::current_request_id();
+        let (finished_tx, finished_rx) = tokio::sync::oneshot::channel();
+        let finished_tx = Arc::new(Mutex::new(Some(finished_tx)));
+        let app = axum::Router::new().route("/ws", axum::routing::get(move |ws: axum::extract::ws::WebSocketUpgrade| {
+            let state = state.dispatch_state.clone();
+            let dispatch = dispatch.clone();
+            let request_id = request_id.clone();
+            let finished_tx = finished_tx.clone();
+            async move {
+                ws.on_upgrade(move |socket| bcs_observability::with_request_id(request_id, async move {
+                    bcs_ws::web::handle_client_connection(socket, state, WorkbenchConnectionAuth::UserBound { actor_id: None },
+                        Arc::new(bcs_test_support::NoopWsLifecycleInstrumentationHook)).await;
+                    finished_tx.lock().await.take().unwrap().send(()).unwrap();
+                }).with_subscriber(dispatch))
+            }
+        }));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap(); });
+        let (mut socket, _) = tokio_tungstenite::connect_async(format!("ws://{addr}/ws")).await.unwrap();
+        socket.send(Message::Binary(vec![1, 2, 3].into())).await.unwrap();
+        socket.send(Message::Text("{".into())).await.unwrap();
+        let response = timeout(Duration::from_secs(2), socket.next()).await.unwrap().unwrap().unwrap();
+        let response: serde_json::Value = serde_json::from_str(response.to_text().unwrap()).unwrap();
+        assert_eq!(response["ok"], false);
+        assert_eq!(response["error"]["code"], "dispatch_error");
+        // Drop TCP without a close frame so the actual read loop observes a protocol error.
+        drop(socket);
+        timeout(Duration::from_secs(2), finished_rx).await.unwrap().unwrap();
+        server.abort();
+        let _ = server.await;
+    }).await;
+    for (message, level) in [("Received unexpected binary frame", "WARN"), ("Frame dispatch error", "WARN"), ("WebSocket error", "ERROR")] {
+        let event = logs.iter().find(|event| event["fields"]["message"] == message).expect(message);
+        assert_eq!(event["level"], level);
+        assert_eq!(event["fields"]["request_id"], "web-socket-diagnostic");
     }
 }
 

--- a/src/bcs/crates/auxiliary/bcs-observability/CONTEXT.md
+++ b/src/bcs/crates/auxiliary/bcs-observability/CONTEXT.md
@@ -37,6 +37,11 @@ request/operation correlation and logging subscriber, never a live span.
 The helper neither enters a span nor prolongs its lifetime. New tasks without an
 explicit wrapper do not inherit task-local correlation automatically.
 
+`with_request_id` carries only log identity for long-lived tasks such as upgraded
+WebSocket connections. It retains no HTTP aggregate and emits no request summary.
+Capture the ID before the upgrade/spawn boundary. `process_instance_id` is a lazy
+process-lifetime UUID; it is log metadata, independent of distributed tracing.
+
 The package does not acquire, store or emit distributed trace IDs. Future tracing
 integration needs its own declared context/propagation contract; the base must
 never import its implementation. This extraction uses the existing tracing

--- a/src/bcs/crates/auxiliary/bcs-observability/CONTEXT.md
+++ b/src/bcs/crates/auxiliary/bcs-observability/CONTEXT.md
@@ -42,6 +42,14 @@ WebSocket connections. It retains no HTTP aggregate and emits no request summary
 Capture the ID before the upgrade/spawn boundary. `process_instance_id` is a lazy
 process-lifetime UUID; it is log metadata, independent of distributed tracing.
 
+`CurrentRequestId` is a display value for synchronous log fields. It borrows the
+active ID while the subscriber formats the event, avoiding a string clone at each
+call site. Use `current_request_id()` to capture an owned ID before spawning work
+or when cancellation can outlive the task-local scope. This also gives the lookup
+one ordinary Rust implementation instead of duplicating its expression across
+tracing and legacy-log macro branches, whose source coverage can map to the unused
+branch. Existing log targets, fields, levels and request IDs are preserved.
+
 The package does not acquire, store or emit distributed trace IDs. Future tracing
 integration needs its own declared context/propagation contract; the base must
 never import its implementation. This extraction uses the existing tracing

--- a/src/bcs/crates/auxiliary/bcs-observability/src/lib.rs
+++ b/src/bcs/crates/auxiliary/bcs-observability/src/lib.rs
@@ -5,7 +5,7 @@
 //! Correlation uses request IDs and parent/child operation IDs, independently of tracing.
 
 mod operation;
-pub use operation::{Operation, observe_result, observe_value, with_request_context, with_request_id, in_current_context, count, current_operation_id, current_request_id};
+pub use operation::{CurrentRequestId, Operation, observe_result, observe_value, with_request_context, with_request_id, in_current_context, count, current_operation_id, current_request_id};
 
 /// Identifies this process instance across restarts, independently of tracing.
 /// Numeric client/pool IDs are only meaningful together with this value.

--- a/src/bcs/crates/auxiliary/bcs-observability/src/lib.rs
+++ b/src/bcs/crates/auxiliary/bcs-observability/src/lib.rs
@@ -5,4 +5,11 @@
 //! Correlation uses request IDs and parent/child operation IDs, independently of tracing.
 
 mod operation;
-pub use operation::{Operation, observe_result, observe_value, with_request_context, in_current_context, count, current_operation_id, current_request_id};
+pub use operation::{Operation, observe_result, observe_value, with_request_context, with_request_id, in_current_context, count, current_operation_id, current_request_id};
+
+/// Identifies this process instance across restarts, independently of tracing.
+/// Numeric client/pool IDs are only meaningful together with this value.
+pub fn process_instance_id() -> &'static str {
+    static ID: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+    ID.get_or_init(|| uuid::Uuid::new_v4().to_string())
+}

--- a/src/bcs/crates/auxiliary/bcs-observability/src/operation.rs
+++ b/src/bcs/crates/auxiliary/bcs-observability/src/operation.rs
@@ -12,7 +12,7 @@ struct Totals {
 #[derive(Clone)]
 struct RequestContext {
     id: String,
-    totals: std::sync::Arc<std::sync::Mutex<std::collections::BTreeMap<&'static str, Totals>>>,
+    totals: Option<std::sync::Arc<std::sync::Mutex<std::collections::BTreeMap<&'static str, Totals>>>>,
 }
 tokio::task_local! {
     static REQUEST_CONTEXT: RequestContext;
@@ -28,7 +28,8 @@ pub fn current_request_id() -> String {
 }
 
 fn accumulate(context: &RequestContext, name: &'static str, outcome: &'static str, duration_ms: f64) {
-    let mut totals = context.totals.lock().unwrap_or_else(|error| error.into_inner());
+    let Some(totals) = &context.totals else { return; };
+    let mut totals = totals.lock().unwrap_or_else(|error| error.into_inner());
     let total = totals.entry(name).or_default();
     total.count += 1;
     total.total_ms += duration_ms;
@@ -41,14 +42,22 @@ pub fn count(name: &'static str, outcome: &'static str) {
 }
 
 pub async fn with_request_context<T>(request_id: String, future: impl Future<Output = T>) -> T {
-    let context = RequestContext { id: request_id, totals: Default::default() };
+    let totals = std::sync::Arc::default();
+    let context = RequestContext { id: request_id, totals: Some(std::sync::Arc::clone(&totals)) };
     let result = REQUEST_CONTEXT.scope(context.clone(), future).await;
-    let totals = context.totals.lock().unwrap_or_else(|error| error.into_inner());
+    let totals = totals.lock().unwrap_or_else(|error| error.into_inner());
     let observations = serde_json::to_string(&*totals).expect("finite operation durations");
     drop(totals);
     tracing::info!(target: "bcs_observation", request_id = %context.id,
         observations = %observations, "http.request.operations");
     result
+}
+
+/// Correlate long-lived work with its initiating request without collecting or
+/// emitting an HTTP request summary. Capture the ID before spawning/upgrading.
+/// This scope never retains a span or the initiating request's totals.
+pub async fn with_request_id<T>(request_id: String, future: impl Future<Output = T>) -> T {
+    REQUEST_CONTEXT.scope(RequestContext { id: request_id, totals: None }, future).await
 }
 
 /// Carry log correlation into detached work without retaining or entering spans.

--- a/src/bcs/crates/auxiliary/bcs-observability/src/operation.rs
+++ b/src/bcs/crates/auxiliary/bcs-observability/src/operation.rs
@@ -27,6 +27,16 @@ pub fn current_request_id() -> String {
     REQUEST_CONTEXT.try_with(|context| context.id.clone()).unwrap_or_default()
 }
 
+/// Displays the request ID at synchronous log emission without cloning it.
+/// Use `current_request_id()` instead when capturing identity for another task.
+pub struct CurrentRequestId;
+
+impl std::fmt::Display for CurrentRequestId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        REQUEST_CONTEXT.try_with(|context| f.write_str(&context.id)).unwrap_or(Ok(()))
+    }
+}
+
 fn accumulate(context: &RequestContext, name: &'static str, outcome: &'static str, duration_ms: f64) {
     let Some(totals) = &context.totals else { return; };
     let mut totals = totals.lock().unwrap_or_else(|error| error.into_inner());

--- a/src/bcs/crates/auxiliary/bcs-observability/tests/operations.rs
+++ b/src/bcs/crates/auxiliary/bcs-observability/tests/operations.rs
@@ -124,6 +124,37 @@ async fn stalled_warning_does_not_timeout_or_repeat() {
 }
 
 #[tokio::test]
+async fn long_lived_work_keeps_only_request_identity_after_handshake_finishes() {
+    let logs = capture(async {
+        let (release, ready) = tokio::sync::oneshot::channel();
+        let task = bcs_observability::with_request_context("ws-handshake-42".into(), async {
+            bcs_observability::observe_value("test.handshake", async {}).await;
+            let request_id = bcs_observability::current_request_id();
+            tokio::spawn(bcs_observability::with_request_id(request_id, async move {
+                ready.await.unwrap();
+                assert_eq!(bcs_observability::current_request_id(), "ws-handshake-42");
+                bcs_observability::observe_value("test.ws_frame", async {}).await;
+                tokio::spawn(bcs_observability::in_current_context(async {
+                    tracing::warn!(request_id = %bcs_observability::current_request_id(), "old WS business error");
+                })).await.unwrap();
+            }).with_current_subscriber())
+        }).await;
+        release.send(()).unwrap();
+        task.await.unwrap();
+        assert_eq!(bcs_observability::current_request_id(), "");
+    }).await;
+    let events: Vec<serde_json::Value> = logs.lines().map(|line| serde_json::from_str(line).unwrap()).collect();
+    let summaries: Vec<_> = events.iter().filter(|event| event["fields"]["message"] == "http.request.operations").collect();
+    assert_eq!(summaries.len(), 1, "WS lifetime must not emit another HTTP summary");
+    let totals: serde_json::Value = serde_json::from_str(summaries[0]["fields"]["observations"].as_str().unwrap()).unwrap();
+    assert_eq!(totals["test.handshake"]["count"], 1);
+    assert!(totals.get("test.ws_frame").is_none());
+    let error = events.iter().find(|event| event["fields"]["message"] == "old WS business error").unwrap();
+    assert_eq!(error["fields"]["request_id"], "ws-handshake-42");
+    assert!(events.iter().all(|event| event.get("span").is_none() && event.get("spans").is_none()));
+}
+
+#[tokio::test]
 async fn non_send_error_can_be_discarded_by_send_caller() {
     tokio::spawn(async {
         let failed = bcs_observability::observe_result("test.non_send", async {

--- a/src/bcs/crates/auxiliary/bcs-observability/tests/operations.rs
+++ b/src/bcs/crates/auxiliary/bcs-observability/tests/operations.rs
@@ -135,7 +135,7 @@ async fn long_lived_work_keeps_only_request_identity_after_handshake_finishes() 
                 assert_eq!(bcs_observability::current_request_id(), "ws-handshake-42");
                 bcs_observability::observe_value("test.ws_frame", async {}).await;
                 tokio::spawn(bcs_observability::in_current_context(async {
-                    tracing::warn!(request_id = %bcs_observability::current_request_id(), "old WS business error");
+                    tracing::warn!(request_id = %bcs_observability::CurrentRequestId, "old WS business error");
                 })).await.unwrap();
             }).with_current_subscriber())
         }).await;
@@ -219,4 +219,52 @@ async fn concurrent_request_scopes_do_not_leak() {
     };
     tokio::join!(request("request-a"), request("request-b"));
     assert_eq!(bcs_observability::current_request_id(), "");
+}
+
+#[tokio::test]
+async fn request_id_log_value_formats_the_emitting_context_without_leaking_between_requests() {
+    let logs = capture(async {
+        // The value is reusable: it reads the emitting context, not the context
+        // where it was constructed. Owned IDs remain necessary across tasks.
+        let field = bcs_observability::CurrentRequestId;
+        let barrier = tokio::sync::Barrier::new(2);
+        let emit = |id: &'static str| bcs_observability::with_request_id(id.into(), async {
+            barrier.wait().await;
+            tracing::warn!(request_id = %field, "request context error");
+        });
+        tokio::join!(emit("request-a"), emit("request-b"));
+        tracing::warn!(request_id = %field, "outside request context");
+    }).await;
+    let events: Vec<serde_json::Value> = logs.lines().map(|line| serde_json::from_str(line).unwrap()).collect();
+    let mut ids: Vec<_> = events.iter().filter(|event| event["fields"]["message"] == "request context error")
+        .map(|event| event["fields"]["request_id"].as_str().unwrap()).collect();
+    ids.sort_unstable();
+    assert_eq!(ids, ["request-a", "request-b"]);
+    let outside = events.iter().find(|event| event["fields"]["message"] == "outside request context").unwrap();
+    assert_eq!(outside["fields"]["request_id"], "");
+    assert!(events.iter().all(|event| event.get("span").is_none() && event.get("spans").is_none()));
+}
+
+#[test]
+fn process_identity_is_shared_by_threads_and_changes_in_a_new_process() {
+    let id = bcs_observability::process_instance_id();
+    uuid::Uuid::parse_str(id).expect("process identity is a UUID");
+    if std::env::var_os("BCS_OBSERVABILITY_PROCESS_PROBE").is_some() {
+        println!("PROCESS_INSTANCE_ID={id}");
+        return;
+    }
+    std::thread::scope(|scope| {
+        let threads: Vec<_> = (0..8).map(|_| scope.spawn(bcs_observability::process_instance_id)).collect();
+        for thread in threads { assert_eq!(thread.join().unwrap(), id); }
+    });
+    let child = std::process::Command::new(std::env::current_exe().unwrap())
+        .args(["--exact", "process_identity_is_shared_by_threads_and_changes_in_a_new_process", "--nocapture"])
+        .env("BCS_OBSERVABILITY_PROCESS_PROBE", "1")
+        .output().expect("start a fresh process to verify restart identity");
+    assert!(child.status.success(), "child process failed ({}): stdout={} stderr={}",
+        child.status, String::from_utf8_lossy(&child.stdout), String::from_utf8_lossy(&child.stderr));
+    let output = String::from_utf8(child.stdout).unwrap();
+    let child_id = output.lines().find_map(|line| line.strip_prefix("PROCESS_INSTANCE_ID=")).expect("child identity");
+    uuid::Uuid::parse_str(child_id).expect("child process identity is a UUID");
+    assert_ne!(child_id, id);
 }

--- a/src/bcs/crates/bootstrap/bcs/src/logging.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/logging.rs
@@ -214,7 +214,7 @@ fn timer_for_output<F: Clone>(
     timer: &LocalTime<F>,
     millisecond_timer: &LocalTime<F>,
 ) -> LocalTime<F> {
-    if output_name == "common-error" {
+    if output_name == "common-error" || output_name == "observability" {
         millisecond_timer.clone()
     } else {
         timer.clone()
@@ -617,4 +617,48 @@ mod tests {
         assert_eq!(json["run_id"], "r1");
         assert_eq!(json["event_type"], "bot_accept");
     }
+    #[test]
+    fn observation_file_duplicates_diagnostics_as_json_with_milliseconds() {
+        let dir = tempfile::tempdir().unwrap();
+        let output = LogOutputConfig {
+            name: "observability".into(), path: dir.path().to_string_lossy().into(),
+            file: "bcs-observability.log".into(), level: "info".into(), rotation: "daily".into(),
+            format: LogOutputFormat::Json, targets: vec!["bcs_observation".into(), "bcs_http_access".into()],
+            max_keep_days: 7,
+        };
+        let timer = LocalTime::new(format_description!("[year]-[month]-[day] [hour]:[minute]:[second]"));
+        let millis = LocalTime::new(format_description!("[year]-[month]-[day] [hour]:[minute]:[second].[subsecond digits:3]"));
+        let (main_writer, main_guard) = buffered_writer(RotatingFileWriter::new(dir.path(), "bcs.log"));
+        let (observation_writer, observation_guard) = buffered_writer(RotatingFileWriter::new(dir.path(), &output.file));
+        let subscriber = tracing_subscriber::registry()
+            .with(tracing_subscriber::fmt::layer().with_ansi(false).with_writer(main_writer))
+            .with(tracing_subscriber::fmt::layer().json().flatten_event(true)
+                .with_current_span(false).with_span_list(false)
+                .with_timer(timer_for_output(&output.name, &timer, &millis))
+                .with_writer(observation_writer).with_filter(build_output_targets_filter(&output)));
+        let dispatch = tracing::Dispatch::new(subscriber);
+        tracing::dispatcher::with_default(&dispatch, || {
+            tracing::warn!(target: "bcs_observation", request_id = "diagnostic-42", operation = "test.io",
+                duration_ms = 123.5, "bcs.operation.finished");
+            tracing::info!(target: "bcs_http_access", request_id = "diagnostic-42", status = 200, "http.request.response_ready");
+            tracing::info!(target: "unrelated_module", "ordinary business log");
+        });
+        drop(dispatch);
+        drop(main_guard);
+        drop(observation_guard);
+        let main = fs::read_to_string(dir.path().join("bcs.log")).unwrap();
+        assert!(main.contains("bcs.operation.finished") && main.contains("http.request.response_ready"));
+        assert!(main.contains("ordinary business log"));
+        let diagnostics = fs::read_to_string(dir.path().join(&output.file)).unwrap();
+        let events: Vec<serde_json::Value> = diagnostics.lines().map(|line| serde_json::from_str(line).unwrap()).collect();
+        assert_eq!(events.len(), 2);
+        for event in &events {
+            assert_eq!(event["request_id"], "diagnostic-42");
+            assert!(event.get("trace_id").is_none() && event.get("span").is_none() && event.get("spans").is_none());
+            assert_eq!(event["timestamp"].as_str().unwrap().as_bytes().get(19), Some(&b'.'));
+        }
+        assert_eq!(events[0]["duration_ms"], 123.5);
+        assert_eq!(events[1]["status"], 200);
+    }
+
 }

--- a/src/bcs/crates/bootstrap/bcs/src/server.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/server.rs
@@ -6220,17 +6220,18 @@ async fn ws_upgrade_handler(
         debug!("WS upgrade: anonymous session (no staff_no in cookie)");
     }
 
+    let request_id = bcs_observability::current_request_id();
     ws.on_upgrade(move |socket| {
         let ws_state = web_ws_dispatch_state(&state, None);
         let metrics_hook = ws_lifecycle_hook(&state);
-        bcs_ws::web::handle_client_connection(
+        bcs_observability::with_request_id(request_id, bcs_ws::web::handle_client_connection(
             socket,
             ws_state,
             bcs_ws::web::WorkbenchConnectionAuth::UserBound {
                 actor_id: bound_actor_id,
             },
             metrics_hook,
-        )
+        ))
     })
 }
 
@@ -6257,16 +6258,17 @@ async fn bot_ws_handler(
         .and_then(|v| v.to_str().ok())
         .map(|s| s.to_string());
 
+    let request_id = bcs_observability::current_request_id();
     ws.on_upgrade(move |socket| {
         let ws_state = bot_ws_dispatch_state(&state);
         let metrics_hook = ws_lifecycle_hook(&state);
-        bcs_ws::bot::handle_connection(
+        bcs_observability::with_request_id(request_id, bcs_ws::bot::handle_connection(
             socket,
             ws_state,
             metrics_hook,
             agent_token,
             agent_code_header,
-        )
+        ))
     })
 }
 

--- a/src/bcs/crates/plugin-api/bcs-auth-api/src/chain.rs
+++ b/src/bcs/crates/plugin-api/bcs-auth-api/src/chain.rs
@@ -69,7 +69,7 @@ impl AuthPluginChain {
                     tracing::debug!(plugin = name, "auth: plugin no match, trying next");
                 }
                 Err(e) => {
-                    tracing::warn!(plugin = name, outcome = "error", "auth: plugin failed");
+                    tracing::warn!(request_id = %bcs_observability::current_request_id(), plugin = name, outcome = "error", "auth: plugin failed");
                     return Err(e);
                 }
             }

--- a/src/bcs/crates/plugin-api/bcs-auth-api/src/chain.rs
+++ b/src/bcs/crates/plugin-api/bcs-auth-api/src/chain.rs
@@ -69,7 +69,7 @@ impl AuthPluginChain {
                     tracing::debug!(plugin = name, "auth: plugin no match, trying next");
                 }
                 Err(e) => {
-                    tracing::warn!(request_id = %bcs_observability::current_request_id(), plugin = name, outcome = "error", "auth: plugin failed");
+                    tracing::warn!(request_id = %bcs_observability::CurrentRequestId, plugin = name, outcome = "error", "auth: plugin failed");
                     return Err(e);
                 }
             }

--- a/src/bcs/crates/services/bcs-bot-store/Cargo.toml
+++ b/src/bcs/crates/services/bcs-bot-store/Cargo.toml
@@ -23,7 +23,7 @@ uuid = { workspace = true }
 [dev-dependencies]
 bcs-cache-local = { workspace = true }
 bcs-db-local = { workspace = true }
-bcs-test-support = { workspace = true }
+bcs-test-support = { workspace = true, features = ["diagnostic-logs"] }
 tempfile = { workspace = true }
 tokio-test = "0.4"
 

--- a/src/bcs/crates/services/bcs-bot-store/src/lib.rs
+++ b/src/bcs/crates/services/bcs-bot-store/src/lib.rs
@@ -491,7 +491,7 @@ impl PersistentBotRepo {
                 Value::from(env.as_str()),
             ]).await
         }.map_err(|e| {
-            warn!(bot_uuid = %bot_uuid, error = %e, "save_to_db: failed");
+            warn!(request_id = %bcs_observability::current_request_id(), bot_uuid = %bot_uuid, error = %e, "save_to_db: failed");
             ServiceError::InternalError(e.to_string())
         })?;
 
@@ -596,6 +596,7 @@ impl PersistentBotRepo {
                 }
                 (None, Some(code)) => {
                     warn!(
+                        request_id = %bcs_observability::current_request_id(),
                         bot_uuid = %bot_uuid,
                         source = "bot_info_fallback",
                         "load_from_mysql: agent_code missing in column, fell back to bot_info JSON"
@@ -777,7 +778,7 @@ impl PersistentBotRepo {
             )
             .await
             .map_err(|e| {
-                warn!(bot_uuid = %bot_uuid, error = %e, "save_token_to_db: failed");
+                warn!(request_id = %bcs_observability::current_request_id(), bot_uuid = %bot_uuid, error = %e, "save_token_to_db: failed");
                 ServiceError::InternalError(e.to_string())
             })?;
 
@@ -813,7 +814,7 @@ impl PersistentBotRepo {
             )
             .await
             .map_err(|e| {
-                warn!(bot_uuid = %bot_uuid, error = %e, "update_created_by_in_db: failed");
+                warn!(request_id = %bcs_observability::current_request_id(), bot_uuid = %bot_uuid, error = %e, "update_created_by_in_db: failed");
                 ServiceError::InternalError(e.to_string())
             })?;
 
@@ -934,7 +935,7 @@ impl PersistentBotRepo {
         {
             Ok(rows) => rows,
             Err(e) => {
-                warn!(token = %token, env = %env, error = %e, "find_bot_by_token_in_db: database query failed");
+                warn!(request_id = %bcs_observability::current_request_id(), token = %token, env = %env, error = %e, "find_bot_by_token_in_db: database query failed");
                 return None;
             }
         };
@@ -948,13 +949,13 @@ impl PersistentBotRepo {
                     return Some(bot_uuid);
                 }
                 Err(e) => {
-                    warn!(token = %token, error = %e, "find_bot_by_token_in_db: failed to get bot_uuid");
+                    warn!(request_id = %bcs_observability::current_request_id(), token = %token, error = %e, "find_bot_by_token_in_db: failed to get bot_uuid");
                     return None;
                 }
             }
         }
 
-        warn!(token = %token, "find_bot_by_token_in_db: no bot found");
+        warn!(request_id = %bcs_observability::current_request_id(), token = %token, "find_bot_by_token_in_db: no bot found");
         None
     }
 
@@ -970,7 +971,7 @@ impl PersistentBotRepo {
         {
             Ok(rows) => rows,
             Err(e) => {
-                warn!(agent_code = %agent_code, env = %env, error = %e, "find_bot_by_agent_code_in_db: query failed");
+                warn!(request_id = %bcs_observability::current_request_id(), agent_code = %agent_code, env = %env, error = %e, "find_bot_by_agent_code_in_db: query failed");
                 return None;
             }
         };
@@ -982,13 +983,13 @@ impl PersistentBotRepo {
                     return Some(bot_uuid);
                 }
                 Err(e) => {
-                    warn!(agent_code = %agent_code, error = %e, "find_bot_by_agent_code_in_db: failed to get bot_uuid");
+                    warn!(request_id = %bcs_observability::current_request_id(), agent_code = %agent_code, error = %e, "find_bot_by_agent_code_in_db: failed to get bot_uuid");
                     return None;
                 }
             }
         }
 
-        warn!(agent_code = %agent_code, "find_bot_by_agent_code_in_db: no bot found");
+        warn!(request_id = %bcs_observability::current_request_id(), agent_code = %agent_code, "find_bot_by_agent_code_in_db: no bot found");
         None
     }
 
@@ -1093,7 +1094,7 @@ impl PersistentBotRepo {
         {
             Ok(r) => r,
             Err(e) => {
-                warn!(error = %e, "list_bots_by_name_and_cooperatable_with_impl (page): failed");
+                warn!(request_id = %bcs_observability::current_request_id(), error = %e, "list_bots_by_name_and_cooperatable_with_impl (page): failed");
                 return (Vec::new(), 0);
             }
         };
@@ -1140,7 +1141,7 @@ impl PersistentBotRepo {
                 .map(|v| v as usize)
                 .unwrap_or(0),
             Err(e) => {
-                warn!(error = %e, "list_bots_by_name_and_cooperatable_with_impl (count): failed");
+                warn!(request_id = %bcs_observability::current_request_id(), error = %e, "list_bots_by_name_and_cooperatable_with_impl (count): failed");
                 0
             }
         };
@@ -1258,7 +1259,7 @@ impl BotMetricsSnapshotPort for PersistentBotRepo {
             .db_query(sql, vec![Value::from(env.as_str())])
             .await
             .map_err(|e| {
-                warn!(env = %env, error = %e, "bot metrics snapshot query failed");
+                warn!(request_id = %bcs_observability::current_request_id(), env = %env, error = %e, "bot metrics snapshot query failed");
                 ServiceError::InternalError(format!("bot metrics snapshot query failed: {}", e))
             })?;
 
@@ -1321,7 +1322,7 @@ impl BotRepoPort for PersistentBotRepo {
         self.save_to_db(&bot_id, &capabilities, session_token.as_deref(), None)
             .await
             .map_err(|e| {
-                warn!(bot_id = %bot_id, error = %e, "Failed to save bot to database during register");
+                warn!(request_id = %bcs_observability::current_request_id(), bot_id = %bot_id, error = %e, "Failed to save bot to database during register");
                 e
             })?;
 
@@ -1439,7 +1440,7 @@ impl BotRepoPort for PersistentBotRepo {
         self.save_to_db(&bot_id, &capabilities, Some(token), Some(created_by))
             .await
             .map_err(|e| {
-                warn!(bot_id = %bot_id, error = %e, "Failed to save bot to database during register_with_owner_and_token");
+                warn!(request_id = %bcs_observability::current_request_id(), bot_id = %bot_id, error = %e, "Failed to save bot to database during register_with_owner_and_token");
                 e
             })?;
 
@@ -1665,7 +1666,7 @@ impl BotRepoPort for PersistentBotRepo {
         // 后期需要其他字段时，应在 RegisteredBotInner 上新增一个 HashMap 内存对象
         // 来承载任意 key/value，而不是继续往 capabilities 上加字段。
         if key != "agent_token" && key != "client_kind" {
-            tracing::warn!(bot_id = %bot_id, key = %key, "add_bot_info: unrecognized key, ignoring");
+            tracing::warn!(request_id = %bcs_observability::current_request_id(), bot_id = %bot_id, key = %key, "add_bot_info: unrecognized key, ignoring");
             return;
         }
         if key == "client_kind" {
@@ -1722,7 +1723,7 @@ impl BotRepoPort for PersistentBotRepo {
                 .filter_map(|row| db_get_column::<String>(&row, "bot_uuid").ok())
                 .collect::<std::collections::HashSet<_>>(),
             Err(error) => {
-                warn!(env = %env, error = %error, "list_active: failed to load active bot ids from DB; returning empty result to preserve DB tombstone authority");
+                warn!(request_id = %bcs_observability::current_request_id(), env = %env, error = %error, "list_active: failed to load active bot ids from DB; returning empty result to preserve DB tombstone authority");
                 return Vec::new();
             }
         };
@@ -1744,7 +1745,7 @@ impl BotRepoPort for PersistentBotRepo {
         {
             Ok(rows) => rows,
             Err(error) => {
-                warn!(env = %env, error = %error, "list_all_bots: failed to load bot rows from DB; returning empty result");
+                warn!(request_id = %bcs_observability::current_request_id(), env = %env, error = %error, "list_all_bots: failed to load bot rows from DB; returning empty result");
                 return Vec::new();
             }
         };
@@ -1822,7 +1823,7 @@ impl BotRepoPort for PersistentBotRepo {
         {
             Ok(bots) => bots,
             Err(error) => {
-                warn!(created_by = %created_by, error = %error, "list_bots_by_creator_from_db: failed");
+                warn!(request_id = %bcs_observability::current_request_id(), created_by = %created_by, error = %error, "list_bots_by_creator_from_db: failed");
                 Vec::new()
             }
         }
@@ -1948,7 +1949,7 @@ impl BotRepoPort for PersistentBotRepo {
         bots.retain(|_, b| !b.is_expired());
         let removed = before - bots.len();
         if removed > 0 {
-            warn!(removed, "Removed expired bot registrations");
+            warn!(request_id = %bcs_observability::current_request_id(), removed, "Removed expired bot registrations");
         }
     }
 
@@ -2022,7 +2023,7 @@ impl BotRepoPort for PersistentBotRepo {
         )
         .await
         .map_err(|e| {
-            warn!(bot_uuid = %bot_id, error = %e, "update_visibility: failed to update database");
+            warn!(request_id = %bcs_observability::current_request_id(), bot_uuid = %bot_id, error = %e, "update_visibility: failed to update database");
             ServiceError::InternalError(e.to_string())
         })?;
 
@@ -2045,6 +2046,7 @@ impl BotRepoPort for PersistentBotRepo {
     #[allow(deprecated)]
     async fn set_hidden(&self, bot_id: &str, hidden: bool) -> ServiceResult<()> {
         warn!(
+            request_id = %bcs_observability::current_request_id(),
             bot_id = %bot_id,
             hidden = %hidden,
             "set_hidden is DEPRECATED and is now a Noop; use update_actor_status(bot_id, ActorStatus::Hidden) instead (Task H.1)"
@@ -2079,6 +2081,7 @@ impl BotRepoPort for PersistentBotRepo {
         .await
         .map_err(|e| {
             warn!(
+                request_id = %bcs_observability::current_request_id(),
                 bot_id = %bot_id,
                 status = %status_str,
                 error = %e,
@@ -2159,6 +2162,7 @@ impl BotRepoPort for PersistentBotRepo {
                 .await
                 .map_err(|e| {
                     warn!(
+                        request_id = %bcs_observability::current_request_id(),
                         bot_uuid = %bot_uuid,
                         error = %e,
                         "ensure_human_actor: failed to backfill bot_info"
@@ -2227,6 +2231,7 @@ impl BotRepoPort for PersistentBotRepo {
             .await
             .map_err(|e| {
                 warn!(
+                    request_id = %bcs_observability::current_request_id(),
                     bot_uuid = %bot_uuid,
                     error = %e,
                     "ensure_human_actor: INSERT IGNORE failed"
@@ -2276,6 +2281,7 @@ impl BotRepoPort for PersistentBotRepo {
             .await
             .map_err(|e| {
                 warn!(
+                    request_id = %bcs_observability::current_request_id(),
                     staff_no = %staff_no,
                     env = %env,
                     error = %e,
@@ -2378,6 +2384,7 @@ impl BotRepoPort for PersistentBotRepo {
         .await
         .map_err(|e| {
             warn!(
+                request_id = %bcs_observability::current_request_id(),
                 bot_uuid = %bot_uuid,
                 error = %e,
                 "update_human_name: failed to update database"
@@ -2479,7 +2486,7 @@ impl BotRepoPort for PersistentBotRepo {
         let result = self.find_bot_by_token_in_db(token).await;
         if result.is_none() {
             let prefix = &token[..8.min(token.len())];
-            warn!(token_prefix = %prefix, "find_bot_by_token: token not found in any layer (cache/memory/database)");
+            warn!(request_id = %bcs_observability::current_request_id(), token_prefix = %prefix, "find_bot_by_token: token not found in any layer (cache/memory/database)");
         }
         result
     }
@@ -2593,6 +2600,7 @@ impl BotRepoPort for PersistentBotRepo {
                 // surfaces as a stale-MOCK reconnect after a BCS restart.
                 if let Err(err) = self.save_token_to_db(&bot_id, &session_token).await {
                     warn!(
+                        request_id = %bcs_observability::current_request_id(),
                         bot_id = %bot_id,
                         error = %err,
                         "connect_or_promote_streaming: promote_mock DB persist failed; refusing ws"
@@ -2649,6 +2657,7 @@ impl BotRepoPort for PersistentBotRepo {
             // real token, already connected → reject
             (true, false, true) => {
                 warn!(
+                    request_id = %bcs_observability::current_request_id(),
                     bot_id = %bot_id,
                     branch = "already_connected",
                     "connect_or_promote_streaming: real-token bot already connected"
@@ -2660,6 +2669,7 @@ impl BotRepoPort for PersistentBotRepo {
             // via the existing reconnect_streaming(token) path.)
             (true, false, false) => {
                 warn!(
+                    request_id = %bcs_observability::current_request_id(),
                     bot_id = %bot_id,
                     branch = "already_registered",
                     "connect_or_promote_streaming: refusing empty/stale-token claim of real-token bot"
@@ -2677,7 +2687,7 @@ impl BotRepoPort for PersistentBotRepo {
         // Check if bot is already connected
         if let Some(bot) = bots.get(&bot_id) {
             if bot.ws_connection.is_some() {
-                warn!(bot_id = %bot_id, "Bot already has an active streaming connection");
+                warn!(request_id = %bcs_observability::current_request_id(), bot_id = %bot_id, "Bot already has an active streaming connection");
                 return Err(());
             }
         }
@@ -2743,7 +2753,7 @@ impl BotRepoPort for PersistentBotRepo {
         // Check if bot is already connected
         if let Some(bot) = bots.get(&bot_id) {
             if bot.ws_connection.is_some() {
-                warn!(bot_id = %bot_id, "Bot already has an active connection");
+                warn!(request_id = %bcs_observability::current_request_id(), bot_id = %bot_id, "Bot already has an active connection");
                 return Err(());
             }
         }
@@ -2834,7 +2844,7 @@ impl BotRepoPort for PersistentBotRepo {
     }
 
     async fn send_frame(&self, bot_id: &str, _frame: String) -> Result<(), ()> {
-        warn!(bot_id = %bot_id, "Bot frame delivery is owned by the ws adapter");
+        warn!(request_id = %bcs_observability::current_request_id(), bot_id = %bot_id, "Bot frame delivery is owned by the ws adapter");
         Err(())
     }
 
@@ -2971,6 +2981,7 @@ fn control_plane_record_from_row(row: &DbRow) -> ServiceResult<BotControlPlaneRe
         .map(|value| {
             serde_json::from_value(serde_json::Value::String(value)).map_err(|error| {
                 warn!(
+                    request_id = %bcs_observability::current_request_id(),
                     bot_id,
                     column = "user_visibility",
                     "Invalid persisted Bot attribute"
@@ -2985,6 +2996,7 @@ fn control_plane_record_from_row(row: &DbRow) -> ServiceResult<BotControlPlaneRe
         .map(|value| {
             serde_json::from_str(&value).map_err(|error| {
                 warn!(
+                    request_id = %bcs_observability::current_request_id(),
                     bot_id,
                     column = "friend_ext",
                     "Invalid persisted Bot attribute"
@@ -2999,6 +3011,7 @@ fn control_plane_record_from_row(row: &DbRow) -> ServiceResult<BotControlPlaneRe
         .map(|value| {
             serde_json::from_value(serde_json::Value::String(value)).map_err(|error| {
                 warn!(
+                    request_id = %bcs_observability::current_request_id(),
                     bot_id,
                     column = "friend_check_in_strategy",
                     "Invalid persisted Bot attribute"

--- a/src/bcs/crates/services/bcs-bot-store/src/lib.rs
+++ b/src/bcs/crates/services/bcs-bot-store/src/lib.rs
@@ -491,7 +491,7 @@ impl PersistentBotRepo {
                 Value::from(env.as_str()),
             ]).await
         }.map_err(|e| {
-            warn!(request_id = %bcs_observability::current_request_id(), bot_uuid = %bot_uuid, error = %e, "save_to_db: failed");
+            warn!(request_id = %bcs_observability::CurrentRequestId, bot_uuid = %bot_uuid, error = %e, "save_to_db: failed");
             ServiceError::InternalError(e.to_string())
         })?;
 
@@ -596,7 +596,7 @@ impl PersistentBotRepo {
                 }
                 (None, Some(code)) => {
                     warn!(
-                        request_id = %bcs_observability::current_request_id(),
+                        request_id = %bcs_observability::CurrentRequestId,
                         bot_uuid = %bot_uuid,
                         source = "bot_info_fallback",
                         "load_from_mysql: agent_code missing in column, fell back to bot_info JSON"
@@ -778,7 +778,7 @@ impl PersistentBotRepo {
             )
             .await
             .map_err(|e| {
-                warn!(request_id = %bcs_observability::current_request_id(), bot_uuid = %bot_uuid, error = %e, "save_token_to_db: failed");
+                warn!(request_id = %bcs_observability::CurrentRequestId, bot_uuid = %bot_uuid, error = %e, "save_token_to_db: failed");
                 ServiceError::InternalError(e.to_string())
             })?;
 
@@ -814,7 +814,7 @@ impl PersistentBotRepo {
             )
             .await
             .map_err(|e| {
-                warn!(request_id = %bcs_observability::current_request_id(), bot_uuid = %bot_uuid, error = %e, "update_created_by_in_db: failed");
+                warn!(request_id = %bcs_observability::CurrentRequestId, bot_uuid = %bot_uuid, error = %e, "update_created_by_in_db: failed");
                 ServiceError::InternalError(e.to_string())
             })?;
 
@@ -935,7 +935,7 @@ impl PersistentBotRepo {
         {
             Ok(rows) => rows,
             Err(e) => {
-                warn!(request_id = %bcs_observability::current_request_id(), token = %token, env = %env, error = %e, "find_bot_by_token_in_db: database query failed");
+                warn!(request_id = %bcs_observability::CurrentRequestId, token = %token, env = %env, error = %e, "find_bot_by_token_in_db: database query failed");
                 return None;
             }
         };
@@ -949,13 +949,13 @@ impl PersistentBotRepo {
                     return Some(bot_uuid);
                 }
                 Err(e) => {
-                    warn!(request_id = %bcs_observability::current_request_id(), token = %token, error = %e, "find_bot_by_token_in_db: failed to get bot_uuid");
+                    warn!(request_id = %bcs_observability::CurrentRequestId, token = %token, error = %e, "find_bot_by_token_in_db: failed to get bot_uuid");
                     return None;
                 }
             }
         }
 
-        warn!(request_id = %bcs_observability::current_request_id(), token = %token, "find_bot_by_token_in_db: no bot found");
+        warn!(request_id = %bcs_observability::CurrentRequestId, token = %token, "find_bot_by_token_in_db: no bot found");
         None
     }
 
@@ -971,7 +971,7 @@ impl PersistentBotRepo {
         {
             Ok(rows) => rows,
             Err(e) => {
-                warn!(request_id = %bcs_observability::current_request_id(), agent_code = %agent_code, env = %env, error = %e, "find_bot_by_agent_code_in_db: query failed");
+                warn!(request_id = %bcs_observability::CurrentRequestId, agent_code = %agent_code, env = %env, error = %e, "find_bot_by_agent_code_in_db: query failed");
                 return None;
             }
         };
@@ -983,13 +983,13 @@ impl PersistentBotRepo {
                     return Some(bot_uuid);
                 }
                 Err(e) => {
-                    warn!(request_id = %bcs_observability::current_request_id(), agent_code = %agent_code, error = %e, "find_bot_by_agent_code_in_db: failed to get bot_uuid");
+                    warn!(request_id = %bcs_observability::CurrentRequestId, agent_code = %agent_code, error = %e, "find_bot_by_agent_code_in_db: failed to get bot_uuid");
                     return None;
                 }
             }
         }
 
-        warn!(request_id = %bcs_observability::current_request_id(), agent_code = %agent_code, "find_bot_by_agent_code_in_db: no bot found");
+        warn!(request_id = %bcs_observability::CurrentRequestId, agent_code = %agent_code, "find_bot_by_agent_code_in_db: no bot found");
         None
     }
 
@@ -1094,7 +1094,7 @@ impl PersistentBotRepo {
         {
             Ok(r) => r,
             Err(e) => {
-                warn!(request_id = %bcs_observability::current_request_id(), error = %e, "list_bots_by_name_and_cooperatable_with_impl (page): failed");
+                warn!(request_id = %bcs_observability::CurrentRequestId, error = %e, "list_bots_by_name_and_cooperatable_with_impl (page): failed");
                 return (Vec::new(), 0);
             }
         };
@@ -1141,7 +1141,7 @@ impl PersistentBotRepo {
                 .map(|v| v as usize)
                 .unwrap_or(0),
             Err(e) => {
-                warn!(request_id = %bcs_observability::current_request_id(), error = %e, "list_bots_by_name_and_cooperatable_with_impl (count): failed");
+                warn!(request_id = %bcs_observability::CurrentRequestId, error = %e, "list_bots_by_name_and_cooperatable_with_impl (count): failed");
                 0
             }
         };
@@ -1259,7 +1259,7 @@ impl BotMetricsSnapshotPort for PersistentBotRepo {
             .db_query(sql, vec![Value::from(env.as_str())])
             .await
             .map_err(|e| {
-                warn!(request_id = %bcs_observability::current_request_id(), env = %env, error = %e, "bot metrics snapshot query failed");
+                warn!(request_id = %bcs_observability::CurrentRequestId, env = %env, error = %e, "bot metrics snapshot query failed");
                 ServiceError::InternalError(format!("bot metrics snapshot query failed: {}", e))
             })?;
 
@@ -1322,7 +1322,7 @@ impl BotRepoPort for PersistentBotRepo {
         self.save_to_db(&bot_id, &capabilities, session_token.as_deref(), None)
             .await
             .map_err(|e| {
-                warn!(request_id = %bcs_observability::current_request_id(), bot_id = %bot_id, error = %e, "Failed to save bot to database during register");
+                warn!(request_id = %bcs_observability::CurrentRequestId, bot_id = %bot_id, error = %e, "Failed to save bot to database during register");
                 e
             })?;
 
@@ -1440,7 +1440,7 @@ impl BotRepoPort for PersistentBotRepo {
         self.save_to_db(&bot_id, &capabilities, Some(token), Some(created_by))
             .await
             .map_err(|e| {
-                warn!(request_id = %bcs_observability::current_request_id(), bot_id = %bot_id, error = %e, "Failed to save bot to database during register_with_owner_and_token");
+                warn!(request_id = %bcs_observability::CurrentRequestId, bot_id = %bot_id, error = %e, "Failed to save bot to database during register_with_owner_and_token");
                 e
             })?;
 
@@ -1666,7 +1666,7 @@ impl BotRepoPort for PersistentBotRepo {
         // 后期需要其他字段时，应在 RegisteredBotInner 上新增一个 HashMap 内存对象
         // 来承载任意 key/value，而不是继续往 capabilities 上加字段。
         if key != "agent_token" && key != "client_kind" {
-            tracing::warn!(request_id = %bcs_observability::current_request_id(), bot_id = %bot_id, key = %key, "add_bot_info: unrecognized key, ignoring");
+            tracing::warn!(request_id = %bcs_observability::CurrentRequestId, bot_id = %bot_id, key = %key, "add_bot_info: unrecognized key, ignoring");
             return;
         }
         if key == "client_kind" {
@@ -1723,7 +1723,7 @@ impl BotRepoPort for PersistentBotRepo {
                 .filter_map(|row| db_get_column::<String>(&row, "bot_uuid").ok())
                 .collect::<std::collections::HashSet<_>>(),
             Err(error) => {
-                warn!(request_id = %bcs_observability::current_request_id(), env = %env, error = %error, "list_active: failed to load active bot ids from DB; returning empty result to preserve DB tombstone authority");
+                warn!(request_id = %bcs_observability::CurrentRequestId, env = %env, error = %error, "list_active: failed to load active bot ids from DB; returning empty result to preserve DB tombstone authority");
                 return Vec::new();
             }
         };
@@ -1745,7 +1745,7 @@ impl BotRepoPort for PersistentBotRepo {
         {
             Ok(rows) => rows,
             Err(error) => {
-                warn!(request_id = %bcs_observability::current_request_id(), env = %env, error = %error, "list_all_bots: failed to load bot rows from DB; returning empty result");
+                warn!(request_id = %bcs_observability::CurrentRequestId, env = %env, error = %error, "list_all_bots: failed to load bot rows from DB; returning empty result");
                 return Vec::new();
             }
         };
@@ -1823,7 +1823,7 @@ impl BotRepoPort for PersistentBotRepo {
         {
             Ok(bots) => bots,
             Err(error) => {
-                warn!(request_id = %bcs_observability::current_request_id(), created_by = %created_by, error = %error, "list_bots_by_creator_from_db: failed");
+                warn!(request_id = %bcs_observability::CurrentRequestId, created_by = %created_by, error = %error, "list_bots_by_creator_from_db: failed");
                 Vec::new()
             }
         }
@@ -1949,7 +1949,7 @@ impl BotRepoPort for PersistentBotRepo {
         bots.retain(|_, b| !b.is_expired());
         let removed = before - bots.len();
         if removed > 0 {
-            warn!(request_id = %bcs_observability::current_request_id(), removed, "Removed expired bot registrations");
+            warn!(request_id = %bcs_observability::CurrentRequestId, removed, "Removed expired bot registrations");
         }
     }
 
@@ -2023,7 +2023,7 @@ impl BotRepoPort for PersistentBotRepo {
         )
         .await
         .map_err(|e| {
-            warn!(request_id = %bcs_observability::current_request_id(), bot_uuid = %bot_id, error = %e, "update_visibility: failed to update database");
+            warn!(request_id = %bcs_observability::CurrentRequestId, bot_uuid = %bot_id, error = %e, "update_visibility: failed to update database");
             ServiceError::InternalError(e.to_string())
         })?;
 
@@ -2046,7 +2046,7 @@ impl BotRepoPort for PersistentBotRepo {
     #[allow(deprecated)]
     async fn set_hidden(&self, bot_id: &str, hidden: bool) -> ServiceResult<()> {
         warn!(
-            request_id = %bcs_observability::current_request_id(),
+            request_id = %bcs_observability::CurrentRequestId,
             bot_id = %bot_id,
             hidden = %hidden,
             "set_hidden is DEPRECATED and is now a Noop; use update_actor_status(bot_id, ActorStatus::Hidden) instead (Task H.1)"
@@ -2081,7 +2081,7 @@ impl BotRepoPort for PersistentBotRepo {
         .await
         .map_err(|e| {
             warn!(
-                request_id = %bcs_observability::current_request_id(),
+                request_id = %bcs_observability::CurrentRequestId,
                 bot_id = %bot_id,
                 status = %status_str,
                 error = %e,
@@ -2162,7 +2162,7 @@ impl BotRepoPort for PersistentBotRepo {
                 .await
                 .map_err(|e| {
                     warn!(
-                        request_id = %bcs_observability::current_request_id(),
+                        request_id = %bcs_observability::CurrentRequestId,
                         bot_uuid = %bot_uuid,
                         error = %e,
                         "ensure_human_actor: failed to backfill bot_info"
@@ -2231,7 +2231,7 @@ impl BotRepoPort for PersistentBotRepo {
             .await
             .map_err(|e| {
                 warn!(
-                    request_id = %bcs_observability::current_request_id(),
+                    request_id = %bcs_observability::CurrentRequestId,
                     bot_uuid = %bot_uuid,
                     error = %e,
                     "ensure_human_actor: INSERT IGNORE failed"
@@ -2281,7 +2281,7 @@ impl BotRepoPort for PersistentBotRepo {
             .await
             .map_err(|e| {
                 warn!(
-                    request_id = %bcs_observability::current_request_id(),
+                    request_id = %bcs_observability::CurrentRequestId,
                     staff_no = %staff_no,
                     env = %env,
                     error = %e,
@@ -2384,7 +2384,7 @@ impl BotRepoPort for PersistentBotRepo {
         .await
         .map_err(|e| {
             warn!(
-                request_id = %bcs_observability::current_request_id(),
+                request_id = %bcs_observability::CurrentRequestId,
                 bot_uuid = %bot_uuid,
                 error = %e,
                 "update_human_name: failed to update database"
@@ -2486,7 +2486,7 @@ impl BotRepoPort for PersistentBotRepo {
         let result = self.find_bot_by_token_in_db(token).await;
         if result.is_none() {
             let prefix = &token[..8.min(token.len())];
-            warn!(request_id = %bcs_observability::current_request_id(), token_prefix = %prefix, "find_bot_by_token: token not found in any layer (cache/memory/database)");
+            warn!(request_id = %bcs_observability::CurrentRequestId, token_prefix = %prefix, "find_bot_by_token: token not found in any layer (cache/memory/database)");
         }
         result
     }
@@ -2600,7 +2600,7 @@ impl BotRepoPort for PersistentBotRepo {
                 // surfaces as a stale-MOCK reconnect after a BCS restart.
                 if let Err(err) = self.save_token_to_db(&bot_id, &session_token).await {
                     warn!(
-                        request_id = %bcs_observability::current_request_id(),
+                        request_id = %bcs_observability::CurrentRequestId,
                         bot_id = %bot_id,
                         error = %err,
                         "connect_or_promote_streaming: promote_mock DB persist failed; refusing ws"
@@ -2657,7 +2657,7 @@ impl BotRepoPort for PersistentBotRepo {
             // real token, already connected → reject
             (true, false, true) => {
                 warn!(
-                    request_id = %bcs_observability::current_request_id(),
+                    request_id = %bcs_observability::CurrentRequestId,
                     bot_id = %bot_id,
                     branch = "already_connected",
                     "connect_or_promote_streaming: real-token bot already connected"
@@ -2669,7 +2669,7 @@ impl BotRepoPort for PersistentBotRepo {
             // via the existing reconnect_streaming(token) path.)
             (true, false, false) => {
                 warn!(
-                    request_id = %bcs_observability::current_request_id(),
+                    request_id = %bcs_observability::CurrentRequestId,
                     bot_id = %bot_id,
                     branch = "already_registered",
                     "connect_or_promote_streaming: refusing empty/stale-token claim of real-token bot"
@@ -2687,7 +2687,7 @@ impl BotRepoPort for PersistentBotRepo {
         // Check if bot is already connected
         if let Some(bot) = bots.get(&bot_id) {
             if bot.ws_connection.is_some() {
-                warn!(request_id = %bcs_observability::current_request_id(), bot_id = %bot_id, "Bot already has an active streaming connection");
+                warn!(request_id = %bcs_observability::CurrentRequestId, bot_id = %bot_id, "Bot already has an active streaming connection");
                 return Err(());
             }
         }
@@ -2753,7 +2753,7 @@ impl BotRepoPort for PersistentBotRepo {
         // Check if bot is already connected
         if let Some(bot) = bots.get(&bot_id) {
             if bot.ws_connection.is_some() {
-                warn!(request_id = %bcs_observability::current_request_id(), bot_id = %bot_id, "Bot already has an active connection");
+                warn!(request_id = %bcs_observability::CurrentRequestId, bot_id = %bot_id, "Bot already has an active connection");
                 return Err(());
             }
         }
@@ -2844,7 +2844,7 @@ impl BotRepoPort for PersistentBotRepo {
     }
 
     async fn send_frame(&self, bot_id: &str, _frame: String) -> Result<(), ()> {
-        warn!(request_id = %bcs_observability::current_request_id(), bot_id = %bot_id, "Bot frame delivery is owned by the ws adapter");
+        warn!(request_id = %bcs_observability::CurrentRequestId, bot_id = %bot_id, "Bot frame delivery is owned by the ws adapter");
         Err(())
     }
 
@@ -2981,7 +2981,7 @@ fn control_plane_record_from_row(row: &DbRow) -> ServiceResult<BotControlPlaneRe
         .map(|value| {
             serde_json::from_value(serde_json::Value::String(value)).map_err(|error| {
                 warn!(
-                    request_id = %bcs_observability::current_request_id(),
+                    request_id = %bcs_observability::CurrentRequestId,
                     bot_id,
                     column = "user_visibility",
                     "Invalid persisted Bot attribute"
@@ -2996,7 +2996,7 @@ fn control_plane_record_from_row(row: &DbRow) -> ServiceResult<BotControlPlaneRe
         .map(|value| {
             serde_json::from_str(&value).map_err(|error| {
                 warn!(
-                    request_id = %bcs_observability::current_request_id(),
+                    request_id = %bcs_observability::CurrentRequestId,
                     bot_id,
                     column = "friend_ext",
                     "Invalid persisted Bot attribute"
@@ -3011,7 +3011,7 @@ fn control_plane_record_from_row(row: &DbRow) -> ServiceResult<BotControlPlaneRe
         .map(|value| {
             serde_json::from_value(serde_json::Value::String(value)).map_err(|error| {
                 warn!(
-                    request_id = %bcs_observability::current_request_id(),
+                    request_id = %bcs_observability::CurrentRequestId,
                     bot_id,
                     column = "friend_check_in_strategy",
                     "Invalid persisted Bot attribute"

--- a/src/bcs/crates/services/bcs-bot-store/src/memory.rs
+++ b/src/bcs/crates/services/bcs-bot-store/src/memory.rs
@@ -314,7 +314,7 @@ impl MemoryBotRepo {
                     Some(BotCapabilities::from(&persisted))
                 }
                 Err(e) => {
-                    warn!(request_id = %bcs_observability::current_request_id(), bot_id = %bot_id, error = %e, "Failed to parse capabilities file");
+                    warn!(request_id = %bcs_observability::CurrentRequestId, bot_id = %bot_id, error = %e, "Failed to parse capabilities file");
                     None
                 }
             },
@@ -975,7 +975,7 @@ impl BotRepoPort for MemoryBotRepo {
         bots.retain(|_, b| !b.is_expired());
         let removed = before - bots.len();
         if removed > 0 {
-            warn!(request_id = %bcs_observability::current_request_id(), removed, "Removed expired bot registrations");
+            warn!(request_id = %bcs_observability::CurrentRequestId, removed, "Removed expired bot registrations");
         }
     }
 
@@ -1055,7 +1055,7 @@ impl BotRepoPort for MemoryBotRepo {
     #[allow(deprecated)]
     async fn set_hidden(&self, bot_id: &str, hidden: bool) -> ServiceResult<()> {
         warn!(
-            request_id = %bcs_observability::current_request_id(),
+            request_id = %bcs_observability::CurrentRequestId,
             bot_id = %bot_id,
             hidden = %hidden,
             "set_hidden is DEPRECATED and is now a Noop; use update_actor_status(bot_id, ActorStatus::Hidden) instead (Task H.1)"
@@ -1381,7 +1381,7 @@ impl BotRepoPort for MemoryBotRepo {
             Ok(content) => match serde_json::from_str::<PersistedCapabilities>(&content) {
                 Ok(persisted) => persisted.token,
                 Err(e) => {
-                    warn!(request_id = %bcs_observability::current_request_id(), bot_id = %bot_id, error = %e, "Failed to parse capabilities file for token");
+                    warn!(request_id = %bcs_observability::CurrentRequestId, bot_id = %bot_id, error = %e, "Failed to parse capabilities file for token");
                     None
                 }
             },
@@ -1569,7 +1569,7 @@ impl BotRepoPort for MemoryBotRepo {
                 // `save_token` re-acquires `bots.write()`.
                 if let Err(err) = self.save_token(&bot_id, &session_token).await {
                     warn!(
-                        request_id = %bcs_observability::current_request_id(),
+                        request_id = %bcs_observability::CurrentRequestId,
                         bot_id = %bot_id,
                         error = %err,
                         "connect_or_promote_streaming: promote_mock disk persist failed; refusing ws"
@@ -1626,7 +1626,7 @@ impl BotRepoPort for MemoryBotRepo {
             }
             (true, false, true) => {
                 warn!(
-                    request_id = %bcs_observability::current_request_id(),
+                    request_id = %bcs_observability::CurrentRequestId,
                     bot_id = %bot_id,
                     branch = "already_connected",
                     "connect_or_promote_streaming: real-token bot already connected"
@@ -1635,7 +1635,7 @@ impl BotRepoPort for MemoryBotRepo {
             }
             (true, false, false) => {
                 warn!(
-                    request_id = %bcs_observability::current_request_id(),
+                    request_id = %bcs_observability::CurrentRequestId,
                     bot_id = %bot_id,
                     branch = "already_registered",
                     "connect_or_promote_streaming: refusing empty/stale-token claim of real-token bot"
@@ -1651,7 +1651,7 @@ impl BotRepoPort for MemoryBotRepo {
         // Check if bot is already connected
         if let Some(bot) = bots.get(&bot_id) {
             if bot.ws_connection.is_some() {
-                warn!(request_id = %bcs_observability::current_request_id(), bot_id = %bot_id, "Bot already has an active streaming connection");
+                warn!(request_id = %bcs_observability::CurrentRequestId, bot_id = %bot_id, "Bot already has an active streaming connection");
                 return Err(());
             }
         }
@@ -1709,7 +1709,7 @@ impl BotRepoPort for MemoryBotRepo {
             match token_to_bot.get(&existing_token) {
                 Some(id) => id.clone(),
                 None => {
-                    warn!(request_id = %bcs_observability::current_request_id(), token = %existing_token, "Unknown token for reconnection");
+                    warn!(request_id = %bcs_observability::CurrentRequestId, token = %existing_token, "Unknown token for reconnection");
                     return Err(());
                 }
             }
@@ -1720,7 +1720,7 @@ impl BotRepoPort for MemoryBotRepo {
         // Check if bot is already connected
         if let Some(bot) = bots.get(&bot_id) {
             if bot.ws_connection.is_some() {
-                warn!(request_id = %bcs_observability::current_request_id(), bot_id = %bot_id, "Bot already has an active connection");
+                warn!(request_id = %bcs_observability::CurrentRequestId, bot_id = %bot_id, "Bot already has an active connection");
                 return Err(());
             }
         }
@@ -1789,7 +1789,7 @@ impl BotRepoPort for MemoryBotRepo {
     }
 
     async fn send_frame(&self, bot_id: &str, _frame: String) -> Result<(), ()> {
-        warn!(request_id = %bcs_observability::current_request_id(), bot_id = %bot_id, "Bot frame delivery is owned by the ws adapter");
+        warn!(request_id = %bcs_observability::CurrentRequestId, bot_id = %bot_id, "Bot frame delivery is owned by the ws adapter");
         Err(())
     }
 

--- a/src/bcs/crates/services/bcs-bot-store/src/memory.rs
+++ b/src/bcs/crates/services/bcs-bot-store/src/memory.rs
@@ -314,7 +314,7 @@ impl MemoryBotRepo {
                     Some(BotCapabilities::from(&persisted))
                 }
                 Err(e) => {
-                    warn!(bot_id = %bot_id, error = %e, "Failed to parse capabilities file");
+                    warn!(request_id = %bcs_observability::current_request_id(), bot_id = %bot_id, error = %e, "Failed to parse capabilities file");
                     None
                 }
             },
@@ -975,7 +975,7 @@ impl BotRepoPort for MemoryBotRepo {
         bots.retain(|_, b| !b.is_expired());
         let removed = before - bots.len();
         if removed > 0 {
-            warn!(removed, "Removed expired bot registrations");
+            warn!(request_id = %bcs_observability::current_request_id(), removed, "Removed expired bot registrations");
         }
     }
 
@@ -1055,6 +1055,7 @@ impl BotRepoPort for MemoryBotRepo {
     #[allow(deprecated)]
     async fn set_hidden(&self, bot_id: &str, hidden: bool) -> ServiceResult<()> {
         warn!(
+            request_id = %bcs_observability::current_request_id(),
             bot_id = %bot_id,
             hidden = %hidden,
             "set_hidden is DEPRECATED and is now a Noop; use update_actor_status(bot_id, ActorStatus::Hidden) instead (Task H.1)"
@@ -1380,7 +1381,7 @@ impl BotRepoPort for MemoryBotRepo {
             Ok(content) => match serde_json::from_str::<PersistedCapabilities>(&content) {
                 Ok(persisted) => persisted.token,
                 Err(e) => {
-                    warn!(bot_id = %bot_id, error = %e, "Failed to parse capabilities file for token");
+                    warn!(request_id = %bcs_observability::current_request_id(), bot_id = %bot_id, error = %e, "Failed to parse capabilities file for token");
                     None
                 }
             },
@@ -1568,6 +1569,7 @@ impl BotRepoPort for MemoryBotRepo {
                 // `save_token` re-acquires `bots.write()`.
                 if let Err(err) = self.save_token(&bot_id, &session_token).await {
                     warn!(
+                        request_id = %bcs_observability::current_request_id(),
                         bot_id = %bot_id,
                         error = %err,
                         "connect_or_promote_streaming: promote_mock disk persist failed; refusing ws"
@@ -1624,6 +1626,7 @@ impl BotRepoPort for MemoryBotRepo {
             }
             (true, false, true) => {
                 warn!(
+                    request_id = %bcs_observability::current_request_id(),
                     bot_id = %bot_id,
                     branch = "already_connected",
                     "connect_or_promote_streaming: real-token bot already connected"
@@ -1632,6 +1635,7 @@ impl BotRepoPort for MemoryBotRepo {
             }
             (true, false, false) => {
                 warn!(
+                    request_id = %bcs_observability::current_request_id(),
                     bot_id = %bot_id,
                     branch = "already_registered",
                     "connect_or_promote_streaming: refusing empty/stale-token claim of real-token bot"
@@ -1647,7 +1651,7 @@ impl BotRepoPort for MemoryBotRepo {
         // Check if bot is already connected
         if let Some(bot) = bots.get(&bot_id) {
             if bot.ws_connection.is_some() {
-                warn!(bot_id = %bot_id, "Bot already has an active streaming connection");
+                warn!(request_id = %bcs_observability::current_request_id(), bot_id = %bot_id, "Bot already has an active streaming connection");
                 return Err(());
             }
         }
@@ -1705,7 +1709,7 @@ impl BotRepoPort for MemoryBotRepo {
             match token_to_bot.get(&existing_token) {
                 Some(id) => id.clone(),
                 None => {
-                    warn!(token = %existing_token, "Unknown token for reconnection");
+                    warn!(request_id = %bcs_observability::current_request_id(), token = %existing_token, "Unknown token for reconnection");
                     return Err(());
                 }
             }
@@ -1716,7 +1720,7 @@ impl BotRepoPort for MemoryBotRepo {
         // Check if bot is already connected
         if let Some(bot) = bots.get(&bot_id) {
             if bot.ws_connection.is_some() {
-                warn!(bot_id = %bot_id, "Bot already has an active connection");
+                warn!(request_id = %bcs_observability::current_request_id(), bot_id = %bot_id, "Bot already has an active connection");
                 return Err(());
             }
         }
@@ -1785,7 +1789,7 @@ impl BotRepoPort for MemoryBotRepo {
     }
 
     async fn send_frame(&self, bot_id: &str, _frame: String) -> Result<(), ()> {
-        warn!(bot_id = %bot_id, "Bot frame delivery is owned by the ws adapter");
+        warn!(request_id = %bcs_observability::current_request_id(), bot_id = %bot_id, "Bot frame delivery is owned by the ws adapter");
         Err(())
     }
 

--- a/src/bcs/crates/services/bcs-bot-store/src/provider.rs
+++ b/src/bcs/crates/services/bcs-bot-store/src/provider.rs
@@ -420,7 +420,7 @@ impl DbProviderStore {
             .await
             .map(|result| result.affected_rows)
             .map_err(|err| {
-                warn!(request_id = %bcs_observability::current_request_id(), operation, error = %err, "db_provider: execute failed");
+                warn!(request_id = %bcs_observability::CurrentRequestId, operation, error = %err, "db_provider: execute failed");
                 service_db_error(operation, err)
             })
     }
@@ -449,7 +449,7 @@ impl DbProviderStore {
         statement: DbStatement,
     ) -> ServiceResult<Vec<DbRow>> {
         self.db.query(statement).await.map_err(|err| {
-            warn!(request_id = %bcs_observability::current_request_id(), operation, error = %err, "db_provider: query failed");
+            warn!(request_id = %bcs_observability::CurrentRequestId, operation, error = %err, "db_provider: query failed");
             service_db_error(operation, err)
         })
     }

--- a/src/bcs/crates/services/bcs-bot-store/src/provider.rs
+++ b/src/bcs/crates/services/bcs-bot-store/src/provider.rs
@@ -420,7 +420,7 @@ impl DbProviderStore {
             .await
             .map(|result| result.affected_rows)
             .map_err(|err| {
-                warn!(operation, error = %err, "db_provider: execute failed");
+                warn!(request_id = %bcs_observability::current_request_id(), operation, error = %err, "db_provider: execute failed");
                 service_db_error(operation, err)
             })
     }
@@ -449,7 +449,7 @@ impl DbProviderStore {
         statement: DbStatement,
     ) -> ServiceResult<Vec<DbRow>> {
         self.db.query(statement).await.map_err(|err| {
-            warn!(operation, error = %err, "db_provider: query failed");
+            warn!(request_id = %bcs_observability::current_request_id(), operation, error = %err, "db_provider: query failed");
             service_db_error(operation, err)
         })
     }

--- a/src/bcs/crates/services/bcs-bot-store/tests/diagnostic_logging.rs
+++ b/src/bcs/crates/services/bcs-bot-store/tests/diagnostic_logging.rs
@@ -1,0 +1,271 @@
+use std::collections::{HashSet, VecDeque};
+use std::sync::{Arc, Mutex};
+
+use bcs_bot_store::{MemoryBotRepo, PersistentBotRepo};
+use bcs_bot_store::provider::DbProviderStore;
+use bcs_cache_local::InMemoryCachePlugin;
+use bcs_db_api::{
+    DbError, DbExecuteResult, DbHealth, DbPlugin, DbResult, DbRow, DbStatement,
+    DbTransactionStep, DbTransactionStepResult, DbValue,
+};
+use bcs_service_api::{
+    BotCapabilities, BotMetricsSnapshotPort, BotRepoPort, ProviderRecord, ProviderRepoPort,
+    ServiceError,
+};
+use bcs_test_support::capture_request_logs;
+use serde_json::Value;
+
+const REQUEST_ID: &str = "bot-store-diagnostic-request";
+const DB_FAILURE: &str = "injected storage unavailable";
+
+// Fail or corrupt a specific DB boundary operation while exercising the real
+// repository's SQL mapping, error conversion, and fallback behavior.
+struct DbStep {
+    method: &'static str,
+    sql_fragment: &'static str,
+    required_params: Vec<DbValue>,
+    rows: DbResult<Vec<DbRow>>,
+}
+
+impl DbStep {
+    fn query(sql: &'static str, params: &[&str], rows: DbResult<Vec<DbRow>>) -> Self {
+        Self {
+            method: "query",
+            sql_fragment: sql,
+            required_params: params.iter().map(|value| DbValue::from(*value)).collect(),
+            rows,
+        }
+    }
+
+    fn failed_write(sql: &'static str, params: &[&str]) -> Self {
+        Self {
+            method: "execute",
+            sql_fragment: sql,
+            required_params: params.iter().map(|value| DbValue::from(*value)).collect(),
+            rows: Err(DbError::Backend(DB_FAILURE.into())),
+        }
+    }
+}
+
+struct ScriptedDb(Mutex<VecDeque<DbStep>>);
+
+impl ScriptedDb {
+    fn new(steps: Vec<DbStep>) -> Arc<Self> {
+        Arc::new(Self(Mutex::new(steps.into())))
+    }
+
+    fn take(&self, method: &str, statement: &DbStatement) -> DbResult<Vec<DbRow>> {
+        let step = self.0.lock().expect("database script lock").pop_front()
+            .expect("unexpected repository database call");
+        assert_eq!(method, step.method);
+        assert!(statement.sql().contains(step.sql_fragment), "unexpected SQL: {}", statement.sql());
+        for param in step.required_params {
+            assert!(statement.params().contains(&param), "repository lost expected parameter {param:?}");
+        }
+        step.rows
+    }
+
+    fn assert_complete(&self) {
+        assert!(self.0.lock().expect("database script lock").is_empty(), "repository skipped an expected DB operation");
+    }
+}
+
+#[async_trait::async_trait]
+impl DbPlugin for ScriptedDb {
+    async fn query(&self, statement: DbStatement) -> DbResult<Vec<DbRow>> {
+        self.take("query", &statement)
+    }
+
+    async fn execute(&self, statement: DbStatement) -> DbResult<DbExecuteResult> {
+        self.take("execute", &statement)?;
+        panic!("these scenarios only script failing writes");
+    }
+
+    async fn transaction(&self, _steps: Vec<DbTransactionStep>) -> DbResult<Vec<DbTransactionStepResult>> {
+        panic!("unexpected transaction");
+    }
+
+    async fn health_check(&self) -> DbResult<DbHealth> {
+        panic!("unexpected health check");
+    }
+}
+
+fn repository(db: Arc<ScriptedDb>) -> PersistentBotRepo {
+    PersistentBotRepo::with_plugins(Arc::new(InMemoryCachePlugin::new()), db)
+}
+
+fn warning<'a>(events: &'a [Value], message: &str) -> &'a Value {
+    let event = events.iter().find(|event| event["fields"]["message"] == message)
+        .unwrap_or_else(|| panic!("missing warning {message}: {events:?}"));
+    assert_eq!(event["level"], "WARN");
+    assert_eq!(event["fields"]["request_id"], REQUEST_ID);
+    event
+}
+
+fn storage_error(error: ServiceError) {
+    match error {
+        ServiceError::InternalError(message) => assert!(message.contains(DB_FAILURE), "{message}"),
+        other => panic!("expected storage failure, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn registration_failures_report_repository_and_persistence_context() {
+    let db = ScriptedDb::new(vec![
+        DbStep::query("SELECT 1 FROM bcs_bots", &["new-bot"], Ok(vec![])),
+        DbStep::failed_write("INSERT INTO bcs_bots", &["new-bot"]),
+        DbStep::query("SELECT 1 FROM bcs_bots", &["owned-bot"], Ok(vec![])),
+        DbStep::failed_write("INSERT INTO bcs_bots", &["owned-bot", "owner-17", "registration-token"]),
+    ]);
+    let repo = repository(db.clone());
+    let (_, events) = capture_request_logs(REQUEST_ID, async {
+        storage_error(repo.register("new-bot".into(), BotCapabilities::default()).await.expect_err("failed registration"));
+        storage_error(repo.register_with_owner_and_token(
+            "owned-bot".into(), BotCapabilities::default(), "owner-17", "registration-token",
+        ).await.expect_err("failed owner registration"));
+    }).await;
+    let saved = warning(&events, "save_to_db: failed");
+    assert_eq!(saved["fields"]["bot_uuid"], "new-bot");
+    assert!(saved["fields"]["error"].as_str().expect("database error").contains(DB_FAILURE));
+    assert_eq!(warning(&events, "Failed to save bot to database during register")["fields"]["bot_id"], "new-bot");
+    assert_eq!(warning(&events, "Failed to save bot to database during register_with_owner_and_token")["fields"]["bot_id"], "owned-bot");
+    db.assert_complete();
+}
+
+#[tokio::test]
+async fn token_owner_and_visibility_write_failures_return_errors_with_bot_context() {
+    let db = ScriptedDb::new(vec![
+        DbStep::failed_write("SET session_token = ?", &["stored-bot", "replacement-token"]),
+        DbStep::failed_write("SET created_by = ?", &["stored-bot", "new-owner"]),
+        DbStep::failed_write("SET visibility = ?", &["stored-bot", "public"]),
+    ]);
+    let repo = repository(db.clone());
+    let (_, events) = capture_request_logs(REQUEST_ID, async {
+        storage_error(repo.save_token("stored-bot", "replacement-token").await.expect_err("token persistence must fail"));
+        storage_error(repo.save_created_by("stored-bot", "new-owner", true).await.expect_err("owner persistence must fail"));
+        storage_error(repo.update_visibility("stored-bot", "public").await.expect_err("visibility persistence must fail"));
+    }).await;
+    for message in ["save_token_to_db: failed", "update_created_by_in_db: failed", "update_visibility: failed to update database"] {
+        let event = warning(&events, message);
+        assert_eq!(event["fields"]["bot_uuid"], "stored-bot");
+        assert!(event["fields"]["error"].as_str().expect("database error").contains(DB_FAILURE));
+    }
+    db.assert_complete();
+}
+
+#[tokio::test]
+async fn identity_lookup_failures_and_invalid_rows_fail_closed_with_request_context() {
+    // A missing required projection is a DB contract violation, distinct from a
+    // query failure or a valid query returning no matching identity.
+    let db = ScriptedDb::new(vec![
+        DbStep::query("WHERE session_token = ?", &["query-token"], Err(DbError::Backend(DB_FAILURE.into()))),
+        DbStep::query("WHERE session_token = ?", &["invalid-row-token"], Ok(vec![DbRow::empty()])),
+        DbStep::query("WHERE agent_code = ?", &["query-agent"], Err(DbError::Backend(DB_FAILURE.into()))),
+        DbStep::query("WHERE agent_code = ?", &["invalid-row-agent"], Ok(vec![DbRow::empty()])),
+        DbStep::query("WHERE agent_code = ?", &["absent-agent"], Ok(vec![])),
+    ]);
+    let repo = repository(db.clone());
+    let (_, events) = capture_request_logs(REQUEST_ID, async {
+        assert_eq!(repo.find_bot_by_token("query-token").await, None);
+        assert_eq!(repo.find_bot_by_token("invalid-row-token").await, None);
+        assert_eq!(repo.find_bot_by_agent_code("query-agent").await, None);
+        assert_eq!(repo.find_bot_by_agent_code("invalid-row-agent").await, None);
+        assert_eq!(repo.find_bot_by_agent_code("absent-agent").await, None);
+    }).await;
+    for message in ["find_bot_by_token_in_db: database query failed", "find_bot_by_agent_code_in_db: query failed"] {
+        assert!(warning(&events, message)["fields"]["error"].as_str().expect("database error").contains(DB_FAILURE));
+    }
+    for message in ["find_bot_by_token_in_db: failed to get bot_uuid", "find_bot_by_agent_code_in_db: failed to get bot_uuid"] {
+        assert!(warning(&events, message)["fields"]["error"].as_str().expect("conversion error").contains("bot_uuid"));
+    }
+    assert_eq!(warning(&events, "find_bot_by_agent_code_in_db: no bot found")["fields"]["agent_code"], "absent-agent");
+    db.assert_complete();
+}
+
+#[tokio::test]
+async fn failed_discovery_count_keeps_the_page_and_distinguishes_page_failure() {
+    let page_row = DbRow::new([
+        ("bot_uuid".into(), DbValue::from("visible-bot")),
+        ("name".into(), DbValue::from("Visible Bot")),
+        ("is_friend".into(), DbValue::from(1_i64)),
+    ].into_iter().collect());
+    let db = ScriptedDb::new(vec![
+        DbStep::query("SELECT b.bot_uuid", &["requesting-bot"], Err(DbError::Backend(DB_FAILURE.into()))),
+        DbStep::query("SELECT b.bot_uuid", &["requesting-bot"], Ok(vec![page_row])),
+        DbStep::query("SELECT count(*) AS total", &["requesting-bot"], Err(DbError::Backend(DB_FAILURE.into()))),
+    ]);
+    let repo = repository(db.clone());
+    let (_, events) = capture_request_logs(REQUEST_ID, async {
+        let (page, total) = repo.list_bots_by_name_and_cooperatable_with(
+            "Visible", "requesting-bot", true, &HashSet::new(), 0, 10,
+        ).await;
+        assert!(page.is_empty());
+        assert_eq!(total, 0);
+        let (page, total) = repo.list_bots_by_name_and_cooperatable_with(
+            "Visible", "requesting-bot", true, &HashSet::new(), 0, 10,
+        ).await;
+        assert_eq!(total, 0);
+        assert_eq!(page.len(), 1);
+        assert_eq!(page[0].0.bot_uuid, "visible-bot");
+        assert_eq!(page[0].0.capabilities.name.as_deref(), Some("Visible Bot"));
+        assert!(page[0].1);
+    }).await;
+    for message in ["list_bots_by_name_and_cooperatable_with_impl (page): failed", "list_bots_by_name_and_cooperatable_with_impl (count): failed"] {
+        assert!(warning(&events, message)["fields"]["error"].as_str().expect("database error").contains(DB_FAILURE));
+    }
+    db.assert_complete();
+}
+
+#[tokio::test]
+async fn metrics_failure_returns_an_error_instead_of_an_empty_snapshot() {
+    let db = ScriptedDb::new(vec![DbStep::query(
+        "GROUP BY actor_kind, status, visibility", &[], Err(DbError::Backend(DB_FAILURE.into())),
+    )]);
+    let repo = repository(db.clone());
+    let (result, events) = capture_request_logs(REQUEST_ID, repo.bot_counts()).await;
+    storage_error(result.expect_err("metrics query must not look like an empty population"));
+    assert!(warning(&events, "bot metrics snapshot query failed")["fields"]["error"].as_str().expect("database error").contains(DB_FAILURE));
+    db.assert_complete();
+}
+
+#[tokio::test]
+async fn provider_read_and_write_failures_report_the_operation_and_keep_the_error() {
+    let db = ScriptedDb::new(vec![
+        DbStep::failed_write("INSERT INTO bcs_providers", &["provider-17", "owner-17"]),
+        DbStep::query("FROM bcs_providers WHERE provider_id = ?", &["provider-17"], Err(DbError::Backend(DB_FAILURE.into()))),
+    ]);
+    let store = DbProviderStore::sqlite(db.clone());
+    let (_, events) = capture_request_logs(REQUEST_ID, async {
+        storage_error(store.insert_provider(ProviderRecord {
+            provider_id: "provider-17".into(),
+            name: "Diagnostic Provider".into(),
+            config: "{}".into(),
+            created_by: "owner-17".into(),
+            owners: "[]".into(),
+            disabled: false,
+            created_at: 1,
+            updated_at: 1,
+        }).await.expect_err("provider write failure"));
+        storage_error(store.get_provider("provider-17").await.expect_err("provider read failure"));
+    }).await;
+    assert_eq!(warning(&events, "db_provider: execute failed")["fields"]["operation"], "insert_provider");
+    assert_eq!(warning(&events, "db_provider: query failed")["fields"]["operation"], "get_provider");
+    db.assert_complete();
+}
+
+#[tokio::test]
+async fn malformed_capabilities_are_reported_without_rewriting_the_file() {
+    let directory = tempfile::tempdir().expect("temporary bot directory");
+    let bot_directory = directory.path().join("corrupted-bot");
+    std::fs::create_dir(&bot_directory).expect("create bot directory");
+    let path = bot_directory.join("bot.json");
+    let malformed = "{not-json}";
+    std::fs::write(&path, malformed).expect("write corrupted capabilities");
+    let repo = MemoryBotRepo::with_base_dir(directory.path().to_path_buf());
+    let (result, events) = capture_request_logs(REQUEST_ID, repo.load_from_storage("corrupted-bot")).await;
+    assert!(result.is_none(), "invalid capabilities must not be loaded");
+    let event = warning(&events, "Failed to parse capabilities file");
+    assert_eq!(event["fields"]["bot_id"], "corrupted-bot");
+    assert!(event["fields"]["error"].as_str().expect("parse error").contains("line 1"));
+    assert_eq!(std::fs::read_to_string(path).expect("read original file"), malformed);
+}

--- a/src/bcs/crates/services/bcs-bot/src/application/actor_directory.rs
+++ b/src/bcs/crates/services/bcs-bot/src/application/actor_directory.rs
@@ -88,7 +88,7 @@ impl ActorDirectory {
                 .collect(),
             Err(error) => {
                 warn!(
-                    request_id = %bcs_observability::current_request_id(),
+                    request_id = %bcs_observability::CurrentRequestId,
                     error = %error,
                     "actor directory: worker profile batch query failed, tags will be empty"
                 );

--- a/src/bcs/crates/services/bcs-bot/src/application/actor_directory.rs
+++ b/src/bcs/crates/services/bcs-bot/src/application/actor_directory.rs
@@ -88,6 +88,7 @@ impl ActorDirectory {
                 .collect(),
             Err(error) => {
                 warn!(
+                    request_id = %bcs_observability::current_request_id(),
                     error = %error,
                     "actor directory: worker profile batch query failed, tags will be empty"
                 );

--- a/src/bcs/crates/services/bcs-bot/src/application/bot.rs
+++ b/src/bcs/crates/services/bcs-bot/src/application/bot.rs
@@ -189,7 +189,7 @@ impl Bot {
                 .unwrap_or_else(|| staff_no.to_string()),
             Ok(None) => {
                 tracing::warn!(
-                    request_id = %bcs_observability::current_request_id(),
+                    request_id = %bcs_observability::CurrentRequestId,
                     staff_no = %staff_no,
                     "user directory returned no profile; falling back to staff_no for human actor name"
                 );
@@ -197,7 +197,7 @@ impl Bot {
             }
             Err(error) => {
                 tracing::warn!(
-                    request_id = %bcs_observability::current_request_id(),
+                    request_id = %bcs_observability::CurrentRequestId,
                     staff_no = %staff_no,
                     error = %error,
                     "user directory lookup failed; falling back to staff_no for human actor name"
@@ -1209,7 +1209,7 @@ impl Bot {
             }
             Err(error) => {
                 tracing::warn!(
-                    request_id = %bcs_observability::current_request_id(),
+                    request_id = %bcs_observability::CurrentRequestId,
                     elapsed_ms = %elapsed_ms,
                     selector = ?selector,
                     error = %error,

--- a/src/bcs/crates/services/bcs-bot/src/application/bot.rs
+++ b/src/bcs/crates/services/bcs-bot/src/application/bot.rs
@@ -189,6 +189,7 @@ impl Bot {
                 .unwrap_or_else(|| staff_no.to_string()),
             Ok(None) => {
                 tracing::warn!(
+                    request_id = %bcs_observability::current_request_id(),
                     staff_no = %staff_no,
                     "user directory returned no profile; falling back to staff_no for human actor name"
                 );
@@ -196,6 +197,7 @@ impl Bot {
             }
             Err(error) => {
                 tracing::warn!(
+                    request_id = %bcs_observability::current_request_id(),
                     staff_no = %staff_no,
                     error = %error,
                     "user directory lookup failed; falling back to staff_no for human actor name"
@@ -1207,6 +1209,7 @@ impl Bot {
             }
             Err(error) => {
                 tracing::warn!(
+                    request_id = %bcs_observability::current_request_id(),
                     elapsed_ms = %elapsed_ms,
                     selector = ?selector,
                     error = %error,

--- a/src/bcs/crates/services/bcs-bot/src/application/provider.rs
+++ b/src/bcs/crates/services/bcs-bot/src/application/provider.rs
@@ -92,7 +92,7 @@ impl ProviderManagement {
                 .unwrap_or_else(|| staff_no.to_string()),
             Ok(None) => {
                 tracing::warn!(
-                    request_id = %bcs_observability::current_request_id(),
+                    request_id = %bcs_observability::CurrentRequestId,
                     staff_no = %staff_no,
                     "user directory returned no profile; falling back to staff_no for human actor name"
                 );
@@ -100,7 +100,7 @@ impl ProviderManagement {
             }
             Err(error) => {
                 tracing::warn!(
-                    request_id = %bcs_observability::current_request_id(),
+                    request_id = %bcs_observability::CurrentRequestId,
                     staff_no = %staff_no,
                     error = %error,
                     "user directory lookup failed; falling back to staff_no for human actor name"
@@ -146,7 +146,7 @@ impl ProviderManagement {
             .await?;
         if provider.disabled {
             tracing::warn!(
-                request_id = %bcs_observability::current_request_id(),
+                request_id = %bcs_observability::CurrentRequestId,
                 provider_id = %provider.provider_id,
                 "disabled provider admin access rejected"
             );
@@ -292,7 +292,7 @@ impl ProviderManagementService for ProviderManagement {
                 Some(bot) => Some(bot.capabilities),
                 None => {
                     tracing::warn!(
-                        request_id = %bcs_observability::current_request_id(),
+                        request_id = %bcs_observability::CurrentRequestId,
                         bot_uuid = %binding.bot_uuid,
                         provider_id = %binding.provider_id,
                         "register_provider_bot: freshly created bot missing from registry; \

--- a/src/bcs/crates/services/bcs-bot/src/application/provider.rs
+++ b/src/bcs/crates/services/bcs-bot/src/application/provider.rs
@@ -92,6 +92,7 @@ impl ProviderManagement {
                 .unwrap_or_else(|| staff_no.to_string()),
             Ok(None) => {
                 tracing::warn!(
+                    request_id = %bcs_observability::current_request_id(),
                     staff_no = %staff_no,
                     "user directory returned no profile; falling back to staff_no for human actor name"
                 );
@@ -99,6 +100,7 @@ impl ProviderManagement {
             }
             Err(error) => {
                 tracing::warn!(
+                    request_id = %bcs_observability::current_request_id(),
                     staff_no = %staff_no,
                     error = %error,
                     "user directory lookup failed; falling back to staff_no for human actor name"
@@ -144,6 +146,7 @@ impl ProviderManagement {
             .await?;
         if provider.disabled {
             tracing::warn!(
+                request_id = %bcs_observability::current_request_id(),
                 provider_id = %provider.provider_id,
                 "disabled provider admin access rejected"
             );
@@ -289,6 +292,7 @@ impl ProviderManagementService for ProviderManagement {
                 Some(bot) => Some(bot.capabilities),
                 None => {
                     tracing::warn!(
+                        request_id = %bcs_observability::current_request_id(),
                         bot_uuid = %binding.bot_uuid,
                         provider_id = %binding.provider_id,
                         "register_provider_bot: freshly created bot missing from registry; \

--- a/src/bcs/crates/services/bcs-bot/src/application/provider_events.rs
+++ b/src/bcs/crates/services/bcs-bot/src/application/provider_events.rs
@@ -21,6 +21,7 @@ use bcs_protocol::stream::{
 use serde_json::{Map, Value, json};
 use tokio::sync::Mutex;
 use tracing::{error, info, warn};
+use tracing::instrument::WithSubscriber;
 
 const COORDINATION_MAGIC_KEY: &str = "__bcs_coordination__";
 const CONTRACT_VERSION: u64 = 1;
@@ -387,12 +388,12 @@ impl ProviderBotEvents {
                     inflight: self.state_machine_terminals_inflight.clone(),
                     key: inflight_key,
                 };
-                tokio::spawn(async move {
+                tokio::spawn(bcs_observability::with_request_id(bcs_observability::current_request_id(), async move {
                     let _inflight_guard = inflight_guard;
                     if let Err(error) = runtime.handle_bot_terminal_event(runtime_command).await {
-                        error!(%error, "provider ingest: async state-machine final failed");
+                        error!(request_id = %bcs_observability::current_request_id(), %error, "provider ingest: async state-machine final failed");
                     }
-                });
+                }).with_current_subscriber());
             }
             return Ok(provider_state_machine_outcome());
         }
@@ -583,6 +584,7 @@ impl ProviderBotEventService for ProviderBotEvents {
                 let identity = self.authenticate_event(&command).await?;
                 if identity.bot_uuid != correlation.assignee_bot_id {
                     warn!(
+                        request_id = %bcs_observability::current_request_id(),
                         provider_id = %command.provider_id,
                         run_id = %command.run_id,
                         provider_bot_id = %identity.bot_uuid,
@@ -656,13 +658,13 @@ impl ProviderBotEventService for ProviderBotEvents {
                         attempt = attempt,
                         "provider callback: state-machine final accepted for async processing"
                     );
-                    tokio::spawn(async move {
-                        let processing = tokio::spawn(async move {
+                    tokio::spawn(bcs_observability::with_request_id(bcs_observability::current_request_id(), async move {
+                        let processing = tokio::spawn(bcs_observability::in_current_context(async move {
                             let _inflight_guard = inflight_guard;
                             collaboration_runtime
                                 .handle_bot_terminal_event(terminal_command)
                                 .await
-                        });
+                        }));
                         match processing.await {
                             Ok(Ok(outcome)) => info!(
                                 provider_id = %provider_id,
@@ -675,6 +677,7 @@ impl ProviderBotEventService for ProviderBotEvents {
                                 "provider callback: async state-machine final processing completed"
                             ),
                             Ok(Err(processing_error)) => error!(
+                                request_id = %bcs_observability::current_request_id(),
                                 provider_id = %provider_id,
                                 run_id = %provider_run_id,
                                 bot_id = %bot_id,
@@ -685,6 +688,7 @@ impl ProviderBotEventService for ProviderBotEvents {
                                 "provider callback: async state-machine final processing failed"
                             ),
                             Err(join_error) => error!(
+                                request_id = %bcs_observability::current_request_id(),
                                 provider_id = %provider_id,
                                 run_id = %provider_run_id,
                                 bot_id = %bot_id,
@@ -695,7 +699,7 @@ impl ProviderBotEventService for ProviderBotEvents {
                                 "provider callback: async state-machine final task failed"
                             ),
                         }
-                    });
+                    }).with_current_subscriber());
                     return Ok(ProviderBotEventOutcome {
                         delivered_count: 1,
                         failed_count: 0,
@@ -754,6 +758,7 @@ impl ProviderBotEventService for ProviderBotEvents {
 
         if identity.bot_uuid != context_bot_id {
             warn!(
+                request_id = %bcs_observability::current_request_id(),
                 provider_id = %command.provider_id,
                 run_id = %command.run_id,
                 provider_bot_id = %identity.bot_uuid,
@@ -865,6 +870,7 @@ impl ProviderBotEventService for ProviderBotEvents {
         let identity = self.authenticate_coordination(&command).await?;
         if identity.bot_uuid != context.bot_id {
             warn!(
+                request_id = %bcs_observability::current_request_id(),
                 provider_id = %command.provider_id,
                 run_id = %command.run_id,
                 provider_bot_id = %identity.bot_uuid,

--- a/src/bcs/crates/services/bcs-bot/src/application/provider_events.rs
+++ b/src/bcs/crates/services/bcs-bot/src/application/provider_events.rs
@@ -391,7 +391,7 @@ impl ProviderBotEvents {
                 tokio::spawn(bcs_observability::with_request_id(bcs_observability::current_request_id(), async move {
                     let _inflight_guard = inflight_guard;
                     if let Err(error) = runtime.handle_bot_terminal_event(runtime_command).await {
-                        error!(request_id = %bcs_observability::current_request_id(), %error, "provider ingest: async state-machine final failed");
+                        error!(request_id = %bcs_observability::CurrentRequestId, %error, "provider ingest: async state-machine final failed");
                     }
                 }).with_current_subscriber());
             }
@@ -584,7 +584,7 @@ impl ProviderBotEventService for ProviderBotEvents {
                 let identity = self.authenticate_event(&command).await?;
                 if identity.bot_uuid != correlation.assignee_bot_id {
                     warn!(
-                        request_id = %bcs_observability::current_request_id(),
+                        request_id = %bcs_observability::CurrentRequestId,
                         provider_id = %command.provider_id,
                         run_id = %command.run_id,
                         provider_bot_id = %identity.bot_uuid,
@@ -677,7 +677,7 @@ impl ProviderBotEventService for ProviderBotEvents {
                                 "provider callback: async state-machine final processing completed"
                             ),
                             Ok(Err(processing_error)) => error!(
-                                request_id = %bcs_observability::current_request_id(),
+                                request_id = %bcs_observability::CurrentRequestId,
                                 provider_id = %provider_id,
                                 run_id = %provider_run_id,
                                 bot_id = %bot_id,
@@ -688,7 +688,7 @@ impl ProviderBotEventService for ProviderBotEvents {
                                 "provider callback: async state-machine final processing failed"
                             ),
                             Err(join_error) => error!(
-                                request_id = %bcs_observability::current_request_id(),
+                                request_id = %bcs_observability::CurrentRequestId,
                                 provider_id = %provider_id,
                                 run_id = %provider_run_id,
                                 bot_id = %bot_id,
@@ -758,7 +758,7 @@ impl ProviderBotEventService for ProviderBotEvents {
 
         if identity.bot_uuid != context_bot_id {
             warn!(
-                request_id = %bcs_observability::current_request_id(),
+                request_id = %bcs_observability::CurrentRequestId,
                 provider_id = %command.provider_id,
                 run_id = %command.run_id,
                 provider_bot_id = %identity.bot_uuid,
@@ -870,7 +870,7 @@ impl ProviderBotEventService for ProviderBotEvents {
         let identity = self.authenticate_coordination(&command).await?;
         if identity.bot_uuid != context.bot_id {
             warn!(
-                request_id = %bcs_observability::current_request_id(),
+                request_id = %bcs_observability::CurrentRequestId,
                 provider_id = %command.provider_id,
                 run_id = %command.run_id,
                 provider_bot_id = %identity.bot_uuid,

--- a/src/bcs/crates/services/bcs-bot/src/core/bot_core.rs
+++ b/src/bcs/crates/services/bcs-bot/src/core/bot_core.rs
@@ -217,7 +217,7 @@ impl BotRegistryCoreService for BotCore {
             return Ok(BotDeliveryTarget::WebSocket { bot_id: bot.bot_uuid });
         };
         if binding.disabled {
-            warn!(request_id = %bcs_observability::current_request_id(), bot_id = %bot_id, provider_id = %binding.provider_id, "resolve_delivery_target: provider bot binding disabled");
+            warn!(request_id = %bcs_observability::CurrentRequestId, bot_id = %bot_id, provider_id = %binding.provider_id, "resolve_delivery_target: provider bot binding disabled");
             return Err(ServiceError::InvalidOperation {
                 message: format!("provider bot '{}' is disabled", bot_id),
                 request_id: None,
@@ -231,14 +231,14 @@ impl BotRegistryCoreService for BotCore {
             .get_provider(&binding.provider_id)
             .await?
             .ok_or_else(|| {
-                warn!(request_id = %bcs_observability::current_request_id(), bot_id = %bot_id, provider_id = %binding.provider_id, "resolve_delivery_target: provider not found");
+                warn!(request_id = %bcs_observability::CurrentRequestId, bot_id = %bot_id, provider_id = %binding.provider_id, "resolve_delivery_target: provider not found");
                 ServiceError::InvalidOperation {
                     message: format!("provider '{}' not found", binding.provider_id),
                     request_id: None,
                 }
             })?;
         if provider.disabled {
-            warn!(request_id = %bcs_observability::current_request_id(), bot_id = %bot_id, provider_id = %provider.provider_id, "resolve_delivery_target: provider disabled");
+            warn!(request_id = %bcs_observability::CurrentRequestId, bot_id = %bot_id, provider_id = %provider.provider_id, "resolve_delivery_target: provider disabled");
             return Err(ServiceError::InvalidOperation {
                 message: format!("provider '{}' is disabled", provider.provider_id),
                 request_id: None,
@@ -246,7 +246,7 @@ impl BotRegistryCoreService for BotCore {
         }
         let downlink = parse_downlink_config(&provider.config)?;
         if !downlink.enabled {
-            warn!(request_id = %bcs_observability::current_request_id(), bot_id = %bot_id, provider_id = %provider.provider_id, "resolve_delivery_target: provider downlink disabled");
+            warn!(request_id = %bcs_observability::CurrentRequestId, bot_id = %bot_id, provider_id = %provider.provider_id, "resolve_delivery_target: provider downlink disabled");
             return Err(ServiceError::InvalidOperation {
                 message: format!("provider '{}' downlink is disabled", provider.provider_id),
                 request_id: None,
@@ -260,7 +260,7 @@ impl BotRegistryCoreService for BotCore {
             .get_credential_by_kind(&provider.provider_id, "downlink_bcs_to_provider")
             .await?
             .ok_or_else(|| {
-                warn!(request_id = %bcs_observability::current_request_id(), bot_id = %bot_id, provider_id = %provider.provider_id, "resolve_delivery_target: downlink credential not found");
+                warn!(request_id = %bcs_observability::CurrentRequestId, bot_id = %bot_id, provider_id = %provider.provider_id, "resolve_delivery_target: downlink credential not found");
                 ServiceError::InvalidOperation {
                     message: format!(
                         "provider '{}' downlink credential not found",
@@ -270,7 +270,7 @@ impl BotRegistryCoreService for BotCore {
                 }
             })?;
         if credential.disabled {
-            warn!(request_id = %bcs_observability::current_request_id(), bot_id = %bot_id, provider_id = %provider.provider_id, "resolve_delivery_target: downlink credential disabled");
+            warn!(request_id = %bcs_observability::CurrentRequestId, bot_id = %bot_id, provider_id = %provider.provider_id, "resolve_delivery_target: downlink credential disabled");
             return Err(ServiceError::InvalidOperation {
                 message: format!(
                     "provider '{}' downlink credential is disabled",
@@ -556,7 +556,7 @@ impl BotRegistryCoreService for BotCore {
         {
             Ok(bindings) => bindings,
             Err(error) => {
-                warn!(request_id = %bcs_observability::current_request_id(), error = %error, "list_runtime_active_bot_ids: failed to list provider bindings");
+                warn!(request_id = %bcs_observability::CurrentRequestId, error = %error, "list_runtime_active_bot_ids: failed to list provider bindings");
                 return active.into_iter().collect();
             }
         };
@@ -574,7 +574,7 @@ impl BotRegistryCoreService for BotCore {
         let providers = match provider_repo.list_providers_by_ids(&provider_ids).await {
             Ok(providers) => providers,
             Err(error) => {
-                warn!(request_id = %bcs_observability::current_request_id(), error = %error, "list_runtime_active_bot_ids: failed to list providers");
+                warn!(request_id = %bcs_observability::CurrentRequestId, error = %error, "list_runtime_active_bot_ids: failed to list providers");
                 return active.into_iter().collect();
             }
         };
@@ -587,7 +587,7 @@ impl BotRegistryCoreService for BotCore {
         {
             Ok(credentials) => credentials,
             Err(error) => {
-                warn!(request_id = %bcs_observability::current_request_id(), error = %error, "list_runtime_active_bot_ids: failed to list provider credentials");
+                warn!(request_id = %bcs_observability::CurrentRequestId, error = %error, "list_runtime_active_bot_ids: failed to list provider credentials");
                 return active.into_iter().collect();
             }
         };
@@ -788,7 +788,7 @@ impl BotRegistryCoreService for BotCore {
                             (reconnected_bot_id, tok)
                         }
                         Err(()) => {
-                            warn!(request_id = %bcs_observability::current_request_id(), bot_id = %bot_id, "Reconnect failed, trying direct register");
+                            warn!(request_id = %bcs_observability::CurrentRequestId, bot_id = %bot_id, "Reconnect failed, trying direct register");
                             let registered_token = self
                                 .repo
                                 .register_streaming_connection(bot_id.clone())

--- a/src/bcs/crates/services/bcs-bot/src/core/bot_core.rs
+++ b/src/bcs/crates/services/bcs-bot/src/core/bot_core.rs
@@ -217,7 +217,7 @@ impl BotRegistryCoreService for BotCore {
             return Ok(BotDeliveryTarget::WebSocket { bot_id: bot.bot_uuid });
         };
         if binding.disabled {
-            warn!(bot_id = %bot_id, provider_id = %binding.provider_id, "resolve_delivery_target: provider bot binding disabled");
+            warn!(request_id = %bcs_observability::current_request_id(), bot_id = %bot_id, provider_id = %binding.provider_id, "resolve_delivery_target: provider bot binding disabled");
             return Err(ServiceError::InvalidOperation {
                 message: format!("provider bot '{}' is disabled", bot_id),
                 request_id: None,
@@ -231,14 +231,14 @@ impl BotRegistryCoreService for BotCore {
             .get_provider(&binding.provider_id)
             .await?
             .ok_or_else(|| {
-                warn!(bot_id = %bot_id, provider_id = %binding.provider_id, "resolve_delivery_target: provider not found");
+                warn!(request_id = %bcs_observability::current_request_id(), bot_id = %bot_id, provider_id = %binding.provider_id, "resolve_delivery_target: provider not found");
                 ServiceError::InvalidOperation {
                     message: format!("provider '{}' not found", binding.provider_id),
                     request_id: None,
                 }
             })?;
         if provider.disabled {
-            warn!(bot_id = %bot_id, provider_id = %provider.provider_id, "resolve_delivery_target: provider disabled");
+            warn!(request_id = %bcs_observability::current_request_id(), bot_id = %bot_id, provider_id = %provider.provider_id, "resolve_delivery_target: provider disabled");
             return Err(ServiceError::InvalidOperation {
                 message: format!("provider '{}' is disabled", provider.provider_id),
                 request_id: None,
@@ -246,7 +246,7 @@ impl BotRegistryCoreService for BotCore {
         }
         let downlink = parse_downlink_config(&provider.config)?;
         if !downlink.enabled {
-            warn!(bot_id = %bot_id, provider_id = %provider.provider_id, "resolve_delivery_target: provider downlink disabled");
+            warn!(request_id = %bcs_observability::current_request_id(), bot_id = %bot_id, provider_id = %provider.provider_id, "resolve_delivery_target: provider downlink disabled");
             return Err(ServiceError::InvalidOperation {
                 message: format!("provider '{}' downlink is disabled", provider.provider_id),
                 request_id: None,
@@ -260,7 +260,7 @@ impl BotRegistryCoreService for BotCore {
             .get_credential_by_kind(&provider.provider_id, "downlink_bcs_to_provider")
             .await?
             .ok_or_else(|| {
-                warn!(bot_id = %bot_id, provider_id = %provider.provider_id, "resolve_delivery_target: downlink credential not found");
+                warn!(request_id = %bcs_observability::current_request_id(), bot_id = %bot_id, provider_id = %provider.provider_id, "resolve_delivery_target: downlink credential not found");
                 ServiceError::InvalidOperation {
                     message: format!(
                         "provider '{}' downlink credential not found",
@@ -270,7 +270,7 @@ impl BotRegistryCoreService for BotCore {
                 }
             })?;
         if credential.disabled {
-            warn!(bot_id = %bot_id, provider_id = %provider.provider_id, "resolve_delivery_target: downlink credential disabled");
+            warn!(request_id = %bcs_observability::current_request_id(), bot_id = %bot_id, provider_id = %provider.provider_id, "resolve_delivery_target: downlink credential disabled");
             return Err(ServiceError::InvalidOperation {
                 message: format!(
                     "provider '{}' downlink credential is disabled",
@@ -556,7 +556,7 @@ impl BotRegistryCoreService for BotCore {
         {
             Ok(bindings) => bindings,
             Err(error) => {
-                warn!(error = %error, "list_runtime_active_bot_ids: failed to list provider bindings");
+                warn!(request_id = %bcs_observability::current_request_id(), error = %error, "list_runtime_active_bot_ids: failed to list provider bindings");
                 return active.into_iter().collect();
             }
         };
@@ -574,7 +574,7 @@ impl BotRegistryCoreService for BotCore {
         let providers = match provider_repo.list_providers_by_ids(&provider_ids).await {
             Ok(providers) => providers,
             Err(error) => {
-                warn!(error = %error, "list_runtime_active_bot_ids: failed to list providers");
+                warn!(request_id = %bcs_observability::current_request_id(), error = %error, "list_runtime_active_bot_ids: failed to list providers");
                 return active.into_iter().collect();
             }
         };
@@ -587,7 +587,7 @@ impl BotRegistryCoreService for BotCore {
         {
             Ok(credentials) => credentials,
             Err(error) => {
-                warn!(error = %error, "list_runtime_active_bot_ids: failed to list provider credentials");
+                warn!(request_id = %bcs_observability::current_request_id(), error = %error, "list_runtime_active_bot_ids: failed to list provider credentials");
                 return active.into_iter().collect();
             }
         };
@@ -788,7 +788,7 @@ impl BotRegistryCoreService for BotCore {
                             (reconnected_bot_id, tok)
                         }
                         Err(()) => {
-                            warn!(bot_id = %bot_id, "Reconnect failed, trying direct register");
+                            warn!(request_id = %bcs_observability::current_request_id(), bot_id = %bot_id, "Reconnect failed, trying direct register");
                             let registered_token = self
                                 .repo
                                 .register_streaming_connection(bot_id.clone())

--- a/src/bcs/crates/services/bcs-bot/src/core/candidate_search_core.rs
+++ b/src/bcs/crates/services/bcs-bot/src/core/candidate_search_core.rs
@@ -126,6 +126,7 @@ impl BotCandidateSearchCore {
             }
             Err(error) => {
                 warn!(
+                    request_id = %bcs_observability::current_request_id(),
                     error = %error,
                     "candidate search: worker recommendation failed, falling back to name search"
                 );
@@ -220,6 +221,7 @@ impl BotCandidateSearchCore {
                 .collect(),
             Err(error) => {
                 warn!(
+                    request_id = %bcs_observability::current_request_id(),
                     error = %error,
                     "candidate search: worker profile lookup failed, tags will be empty"
                 );

--- a/src/bcs/crates/services/bcs-bot/src/core/candidate_search_core.rs
+++ b/src/bcs/crates/services/bcs-bot/src/core/candidate_search_core.rs
@@ -126,7 +126,7 @@ impl BotCandidateSearchCore {
             }
             Err(error) => {
                 warn!(
-                    request_id = %bcs_observability::current_request_id(),
+                    request_id = %bcs_observability::CurrentRequestId,
                     error = %error,
                     "candidate search: worker recommendation failed, falling back to name search"
                 );
@@ -221,7 +221,7 @@ impl BotCandidateSearchCore {
                 .collect(),
             Err(error) => {
                 warn!(
-                    request_id = %bcs_observability::current_request_id(),
+                    request_id = %bcs_observability::CurrentRequestId,
                     error = %error,
                     "candidate search: worker profile lookup failed, tags will be empty"
                 );

--- a/src/bcs/crates/services/bcs-bot/src/core/provider_core.rs
+++ b/src/bcs/crates/services/bcs-bot/src/core/provider_core.rs
@@ -205,6 +205,7 @@ impl ProviderCore {
                     .await
                     .inspect_err(|err| {
                         warn!(
+                            request_id = %bcs_observability::current_request_id(),
                             provider_id = %provider.provider_id,
                             bot_uuid = %bot_uuid,
                             error = %err,
@@ -226,6 +227,7 @@ impl ProviderCore {
                     .await
                     .inspect_err(|err| {
                         warn!(
+                            request_id = %bcs_observability::current_request_id(),
                             provider_id = %provider.provider_id,
                             bot_uuid = %bot_uuid,
                             provider_bot_ref = %provider_bot_ref,
@@ -267,6 +269,7 @@ impl ProviderCore {
                     .await
                     .inspect_err(|err| {
                         warn!(
+                            request_id = %bcs_observability::current_request_id(),
                             provider_id = %provider.provider_id,
                             bot_uuid = %bot_uuid,
                             error = %err,
@@ -681,6 +684,7 @@ impl ProviderCoreService for ProviderCore {
             .await
             .inspect_err(|err| {
                 warn!(
+                    request_id = %bcs_observability::current_request_id(),
                     provider_id = %provider_id,
                     error = %err,
                     "register_provider: insert_provider failed"
@@ -699,6 +703,7 @@ impl ProviderCoreService for ProviderCore {
             .await
             .inspect_err(|err| {
                 warn!(
+                    request_id = %bcs_observability::current_request_id(),
                     provider_id = %provider_id,
                     kind = "provider_admin",
                     error = %err,
@@ -717,6 +722,7 @@ impl ProviderCoreService for ProviderCore {
             .await
             .inspect_err(|err| {
                 warn!(
+                    request_id = %bcs_observability::current_request_id(),
                     provider_id = %provider_id,
                     kind = "downlink_bcs_to_provider",
                     error = %err,

--- a/src/bcs/crates/services/bcs-bot/src/core/provider_core.rs
+++ b/src/bcs/crates/services/bcs-bot/src/core/provider_core.rs
@@ -205,7 +205,7 @@ impl ProviderCore {
                     .await
                     .inspect_err(|err| {
                         warn!(
-                            request_id = %bcs_observability::current_request_id(),
+                            request_id = %bcs_observability::CurrentRequestId,
                             provider_id = %provider.provider_id,
                             bot_uuid = %bot_uuid,
                             error = %err,
@@ -227,7 +227,7 @@ impl ProviderCore {
                     .await
                     .inspect_err(|err| {
                         warn!(
-                            request_id = %bcs_observability::current_request_id(),
+                            request_id = %bcs_observability::CurrentRequestId,
                             provider_id = %provider.provider_id,
                             bot_uuid = %bot_uuid,
                             provider_bot_ref = %provider_bot_ref,
@@ -269,7 +269,7 @@ impl ProviderCore {
                     .await
                     .inspect_err(|err| {
                         warn!(
-                            request_id = %bcs_observability::current_request_id(),
+                            request_id = %bcs_observability::CurrentRequestId,
                             provider_id = %provider.provider_id,
                             bot_uuid = %bot_uuid,
                             error = %err,
@@ -684,7 +684,7 @@ impl ProviderCoreService for ProviderCore {
             .await
             .inspect_err(|err| {
                 warn!(
-                    request_id = %bcs_observability::current_request_id(),
+                    request_id = %bcs_observability::CurrentRequestId,
                     provider_id = %provider_id,
                     error = %err,
                     "register_provider: insert_provider failed"
@@ -703,7 +703,7 @@ impl ProviderCoreService for ProviderCore {
             .await
             .inspect_err(|err| {
                 warn!(
-                    request_id = %bcs_observability::current_request_id(),
+                    request_id = %bcs_observability::CurrentRequestId,
                     provider_id = %provider_id,
                     kind = "provider_admin",
                     error = %err,
@@ -722,7 +722,7 @@ impl ProviderCoreService for ProviderCore {
             .await
             .inspect_err(|err| {
                 warn!(
-                    request_id = %bcs_observability::current_request_id(),
+                    request_id = %bcs_observability::CurrentRequestId,
                     provider_id = %provider_id,
                     kind = "downlink_bcs_to_provider",
                     error = %err,

--- a/src/bcs/crates/test-support/bcs-test-support/CONTEXT.md
+++ b/src/bcs/crates/test-support/bcs-test-support/CONTEXT.md
@@ -5,17 +5,21 @@
 - Shared contract-test harnesses for BCS service and plugin boundaries.
 - Reusable fixtures and helpers for local conformance testing.
 - A single place to host boundary-level test utilities reused across crates.
+- Request-scoped JSON log capture for checking failure diagnostics and correlation,
+  enabled only through the consuming crate's dev-dependency `diagnostic-logs` feature.
 
 ## Consumes
 
 - `bcs-service-api`, `bcs-cache-api`, and `bcs-db-api` contract crates.
 - Test runtime crates such as `tokio`.
+- Optional `bcs-observability` request-ID scopes and `tracing-subscriber` for test-local log capture.
 
 ## Allowed dependencies
 
 - `service-api/*`
 - `plugin-api/*`
 - Test-only helper crates
+- `auxiliary/bcs-observability` for diagnostic test context
 
 ## Forbidden dependencies
 

--- a/src/bcs/crates/test-support/bcs-test-support/Cargo.toml
+++ b/src/bcs/crates/test-support/bcs-test-support/Cargo.toml
@@ -10,6 +10,9 @@ rust-version.workspace = true
 [lints]
 workspace = true
 
+[features]
+diagnostic-logs = ["dep:bcs-observability", "dep:tracing", "dep:tracing-subscriber"]
+
 [dependencies]
 bcs-domain      = { workspace = true }
 bcs-service-api = { workspace = true }
@@ -20,6 +23,9 @@ bcs-llm-api     = { workspace = true }
 bcs-human-notify-api = { workspace = true }
 bcs-session     = { workspace = true }
 bcs-session-file = { workspace = true }
+bcs-observability = { workspace = true, optional = true }
+tracing         = { workspace = true, optional = true }
+tracing-subscriber = { workspace = true, optional = true }
 axum            = { workspace = true }
 tokio           = { workspace = true }
 async-trait     = { workspace = true }

--- a/src/bcs/crates/test-support/bcs-test-support/src/lib.rs
+++ b/src/bcs/crates/test-support/bcs-test-support/src/lib.rs
@@ -6,6 +6,11 @@ mod auth_noop;
 mod auth_oauth_mock;
 mod edge_permission_noop;
 mod noop;
+#[cfg(feature = "diagnostic-logs")]
+mod logs;
+
+#[cfg(feature = "diagnostic-logs")]
+pub use logs::capture_request_logs;
 
 pub use auth_noop::{NoopAuthPlugin, NoopUserIdentityPort};
 pub use auth_oauth_mock::{

--- a/src/bcs/crates/test-support/bcs-test-support/src/logs.rs
+++ b/src/bcs/crates/test-support/bcs-test-support/src/logs.rs
@@ -1,0 +1,32 @@
+use std::{future::Future, io::Write, sync::{Arc, Mutex}};
+
+use tracing::instrument::WithSubscriber;
+
+#[derive(Clone, Default)]
+struct LogBuffer(Arc<Mutex<Vec<u8>>>);
+
+impl Write for LogBuffer {
+    fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+        self.0.lock().unwrap().extend_from_slice(bytes);
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> { Ok(()) }
+}
+
+/// Captures real JSON events emitted by a future under a request-ID scope.
+/// The subscriber is scoped to each poll, so concurrent tests do not share logs.
+/// Spawned work must inherit its subscriber through the production boundary and
+/// finish before the supplied future returns.
+pub async fn capture_request_logs<T>(request_id: &str, future: impl Future<Output = T>) -> (T, Vec<serde_json::Value>) {
+    let buffer = LogBuffer::default();
+    let writer = buffer.clone();
+    let subscriber = tracing_subscriber::fmt().json().with_max_level(tracing::Level::TRACE)
+        .with_writer(move || writer.clone()).finish();
+    let result = bcs_observability::with_request_id(request_id.to_owned(), future)
+        .with_subscriber(subscriber).await;
+    let bytes = buffer.0.lock().unwrap().clone();
+    let text = String::from_utf8(bytes).expect("UTF-8 log output");
+    let events = text.lines().map(|line| serde_json::from_str(line).expect("JSON log event")).collect();
+    (result, events)
+}


### PR DESCRIPTION
## Problem

Existing HTTP, authentication, bot/store, and WebSocket warning and error logs often lack a request ID. Request-local context is also lost when processing crosses WebSocket upgrade or detached provider-final task boundaries. As a result, a failed background callback can be difficult to associate with the HTTP request that initiated it.

Successful WebSocket handshakes are additionally logged as `outcome=http_error` for status 101, inflating log-derived error rates.

## Solution

- Add `request_id` to existing business warning/error events in the affected HTTP, authentication, bot/store, and WebSocket paths. Synchronous events use the `CurrentRequestId` display value to borrow the emitting task context without cloning; asynchronous boundaries continue to capture an owned ID.
- Add a log-only `with_request_id` scope for long-lived work. Capture the initiating ID before WebSocket upgrades and detached provider-final processing, including nested tasks, without retaining HTTP operation totals or emitting a second HTTP summary.
- Add a process-lifetime `process_instance_id()` UUID that dependency clients can combine with their local connection, pool, or client identifiers across restarts.
- Classify HTTP 101 as `outcome=upgraded`, preserving the response status, request-ID header, and existing classification of other statuses.
- Use millisecond timestamps for configured outputs named `observability`, and verify diagnostic events can be written to both the main log and an additional JSON file. Output selection and log collection remain deployment configuration.

## Validation

The latest local instrumented run passed **289 tests**, with **19 existing ignored tests** unchanged. It covers the affected HTTP/WS libraries and focused diagnostic integration tests:

```text
cargo llvm-cov --offline --locked -p bcs-http -p bcs-ws -p bcs-bot-store \
  --lib --test secret_diagnostics --test frame_compat --test web_frame_compat \
  --test diagnostic_registries --test diagnostic_logging --cobertura
```

This adds **25 tests** for actual failure diagnostics, asserting both emitted request IDs and behavior:

- OAuth token exchange/userinfo, identity lookup/persistence, callback validation, refresh, logout and authentication-chain failures.
- Bot/store DB write/query failures, malformed identity rows, pagination/count failures, provider persistence, and damaged local capability files.
- Unregistered/malformed WebSocket frames, failed deliveries, expired channels, full queues, replay/resolve service failures, and real socket disconnect/error cleanup.
- Secret-route non-loopback rejection and downstream unavailability, preserving HTTP response codes and request-ID headers.

Each log capture uses an isolated subscriber and a request-ID scope. The helper and its dependencies are behind an optional `diagnostic-logs` feature enabled only by dev-dependencies. The normal dependency graph was checked to leave this feature disabled.

The previous remote run passed all **4,443 tests**, but failed changed-line coverage at **52.14%** (73/140; minimum 80%). The new focused coverage report directly confirms execution of **54 of the 67 previously missed lines**, without changing production behavior, logger features, or coverage gates. This is targeted evidence; the updated remote CI run remains the authority for full coverage.

Additional checks passed:

- `bash scripts/ci/check-observability-deps.sh`
- `git diff --check`
- Independent review of diagnostic fixtures and subscriber isolation.

Previous remote BCS E2E coverage and Singlebox coverage jobs passed. Full local workspace coverage was not rerun before pushing; the prior attempt was stopped by SIGKILL during test discovery. Live failover and deployment fault-path validation remain separate steps.

## Compatibility and risk

The change adds log fields and correlation helpers and corrects the 101 log outcome. It does not change HTTP response contracts, dependency results, retries, deadlines, or existing A2A tracing, and introduces no spans, distributed trace IDs, or metric exports.

For WebSocket sessions, `request_id` identifies the initiating handshake; existing frame/run IDs continue to distinguish individual messages. Work without an initiating request can still have an empty request ID.

Creating or collecting an additional diagnostic file requires deployment logging configuration. Existing outputs keep their formatting unless explicitly named `observability`.
