### PR TITLE
refactor(backend): encapsulate steady-state skill delivery

### DIFF
--- a/src/backend/specs/2026-09-08-skill-runtime-delivery-convergence/spec.md
+++ b/src/backend/specs/2026-09-08-skill-runtime-delivery-convergence/spec.md
@@ -1,0 +1,94 @@
+# Skill Runtime 日常交付收口（方案一）
+
+## Problem Statement
+
+Skill 模块 Owner 希望在 OpenClaw/Hermes 尚未全量切 Pool、Legacy 与 Pool 将继续共存的前提下，降低日常能力操作对布局迁移细节的依赖。
+
+当前 PerDomainRuntimeProjection 同时处理 Skill/MCP 调度、布局状态、Legacy 分流、协议选择、设备推送验证和结果解释。迁移知识因此暴露在日常投影策略中，后续维护容易把迁移的严格约束与普通交付的降级语义混合。
+
+本期需要隔离这些知识，而不是重新实现 Pool，也不是将所有历史设备强制切换到新协议。
+
+## Solution
+
+将日常文件型 Skill 交付收口到一个内部模块：接收已经解析好的 Plan 与明确退休映射，内部选择原有交付路线并解释结果；PerDomainRuntimeProjection 保留 Skill/MCP 调度、异常隔离和结果组合。
+
+公开接口、控制面事实、设备协议、迁移流程及用户可观察行为保持兼容。复杂逻辑从旧位置迁出，不能新增一层透传后仍让调用方维护同样的判断。
+
+## User Stories
+
+1. 作为 Skill 模块 Owner，我希望日常投影策略不理解迁移阶段，以便布局兼容集中维护。
+2. 作为 SkillSet 用户，我希望重构后激活与停用仍保持原有控制面行为，以便不影响产品操作。
+3. 作为 Direct Skill 用户，我希望单项激活与停用的结果保持兼容，以便调用方无需适配。
+4. 作为 Legacy Bot 用户，我希望纯 Local Skill 仍走原交付路线，以便旧设备无需支持新 Mapping endpoint。
+5. 作为 Legacy Bot 用户，我希望空集合处理仍保持原有清理行为，以便重构不改变已有能力清理语义。
+6. 作为 Pool Bot 用户，我希望逻辑映射仍使用正确的实际布局，以便切换过程不会读回已退休的 Legacy 目录。
+7. 作为 Repo Skill 用户，我希望 Repo 映射继续使用现有协议与来源，以便不改变共享内容交付。
+8. 作为 Center Skill 用户，我希望 UUID 和精确版本保持不变，以便一次交付不会重新解析到另一个 latest。
+9. 作为用户，我希望已提交的 Installation 不因设备暂不可达被回滚，以便保存的能力意图仍然有效。
+10. 作为用户，我希望保留逐 Skill 的错误、原因和建议，以便知道哪个能力尚未收敛。
+11. 作为用户，我希望实体目录和外部软链仍按现有规则保留，以便不会因重构丢失容器内维护的内容。
+12. 作为调用者，我希望明确退休的映射仍被处理，即使 Skill scope 未显式开启，以便不会留下应退出的受管链接。
+13. 作为 MCP 用户，我希望 MCP-only 操作不新增 Skill I/O，以便保持现有操作成本。
+14. 作为用户，我希望 Skill 交付异常不阻断原本应执行的 MCP 半链路，以便保留现有异常隔离。
+15. 作为 Track Latest 消费者，我希望复用已有 Projector 路线，以便无需为本次重构新增调用方式。
+16. 作为启动恢复链路维护者，我希望已接入 Projector 的入口自然复用新模块，以便不复制第二套交付逻辑。
+17. 作为 Service Bot Owner，我希望发布前普通投影受益于收口，同时 Artifact 构建仍遵循原合同，以便历史版本不漂移。
+18. 作为 Teclaw 用户，我希望继续使用 Whole Artifact，以便不会被强加文件型 probe 或布局要求。
+19. 作为下游运行环境维护者，我希望继续通过既有设备运输层交付，以便保留认证、设备绑定和实例亲和性。
+20. 作为 Pool 迁移维护者，我希望迁移与回滚继续使用原底层 Runtime，以便严格文件保护不与日常 best-effort 混合。
+21. 作为维护者，我希望本次不增加有效态查询、设备调用和自动重试，以便纯职责收口不引入额外性能成本。
+22. 作为实现者，我希望以同一套输入输出合同验证迁移前后行为，以便发现分流、状态及明细方面的回归。
+
+## Implementation Decisions
+
+1. **输入已定稿：**复用现有 ResolvedSkillPlan 与 retired_mappings，不新建专用输入 DTO，不要求调用方新增 source_layout、probe 或目录参数。
+2. Plan 携带的 Bot 身份、元数据、已解析资产、逻辑映射和 Legacy Runtime capability 可在内部使用；只读消费，不修改 Plan 或其 Bot 元数据。
+3. 新模块不重查 Installation/SkillSet，不重新解析 latest。上游 Reader、VersionResolver 和 Resolver 的事实所有权不变。
+4. 允许新模块内部读取现有 layout state，并沿用 runtime_uses_pool_paths 对中间阶段的判断。配置不是实际布局事实，不能仅用 active_layout 替代既有选择规则。
+5. **分流已定稿：**Legacy、仅 Local 或空集合且无 retired 时，保留原 project_skills/DeviceSync 路线；Pool、包含 Repo/Center 或存在 retired 时，保留原 Mapping 路线。当前实际 Engine 身份解析不变。
+6. 协议协商、Center probe/ensure 前置步骤、Mapping publish/verify、既有顺序、请求形状、超时及 BEST_EFFORT 选择保持不变。批次 ensure 与逐项降级的差异不在本期修改。
+7. **输出已定稿：**返回现有 RuntimeProjectionResult，仅表达 Skill 分量。Legacy bool、Mapping publish/verify 结果及其明细由新模块解释，不暴露给 PerDomain 再次解析。
+8. 沿用现有状态、错误码、逐项信息、中文文案和建议。未知异常保留日志与 PerDomain 现有兜底，不新增自动重试、Installation 回滚或响应 schema。
+9. PerDomain 保留 Skill/MCP scope、retired 强制交付条件、MCP claimed/released 过滤、两条半链路异常隔离及结果组合。它不再直接读取 layout Repository或编排、解释 Skill 设备协议。
+10. **复用范围已定稿：**新模块仅用于 PerDomain 的日常 Skill 投影。已通过 Projector 的 SkillSet、Direct、Track Latest、启动恢复和发布前投影自然受益，不逐入口新增接线。
+11. Teclaw 继续经 Registry 使用 WholeArtifactRuntimeProjection；Pool cutover/rollback/recovery 继续使用原 SkillsPoolRuntimeProtocol；Artifact 独立 probe、capture 和验证不改。
+12. 优先提取职责明确的内部模块，复用现有 Runtime/Repository 和 composition root。不新建插件框架、通用 DTO 或额外配置开关。具体命名与内部拆分按现有惯例决定。
+13. 原位置的相关实现必须删除或迁出，不能保留第二份布局选择和结果归一逻辑。永久模型属地的大规模整理不夹带在本期。
+14. 下游实现继续通过 DeviceAdapterTransport 绑定交付。保留 Legacy DeviceSync 和延迟 composer 装配；不直接依赖专有 concrete、不自行拼设备 URL、不绕过认证或实例亲和性。
+15. 不修改公开 HTTP、Engine wire、底层 Runtime Protocol、数据库 schema、持久 locator 或历史数据。Gateway 生成合同不应因本期发生变化。
+
+## Testing Decisions
+
+1. **主要测试 seam：**优先通过现有 BotRuntimeProjector 的公开调用验证已装配的 PerDomain 行为，用现有 Runtime/Legacy capability fake 观察交付请求和结果。上层 command 测试确认 Installation 与公开响应未回归；不要以私有方法名或文件移动作为行为测试目标。
+2. 内部交付模块需要隔离测试时，经其交付入口验证结果，不为测试访问内部辅助方法另建接口。架构门禁可独立检查 PerDomain 不再直接依赖 layout/协议编排，这是职责验收，不代替行为测试。
+3. 覆盖 Legacy Local-only、空集合、Pool、Legacy Repo/Center、混合 corpus、retired 非空与空、缺失布局记录及 cutover 中间阶段。断言原分流和 source_layout/wire 保持兼容。
+4. 覆盖不变 scope、MCP-only、Skill-only、retired 强制交付和完整投影；断言无新增设备调用或重复有效态查询，Skill 异常不跳过应执行的 MCP。
+5. 覆盖 Center 精确版本、v3 能力、ensure 失败、设备不可达、publish/verify 逐项结果、用户实体与外部链接、合法源缺失以及异常兜底。验证状态、逐项错误、文案、重试属性和结果组合保持既有兼容性。
+6. 覆盖 Teclaw 路线隔离，无文件型模块调用、无新增 probe。保留现有 Whole Artifact 行为。
+7. 下游集成测试通过公共 Consumer/Runtime 与替代 `DeviceAdapterTransport` 绑定、mock 网络验证 method/path/body、调用顺序、owner+bot、超时及设备亲和性不丢失。检查 Legacy clean/bindpath 与 lazy composer 兼容。
+8. Prior art：现有 SkillSetManagement/Projector 行为测试、Runtime projection message 测试、SkillsPoolRuntime 测试、下游 DeviceAdapterTransport/desktop 测试、Engine Mapping/Router 合同测试。优先复用其 fixtures，避免新增同义测试框架。
+9. 先补当前行为的缺失测试，再提取实现；跑贴近改动的单测、合同、DI、架构与兼容门禁，之后 Standards/Spec 双轴 review，修复高优问题后执行最终门禁。完整 Backend 套件不在每个增量反复运行。
+10. 新发现的既有缺陷单列证据与影响，不悄悄改变产品语义，也不把错误行为提升为长期领域合同；若影响本期验收，明确报告并解决范围判断。
+11. 合并与企业 gitlink 集成后，预发验证 Legacy/Pool 正常交付和错误明细；区分本地、CI、评审、集成、部署和真实 Runtime 证据。
+
+## Out of Scope
+
+- 开启全量 rollout、修改名单、强制重启或对历史 Bot 执行数据迁移。
+- 重写 Pool claim、cutover、rollback、quarantine、cleanup 或取消必要文件保护。
+- 为所有 Legacy 设备强制启用 Mapping endpoint。
+- 改变 Center ensure 的整批阻断方式、增加重试或性能优化策略。
+- Local 逻辑 locator 演进、git_path 数据转换、上传/删除内容模块重构。
+- Artifact/共享目录排除、挂载脚本、路径规划协议和镜像改造。
+- 新增 AICoding/Claude Code Runtime 能力或推进其我方 Pool 迁移。
+- 改动 Installation 事实、SkillSet 规则、MCP 策略或 Teclaw Whole Artifact。
+- 承诺第一步后整个 Backend 已完全不感知目录；Factory、内容与 Artifact 的耦合仍为后续工作。
+
+## Further Notes
+
+- 2026-09-08 用户完成四轮设计确认，并要求转为 Spec。本 Spec 取代先前范围草案中未决措辞；研究报告和 HTML 是解释材料，不能扩大本期范围。
+- 目标分支为 Avernet `dev`。实施前重新刷新基线并复核相关变更；下游以精确集成提交为准，不能以分支状态代替集成或部署验证。
+- 下游专有组装与外部 Runtime 的真实部署行为不由本公开仓源码证明；需在对应集成与运行环境中独立验证。
+- 后续的 Pool rollout 与本 Spec 的日常交付职责收口分属不同阶段；本变更不开启切流、不执行迁移。
+- 与 [Avernet #455](https://github.com/inclusionAI/Avernet/issues/455) 相关，但只实现日常交付收口，不能据此关闭整个路径权威重构议题。
+- 预计一个 Avernet 主 PR；下游按实际补测及集成需要配套。不拆多个 stacked PR，不预设下游零改动。
+- 验收完成的结构性标准：PerDomain 只调度和组合；布局兼容及 Skill 设备结果解释有唯一维护位置；所有相关用户可观察合同保持兼容。

--- a/src/backend/src/agentclaw/community/core/skill_center/AGENTS.md
+++ b/src/backend/src/agentclaw/community/core/skill_center/AGENTS.md
@@ -139,6 +139,8 @@ SC Public 引用已是持久异步批量 Operation：
 
 修改投影时依次读 `services/bot_runtime_projector.py`、`runtime_resolver.py`、`services/runtime_projections/{per_domain,whole_artifact,registry}.py`。Reader 负责 DB 有效态，Resolver 负责计算，Projector/策略负责设备副作用；flush 本身没有设备 I/O。
 
+`services/runtime_projections/skill_runtime_delivery.py` 是文件型 Engine 的日常 Skill 交付边界：它接收已解析的 `ResolvedSkillPlan + retired_mappings`，内部统一维护 Legacy DeviceSync 与 Pool/Repo/Center Mapping 的布局分流、协议编排和 Skill 结果解释。`PerDomainRuntimeProjection` 只保留 Skill/MCP scope、异常隔离和结果组合；Pool cutover/rollback/recovery 仍直接消费 `SkillsPoolRuntimeProtocol`，Teclaw 仍走 Whole Artifact。
+
 `services/track_latest.py` 把 Version 发布转成 fanout 和逐 Bot reconcile 任务。候选 Bot 查询兼容尚未物化的历史 Set；最终有效态仍经 Reader。MCP 变化使用 claimed/released delta；投影 PENDING 可重试，DEGRADED 依当前任务语义记录后继续。Published Service Bot 的历史 Artifact 不跟随 latest。
 
 `services/skill_symlink_listener.py` 处理设备激活和重投影事件；通过正式 Projector 恢复当前 Desired State。既有兼容 fallback 不是新增业务写入入口。

--- a/src/backend/src/agentclaw/community/core/skill_center/README.md
+++ b/src/backend/src/agentclaw/community/core/skill_center/README.md
@@ -185,6 +185,15 @@ internal_dependencies:
 
 ### Change impact
 
+`SkillRuntimeDelivery` owns steady-state filesystem Skill delivery after plan
+resolution: Legacy Local-only and empty snapshots retain DeviceSync, while
+Pool, Repo, Center, and explicit retirement retain the logical Mapping route.
+`PerDomainRuntimeProjection` only schedules the Skill and MCP halves, isolates
+their failures, and combines results. Pool migration/recovery still consumes
+`SkillsPoolRuntimeProtocol` directly, and Teclaw still uses Whole Artifact;
+changing either route requires compatibility review across Projector, public
+Runtime, community DI, and the Corp transport binding.
+
 `SpaceSkillEditorRequestService` is an additional consumer of the existing
 `StaffDeptPlugin` profile lookup: newly created Skill editor-request approval
 notifications persist the applicant as `「花名」(工号)` when the directory returns

--- a/src/backend/src/agentclaw/community/core/skill_center/services/runtime_projections/per_domain.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/runtime_projections/per_domain.py
@@ -4,41 +4,21 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 
-from agentclaw.community.core.skill_center.errors import (
-    SkillSetRuntimeReconcileError,
-)
 from agentclaw.community.core.skill_center.runtime_projection_contract import (
     EngineRuntimeProjection,
     ProjectionScope,
     ResolvedCapabilityPlan,
     ResolvedSkillPlan,
-    RuntimeProjectionIssue,
     RuntimeProjectionResult,
     RuntimeProjectionStatus,
 )
-from agentclaw.community.core.skill_center.runtime_resolver import RuntimeSkillProjection
-from agentclaw.community.core.repository.protocols.skills_pool import (
-    SkillsPoolLayoutRepositoryProtocol,
-)
-from agentclaw.community.core.skills_pool.mapping_intent import (
-    MAPPING_CONTRACT_V3,
-    mapping_contract_for,
+from agentclaw.community.core.skill_center.services.runtime_projections.skill_runtime_delivery import (
+    SkillRuntimeDelivery,
 )
 from agentclaw.community.core.skills_pool.models import (
-    MappingApplyMode,
-    MappingProjectionStatus,
-    MappingPublishResult,
-    MappingVerificationResult,
     PoolSkillMapping,
     RegisteredSkillAsset,
-    SkillMappingSourceLayout,
 )
-from agentclaw.community.core.skills_pool.ports import SkillsPoolRuntimeProtocol
-from agentclaw.community.core.skills_pool.types import (
-    BotSkillLayoutScope,
-    runtime_uses_pool_paths,
-)
-from agentclaw.community.core.workspace.skill_layout import runtime_layout_engine_for_bot
 from agentclaw.community.log import get_logger
 
 
@@ -59,11 +39,9 @@ class PerDomainRuntimeProjection(EngineRuntimeProjection):
     def __init__(
         self,
         *,
-        pool_runtime: SkillsPoolRuntimeProtocol,
-        pool_layouts: SkillsPoolLayoutRepositoryProtocol,
+        skill_delivery: SkillRuntimeDelivery,
     ) -> None:
-        self._pool_runtime = pool_runtime
-        self._pool_layouts = pool_layouts
+        self._skill_delivery = skill_delivery
 
     def validate_plan(
         self,
@@ -104,7 +82,7 @@ class PerDomainRuntimeProjection(EngineRuntimeProjection):
         if scope.skills or retired_mappings:
             try:
                 results.append(
-                    await self._apply_skill_projection(
+                    await self._skill_delivery.deliver(
                         plan=plan, retired_mappings=retired_mappings
                     )
                 )
@@ -125,9 +103,12 @@ class PerDomainRuntimeProjection(EngineRuntimeProjection):
             logger.info(
                 "[PerDomainRuntimeProjection] Skill projection skipped, scope "
                 "declares no Skill change: bot_id=%s, engine=%s",
-                plan.bot_id, plan.engine,
+                plan.bot_id,
+                plan.engine,
             )
-            results.append(RuntimeProjectionResult.skipped(reason="SKILL_SCOPE_UNCHANGED"))
+            results.append(
+                RuntimeProjectionResult.skipped(reason="SKILL_SCOPE_UNCHANGED")
+            )
         if scope.mcp:
             if not isinstance(plan, ResolvedCapabilityPlan):
                 results.append(
@@ -138,7 +119,9 @@ class PerDomainRuntimeProjection(EngineRuntimeProjection):
                 )
             else:
                 try:
-                    results.append(await self._apply_mcp_projection(plan=plan, scope=scope))
+                    results.append(
+                        await self._apply_mcp_projection(plan=plan, scope=scope)
+                    )
                 except Exception:
                     logger.exception(
                         "[PerDomainRuntimeProjection] MCP projection unavailable "
@@ -156,63 +139,13 @@ class PerDomainRuntimeProjection(EngineRuntimeProjection):
             logger.info(
                 "[PerDomainRuntimeProjection] MCP projection skipped, scope "
                 "declares no MCP change: bot_id=%s, engine=%s",
-                plan.bot_id, plan.engine,
+                plan.bot_id,
+                plan.engine,
             )
-            results.append(RuntimeProjectionResult.skipped(reason="MCP_SCOPE_UNCHANGED"))
+            results.append(
+                RuntimeProjectionResult.skipped(reason="MCP_SCOPE_UNCHANGED")
+            )
         return RuntimeProjectionResult.combine(*results)
-
-    async def _apply_skill_projection(
-        self,
-        *,
-        plan: ResolvedSkillPlan,
-        retired_mappings: Sequence[PoolSkillMapping],
-    ) -> RuntimeProjectionResult:
-        mappings = list(plan.projection.skill_mappings)
-        retired = list(retired_mappings)
-        bot = plan.bot
-
-        scope = BotSkillLayoutScope(
-            env=str(bot["env"]),
-            entity_id=str(bot.get("entity_id") or plan.owner_id),
-            bot_id=plan.bot_id,
-        )
-        layout_state = self._pool_layouts.get(scope)
-        pool_owns_runtime = layout_state is not None and runtime_uses_pool_paths(
-            layout_state
-        )
-        if (
-            pool_owns_runtime
-            or any(
-                mapping.corpus in {"repo", "center"}
-                for mapping in [*mappings, *retired]
-            )
-            or retired
-        ):
-            return await self._apply_pool_mappings(
-                bot_id=plan.bot_id,
-                owner_id=plan.owner_id,
-                layout_engine=runtime_layout_engine_for_bot(bot),
-                mappings=mappings,
-                retired_mappings=retired,
-                source_layout=(
-                    SkillMappingSourceLayout.POOL
-                    if pool_owns_runtime
-                    else SkillMappingSourceLayout.LEGACY
-                ),
-            )
-        # A plain await: the blocking device call behind ``project_skills``
-        # is dispatched off the event loop by that method itself, so this
-        # legacy path gets the guarantee without restating it.
-        elif not await plan.service.project_skills(
-            desired_skills=self._desired_skills(plan.projection),
-        ):
-            return RuntimeProjectionResult.pending(
-                code="SKILL_RUNTIME_UNAVAILABLE",
-                reason="Skill 运行环境当前不可连接，能力状态已保存但尚未同步",
-            )
-        return RuntimeProjectionResult.converged(
-            components={"skills": RuntimeProjectionStatus.CONVERGED}
-        )
 
     async def _apply_mcp_projection(
         self,
@@ -243,8 +176,10 @@ class PerDomainRuntimeProjection(EngineRuntimeProjection):
                     "[PerDomainRuntimeProjection] MCP scope guarded against the "
                     "projected set: bot_id=%s, claimed %s->%s, released %s->%s",
                     plan.bot_id,
-                    sorted(scope.claimed_mcp), sorted(claimed),
-                    sorted(scope.released_mcp), sorted(released),
+                    sorted(scope.claimed_mcp),
+                    sorted(claimed),
+                    sorted(scope.released_mcp),
+                    sorted(released),
                 )
         # One call, not two: how many device writes an MCP projection takes,
         # and in what order, is decided by the service that owns device
@@ -259,240 +194,6 @@ class PerDomainRuntimeProjection(EngineRuntimeProjection):
         return RuntimeProjectionResult.converged(
             components={"mcp": RuntimeProjectionStatus.CONVERGED}
         )
-
-    async def _apply_pool_mappings(
-        self,
-        *,
-        bot_id: str,
-        owner_id: str,
-        layout_engine: str,
-        mappings: list[PoolSkillMapping],
-        retired_mappings: list[PoolSkillMapping],
-        source_layout: SkillMappingSourceLayout,
-    ) -> RuntimeProjectionResult:
-        try:
-            contract_mappings = [*mappings, *retired_mappings]
-            supported_versions: object = None
-            if any(mapping.corpus == "center" for mapping in contract_mappings):
-                probe = await self._pool_runtime.probe(
-                    bot_id=bot_id,
-                    user_id=owner_id,
-                    engine=layout_engine,
-                )
-                supported_versions = probe.evidence.get(
-                    "supported_mapping_contract_versions"
-                )
-                center_mount = probe.evidence.get("center_mount")
-                if (
-                    isinstance(center_mount, dict)
-                    and center_mount.get("restart_required") is True
-                    and (
-                        not isinstance(supported_versions, list)
-                        or MAPPING_CONTRACT_V3 not in supported_versions
-                    )
-                ):
-                    return RuntimeProjectionResult.pending(
-                        code="CENTER_RUNTIME_RESTART_REQUIRED",
-                        reason="Bot 尚未加载 Skill Center 目录，请重启 Bot 后重试",
-                    )
-            contract = mapping_contract_for(contract_mappings, supported_versions)
-            raw_published = await self._pool_runtime.publish_mappings(
-                bot_id=bot_id,
-                user_id=owner_id,
-                mappings=mappings,
-                retired_mappings=retired_mappings,
-                source_layout=source_layout,
-                mapping_contract_version=contract,
-                apply_mode=MappingApplyMode.BEST_EFFORT,
-            )
-            raw_verified = await self._pool_runtime.verify_mappings(
-                bot_id=bot_id,
-                user_id=owner_id,
-                mappings=mappings,
-                retired_mappings=retired_mappings,
-                source_layout=source_layout,
-                mapping_contract_version=contract,
-                apply_mode=MappingApplyMode.BEST_EFFORT,
-            )
-            published = self._publish_result(raw_published)
-            verified = self._verification_result(raw_verified)
-        except Exception as exc:
-            raise SkillSetRuntimeReconcileError() from exc
-        return self._mapping_result(
-            mappings=mappings,
-            published=published,
-            verified=verified,
-        )
-
-    @staticmethod
-    def _mapping_result(
-        *,
-        mappings: list[PoolSkillMapping],
-        published: MappingPublishResult,
-        verified: MappingVerificationResult,
-    ) -> RuntimeProjectionResult:
-        published_by_target = {item.target: item for item in published.items}
-        verified_by_target = {item.target: item for item in verified.items}
-        # Verify observes the filesystem *after* publish. If a transient
-        # publish I/O error left no target at all, verify can only call it
-        # TARGET_NOT_SYMLINK; retain the publisher's retryable PENDING rather
-        # than turning a recoverable outage into a non-retryable degradation.
-        item_by_target = {
-            target: (
-                published_item
-                if published_item.status is MappingProjectionStatus.PENDING
-                else verified_by_target.get(target, published_item)
-            )
-            for target, published_item in published_by_target.items()
-        }
-        item_by_target.update(
-            {
-                target: verified_item
-                for target, verified_item in verified_by_target.items()
-                if target not in item_by_target
-            }
-        )
-        issues: list[RuntimeProjectionIssue] = []
-        mapping_by_name = {mapping.link_name: mapping for mapping in mappings}
-        for item in item_by_target.values():
-            if item.status is MappingProjectionStatus.CONVERGED:
-                continue
-            logical_name = item.target.rsplit("/", 1)[-1]
-            mapping = mapping_by_name.get(logical_name)
-            code, reason, suggested_action, observed, expected = (
-                PerDomainRuntimeProjection._mapping_message(item.code)
-            )
-            issues.append(
-                RuntimeProjectionIssue(
-                    resource_type="SKILL",
-                    resource_id=None,
-                    name=logical_name,
-                    corpus=mapping.corpus.upper() if mapping is not None else None,
-                    code=code,
-                    reason=reason,
-                    status=(
-                        RuntimeProjectionStatus.PENDING
-                        if item.status is MappingProjectionStatus.PENDING
-                        else RuntimeProjectionStatus.DEGRADED
-                    ),
-                    retryable=item.retryable,
-                    observed_entry_type=observed,
-                    expected_entry_type=expected,
-                    logical_location=f"active-skills/{logical_name}",
-                    suggested_action=suggested_action,
-                )
-            )
-        item_statuses = {item.status for item in item_by_target.values()}
-        status = (
-            RuntimeProjectionStatus.DEGRADED
-            if MappingProjectionStatus.DEGRADED in item_statuses
-            else (
-                RuntimeProjectionStatus.PENDING
-                if MappingProjectionStatus.PENDING in item_statuses
-                else RuntimeProjectionStatus.CONVERGED
-            )
-        )
-        if not issues and status is not RuntimeProjectionStatus.CONVERGED:
-            issues.append(
-                RuntimeProjectionIssue(
-                    resource_type="RUNTIME",
-                    code="SKILL_MAPPING_RUNTIME_UNAVAILABLE",
-                    reason="Skill 运行环境当前不可连接，能力状态已保存但尚未同步",
-                    status=status,
-                    retryable=status is RuntimeProjectionStatus.PENDING,
-                    suggested_action=(
-                        "Bot 当前未完成运行时同步。请稍后再次保存能力集；若持续失败，"
-                        "请联系管理员并提供错误详情。"
-                    ),
-                )
-            )
-        return RuntimeProjectionResult(
-            status=status,
-            components={"skills": status},
-            issues=tuple(issues),
-        )
-
-    @staticmethod
-    def _publish_result(value: object) -> MappingPublishResult:
-        if isinstance(value, MappingPublishResult):
-            return value
-        return MappingPublishResult(
-            published=bool(value),
-            status=(
-                MappingProjectionStatus.CONVERGED
-                if value
-                else MappingProjectionStatus.PENDING
-            ),
-        )
-
-    @staticmethod
-    def _verification_result(value: object) -> MappingVerificationResult:
-        if isinstance(value, MappingVerificationResult):
-            return value
-        return MappingVerificationResult(
-            valid=bool(value),
-            status=(
-                MappingProjectionStatus.CONVERGED
-                if value
-                else MappingProjectionStatus.PENDING
-            ),
-        )
-
-    @staticmethod
-    def _mapping_message(
-        code: str | None,
-    ) -> tuple[str, str, str, str | None, str | None]:
-        messages = {
-            "MANAGED_SOURCE_MISSING": (
-                "MANAGED_SOURCE_MISSING",
-                "Skill 的源文件已被删除或移动，平台已保留目标软链",
-                "该技能的内容暂时不可用。请重新同步或重新添加该技能后，再保存能力集。",
-                "DANGLING_SYMLINK",
-                "SYMLINK",
-            ),
-            "UNMANAGED_ACTIVE_ENTRY_RETAINED": (
-                "UNMANAGED_ACTIVE_ENTRY_RETAINED",
-                "Bot 生效目录中存在同名实体目录，平台没有覆盖或删除该目录",
-                "该技能已在 Bot 内被手动维护。为避免覆盖现有内容，平台没有替换它。"
-                "请联系 Bot 管理员确认处理后，再保存能力集。",
-                "DIRECTORY",
-                "SYMLINK",
-            ),
-            "EXTERNAL_ACTIVE_ENTRY_RETAINED": (
-                "EXTERNAL_ACTIVE_ENTRY_RETAINED",
-                "同名软链指向平台管理目录之外，平台没有修改该软链",
-                "该技能当前由其他配置管理，平台没有修改它。请联系 Bot 管理员确认"
-                "是否交由平台管理后，再保存能力集。",
-                "EXTERNAL_SYMLINK",
-                "SYMLINK",
-            ),
-        }
-        return messages.get(
-            code or "",
-            (
-                code or "SKILL_MAPPING_DEGRADED",
-                "Skill 运行时投影尚未完成",
-                "部分技能未完成运行时同步。请稍后再次保存能力集；若持续失败，"
-                "请联系管理员并提供错误详情。",
-                None,
-                None,
-            ),
-        )
-
-    @staticmethod
-    def _desired_skills(
-        projection: RuntimeSkillProjection,
-    ) -> list[dict[str, str | None]]:
-        return [
-            {
-                "id": str(asset.skill_id),
-                "name": asset.name,
-                "git_path": asset.git_path,
-                "skill_uuid": asset.skill_uuid,
-                "sc_version_number": asset.sc_version_number,
-            }
-            for asset in projection.skill_assets
-        ]
 
 
 __all__ = ["PerDomainRuntimeProjection"]

--- a/src/backend/src/agentclaw/community/core/skill_center/services/runtime_projections/skill_runtime_delivery.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/runtime_projections/skill_runtime_delivery.py
@@ -1,0 +1,350 @@
+"""Steady-state filesystem Skill delivery and compatibility routing."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from agentclaw.community.core.repository.protocols.skills_pool import (
+    SkillsPoolLayoutRepositoryProtocol,
+)
+from agentclaw.community.core.skill_center.errors import (
+    SkillSetRuntimeReconcileError,
+)
+from agentclaw.community.core.skill_center.runtime_projection_contract import (
+    ResolvedSkillPlan,
+    RuntimeProjectionIssue,
+    RuntimeProjectionResult,
+    RuntimeProjectionStatus,
+)
+from agentclaw.community.core.skill_center.runtime_resolver import (
+    RuntimeSkillProjection,
+)
+from agentclaw.community.core.skills_pool.mapping_intent import (
+    MAPPING_CONTRACT_V3,
+    mapping_contract_for,
+)
+from agentclaw.community.core.skills_pool.models import (
+    MappingApplyMode,
+    MappingProjectionStatus,
+    MappingPublishResult,
+    MappingVerificationResult,
+    PoolSkillMapping,
+    SkillMappingSourceLayout,
+)
+from agentclaw.community.core.skills_pool.ports import SkillsPoolRuntimeProtocol
+from agentclaw.community.core.skills_pool.types import (
+    BotSkillLayoutScope,
+    runtime_uses_pool_paths,
+)
+from agentclaw.community.core.workspace.skill_layout import (
+    runtime_layout_engine_for_bot,
+)
+
+
+class SkillRuntimeDelivery:
+    """Deliver one resolved Skill plan without exposing layout compatibility.
+
+    This is the single steady-state boundary for filesystem engines. It keeps
+    the historical DeviceSync route for Legacy Local-only snapshots and owns
+    the logical Mapping route for Pool, Repo, Center, and explicit retirement.
+    Pool migration and recovery continue to consume ``SkillsPoolRuntimeProtocol``
+    directly because their strict data-safety semantics are different.
+    """
+
+    def __init__(
+        self,
+        *,
+        pool_runtime: SkillsPoolRuntimeProtocol,
+        pool_layouts: SkillsPoolLayoutRepositoryProtocol,
+    ) -> None:
+        self._pool_runtime = pool_runtime
+        self._pool_layouts = pool_layouts
+
+    async def deliver(
+        self,
+        *,
+        plan: ResolvedSkillPlan,
+        retired_mappings: Sequence[PoolSkillMapping] = (),
+    ) -> RuntimeProjectionResult:
+        """Deliver the already-resolved plan and interpret its Skill result."""
+        mappings = list(plan.projection.skill_mappings)
+        retired = list(retired_mappings)
+        bot = plan.bot
+
+        scope = BotSkillLayoutScope(
+            env=str(bot["env"]),
+            entity_id=str(bot.get("entity_id") or plan.owner_id),
+            bot_id=plan.bot_id,
+        )
+        layout_state = self._pool_layouts.get(scope)
+        pool_owns_runtime = layout_state is not None and runtime_uses_pool_paths(
+            layout_state
+        )
+        if (
+            pool_owns_runtime
+            or any(
+                mapping.corpus in {"repo", "center"}
+                for mapping in [*mappings, *retired]
+            )
+            or retired
+        ):
+            return await self._apply_pool_mappings(
+                bot_id=plan.bot_id,
+                owner_id=plan.owner_id,
+                layout_engine=runtime_layout_engine_for_bot(bot),
+                mappings=mappings,
+                retired_mappings=retired,
+                source_layout=(
+                    SkillMappingSourceLayout.POOL
+                    if pool_owns_runtime
+                    else SkillMappingSourceLayout.LEGACY
+                ),
+            )
+
+        # ``project_skills`` owns dispatching its blocking device work off the
+        # event loop, so this compatibility route remains a plain await.
+        if not await plan.service.project_skills(
+            desired_skills=self._desired_skills(plan.projection),
+        ):
+            return RuntimeProjectionResult.pending(
+                code="SKILL_RUNTIME_UNAVAILABLE",
+                reason="Skill 运行环境当前不可连接，能力状态已保存但尚未同步",
+            )
+        return RuntimeProjectionResult.converged(
+            components={"skills": RuntimeProjectionStatus.CONVERGED}
+        )
+
+    async def _apply_pool_mappings(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+        layout_engine: str,
+        mappings: list[PoolSkillMapping],
+        retired_mappings: list[PoolSkillMapping],
+        source_layout: SkillMappingSourceLayout,
+    ) -> RuntimeProjectionResult:
+        try:
+            contract_mappings = [*mappings, *retired_mappings]
+            supported_versions: object = None
+            if any(mapping.corpus == "center" for mapping in contract_mappings):
+                probe = await self._pool_runtime.probe(
+                    bot_id=bot_id,
+                    user_id=owner_id,
+                    engine=layout_engine,
+                )
+                supported_versions = probe.evidence.get(
+                    "supported_mapping_contract_versions"
+                )
+                center_mount = probe.evidence.get("center_mount")
+                if (
+                    isinstance(center_mount, dict)
+                    and center_mount.get("restart_required") is True
+                    and (
+                        not isinstance(supported_versions, list)
+                        or MAPPING_CONTRACT_V3 not in supported_versions
+                    )
+                ):
+                    return RuntimeProjectionResult.pending(
+                        code="CENTER_RUNTIME_RESTART_REQUIRED",
+                        reason="Bot 尚未加载 Skill Center 目录，请重启 Bot 后重试",
+                    )
+            contract = mapping_contract_for(contract_mappings, supported_versions)
+            raw_published = await self._pool_runtime.publish_mappings(
+                bot_id=bot_id,
+                user_id=owner_id,
+                mappings=mappings,
+                retired_mappings=retired_mappings,
+                source_layout=source_layout,
+                mapping_contract_version=contract,
+                apply_mode=MappingApplyMode.BEST_EFFORT,
+            )
+            raw_verified = await self._pool_runtime.verify_mappings(
+                bot_id=bot_id,
+                user_id=owner_id,
+                mappings=mappings,
+                retired_mappings=retired_mappings,
+                source_layout=source_layout,
+                mapping_contract_version=contract,
+                apply_mode=MappingApplyMode.BEST_EFFORT,
+            )
+            published = self._publish_result(raw_published)
+            verified = self._verification_result(raw_verified)
+        except Exception as exc:
+            raise SkillSetRuntimeReconcileError() from exc
+        return self._mapping_result(
+            mappings=mappings,
+            published=published,
+            verified=verified,
+        )
+
+    @staticmethod
+    def _mapping_result(
+        *,
+        mappings: list[PoolSkillMapping],
+        published: MappingPublishResult,
+        verified: MappingVerificationResult,
+    ) -> RuntimeProjectionResult:
+        published_by_target = {item.target: item for item in published.items}
+        verified_by_target = {item.target: item for item in verified.items}
+        # Verify observes the filesystem after publish. Preserve a retryable
+        # publish outage when verify can only observe the missing target.
+        item_by_target = {
+            target: (
+                published_item
+                if published_item.status is MappingProjectionStatus.PENDING
+                else verified_by_target.get(target, published_item)
+            )
+            for target, published_item in published_by_target.items()
+        }
+        item_by_target.update(
+            {
+                target: verified_item
+                for target, verified_item in verified_by_target.items()
+                if target not in item_by_target
+            }
+        )
+        issues: list[RuntimeProjectionIssue] = []
+        mapping_by_name = {mapping.link_name: mapping for mapping in mappings}
+        for item in item_by_target.values():
+            if item.status is MappingProjectionStatus.CONVERGED:
+                continue
+            logical_name = item.target.rsplit("/", 1)[-1]
+            mapping = mapping_by_name.get(logical_name)
+            code, reason, suggested_action, observed, expected = (
+                SkillRuntimeDelivery._mapping_message(item.code)
+            )
+            issues.append(
+                RuntimeProjectionIssue(
+                    resource_type="SKILL",
+                    resource_id=None,
+                    name=logical_name,
+                    corpus=mapping.corpus.upper() if mapping is not None else None,
+                    code=code,
+                    reason=reason,
+                    status=(
+                        RuntimeProjectionStatus.PENDING
+                        if item.status is MappingProjectionStatus.PENDING
+                        else RuntimeProjectionStatus.DEGRADED
+                    ),
+                    retryable=item.retryable,
+                    observed_entry_type=observed,
+                    expected_entry_type=expected,
+                    logical_location=f"active-skills/{logical_name}",
+                    suggested_action=suggested_action,
+                )
+            )
+        item_statuses = {item.status for item in item_by_target.values()}
+        status = (
+            RuntimeProjectionStatus.DEGRADED
+            if MappingProjectionStatus.DEGRADED in item_statuses
+            else (
+                RuntimeProjectionStatus.PENDING
+                if MappingProjectionStatus.PENDING in item_statuses
+                else RuntimeProjectionStatus.CONVERGED
+            )
+        )
+        if not issues and status is not RuntimeProjectionStatus.CONVERGED:
+            issues.append(
+                RuntimeProjectionIssue(
+                    resource_type="RUNTIME",
+                    code="SKILL_MAPPING_RUNTIME_UNAVAILABLE",
+                    reason="Skill 运行环境当前不可连接，能力状态已保存但尚未同步",
+                    status=status,
+                    retryable=status is RuntimeProjectionStatus.PENDING,
+                    suggested_action=(
+                        "Bot 当前未完成运行时同步。请稍后再次保存能力集；若持续失败，"
+                        "请联系管理员并提供错误详情。"
+                    ),
+                )
+            )
+        return RuntimeProjectionResult(
+            status=status,
+            components={"skills": status},
+            issues=tuple(issues),
+        )
+
+    @staticmethod
+    def _publish_result(value: object) -> MappingPublishResult:
+        if isinstance(value, MappingPublishResult):
+            return value
+        return MappingPublishResult(
+            published=bool(value),
+            status=(
+                MappingProjectionStatus.CONVERGED
+                if value
+                else MappingProjectionStatus.PENDING
+            ),
+        )
+
+    @staticmethod
+    def _verification_result(value: object) -> MappingVerificationResult:
+        if isinstance(value, MappingVerificationResult):
+            return value
+        return MappingVerificationResult(
+            valid=bool(value),
+            status=(
+                MappingProjectionStatus.CONVERGED
+                if value
+                else MappingProjectionStatus.PENDING
+            ),
+        )
+
+    @staticmethod
+    def _mapping_message(
+        code: str | None,
+    ) -> tuple[str, str, str, str | None, str | None]:
+        messages = {
+            "MANAGED_SOURCE_MISSING": (
+                "MANAGED_SOURCE_MISSING",
+                "Skill 的源文件已被删除或移动，平台已保留目标软链",
+                "该技能的内容暂时不可用。请重新同步或重新添加该技能后，再保存能力集。",
+                "DANGLING_SYMLINK",
+                "SYMLINK",
+            ),
+            "UNMANAGED_ACTIVE_ENTRY_RETAINED": (
+                "UNMANAGED_ACTIVE_ENTRY_RETAINED",
+                "Bot 生效目录中存在同名实体目录，平台没有覆盖或删除该目录",
+                "该技能已在 Bot 内被手动维护。为避免覆盖现有内容，平台没有替换它。"
+                "请联系 Bot 管理员确认处理后，再保存能力集。",
+                "DIRECTORY",
+                "SYMLINK",
+            ),
+            "EXTERNAL_ACTIVE_ENTRY_RETAINED": (
+                "EXTERNAL_ACTIVE_ENTRY_RETAINED",
+                "同名软链指向平台管理目录之外，平台没有修改该软链",
+                "该技能当前由其他配置管理，平台没有修改它。请联系 Bot 管理员确认"
+                "是否交由平台管理后，再保存能力集。",
+                "EXTERNAL_SYMLINK",
+                "SYMLINK",
+            ),
+        }
+        return messages.get(
+            code or "",
+            (
+                code or "SKILL_MAPPING_DEGRADED",
+                "Skill 运行时投影尚未完成",
+                "部分技能未完成运行时同步。请稍后再次保存能力集；若持续失败，"
+                "请联系管理员并提供错误详情。",
+                None,
+                None,
+            ),
+        )
+
+    @staticmethod
+    def _desired_skills(
+        projection: RuntimeSkillProjection,
+    ) -> list[dict[str, str | None]]:
+        return [
+            {
+                "id": str(asset.skill_id),
+                "name": asset.name,
+                "git_path": asset.git_path,
+                "skill_uuid": asset.skill_uuid,
+                "sc_version_number": asset.sc_version_number,
+            }
+            for asset in projection.skill_assets
+        ]
+
+
+__all__ = ["SkillRuntimeDelivery"]

--- a/src/backend/src/agentclaw/community/di/modules/skill_center_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/skill_center_module.py
@@ -579,14 +579,19 @@ class SkillCenterModule(
         from agentclaw.community.core.skill_center.services.runtime_projections.per_domain import (
             PerDomainRuntimeProjection,
         )
+        from agentclaw.community.core.skill_center.services.runtime_projections.skill_runtime_delivery import (
+            SkillRuntimeDelivery,
+        )
         from agentclaw.community.core.skill_center.services.runtime_projections.whole_artifact import (
             WholeArtifactRuntimeProjection,
         )
 
         return EngineRuntimeProjectionRegistry(
             default=PerDomainRuntimeProjection(
-                pool_runtime=pool_runtime,
-                pool_layouts=pool_layouts,
+                skill_delivery=SkillRuntimeDelivery(
+                    pool_runtime=pool_runtime,
+                    pool_layouts=pool_layouts,
+                ),
             ),
             by_engine={"teclaw": WholeArtifactRuntimeProjection()},
         )

--- a/src/backend/tests/community/core/skill_center/services/runtime_projections/test_runtime_projection_messages.py
+++ b/src/backend/tests/community/core/skill_center/services/runtime_projections/test_runtime_projection_messages.py
@@ -5,11 +5,56 @@ from __future__ import annotations
 import pytest
 
 from agentclaw.community.core.skill_center.runtime_projection_contract import (
+    ResolvedSkillPlan,
     RuntimeProjectionResult,
 )
-from agentclaw.community.core.skill_center.services.runtime_projections.per_domain import (
-    PerDomainRuntimeProjection,
+from agentclaw.community.core.skill_center.runtime_resolver import (
+    RuntimeProjectionResolver,
 )
+from agentclaw.community.core.skill_center.services.runtime_projections.skill_runtime_delivery import (
+    SkillRuntimeDelivery,
+)
+from agentclaw.community.core.skills_pool.models import (
+    MappingItemResult,
+    MappingProjectionStatus,
+    MappingPublishResult,
+    MappingVerificationResult,
+    RegisteredSkillAsset,
+)
+
+
+class _MappingResultRuntime:
+    def __init__(self, code: str) -> None:
+        self.item = MappingItemResult(
+            target="/runtime/active/repo-skill",
+            source="/runtime/repo/repo-skill",
+            status=MappingProjectionStatus.DEGRADED,
+            code=code,
+        )
+
+    async def publish_mappings(self, **_kwargs):
+        return MappingPublishResult(
+            published=False,
+            status=MappingProjectionStatus.DEGRADED,
+            items=(self.item,),
+        )
+
+    async def verify_mappings(self, **_kwargs):
+        return MappingVerificationResult(
+            valid=False,
+            status=MappingProjectionStatus.DEGRADED,
+            items=(self.item,),
+        )
+
+
+class _MissingLayouts:
+    def get(self, _scope):
+        return None
+
+
+class _UnusedLegacyService:
+    async def project_skills(self, **_kwargs):
+        raise AssertionError("Repo mapping must not use Legacy DeviceSync")
 
 
 @pytest.mark.parametrize(
@@ -36,13 +81,36 @@ from agentclaw.community.core.skill_center.services.runtime_projections.per_doma
         ),
     ],
 )
-def test_mapping_message_exposes_complete_user_action(
+@pytest.mark.asyncio
+async def test_mapping_message_exposes_complete_user_action(
     code: str,
     expected_action: str,
 ) -> None:
-    _, _, suggested_action, _, _ = PerDomainRuntimeProjection._mapping_message(code)
+    asset = RegisteredSkillAsset(
+        skill_id=7,
+        name="repo-skill",
+        git_path="git://team/repo-skill",
+    )
+    plan = ResolvedSkillPlan(
+        bot_id="bot-1",
+        owner_id="owner-1",
+        service=_UnusedLegacyService(),
+        bot={
+            "env": "pre",
+            "entity_id": "owner-1",
+            "active_engine": "openclaw",
+        },
+        engine="openclaw",
+        projection=RuntimeProjectionResolver().resolve_skills((asset,)),
+    )
+    delivery = SkillRuntimeDelivery(
+        pool_runtime=_MappingResultRuntime(code),
+        pool_layouts=_MissingLayouts(),
+    )
 
-    assert suggested_action == expected_action
+    result = await delivery.deliver(plan=plan)
+
+    assert result.issues[0].suggested_action == expected_action
 
 
 def test_pending_runtime_action_is_exposed_to_the_caller() -> None:

--- a/src/backend/tests/community/core/skill_center/services/runtime_projections/test_skill_runtime_delivery.py
+++ b/src/backend/tests/community/core/skill_center/services/runtime_projections/test_skill_runtime_delivery.py
@@ -1,0 +1,235 @@
+"""Behaviour contract for steady-state filesystem Skill delivery."""
+
+from __future__ import annotations
+
+import pytest
+
+from agentclaw.community.core.skill_center.runtime_projection_contract import (
+    ResolvedSkillPlan,
+    RuntimeProjectionStatus,
+)
+from agentclaw.community.core.skill_center.runtime_resolver import (
+    RuntimeProjectionResolver,
+)
+from agentclaw.community.core.skill_center.services.runtime_projections.skill_runtime_delivery import (
+    SkillRuntimeDelivery,
+)
+from agentclaw.community.core.skills_pool.models import (
+    PoolSkillMapping,
+    RegisteredSkillAsset,
+    SkillMappingSourceLayout,
+)
+from agentclaw.community.core.skills_pool.types import (
+    BotSkillLayoutScope,
+    BotSkillLayoutState,
+    SkillLayout,
+    SkillLayoutPhase,
+)
+
+
+class _LegacyRuntimeService:
+    def __init__(self) -> None:
+        self.desired_skills: list[dict[str, str | None]] | None = None
+
+    async def project_skills(
+        self,
+        *,
+        desired_skills: list[dict[str, str | None]],
+        effective_mcps: list[dict] | None = None,
+    ) -> bool:
+        assert effective_mcps is None
+        self.desired_skills = desired_skills
+        return True
+
+
+class _UnusedPoolRuntime:
+    async def probe(self, **_kwargs):
+        raise AssertionError("Legacy Local-only delivery must not probe")
+
+    async def publish_mappings(self, **_kwargs):
+        raise AssertionError("Legacy Local-only delivery must not publish mappings")
+
+    async def verify_mappings(self, **_kwargs):
+        raise AssertionError("Legacy Local-only delivery must not verify mappings")
+
+
+class _MissingLayoutRepository:
+    def get(self, _scope):
+        return None
+
+
+class _RecordingPoolRuntime:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict]] = []
+
+    async def probe(self, **kwargs):
+        self.calls.append(("probe", kwargs))
+        return type("Probe", (), {"evidence": {}})()
+
+    async def publish_mappings(self, **kwargs):
+        self.calls.append(("publish", kwargs))
+        return True
+
+    async def verify_mappings(self, **kwargs):
+        self.calls.append(("verify", kwargs))
+        return True
+
+
+class _LayoutRepository:
+    def __init__(self, state: BotSkillLayoutState) -> None:
+        self.state = state
+        self.scopes: list[BotSkillLayoutScope] = []
+
+    def get(self, scope: BotSkillLayoutScope):
+        self.scopes.append(scope)
+        return self.state
+
+
+def _plan(
+    service: _LegacyRuntimeService,
+    *assets: RegisteredSkillAsset,
+) -> ResolvedSkillPlan:
+    return ResolvedSkillPlan(
+        bot_id="bot-1",
+        owner_id="owner-1",
+        service=service,
+        bot={
+            "env": "pre",
+            "entity_id": "owner-1",
+            "active_engine": "openclaw",
+        },
+        engine="openclaw",
+        projection=RuntimeProjectionResolver().resolve_skills(tuple(assets)),
+    )
+
+
+@pytest.mark.asyncio
+async def test_legacy_local_only_delivery_keeps_device_sync_request_and_result() -> (
+    None
+):
+    service = _LegacyRuntimeService()
+    asset = RegisteredSkillAsset(
+        skill_id=7,
+        name="local-skill",
+        git_path="local:///home/admin/.openclaw/workspace/skills/skills-local/local-skill",
+    )
+    plan = _plan(service, asset)
+    delivery = SkillRuntimeDelivery(
+        pool_runtime=_UnusedPoolRuntime(),
+        pool_layouts=_MissingLayoutRepository(),
+    )
+
+    result = await delivery.deliver(plan=plan, retired_mappings=())
+
+    assert result.status is RuntimeProjectionStatus.CONVERGED
+    assert result.components == {"skills": RuntimeProjectionStatus.CONVERGED}
+    assert service.desired_skills == [
+        {
+            "id": "7",
+            "name": "local-skill",
+            "git_path": asset.git_path,
+            "skill_uuid": None,
+            "sc_version_number": None,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_legacy_empty_delivery_keeps_device_sync_cleanup_route() -> None:
+    service = _LegacyRuntimeService()
+    delivery = SkillRuntimeDelivery(
+        pool_runtime=_UnusedPoolRuntime(),
+        pool_layouts=_MissingLayoutRepository(),
+    )
+
+    result = await delivery.deliver(plan=_plan(service))
+
+    assert result.status is RuntimeProjectionStatus.CONVERGED
+    assert service.desired_skills == []
+
+
+@pytest.mark.asyncio
+async def test_repo_delivery_keeps_legacy_mapping_wire_and_order() -> None:
+    service = _LegacyRuntimeService()
+    pool = _RecordingPoolRuntime()
+    asset = RegisteredSkillAsset(
+        skill_id=8,
+        name="repo-skill",
+        git_path="git://team/repo-skill",
+    )
+    delivery = SkillRuntimeDelivery(
+        pool_runtime=pool,
+        pool_layouts=_MissingLayoutRepository(),
+    )
+
+    result = await delivery.deliver(plan=_plan(service, asset))
+
+    assert result.status is RuntimeProjectionStatus.CONVERGED
+    assert [name for name, _ in pool.calls] == ["publish", "verify"]
+    for _, request in pool.calls:
+        assert request["bot_id"] == "bot-1"
+        assert request["user_id"] == "owner-1"
+        assert request["source_layout"] is SkillMappingSourceLayout.LEGACY
+        assert request["mapping_contract_version"] == "skills-pool-mapping-v2"
+        assert request["retired_mappings"] == []
+    assert service.desired_skills is None
+
+
+@pytest.mark.asyncio
+async def test_cutover_intermediate_state_uses_pool_mapping_sources() -> None:
+    service = _LegacyRuntimeService()
+    pool = _RecordingPoolRuntime()
+    scope = BotSkillLayoutScope(env="pre", entity_id="owner-1", bot_id="bot-1")
+    layouts = _LayoutRepository(
+        BotSkillLayoutState(
+            scope=scope,
+            active_layout=SkillLayout.LEGACY,
+            target_layout=SkillLayout.POOL,
+            phase=SkillLayoutPhase.POOL_ACTIVATING_PRE_CUTOVER,
+            migration_generation="generation-1",
+            persisted=True,
+        )
+    )
+    asset = RegisteredSkillAsset(
+        skill_id=7,
+        name="local-skill",
+        git_path="local:///home/admin/.openclaw/workspace/skills/skills-local/local-skill",
+    )
+    delivery = SkillRuntimeDelivery(pool_runtime=pool, pool_layouts=layouts)
+
+    await delivery.deliver(plan=_plan(service, asset))
+
+    assert layouts.scopes == [scope]
+    assert [name for name, _ in pool.calls] == ["publish", "verify"]
+    assert all(
+        request["source_layout"] is SkillMappingSourceLayout.POOL
+        for _, request in pool.calls
+    )
+    assert service.desired_skills is None
+
+
+@pytest.mark.asyncio
+async def test_explicit_retirement_uses_mapping_route_for_empty_legacy_plan() -> None:
+    service = _LegacyRuntimeService()
+    pool = _RecordingPoolRuntime()
+    retired = PoolSkillMapping(
+        corpus="local",
+        relative_path="retired-skill",
+        link_name="retired-skill",
+    )
+    delivery = SkillRuntimeDelivery(
+        pool_runtime=pool,
+        pool_layouts=_MissingLayoutRepository(),
+    )
+
+    await delivery.deliver(
+        plan=_plan(service),
+        retired_mappings=(retired,),
+    )
+
+    assert [name for name, _ in pool.calls] == ["publish", "verify"]
+    for _, request in pool.calls:
+        assert request["mappings"] == []
+        assert request["retired_mappings"] == [retired]
+        assert request["source_layout"] is SkillMappingSourceLayout.LEGACY
+    assert service.desired_skills is None

--- a/src/backend/tests/community/core/skill_center/test_skill_set_management_service.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_set_management_service.py
@@ -511,6 +511,9 @@ def _registry(*, pool_runtime, pool_layouts):
     from agentclaw.community.core.skill_center.services.runtime_projections.registry import (
         EngineRuntimeProjectionRegistry,
     )
+    from agentclaw.community.core.skill_center.services.runtime_projections.skill_runtime_delivery import (
+        SkillRuntimeDelivery,
+    )
     from agentclaw.community.core.skill_center.services.runtime_projections.whole_artifact import (
         WholeArtifactRuntimeProjection,
     )
@@ -519,8 +522,10 @@ def _registry(*, pool_runtime, pool_layouts):
     # stop describing production.
     return EngineRuntimeProjectionRegistry(
         default=PerDomainRuntimeProjection(
-            pool_runtime=pool_runtime,
-            pool_layouts=pool_layouts,
+            skill_delivery=SkillRuntimeDelivery(
+                pool_runtime=pool_runtime,
+                pool_layouts=pool_layouts,
+            ),
         ),
         by_engine={"teclaw": WholeArtifactRuntimeProjection()},
     )
@@ -751,6 +756,12 @@ class _RuntimePool:
     async def verify_mappings(self, **kwargs):
         self.verify_calls.append(kwargs)
         return self._verified
+
+
+class _FailingPublishRuntimePool(_RuntimePool):
+    async def publish_mappings(self, **kwargs):
+        self.publish_calls.append(kwargs)
+        raise RuntimeError("device unavailable")
 
 
 class _CenterRuntimePool(_RuntimePool):
@@ -3386,6 +3397,26 @@ def test_projector_and_per_domain_contain_no_engine_identity_test():
         )
 
 
+def test_per_domain_delegates_filesystem_delivery_without_layout_knowledge():
+    """PerDomain owns half scheduling, not filesystem compatibility."""
+    from pathlib import Path
+
+    from agentclaw.community.core.skill_center.services.runtime_projections import (
+        per_domain,
+    )
+
+    source = Path(per_domain.__file__).read_text(encoding="utf-8")
+    for forbidden in (
+        "SkillsPoolLayoutRepositoryProtocol",
+        "SkillsPoolRuntimeProtocol",
+        "runtime_uses_pool_paths",
+        "mapping_contract_for",
+        "_apply_pool_mappings",
+        "_mapping_message",
+    ):
+        assert forbidden not in source
+
+
 
 @pytest.mark.asyncio
 async def test_per_domain_engine_keeps_the_scope_split():
@@ -3422,6 +3453,36 @@ async def test_per_domain_engine_keeps_the_scope_split():
     assert claimed <= set(declared)
     assert released == frozenset()
     assert pool.publish_calls == []
+
+
+@pytest.mark.asyncio
+async def test_failed_skill_delivery_does_not_skip_the_mcp_half():
+    pool = _FailingPublishRuntimePool()
+    factory = _RuntimeFactory()
+    repo_skill = RegisteredSkillAsset(
+        skill_id=8,
+        name="repo-skill",
+        git_path="git://team/repo-skill",
+    )
+    runtime = BotRuntimeProjector(
+        factory=factory,
+        bot_repo=_RuntimeBots(),
+        repository=_McpInstallations(),
+        reader=_reader(_RuntimeSkills([repo_skill])),
+        registry=_registry(pool_runtime=pool, pool_layouts=_RuntimeLayouts()),
+        passport=_RuntimePassport(),
+        caller_identity_repo=_RuntimeCallerIdentity(),
+    )
+
+    result = await runtime.project(
+        bot_id="bot-1",
+        owner_id="true-owner",
+        scope=ProjectionScope.everything(),
+    )
+
+    assert result.status.value == "PENDING"
+    assert result.issues[0].code == "SKILL_RUNTIME_UNAVAILABLE"
+    assert len(factory.service.mcp_projections) == 1
 
 
 # ── Skill mutations carry the Skill's MCP dependencies ───────────────

--- a/src/backend/tests/community/di/test_skills_pool_wiring.py
+++ b/src/backend/tests/community/di/test_skills_pool_wiring.py
@@ -61,6 +61,15 @@ from agentclaw.community.core.skill_center.factories import SkillServiceFactory
 from agentclaw.community.core.skill_center.services.skill_symlink_listener import (
     SkillSymlinkListener,
 )
+from agentclaw.community.core.skill_center.services.runtime_projections.per_domain import (
+    PerDomainRuntimeProjection,
+)
+from agentclaw.community.core.skill_center.services.runtime_projections.skill_runtime_delivery import (
+    SkillRuntimeDelivery,
+)
+from agentclaw.community.core.skill_center.services.runtime_projections.whole_artifact import (
+    WholeArtifactRuntimeProjection,
+)
 from agentclaw.community.core.skill_center.runtime_projection_contract import (
     ProjectionScope,
 )
@@ -71,6 +80,23 @@ from agentclaw.community.di import DeployProfile, build_injector
 from agentclaw.community.di.modules.skill_center_module import SkillCenterModule
 from agentclaw.community.core.repository.implementations.skills_pool.layout import SkillsPoolLayoutRepository
 from agentclaw.community.core.repository.implementations.skill_center.skill import SkillRepository
+
+
+def test_skill_runtime_delivery_is_wired_only_into_per_domain_projection() -> None:
+    pool_runtime = MagicMock(spec=SkillsPoolRuntimeProtocol)
+    pool_layouts = MagicMock(spec=SkillsPoolLayoutRepositoryProtocol)
+
+    registry = SkillCenterModule().engine_runtime_projection_registry(
+        pool_runtime=pool_runtime,
+        pool_layouts=pool_layouts,
+    )
+
+    per_domain = registry.for_engine("openclaw")
+    assert isinstance(per_domain, PerDomainRuntimeProjection)
+    assert isinstance(per_domain._skill_delivery, SkillRuntimeDelivery)
+    assert per_domain._skill_delivery._pool_runtime is pool_runtime
+    assert per_domain._skill_delivery._pool_layouts is pool_layouts
+    assert isinstance(registry.for_engine("teclaw"), WholeArtifactRuntimeProjection)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

`PerDomainRuntimeProjection` currently owns both Skill/MCP half scheduling and filesystem Skill delivery details: layout-state selection, Legacy compatibility routing, Mapping protocol orchestration, and result interpretation. This exposes migration compatibility knowledge in the routine projection strategy while Legacy and Pool layouts coexist.

## Solution

- Add an internal `SkillRuntimeDelivery` module that consumes the existing `ResolvedSkillPlan + retired_mappings` contract.
- Move Legacy DeviceSync versus logical Mapping routing, layout-state interpretation, probe/publish/verify ordering, and Skill result normalization into that module.
- Keep `PerDomainRuntimeProjection` responsible only for scope handling, Skill/MCP failure isolation, and result combination.
- Wire the delivery module only into the per-domain registry path; Teclaw Whole Artifact and strict Pool migration/recovery callers remain unchanged.
- Add the implementation-ready Spec and update the Skill Center boundary documentation.

## Validation

- TDD red/green coverage for Legacy Local-only and empty snapshots, Repo Mapping, explicit retirement, cutover intermediate layout, and request/result compatibility.
- Focused Projector, Direct, Track Latest, startup recovery, Skills Pool, Service Artifact, DI, architecture, and contract suites passed.
- Downstream public-Runtime plus alternate `DeviceAdapterTransport` integration smoke passed, including method/path/body, ordering, 30s timeout, owner/bot identity, and device affinity; downstream transport/DeviceSync/DI suites: 63 passed.
- Python SAST block scan passed.
- Standards/Spec two-axis review: both axes no findings after resolving the public-document hygiene finding.
- Final Backend CI gate: 17,815 passed, 60 skipped; case pass rate 100%; line coverage 88.78%; changed-line coverage 96.67%.

## Compatibility and risk

No public HTTP, Gateway schema, database schema, Engine wire, low-level Runtime Protocol, Installation rules, MCP policy, Artifact contract, or Teclaw behavior changes. No rollout, migration, deployment, or retry policy is introduced. Downstream gitlink integration, deployment, and real Runtime validation remain separate follow-up stages.

## Spec

`src/backend/specs/2026-09-08-skill-runtime-delivery-convergence/spec.md`

## Related issues

Closes #1999.
Related to #455; this PR does not close or complete that broader refactor.
