### PR TITLE
docs(clawinsight): clarify weekly trend aggregation semantics

### DIFF
--- a/src/evolverun/clawweb/public/modules/clawinsight/web/pages/InsightCenter/InsightOverview.tsx
+++ b/src/evolverun/clawweb/public/modules/clawinsight/web/pages/InsightCenter/InsightOverview.tsx
@@ -124,6 +124,7 @@ function aggregateTrendPoints(points: InsightTrendPoint[], granularity: TrendGra
     buckets.set(period.start, bucket)
   }
 
+  // Weekly counts are summed; rates and their standard deviations use the available daily values.
   return [...buckets.values()].sort((left, right) => left.period.start.localeCompare(right.period.start)).map(({ period, points: bucketPoints }) => ({
     date: period.start,
     periodStart: period.start,


### PR DESCRIPTION
## Problem

The weekly trend aggregation combines additive task counts with daily rate statistics, but that distinction is not documented next to the aggregation code.

## Solution

Add one explanatory comment stating that weekly counts are summed, while rates and their standard deviations use the available daily values.

## Validation

- Confirmed that removing the added comment restores the original source byte-for-byte.
- `git diff --check` passed.
- `npm run build` passed for the ClawWeb workspace.
- `npm run check` passed for the ClawWeb workspace.
- `npm test --workspace @avernet/clawinsight -- web/pages/InsightCenter/__tests__/InsightOverview.test.tsx` passed (1 test).
- Local validation used Node.js 22. Full workspace tests and deployment validation were not run locally.

## Compatibility and risk

Comment-only change: no executable logic, UI, API, schema, configuration, or dependency changes.
