### PR TITLE
fix(engine): converge Hermes Pool bridge lifecycle

### DIFF
--- a/docs/specs/2026-09-08-pool-bridge-lifecycle/spec.md
+++ b/docs/specs/2026-09-08-pool-bridge-lifecycle/spec.md
@@ -1,0 +1,100 @@
+# OpenClaw/Hermes Pool 启动与兼容桥生命周期收敛（方案二）
+
+## Problem Statement
+
+Skill 模块 Owner 希望在既有 Pool 迁移机制上，可靠支持 OpenClaw/Hermes 新建及重启后的渐进切流，并降低不再被使用的兼容桥对正常运行的干扰。
+
+当前准备期 Repo mount 已可能位于 Pool，但旧引用尚未切换，因此需要 Legacy Repo 地址桥。切换完成后正常映射直达 Pool，Hermes 外部旧 Repo 桥却仍被多处校验强制要求存在。另一个已复现的问题是 Hermes 启动先执行 H0，重建了切换后已退休的 Local 目录桥，使后续 Pool 准备校验失败。
+
+这些问题需要按阶段收敛，而不是全局删除软链、放宽所有文件安全校验或重做迁移平台。
+
+## Solution
+
+准备期保持必要兼容；完成 Pool 切换后，平台映射直接使用 Pool，不再长期依赖 Hermes 外部旧 Repo 地址。升级后的启动/Engine 实现按阶段保护文件现状、幂等退休平台旧桥，并一致更新准备、探测、切换和恢复规则。
+
+Bot 启动与 Pool 迁移继续异步；保留现有任务准入、重试、在途恢复和低峰切流方式。不建设新的状态表、队列或协议版本。Hermes Service Bot 不在产品支持范围，本期不新增相关能力。
+
+## User Stories
+
+1. 作为 Legacy Bot 用户，我希望 Pool 准备期间旧 Repo 引用保持可读，以便尚未切流时仍能正常使用 Skill。
+2. 作为 OpenClaw 用户，我希望既有准备与切换行为保持兼容，以便 Hermes 修复不影响我的 Bot。
+3. 作为 Hermes 用户，我希望切换后的逐 Skill 入口直接指向 Pool，以便不再依赖旧 Repo 地址。
+4. 作为 Hermes 用户，我希望 Pool 状态下再次重启不会重建旧 Local 桥，以便重启不会破坏已经完成的布局。
+5. 作为用户，我希望准备失败不新增同步启动门禁，以便 Bot 启动不被额外阻塞。
+6. 作为用户，我希望启动成功与迁移完成分别可观察，以便不会将 ACTIVE 误认为 POOL_ACTIVE。
+7. 作为已有 Pool Bot 用户，我希望下次启动或收敛能处理平台旧桥，以便不需要集中清理容器。
+8. 作为已有 Pool Bot 用户，我希望旧桥已不存在时能够正常通过校验，以便重复收敛是幂等的。
+9. 作为用户，我希望退休平台旧桥只删除链接、不删除 Pool 内容，以便共享仓库保持安全。
+10. 作为用户，我希望旧地址被我改成实体目录时平台保留它，以便不误删容器内数据。
+11. 作为用户，我希望不再使用的旧 Repo 地址指向意外位置时不会卡住正常 Pool，以便旧地址不成为无关阻断项。
+12. 作为维护者，我希望此类非预期占位有可定位的诊断，以便仍能解释保留原因。
+13. 作为迁移维护者，我希望正在完成切换的启动过程不重建 Legacy，以便已有数据面切换不会被覆盖。
+14. 作为用户，我希望 Pool 标记损坏或不可读时文件现状被保护，以便平台不会凭猜测创建另一套 Legacy 数据。
+15. 作为维护者，我希望异常标记不会被假报为 READY，以便真正的迁移问题仍能被检测和恢复。
+16. 作为运维人员，我希望已认领任务继续按原阶段恢复，以便关闭准入配置不会遗留半完成迁移。
+17. 作为运维人员，我希望保留当前任务执行时准入和显式 wake 能力，以便不为极少数延迟事件建设新机制。
+18. 作为模块 Owner，我接受低峰切流时少量旧启动任务延迟执行，以便优先保持实现简单。
+19. 作为旧 Engine 用户，我希望 Backend 不单方面删除旧 Engine 仍要求的桥，以便配套升级前保持正常工作。
+20. 作为运维人员，我希望布局 rollback 能按需重建 Legacy view，以便取消长期桥不等于删除回滚能力。
+21. 作为 OpenClaw Service Bot 用户，我希望历史发布物继续按冻结布局恢复，以便当前 Pool 默认策略不会改写历史版本。
+22. 作为实现者，我希望共享 Engine 逻辑的修改明确限定到目标引擎与阶段，以便不改变 Claude Code/AICoding 兼容行为。
+23. 作为模块 Owner，我希望完整启动顺序被测试，以便不再出现单个 prepare 测试通过、真实调用顺序失败的问题。
+24. 作为发布维护者，我希望 Avernet、OCB 和 daas 依赖链共同核验，以便代码通过不被误当成企业部署已验证。
+
+## Implementation Decisions
+
+1. **职责与范围：**Avernet 负责公共 Engine 布局/探测/切换/恢复合同及相关 Backend 消费；OCB 负责企业 Engine 装配和镜像启动准备；daas 的既有 Service 恢复行为纳入兼容检查。按实际必要性修改，不预设每仓都必须有生产代码 PR。
+2. **准备期：**保留 OpenClaw/Hermes 所需的 Legacy Repo → Pool Repo 地址桥，不提前退休尚有 Legacy 引用的桥，不改为双挂载或推迟整个挂载流程。Local 准备复制与 Repo 地址桥不是同一语义。
+3. **切换完成：**正常平台映射直达 canonical Pool。Hermes active root 外的旧 Repo 地址不再作为长期可用性保证，相关 probe/prepare/finalize 不再强制要求该桥存在。
+4. 首次切换完成、已有 Pool Bot 后续启动或正常布局收敛时，由配套执行端幂等退休平台确认的旧 Repo 桥。不存在即无须处理；删除链接本身，不递归操作链接目标。
+5. 旧 Repo 地址为用户实体目录、非预期软链或无法安全退休的占位时，保留并记录诊断；对于已经生效且不再依赖该旧地址的 Pool，不因此判定整体布局无效。
+6. 上述放宽仅适用于无用的外部旧 Repo 地址。canonical Pool 目录、实际挂载、必要内容、Local 迁移保护以及 active root 内整库入口规则保持原有安全要求。准备期实际使用的 Legacy 引用不适用该放宽。
+7. probe 保持只读；桥退休在启动/收敛等执行路径进行。新校验须兼容历史 Pool 状态中仍有预期桥，以及新状态中桥已退休，避免依赖“先删桥才能通过probe、先通过probe才能删桥”的循环。
+8. **H0 修复：**在 Hermes 启动准备修改 Legacy Local 或桥之前检查已有激活标记。active/finalizing 不再进入 Legacy 重建；分别按已有完成/恢复阶段处理，不将 finalizing 直接视为完成。
+9. 标记存在但损坏、不可读、对象形态异常时，保留文件现状并记录问题，不默认当作首次 Legacy、不自动重建旧内容、不假报 READY。标记缺失时走原 Legacy 准备及其安全校验。
+10. 启动判断须贯穿 H0、mount 选择和完整 prepare，避免仅跳过 H0 后又因错误的前置结果选择 Legacy 挂载或重建旧目录。复用现有标记与布局能力，不新增并行事实源，也不取消原挂载失败保护。
+11. **异步语义：**Bot ACTIVE 与 POOL_ACTIVE 独立；不新增“迁移成功才允许启动”的同步门禁。迁移失败按原阶段保护与恢复，不在已经 cutover 后擅自回退 Legacy。
+12. **首次准入：**保留执行时读取准入配置的现状，不增加启动时间或新启动周期校验。接受有限 deadline 内开放前启动任务延迟执行的极端情况，计划低峰切流；不是严格的“配置开放后必须再次重启”时间保证。
+13. 普通 ACTIVE 心跳不新建迁移任务、已 claim 继续恢复、人工 wake 等原有逻辑保持。关闭开关阻止新准入，不取消半完成迁移。本期不重构 TaskQueue。
+14. **旧 Engine：**由已升级的配套启动/Engine 实现执行桥退休，不由 Backend 远程单方面清理仍使用旧合同的容器。先具备兼容校验与启动逻辑，再允许退休；沿用镜像发布、切流和版本核验，不新增双布局协议版本或状态表。
+15. **回滚：**显式布局 rollback 按需恢复必要 Legacy view。代码/镜像降级与布局 rollback 是不同操作；不承诺删除桥后任意旧镜像直接可用。降级到仍要求桥的版本前，必须恢复其必要结构或使用已验证恢复流程。
+16. **产品范围：**只推进 OpenClaw/Hermes 的既有受支持形态。Hermes 不支持 Service Bot；不新增 Hermes Service 路径解析、安装位置、Artifact 或恢复能力，也不为此新增产品门禁。
+17. OpenClaw 已有 Service Artifact 冻结语义保持；不批量重打历史发布物，不按当前配置重解释历史布局。daas 未实现 Hermes Pool Service 不作为本期缺陷或阻塞。
+18. Claude Code/AICoding 的 Engine 与切流不扩展；修改共享函数时按明确引擎/阶段保持原兼容。Aix 上游实现不纳入开发范围。
+19. 不改 Installation 生效事实、SkillSet/Direct 公开行为、Local locator 格式或 API/Gateway schema。不重复方案一的 SkillRuntimeDelivery 重构。
+20. 结构诊断可使用现有日志/内部证据，须能定位阶段与保留原因；不为诊断新增表、用户界面或公开响应模型。
+
+## Testing Decisions
+
+1. **主要 seam：**以现有启动准备调用链和 Engine 布局 lifecycle 入口验证完整行为，用临时文件系统与可控 mount 检查替身模拟环境；观察文件、链接目标、标记和阶段结果。不是只测试私有 helper 或某一个独立 prepare 调用。
+2. 复现测试先固定 Hermes 真实 H0 → mount选择 → prepare 顺序：有效 Pool-active fixture 直接 prepare 原本成功，前置 H0 会重建退休 Local 桥。修复后完整顺序不得再重建。
+3. 覆盖 Legacy 初次准备、READY 尚未cutover、首次cutover、active再次重启、finalizing恢复、标记缺失/损坏/不可读/异常对象形态。每项断言实际路径选择和原内容未被破坏。
+4. 准备期验证旧 Repo 单 Skill 引用仍可解析，不将准备成功当成 Pool 已提交；cutover 后验证映射直达 Pool、active内退休入口不重现。
+5. 对 Pool 外部旧 Repo 地址覆盖：缺失、预期绝对/等价相对链接（按既有安全识别合同）、意外目标、非空实体、其他对象与退休失败。验证不误删、不跟随链接删除 Pool，非预期占位不阻断本来有效的Pool；关键Pool错误仍被识别。
+6. 验证 probe 全程无文件副作用；启动/收敛重复执行幂等，不因桥可选而误接受损坏激活标记或非法实际内容库。
+7. 验证显式 rollback 恢复所需 Legacy view；错误阶段不擅自rollback。区分旧镜像兼容和布局回滚，不以单纯存在目录作为成功证明。
+8. 保留 Backend 新建/重启唤醒、普通ACTIVE心跳不唤醒、旧任务延迟准入、sticky claim和异步恢复的既有测试；不把现有行为改成新时间门禁。
+9. 对 OpenClaw 跑原有prepare/probe/cutover/restart回归；对受支持的OpenClaw Service恢复，验证冻结链接及桥退休行为不变。Claude Code/AICoding共享代码的既有测试用于防回归，不作为新增产品能力验收。
+10. Prior art：现有 OCB Pool preparation/entrypoint 测试、公共 Hermes Pool layout/probe/activation 测试、Desktop bridge bootstrap测试、Backend reconcile/claim/task测试、daas Service layout/transition测试。优先复用这些真实入口与fixtures，避免新增测试框架。
+11. 三仓按实际变更运行相关窄门禁；公共与Corp装配、旧记录兼容、源/目标发布物处理均需核验。先完成Standards/Spec双轴review及高优问题修复，再执行最终模块门禁，不反复提前跑Backend全量。
+12. 后续预发验收须有具体镜像/脚本/gitlink证据，覆盖至少一次首次切换及Pool再次重启；本地临时目录验证不代表真实mount、部署或全量完成。
+
+## Out of Scope
+
+- 实际开启全量配置、修改名单、强制重启、批量DB订正或集中容器清理。
+- 新建迁移平台、表、队列、协议版本、启动epoch或严格事件时间门禁。
+- 重做mount策略、引入双挂载或统一全引擎物理目录。
+- 放宽Local内容迁移安全、忽略损坏Pool标记、允许任意删除用户实体或未知链接。
+- Hermes Service Bot、Aix上游实现、Claude Code/AICoding具体切流或新增产品能力。
+- 改变历史Artifact合同、重打发布物、承诺任意旧镜像无条件降级兼容。
+- 方案一日常交付收口、Local locator演进、Installation/MCP规则或公开API修改。
+
+## Further Notes
+
+- Q1–Q8已逐项确认；用户要求转Spec，访谈结束。本文为方案二执行合同，研究建议中已被用户排除的Hermes Service扩展不得带回实现。
+- 目标以 Avernet/OCB `dev` 为准；daas作为相关第三仓核验其`dev`。研究基线为 Avernet `c6a862959538b084649eb8f61d04a187896c5fc0`、OCB `12f8383630ee2aa7bee8091469a00c51d2427572`（gitlink `4fecbb141e1baafd95dce27e2fc960c8c0a6b58b`）、daas `43331d1364090df9703567f4c46e1631bc2832ac`。桥研究当轮Avernet fetch失败，故不能把该固定基线称作实施时最新dev。
+- 方案一 [#1999](https://github.com/inclusionAI/Avernet/issues/1999) 的 [PR #2001](https://github.com/inclusionAI/Avernet/pull/2001) 据执行任务回报已合入，merge `e006e5144d36edff8f45b7d98d8b0cc76f608e4d`。实施前刷新各仓，核对该合并及最新gitlink，不复制旧PerDomain逻辑。
+- 与较大架构议题 [#455](https://github.com/inclusionAI/Avernet/issues/455) 相关；本期完成不等于整个路径权威重构完成。
+- 相关领域约束采用仓库现行术语与ADR；尤其维持已发布Service Artifact的冻结语义。桥退休的兼容边界以本Spec明确取舍为准，不把“旧地址永久可用”重新当成隐含要求。
+- 已有研究证据：真实OCB函数组合在临时目录复现H0问题，Pool内容保持；daas纯路径函数验证不支持Hermes Pool Service，后者已按产品范围排除。未在本Spec生成阶段运行真实迁移、修改配置或验证部署。
+- 预期Avernet/OCB按实际实现配套提出PR；daas先检查和回归，不预设必须修改。部署必须记录真实gitlink与包/镜像版本，代码合入不等于企业已集成或已切流。

--- a/src/backend/src/agentclaw/community/core/skill_center/AGENTS.md
+++ b/src/backend/src/agentclaw/community/core/skill_center/AGENTS.md
@@ -181,6 +181,10 @@ Engine 拥有物理布局。Backend 通过 `community/core/skills_pool/` 的版�
 - 迁移中的实际来源选择按 `community/core/skills_pool/types.py::runtime_uses_pool_paths` 和 Engine evidence 判断，不能只看配置、目录是否存在或 DB `active_layout`。数据面 cutover 已完成而 DB 尚未最终提交时，也可能必须读取 Pool。
 - 产品 `active_engine=claude_code` 可能实际运行 AICoding 模板；先用 `runtime_layout_engine_for_bot` 解析实际文件型身份，再选择路径，不能仅凭产品 Engine 字符串套 Claude Code 行。
 - Teclaw 是 Artifact capability：使用 Whole Artifact/StoreRef，不使用这张文件型 active-root 表，也不需要伪造 Legacy/Pool 文件目录。
+- Hermes 的 `.hermes/skills-repo` 是准备期 Legacy Repo 地址，不是 Pool 稳态
+  内容根。Pool 激活后逐 Skill 映射直接指向 canonical Pool Repo，Engine/启动
+  路径只退休仍指向该 canonical Repo 的平台软链；用户实体或意外链接保留并
+  诊断，probe 保持只读。显式 layout rollback 会按需恢复 Legacy view。
 - 本表列出代码支持的布局，不表示所有引擎已完成迁移或现场验收。后续全量 Pool 推进范围是 OpenClaw/Hermes；Claude Code/AICoding 的 Engine 适配由 Aix 维护，不因表中存在 Pool descriptor 就扩大迁移范围。
 
 例如 OpenClaw 的 Center 链接在 Legacy/Pool 下均解析为 `/home/admin/.openclaw/workspace/skills/<name>` → `/home/admin/.openclaw/workspace/skills-pool/skill-center/<uuid>/<exact-version>`；Local 链接目标才随 layout 在 `skills/skills-local` 与 `skills-pool/skills-local` 之间变化。历史整库桥和用户实体目录按兼容/降级规则处理，不作为新映射的模板。

--- a/src/backend/src/agentclaw/community/core/skills_pool/README.md
+++ b/src/backend/src/agentclaw/community/core/skills_pool/README.md
@@ -59,8 +59,11 @@ Hermes；物理路径投影由 Engine Layout Descriptor 统一持有。
   best-effort 后置合并；随后发布并验证直接指向 canonical Pool 的 active
   mapping。持久化 `.pool-active` 的 `finalizing → active` 后，active root
   中的 local corpus bridge 必须退役；OpenClaw、Claude Code 位于 active
-  root 内的 repo bridge 同时退役，AICoding、Hermes 位于 active root 外的
-  稳定 repo namespace 则保留并继续只读指向 canonical Pool。
+  root 内的 repo bridge 同时退役。AICoding 位于 active root 外的稳定 repo
+  namespace 保留并继续只读指向 canonical Pool；Hermes 的外部 Legacy Repo
+  地址在准备期保留，Pool 生效后由 Engine/启动收敛幂等退休。该地址若已被用户
+  占用或指向意外目标则保留并记录诊断，不影响 canonical Pool 与逐 Skill 映射
+  已经有效的布局。
 - 激活前同时核对已登记 local，并从文件系统枚举未登记 local、受管 active
   entry 与外部 entry；完整 local 内容进入 Pool，但不会为未登记内容创建
   数据库记录，外部 entry 保持原目标。

--- a/src/engine/src/engine/community/plugins/hermes/tests/test_pool_layout.py
+++ b/src/engine/src/engine/community/plugins/hermes/tests/test_pool_layout.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from engine.community.core.skills.layout_planner import (
     MAPPING_CONTRACT_VERSION,
 )
@@ -16,6 +18,72 @@ from engine.community.plugins.hermes.layout_pool import (
     rollback_hermes_pool,
     verify_hermes_pool_mappings,
 )
+
+PREPARATION_ID = "b7f7a125-9133-45fd-956d-fb66da81f68d"
+
+
+def _pool_active_fixture(tmp_path: Path) -> tuple[Path, Path, Path, Path]:
+    home = tmp_path / "home" / "admin"
+    active_root = home / ".hermes" / "skills"
+    pool_root = home / ".hermes" / "workspace" / "skills-pool"
+    pool_local = pool_root / "skills-local"
+    pool_repo = pool_root / "skills-repo"
+    repo_bridge = home / ".hermes" / "skills-repo"
+    pool_local.mkdir(parents=True)
+    pool_repo.mkdir(parents=True)
+    active_root.mkdir(parents=True)
+    (pool_root / ".pool-ready").write_text(
+        json.dumps(
+            {
+                "engine": "hermes",
+                "layout_contract_version": "skills-pool-p3-v1",
+                "preparation_id": PREPARATION_ID,
+                "prepared_at": "2026-07-24T00:00:00Z",
+                "pool_local_root": str(pool_local),
+                "pool_repo_root": str(pool_repo),
+                "validation_summary": {
+                    "all_valid": True,
+                    "legacy_bridge_verified": True,
+                    "pool_local": {"path": str(pool_local), "valid": True},
+                    "pool_repo": {
+                        "path": str(pool_repo),
+                        "readable_mount": True,
+                        "valid": True,
+                    },
+                    "managed_active_entries": [],
+                    "structural_bridges": [
+                        {
+                            "name": "stable_local_bridge",
+                            "path": str(active_root / "skills-local"),
+                            "target": str(
+                                home / ".hermes/workspace/skills/skills-local"
+                            ),
+                            "valid": True,
+                        },
+                        {
+                            "name": "stable_repo_bridge",
+                            "path": str(repo_bridge),
+                            "target": str(pool_repo),
+                            "valid": True,
+                        },
+                    ],
+                },
+            }
+        )
+    )
+    (pool_root / ".pool-active").write_text(
+        json.dumps(
+            {
+                "engine": "hermes",
+                "layout_contract_version": "skills-pool-p3-v1",
+                "preparation_id": PREPARATION_ID,
+                "migration_generation": "generation-1",
+                "activation_state": "active",
+                "mappings": [],
+            }
+        )
+    )
+    return home, active_root, pool_repo, repo_bridge
 
 
 def test_probe_requires_verified_hermes_legacy_bridge(tmp_path: Path) -> None:
@@ -83,10 +151,7 @@ def test_probe_requires_verified_hermes_legacy_bridge(tmp_path: Path) -> None:
     assert result.status is RuntimeLayoutInspectionStatus.READY
     assert result.engine == "hermes"
     assert result.evidence["checks"]["legacy_local_bridge_valid"] is True
-    assert (
-        result.evidence["mapping_contract_version"]
-        == MAPPING_CONTRACT_VERSION
-    )
+    assert result.evidence["mapping_contract_version"] == MAPPING_CONTRACT_VERSION
     assert result.evidence["resolved_layout"]["active_root"] == str(
         home / ".hermes/skills"
     )
@@ -108,13 +173,10 @@ def test_probe_requires_verified_hermes_legacy_bridge(tmp_path: Path) -> None:
     )
 
     assert missing_h0_evidence.status is RuntimeLayoutInspectionStatus.INVALID
-    assert (
-        missing_h0_evidence.evidence["reason"]
-        == "marker_contract_mismatch"
-    )
+    assert missing_h0_evidence.evidence["reason"] == "marker_contract_mismatch"
 
 
-def test_activation_retires_hermes_local_bridges_and_keeps_repo_namespace(
+def test_activation_retires_hermes_platform_bridges_and_uses_pool_mappings(
     tmp_path: Path,
 ) -> None:
     home = tmp_path / "home" / "admin"
@@ -193,8 +255,8 @@ def test_activation_retires_hermes_local_bridges_and_keeps_repo_namespace(
     assert not legacy_local.is_symlink()
     assert not local_bridge.exists()
     assert not local_bridge.is_symlink()
-    assert repo_bridge.is_symlink()
-    assert repo_bridge.resolve() == pool_repo.resolve()
+    assert not repo_bridge.exists()
+    assert not repo_bridge.is_symlink()
     assert (pool_local / "handmade" / "SKILL.md").read_text() == "latest"
 
     ready = inspect_hermes_runtime_layout(
@@ -202,7 +264,22 @@ def test_activation_retires_hermes_local_bridges_and_keeps_repo_namespace(
         repo_is_mounted=lambda path: path == pool_repo,
     )
     assert ready.status is RuntimeLayoutInspectionStatus.READY
-    assert ready.evidence["checks"]["stable_repo_bridge_valid"] is True
+    assert ready.evidence["checks"]["legacy_repo_bridge_status"] == "absent"
+
+    repeated = activate_hermes_pool(
+        migration_generation="generation-1",
+        preparation_id="b7f7a125-9133-45fd-956d-fb66da81f68d",
+        registered_local_names=["handmade"],
+        mappings=[
+            SkillMapping(
+                source=str(pool_local / "handmade"),
+                target=str(active_root / "handmade"),
+            )
+        ],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+    assert repeated.status is PoolActivationStatus.ALREADY_COMMITTED
 
     mapping = SkillMapping(
         source=str(pool_local / "handmade"),
@@ -227,6 +304,260 @@ def test_activation_retires_hermes_local_bridges_and_keeps_repo_namespace(
     assert not legacy_local.is_symlink()
     assert (legacy_local / "handmade" / "SKILL.md").read_text() == "pool-write"
     assert local_bridge.resolve() == legacy_local.resolve()
+    assert repo_bridge.is_symlink()
+    assert repo_bridge.resolve() == pool_repo.resolve()
+
+
+def test_pool_active_probe_is_read_only_for_unexpected_hermes_repo_path(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home" / "admin"
+    active_root = home / ".hermes" / "skills"
+    pool_root = home / ".hermes" / "workspace" / "skills-pool"
+    pool_local = pool_root / "skills-local"
+    pool_repo = pool_root / "skills-repo"
+    repo_bridge = home / ".hermes" / "skills-repo"
+    pool_local.mkdir(parents=True)
+    pool_repo.mkdir(parents=True)
+    active_root.mkdir(parents=True)
+    repo_bridge.mkdir(parents=True)
+    (repo_bridge / "user-data").write_text("preserve")
+    preparation_id = "b7f7a125-9133-45fd-956d-fb66da81f68d"
+    (pool_root / ".pool-ready").write_text(
+        json.dumps(
+            {
+                "engine": "hermes",
+                "layout_contract_version": "skills-pool-p3-v1",
+                "preparation_id": preparation_id,
+                "prepared_at": "2026-07-24T00:00:00Z",
+                "pool_local_root": str(pool_local),
+                "pool_repo_root": str(pool_repo),
+                "validation_summary": {
+                    "all_valid": True,
+                    "legacy_bridge_verified": True,
+                    "pool_local": {"path": str(pool_local), "valid": True},
+                    "pool_repo": {
+                        "path": str(pool_repo),
+                        "readable_mount": True,
+                        "valid": True,
+                    },
+                    "managed_active_entries": [],
+                    "structural_bridges": [
+                        {
+                            "name": "stable_local_bridge",
+                            "path": str(active_root / "skills-local"),
+                            "target": str(
+                                home / ".hermes/workspace/skills/skills-local"
+                            ),
+                            "valid": True,
+                        },
+                        {
+                            "name": "stable_repo_bridge",
+                            "path": str(repo_bridge),
+                            "target": str(pool_repo),
+                            "valid": True,
+                        },
+                    ],
+                },
+            }
+        )
+    )
+    (pool_root / ".pool-active").write_text(
+        json.dumps(
+            {
+                "engine": "hermes",
+                "layout_contract_version": "skills-pool-p3-v1",
+                "preparation_id": preparation_id,
+                "migration_generation": "generation-1",
+                "activation_state": "active",
+                "mappings": [],
+            }
+        )
+    )
+
+    result = inspect_hermes_runtime_layout(
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert result.status is RuntimeLayoutInspectionStatus.READY
+    assert result.evidence["checks"]["legacy_repo_bridge_status"] == "retained_object"
+    assert (repo_bridge / "user-data").read_text() == "preserve"
+
+
+def test_pool_active_probe_diagnoses_expected_and_unexpected_hermes_links(
+    tmp_path: Path,
+) -> None:
+    home, _active_root, pool_repo, repo_bridge = _pool_active_fixture(tmp_path)
+    relative_target = repo_bridge.parent / "workspace/skills-pool/skills-repo"
+    repo_bridge.symlink_to(
+        relative_target.relative_to(repo_bridge.parent),
+        target_is_directory=True,
+    )
+    expected = inspect_hermes_runtime_layout(
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+    assert expected.status is RuntimeLayoutInspectionStatus.READY
+    assert (
+        expected.evidence["checks"]["legacy_repo_bridge_status"]
+        == "expected_bridge_present"
+    )
+    assert repo_bridge.is_symlink()
+
+    repo_bridge.unlink()
+    unexpected = home / "unexpected-repo"
+    unexpected.mkdir()
+    repo_bridge.symlink_to(unexpected, target_is_directory=True)
+    retained = inspect_hermes_runtime_layout(
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+    assert retained.status is RuntimeLayoutInspectionStatus.READY
+    assert (
+        retained.evidence["checks"]["legacy_repo_bridge_status"]
+        == "retained_unexpected_symlink"
+    )
+    assert repo_bridge.is_symlink()
+
+
+def test_pool_active_probe_treats_unreadable_hermes_repo_link_as_diagnostic(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    home, _active_root, pool_repo, repo_bridge = _pool_active_fixture(tmp_path)
+    repo_bridge.symlink_to(pool_repo, target_is_directory=True)
+    original_readlink = Path.readlink
+
+    def fail_repo_readlink(path):
+        if path == repo_bridge:
+            raise OSError("unreadable link")
+        return original_readlink(path)
+
+    monkeypatch.setattr(Path, "readlink", fail_repo_readlink)
+
+    result = inspect_hermes_runtime_layout(
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert result.status is RuntimeLayoutInspectionStatus.READY
+    assert (
+        result.evidence["checks"]["legacy_repo_bridge_status"] == "retained_unreadable"
+    )
+
+
+def test_pool_active_reconciliation_preserves_unowned_hermes_repo_entries(
+    tmp_path: Path,
+    caplog,
+) -> None:
+    home, _active_root, pool_repo, repo_bridge = _pool_active_fixture(tmp_path)
+    repo_bridge.mkdir()
+    (repo_bridge / "user-data").write_text("preserve")
+
+    result = activate_hermes_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=[],
+        mappings=[],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert result.status is PoolActivationStatus.ALREADY_COMMITTED
+    assert (repo_bridge / "user-data").read_text() == "preserve"
+    assert "retained unowned Legacy repo object" in caplog.text
+
+
+def test_pool_active_reconciliation_preserves_unexpected_hermes_repo_link(
+    tmp_path: Path,
+    caplog,
+) -> None:
+    home, _active_root, pool_repo, repo_bridge = _pool_active_fixture(tmp_path)
+    unexpected = home / "unexpected-repo"
+    unexpected.mkdir()
+    repo_bridge.symlink_to(unexpected, target_is_directory=True)
+
+    result = activate_hermes_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=[],
+        mappings=[],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert result.status is PoolActivationStatus.ALREADY_COMMITTED
+    assert repo_bridge.resolve() == unexpected
+    assert "retained unexpected Legacy repo symlink" in caplog.text
+
+
+def test_pool_active_reconciliation_retries_hermes_repo_retirement_failure(
+    tmp_path: Path,
+    monkeypatch,
+    caplog,
+) -> None:
+    home, _active_root, pool_repo, repo_bridge = _pool_active_fixture(tmp_path)
+    repo_bridge.symlink_to(pool_repo, target_is_directory=True)
+    original_unlink = Path.unlink
+
+    def fail_repo_unlink(path, *args, **kwargs):
+        if path == repo_bridge:
+            raise OSError("read-only filesystem")
+        return original_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", fail_repo_unlink)
+
+    result = activate_hermes_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=[],
+        mappings=[],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert result.status is PoolActivationStatus.ALREADY_COMMITTED
+    assert repo_bridge.is_symlink()
+    assert "could not retire obsolete repo bridge" in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("method_name", "diagnostic"),
+    [
+        ("lstat", "could not inspect obsolete repo bridge"),
+        ("readlink", "retained unreadable Legacy repo symlink"),
+    ],
+)
+def test_pool_active_reconciliation_tolerates_unreadable_hermes_repo_entry(
+    tmp_path: Path,
+    monkeypatch,
+    caplog,
+    method_name,
+    diagnostic,
+) -> None:
+    home, _active_root, pool_repo, repo_bridge = _pool_active_fixture(tmp_path)
+    repo_bridge.symlink_to(pool_repo, target_is_directory=True)
+    original = getattr(Path, method_name)
+
+    def fail_repo_inspection(path, *args, **kwargs):
+        if path == repo_bridge:
+            raise OSError("unreadable entry")
+        return original(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, method_name, fail_repo_inspection)
+
+    result = activate_hermes_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=[],
+        mappings=[],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert result.status is PoolActivationStatus.ALREADY_COMMITTED
+    assert diagnostic in caplog.text
 
 
 def test_mapping_rejects_openclaw_source_instead_of_falling_back(

--- a/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
@@ -450,6 +450,53 @@ def _retire_bridge(path: Path, *, allowed_targets: tuple[Path, ...]) -> None:
     path.unlink()
 
 
+def _settle_hermes_repo_bridge(layout: _Layout) -> None:
+    """Retire the obsolete platform bridge while preserving unowned objects."""
+
+    path = layout.repo_bridge
+    try:
+        entry_stat = path.lstat()
+    except FileNotFoundError:
+        return
+    except OSError as error:
+        logger.warning(
+            "Hermes Pool could not inspect obsolete repo bridge path=%s error=%s",
+            path,
+            type(error).__name__,
+        )
+        return
+    if not stat.S_ISLNK(entry_stat.st_mode):
+        logger.warning("Hermes Pool retained unowned Legacy repo object path=%s", path)
+        return
+    try:
+        target = _lexical_target(path)
+    except OSError as error:
+        logger.warning(
+            "Hermes Pool retained unreadable Legacy repo symlink path=%s error=%s",
+            path,
+            type(error).__name__,
+        )
+        return
+    expected = Path(os.path.abspath(layout.pool_repo))
+    if target != expected:
+        logger.warning(
+            "Hermes Pool retained unexpected Legacy repo symlink path=%s target=%s",
+            path,
+            target,
+        )
+        return
+    try:
+        path.unlink()
+    except OSError as error:
+        logger.warning(
+            "Hermes Pool could not retire obsolete repo bridge path=%s error=%s",
+            path,
+            type(error).__name__,
+        )
+        return
+    logger.info("Hermes Pool retired obsolete repo bridge path=%s", path)
+
+
 def _publish_structural_bridge(path: Path, target: Path) -> None:
     """Atomically publish a descriptor-owned directory symlink."""
 
@@ -582,8 +629,10 @@ def _finalize_active_root(
         allowed_targets=(layout.legacy_local, layout.pool_local),
     )
     repo_delivery = current_repo_delivery()
-    if repo_delivery is RepoDelivery.DOWNLOAD and engine in {"aicoding", "hermes"}:
+    if repo_delivery is RepoDelivery.DOWNLOAD and engine == "aicoding":
         _publish_structural_bridge(layout.repo_bridge, layout.pool_repo)
+    if engine == "hermes":
+        _settle_hermes_repo_bridge(layout)
     if engine in {"openclaw", "claude_code"}:
         _retire_bridge(
             layout.repo_bridge,
@@ -607,7 +656,7 @@ def _finalize_active_root(
                 "paths": sorted(remaining_storage_entries),
             },
         )
-    if engine in {"aicoding", "hermes"}:
+    if engine == "aicoding":
         try:
             stable_repo_bridge_valid = (
                 layout.repo_bridge.is_symlink()
@@ -1087,8 +1136,7 @@ def _mapping_target_invalid(
 ) -> bool:
     return (
         not target.is_absolute()
-        or target.parent
-        not in {layout.active_root, *additional_retirement_roots}
+        or target.parent not in {layout.active_root, *additional_retirement_roots}
         or target
         in {
             layout.legacy_local,
@@ -1424,7 +1472,9 @@ def _best_effort_mapping_results(
                         target=str(target),
                         source=str(source),
                         status=MappingProjectionStatus.DEGRADED,
-                        code="TARGET_NOT_SYMLINK" if not target.is_symlink() else "TARGET_MISMATCH",
+                        code="TARGET_NOT_SYMLINK"
+                        if not target.is_symlink()
+                        else "TARGET_MISMATCH",
                     )
                 )
             else:

--- a/src/engine/src/engine/community/plugins/skills_pool/layout_probe.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_probe.py
@@ -181,6 +181,26 @@ def _lexical_symlink_target(path: Path) -> Path:
     return Path(os.path.abspath(target))
 
 
+def _hermes_repo_bridge_status(layout: _FilesystemPoolLayout) -> str:
+    """Describe the obsolete external bridge without mutating or gating Pool."""
+
+    try:
+        entry_stat = layout.repo_bridge.lstat()
+    except FileNotFoundError:
+        return "absent"
+    except OSError:
+        return "retained_unreadable"
+    if not stat.S_ISLNK(entry_stat.st_mode):
+        return "retained_object"
+    try:
+        target = _lexical_symlink_target(layout.repo_bridge)
+    except OSError:
+        return "retained_unreadable"
+    if target == Path(os.path.abspath(layout.pool_repo)):
+        return "expected_bridge_present"
+    return "retained_unexpected_symlink"
+
+
 def _marker_contract_valid(
     marker: dict[str, Any],
     *,
@@ -773,7 +793,7 @@ def inspect_runtime_layout(
                         reason=f"retired_{bridge_name}_bridge_present",
                         preparation_id=preparation_id,
                     )
-            if engine in {"aicoding", "hermes"}:
+            if engine == "aicoding":
                 try:
                     repo_bridge_valid = (
                         layout.repo_bridge.is_symlink()
@@ -839,11 +859,12 @@ def inspect_runtime_layout(
         if center_mount.status is CenterMountStatus.READY:
             active_checks["pool_center_mounted"] = True
             active_checks["pool_center_readable"] = True
-        if (
-            engine in {"aicoding", "hermes"}
-            and active_marker["activation_state"] == "active"
-        ):
+        if engine == "aicoding" and active_marker["activation_state"] == "active":
             active_checks["stable_repo_bridge_valid"] = True
+        if engine == "hermes" and active_marker["activation_state"] == "active":
+            active_checks["legacy_repo_bridge_status"] = _hermes_repo_bridge_status(
+                layout
+            )
         return RuntimeLayoutInspection(
             status=RuntimeLayoutInspectionStatus.READY,
             engine=engine,

--- a/src/engine/src/engine/community/tests/contracts/test_skills_pool_probe_evidence.py
+++ b/src/engine/src/engine/community/tests/contracts/test_skills_pool_probe_evidence.py
@@ -125,8 +125,10 @@ def test_stable_repo_bridge_check_is_conditional_and_verified(
     assert resolved["layout_contract_version"] == LAYOUT_CONTRACT_VERSION
     assert resolved["pool_center"] == str(layout.pool_center)
     checks = active.evidence["checks"]
-    if engine in {"aicoding", "hermes"}:
+    if engine == "aicoding":
         assert checks["stable_repo_bridge_valid"] is True
+    elif engine == "hermes":
+        assert checks["legacy_repo_bridge_status"] == "absent"
     else:
         assert "stable_repo_bridge_valid" not in checks
 

--- a/src/engine/src/engine/community/tests/core/skills/test_desktop_layout_activation.py
+++ b/src/engine/src/engine/community/tests/core/skills/test_desktop_layout_activation.py
@@ -123,15 +123,11 @@ def test_desktop_download_layout_uses_public_cutover_and_rollback(
     )
 
     assert activated.status is PoolActivationStatus.COMMITTED
-    assert (layout.pool_repo / "business/reviewer/SKILL.md").read_text() == (
-        "repo"
-    )
+    assert (layout.pool_repo / "business/reviewer/SKILL.md").read_text() == ("repo")
     assert layout.pool_repo.is_dir()
     assert not layout.pool_repo.is_symlink()
-    assert _target(layout.active_root / "handmade") == (
-        layout.pool_local / "handmade"
-    )
-    if engine in {"aicoding", "hermes"}:
+    assert _target(layout.active_root / "handmade") == (layout.pool_local / "handmade")
+    if engine == "aicoding":
         assert _target(layout.repo_bridge) == layout.pool_repo
     else:
         assert not layout.repo_bridge.exists()
@@ -142,8 +138,10 @@ def test_desktop_download_layout_uses_public_cutover_and_rollback(
         repo_delivery=RepoDelivery.DOWNLOAD,
     )
     assert active.status is RuntimeLayoutInspectionStatus.READY
-    if engine in {"aicoding", "hermes"}:
+    if engine == "aicoding":
         assert active.evidence["checks"]["stable_repo_bridge_valid"] is True
+    elif engine == "hermes":
+        assert active.evidence["checks"]["legacy_repo_bridge_status"] == "absent"
     else:
         assert "stable_repo_bridge_valid" not in active.evidence["checks"]
 

--- a/src/engine/src/engine/community/tests/core/skills/test_desktop_preparation.py
+++ b/src/engine/src/engine/community/tests/core/skills/test_desktop_preparation.py
@@ -267,12 +267,8 @@ def test_downloaded_repo_cutover_leaves_corpus_outside_active_root(
         layout.pool_repo / "business/reviewer"
     )
     assert external.is_symlink()
-    if engine in {"openclaw", "claude_code"}:
-        assert not layout.repo_bridge.exists()
-        assert not layout.repo_bridge.is_symlink()
-    else:
-        assert layout.repo_bridge.is_symlink()
-        assert _target(layout.repo_bridge) == layout.pool_repo
+    assert not layout.repo_bridge.exists()
+    assert not layout.repo_bridge.is_symlink()
 
     refreshed = tmp_path / f"{engine}-repo-refresh"
     (refreshed / "business/reviewer").mkdir(parents=True)


### PR DESCRIPTION
## Problem
Hermes startup rebuilt the retired Legacy Local bridge before mount selection, and Pool-active validation still required the external Legacy Repo bridge. A restart could therefore invalidate an already-active Pool layout, while obsolete or user-owned Repo-path objects could block otherwise valid canonical Pool mappings.

## Solution
- Make Hermes Pool activation and probe treat the external Legacy Repo address as a preparation-only compatibility bridge after cutover.
- Retire only the platform-owned bridge that points to canonical Pool; preserve and diagnose user directories, unexpected links, unreadable objects, and retirement failures.
- Keep probe read-only and preserve explicit rollback reconstruction of the Legacy view.
- Document the lifecycle contract and include the accepted Issue #2002 spec.

## Validation
- Engine final gate: 2,578 passed, 5 deselected; total line coverage 93.42%; changed-line coverage 99.44%.
- Focused cross-engine Pool regression: 663 passed.
- Backend Skills Pool/runtime/frozen Service regression: 486 passed, 2 deselected.
- Ruff/SAST and diff checks passed.
- Standards/Spec dual-axis review found two P1 integration gaps; both were fixed and final re-review passed.
- GitHub required checks are green, including Backend, Engine, BCS, BaaS, Gateway, sandbox-proxy, design/title gates, and Singlebox coverage.

## Compatibility and risk
No public API, Mapping contract version, Installation, Local locator, database schema, or synchronous startup gate changes. OpenClaw, Claude Code, and AICoding behavior remains covered by the shared regression suite. OCB branch `codex/issue-2002-pool-bridge-lifecycle` pins this exact head and carries the paired startup/bootstrap changes; its AntCode PR creation is currently blocked only by the project-required internal workitem. No deployment or live-container validation was performed.

## Related issues
Relates to #2002. Related architecture issue: #455 (not closed by this PR).
