### PR TITLE
fix(backend): align ac_bot_startup_script DDL with the deployed table

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_startup_script/repository/models.py
+++ b/src/backend/src/agentclaw/community/core/bot_startup_script/repository/models.py
@@ -97,10 +97,23 @@ class BotStartupScriptModel(Base):
     #: Written by the repository, never by a caller. Hex sha256 is 64 ASCII
     #: characters, and the tenant is carried alongside rather than hashed in, so
     #: the isolation boundary stays visible in the key itself.
+    #:
+    #: Declared 256 to match the deployed column, which is ``varchar(256)`` --
+    #: wider than the 64 characters that can ever be written here. The width is
+    #: mirrored rather than tightened because this declaration's job is to say
+    #: what the table *is*; the value's real width is stated above, and the
+    #: repository is what holds it to 64 by only ever writing a hex digest.
     script_key = Column(
-        String(64), nullable=False, comment="唯一键代理：sha256(env|entity_id|bot_id)"
+        String(256), nullable=False, comment="唯一键代理：sha256(env|entity_id|bot_id)"
     )
 
+    # ``DateTime`` here, ``timestamp`` in the DDL, and the two are not in
+    # conflict: these types only shape the local-mode ``create_all`` schema,
+    # and SQLite has no TIMESTAMP/DATETIME distinction to shape. The column
+    # type that matters is the one in the .sql file, which states the rule --
+    # database-filled times are TIMESTAMP. Every sibling model in this repo is
+    # declared the same way; switching this one to ``TIMESTAMP`` would make it
+    # the outlier without changing a single byte of behaviour.
     gmt_create = Column(
         DateTime, default=func.now(), nullable=False, comment="创建时间"
     )
@@ -112,11 +125,19 @@ class BotStartupScriptModel(Base):
         comment="修改时间",
     )
 
+    # ``_v2`` because the plain name is occupied in the deployed environments
+    # by a key on (avernet_tenant, env, entity_id, bot_id) -- this key's name
+    # carrying the pre-surrogate design's columns -- which cannot be dropped
+    # there, so the surrogate key is added alongside it. The suffix is not a
+    # second constraint: the two enforce the same logical uniqueness, because
+    # script_key is injective over the three columns it hashes. Declared here
+    # under the name the deployed key actually has, so create_all, the .sql
+    # file and every environment agree on one name.
     __table_args__ = (
         UniqueConstraint(
             "avernet_tenant",
             "script_key",
-            name="uk_tenant_script_key",
+            name="uk_tenant_script_key_v2",
         ),
     )
 

--- a/src/backend/src/agentclaw/community/core/bot_startup_script/repository/models.py
+++ b/src/backend/src/agentclaw/community/core/bot_startup_script/repository/models.py
@@ -107,13 +107,25 @@ class BotStartupScriptModel(Base):
         String(256), nullable=False, comment="唯一键代理：sha256(env|entity_id|bot_id)"
     )
 
-    # ``DateTime`` here, ``timestamp`` in the DDL, and the two are not in
-    # conflict: these types only shape the local-mode ``create_all`` schema,
-    # and SQLite has no TIMESTAMP/DATETIME distinction to shape. The column
-    # type that matters is the one in the .sql file, which states the rule --
-    # database-filled times are TIMESTAMP. Every sibling model in this repo is
-    # declared the same way; switching this one to ``TIMESTAMP`` would make it
-    # the outlier without changing a single byte of behaviour.
+    # ``DateTime`` here, ``timestamp`` in the DDL. Deliberate, and the same
+    # split apply_models.py states for the same reason.
+    #
+    # It cannot disagree with the deployed column, because it never describes
+    # it: the OceanBase schema is operator-provisioned (``create_schema:
+    # false``), so the .sql file creates these and the ORM emits no DDL there.
+    # For reads and writes the declaration makes no difference either --
+    # SQLAlchemy's ``TIMESTAMP`` is a subclass of ``DateTime``, both bind and
+    # return ``datetime``, and the driver hands back a ``datetime`` for a
+    # TIMESTAMP column whichever is declared.
+    #
+    # Where it is NOT a no-op, and this is the part worth knowing: a community
+    # deployment on MySQL with ``create_schema: true`` bootstraps through
+    # ``create_all(mysql=True)``, which emits DATETIME from this declaration.
+    # That gap is repo-wide rather than this table's -- every model here is
+    # declared this way -- and switching this one column would only half-close
+    # it, since ``default=``/``onupdate=`` are client-side constructs: the
+    # bootstrap emits neither DEFAULT CURRENT_TIMESTAMP nor ON UPDATE
+    # CURRENT_TIMESTAMP for any table here, whatever the type says.
     gmt_create = Column(
         DateTime, default=func.now(), nullable=False, comment="创建时间"
     )

--- a/src/backend/src/agentclaw/community/core/bot_startup_script/sql/2026_08_10_bot_startup_script.sql
+++ b/src/backend/src/agentclaw/community/core/bot_startup_script/sql/2026_08_10_bot_startup_script.sql
@@ -6,7 +6,10 @@
 -- "no script" are the same state.
 --
 -- Key is (avernet_tenant, script_key), where script_key is a sha256 of the
--- logical key (env, entity_id, bot_id). The tenant is in the key because
+-- logical key (env, entity_id, bot_id). The table also carries an older unique
+-- key over those three columns directly -- both are declared below, both are
+-- really in the deployed table, and they are equivalent; only the surrogate is
+-- indexed the way the repository reads. The tenant is in the key because
 -- ac_bots is itself tenant-scoped, so a bot_id is unique only within a tenant —
 -- legacy "default" bots carry documented residual cross-tenant collision on
 -- that identifier. Without the tenant here, two such bots would share one
@@ -76,20 +79,34 @@ CREATE TABLE `ac_bot_startup_script` (
   `gmt_create`    timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
   `gmt_modified`  timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '修改时间',
   PRIMARY KEY (`id`),
-  -- The index every read uses: the repository filters on script_key rather
-  -- than on the three columns it hashes, so there is no second lookup key here
-  -- to drift out of step with the ORM model.
+  -- TWO UNIQUE KEYS, AND BOTH ARE REALLY THERE. They enforce the same logical
+  -- uniqueness -- script_key is injective over (env, entity_id, bot_id), so a
+  -- row accepted by one is accepted by the other, and either may be the one
+  -- that raises the IntegrityError the repository's upsert retries on. Nothing
+  -- depends on which.
   --
-  -- WHY THE ``_v2`` SUFFIX ON A TABLE THAT HAS NO v1. The name a fresh table
-  -- would want, ``uk_tenant_script_key``, is occupied in the already-deployed
-  -- environments by a key on (avernet_tenant, env, entity_id, bot_id) -- the
-  -- pre-surrogate design, carrying this key's name but not its columns -- and
-  -- that key cannot be dropped there. So the surrogate key is added alongside
-  -- it under this name, and this file uses the same name so that ONE name is
-  -- correct in every environment and in the ORM model. A fresh table gets only
-  -- this key; a migrated one carries the legacy key too, which is redundant
-  -- rather than wrong: script_key is injective over (env, entity_id, bot_id),
-  -- so both enforce the same logical uniqueness, and either may be the one
-  -- that raises the IntegrityError the repository's upsert retries on.
+  -- The first is the ORIGINAL key under the name the second one wants. It was
+  -- provisioned with this key's name and the pre-surrogate design's columns,
+  -- and dropping an index is not available in the deployed environments, so it
+  -- stays. It is declared here rather than quietly omitted because this file's
+  -- whole contract is that it reads back identically to ``SHOW CREATE TABLE``:
+  -- an index that exists in the database and not in this file is the same
+  -- invisible drift as a column type that does, and it is how the mediumint /
+  -- mediumtext transcription error stayed hidden.
+  --
+  -- ITS KEY IS 5456 utf8mb4 BYTES (64+20+1024+256 chars), past InnoDB's
+  -- 3072-byte cap. OceanBase accepts it; stock MySQL/InnoDB would refuse this
+  -- CREATE TABLE outright. That makes this file OceanBase-targeted, which it
+  -- already was in practice -- and it is exactly the constraint that made the
+  -- surrogate necessary in the first place. A fresh environment on InnoDB must
+  -- omit this first key; it loses nothing by doing so, because the second one
+  -- enforces the same rule within the cap.
+  UNIQUE KEY `uk_tenant_script_key` (`avernet_tenant`, `env`, `entity_id`, `bot_id`),
+  -- The second is the key EVERY READ USES: ``get``, ``upsert`` and ``delete``
+  -- all filter on script_key alone, so without this one each of them is a full
+  -- scan -- on a table ``_build_create_bot_payload`` reads on every payload it
+  -- composes. The ``_v2`` suffix is not a version of anything: it is simply the
+  -- name left over once the key above took the obvious one, and it is the name
+  -- the ORM model declares too, so one name is correct everywhere.
   UNIQUE KEY `uk_tenant_script_key_v2` (`avernet_tenant`, `script_key`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='Bot 启动脚本';

--- a/src/backend/src/agentclaw/community/core/bot_startup_script/sql/2026_08_10_bot_startup_script.sql
+++ b/src/backend/src/agentclaw/community/core/bot_startup_script/sql/2026_08_10_bot_startup_script.sql
@@ -58,12 +58,38 @@ CREATE TABLE `ac_bot_startup_script` (
   -- constraint is carried on a fixed-width sha256 hex digest instead. Written
   -- by the repository; the tenant is carried alongside rather than hashed in,
   -- so the isolation boundary stays visible in the key.
-  `script_key`    char(64)      NOT NULL COMMENT '唯一键代理：sha256(env|entity_id|bot_id)',
-  `gmt_create`    datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
-  `gmt_modified`  datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '修改时间',
+  -- varchar(256) rather than char(64), matching the deployed table. The value
+  -- is always exactly 64 lowercase hex characters -- the column is wider than
+  -- anything that can be stored in it, and deliberately so: this file has to
+  -- read back identically to ``SHOW CREATE TABLE``, or the next transcription
+  -- error hides in the diff between them the way the mediumint/mediumtext one
+  -- did. CHAR's blank-padding is not relied on anywhere: the repository writes
+  -- a hex digest and compares it for equality.
+  `script_key`    varchar(256)  NOT NULL COMMENT '唯一键代理：sha256(env|entity_id|bot_id)',
+  -- TIMESTAMP, not DATETIME, and the split is the module rule the manifest
+  -- DDL states: a column the *database* fills round-trips through TIMESTAMP's
+  -- session-offset conversion unchanged, while one the *application* binds
+  -- would be stored shifted. Both of these are database-filled -- the ORM
+  -- maps them to ``func.now()``, which renders server-side as ``now()``, and
+  -- the upsert re-stamps gmt_modified the same way -- so TIMESTAMP is the
+  -- correct half of that rule and matches ac_bots.
+  `gmt_create`    timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `gmt_modified`  timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '修改时间',
   PRIMARY KEY (`id`),
-  -- The only index, and every read uses it: the repository filters on
-  -- script_key rather than on the three columns it hashes, so there is no
-  -- second lookup key here to drift out of step with the ORM model.
-  UNIQUE KEY `uk_tenant_script_key` (`avernet_tenant`, `script_key`)
+  -- The index every read uses: the repository filters on script_key rather
+  -- than on the three columns it hashes, so there is no second lookup key here
+  -- to drift out of step with the ORM model.
+  --
+  -- WHY THE ``_v2`` SUFFIX ON A TABLE THAT HAS NO v1. The name a fresh table
+  -- would want, ``uk_tenant_script_key``, is occupied in the already-deployed
+  -- environments by a key on (avernet_tenant, env, entity_id, bot_id) -- the
+  -- pre-surrogate design, carrying this key's name but not its columns -- and
+  -- that key cannot be dropped there. So the surrogate key is added alongside
+  -- it under this name, and this file uses the same name so that ONE name is
+  -- correct in every environment and in the ORM model. A fresh table gets only
+  -- this key; a migrated one carries the legacy key too, which is redundant
+  -- rather than wrong: script_key is injective over (env, entity_id, bot_id),
+  -- so both enforce the same logical uniqueness, and either may be the one
+  -- that raises the IntegrityError the repository's upsert retries on.
+  UNIQUE KEY `uk_tenant_script_key_v2` (`avernet_tenant`, `script_key`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='Bot 启动脚本';

--- a/src/backend/tests/community/core/bot_config_manifest/test_manifest_ddl_contract.py
+++ b/src/backend/tests/community/core/bot_config_manifest/test_manifest_ddl_contract.py
@@ -12,21 +12,30 @@ OceanBase modifiers these files carry. The distinction being guarded therefore
 cannot be observed by creating the tables — only by reading what is declared.
 The sibling ``core/task_queue/test_task_queue_schema_contract.py`` guards its
 file the same way and for the same reason.
+
+WHY ``bot_startup_script/sql`` IS IN SCOPE HERE. The rule these tests state is
+about a column-type choice under OceanBase, not about one module, and
+``ac_bot_startup_script`` is materialised by this module's ``script`` category
+-- it is the manifest's own storage for that construct, kept in its own package
+only because #926 shipped it first. It sat outside this directory and therefore
+outside this rule, and that is exactly where the drift turned up: the deployed
+table carries TIMESTAMP audit columns while the file declared DATETIME, found by
+reading a ``SHOW CREATE TABLE`` rather than by anything in CI. Scoping by rule
+instead of by directory is what closes that.
 """
 
 from pathlib import Path
 import re
 
 
-_SQL_DIR = (
-    Path(__file__).parents[4]
-    / "src"
-    / "agentclaw"
-    / "community"
-    / "core"
-    / "bot_config_manifest"
-    / "sql"
-)
+_CORE = Path(__file__).parents[4] / "src" / "agentclaw" / "community" / "core"
+
+_SQL_DIR = _CORE / "bot_config_manifest" / "sql"
+
+#: Every directory whose DDL this rule governs. ``_SQL_DIR`` stays a single
+#: directory because ``_APPLICATION_SUPPLIED`` addresses files inside it by
+#: name.
+_SQL_DIRS = (_SQL_DIR, _CORE / "bot_startup_script" / "sql")
 
 #: Columns filled by the application, which must stay DATETIME. TIMESTAMP reads
 #: the bound naive value as session-local and converts it, so an instant the
@@ -109,8 +118,15 @@ def _declarations(path: Path) -> dict[str, str]:
 
 
 def _sql_files() -> list[Path]:
-    files = sorted(_SQL_DIR.glob("*.sql"))
-    assert files, f"no DDL found under {_SQL_DIR}"
+    files = sorted(path for directory in _SQL_DIRS for path in directory.glob("*.sql"))
+    assert files, f"no DDL found under {[str(d) for d in _SQL_DIRS]}"
+    # Asserted per directory as well as overall: a mistyped path would other-
+    # wise leave one directory silently contributing nothing, which is the
+    # shape of the shadowing bug ``_tables`` already documents.
+    for directory in _SQL_DIRS:
+        assert any(
+            path.parent == directory for path in files
+        ), f"no DDL found under {directory}"
     return files
 
 
@@ -170,6 +186,7 @@ def test_every_table_in_every_file_is_parsed() -> None:
         "ac_manifest_content",
         "ac_source_credential",
         "ac_bot_cli_tool",
+        "ac_bot_startup_script",
     }
 
 


### PR DESCRIPTION
## Problem

`POST /openapi/v1/bots/with-manifest` reported `APPLY_FAILED` with the `script`
category aborted:

```
write failed: (mysql.connector.errors.DatabaseError) 1366 (HY000):
Incorrect integer value for column 'script' at row 1
```

`SHOW CREATE TABLE ac_bot_startup_script` shows the deployed table differs from
`sql/2026_08_10_bot_startup_script.sql` in four places. All four are
transcription errors made while applying that file by hand, not decisions:

| | file declared | deployed | effect |
| --- | --- | --- | --- |
| `script` | `mediumtext` | `mediumint(9)` | **every script write rejected** — the error above |
| `uk_tenant_script_key` | `(avernet_tenant, script_key)` | `(avernet_tenant, env, entity_id, bot_id)` | **no index on `script_key`** — every read is a full scan |
| `script_key` | `char(64)` | `varchar(256)` | none |
| `gmt_create` / `gmt_modified` | `datetime` | `timestamp` | none today |

The second one matters more than it looks. The repository filters `get`,
`upsert` and `delete` on `script_key` **alone** — that is the stated reason the
surrogate exists (`_script_key`'s docstring: *"filtering on the surrogate is
what keeps a lookup on the one index the table has"*). The deployed key carries
this key's name with the pre-surrogate design's columns, so it enforces the
right constraint while leaving the column every query filters on unindexed, on a
table `_build_create_bot_payload` reads on every payload it composes.

The root cause of the hand-transcription is the one #1977 found on the apply
table: the DDL review standard (研发规范) that gates OceanBase provisioning
refuses `DATETIME`. This file as written could not have provisioned the table it
describes.

## Solution

**One principle throughout: this file must read back identically to `SHOW CREATE
TABLE`.** An index or a column type that exists in the database and not in this
file is invisible drift, and invisible drift is exactly how the
`mediumint`/`mediumtext` error survived. So the file is updated to describe the
table that actually exists after repair, rather than an idealised one.

**`gmt_create` / `gmt_modified` → `timestamp`.** Required by the DDL review
standard, and independently the correct half of the rule this module already
tests: a database-filled column round-trips through TIMESTAMP's session-offset
conversion unchanged, while an application-bound one would be stored shifted.
Both are database-filled — the ORM maps them to `func.now()`, which renders
server-side as `now()`, and the upsert re-stamps `gmt_modified` the same way —
so nothing the application reads is lost. Matches both sibling tables in
`bot_config_manifest/sql/`.

**`script_key` → `varchar(256)`.** The value is always 64 lowercase hex
characters, so the column is wider than anything that can be written to it. The
width is mirrored rather than tightened because this file's job is to say what
the table *is*. CHAR's blank-padding was not relied on anywhere.

**Both unique keys are now declared.** The original key holds the name the
surrogate wanted while spanning the pre-surrogate columns, and dropping an index
is not available in the deployed environments — so the surrogate was added
alongside it as `uk_tenant_script_key_v2`, and the file now carries both:

```sql
UNIQUE KEY `uk_tenant_script_key`    (`avernet_tenant`, `env`, `entity_id`, `bot_id`),
UNIQUE KEY `uk_tenant_script_key_v2` (`avernet_tenant`, `script_key`)
```

They are equivalent — `script_key` is injective over the three columns the older
key spans, so a row accepted by one is accepted by the other, and nothing
depends on which raises the `IntegrityError` the upsert retries on. Only the
surrogate is indexed the way the repository reads, which is why it had to be
added at all.

⚠️ **Declaring the older key has a cost, recorded in the file:** its key is 5456
utf8mb4 bytes (64+20+1024+256 chars), past InnoDB's 3072-byte cap. OceanBase
accepts it; stock MySQL/InnoDB would refuse this `CREATE TABLE` outright. That
makes this file OceanBase-targeted, which it already was in practice — and that
cap is the same constraint that made the surrogate necessary in the first place.
A fresh InnoDB environment must omit the older key and loses nothing by doing so.

**The ORM keeps declaring only the surrogate** — it is the constraint the code
relies on, the one that fits the cap, and `create_all` has no older key to
preserve.

**The ORM model keeps `DateTime`**, as `apply_models.py` does for the same
reason. It cannot disagree with the deployed column because it never describes
it: the OceanBase schema is operator-provisioned (`create_schema: false`), so
the `.sql` file creates these and the ORM emits no DDL there. For reads and
writes the declaration is inert either way — SQLAlchemy's `TIMESTAMP` is a
subclass of `DateTime`, both bind and return `datetime`.

Where it is **not** inert: a community deployment on MySQL with `create_schema:
true` bootstraps through `create_all(mysql=True)`, which emits `DATETIME` from
this declaration. That gap is repo-wide rather than this table's — every model
here is declared this way — and switching this one column would only half-close
it, since `default=`/`onupdate=` are client-side constructs: the bootstrap emits
neither `DEFAULT CURRENT_TIMESTAMP` nor `ON UPDATE CURRENT_TIMESTAMP` for any
table here whatever the type says. Closing it properly is a repo-wide follow-up.

**`test_manifest_ddl_contract.py` now covers `bot_startup_script/sql/`.** The
rule it states is about a column-type choice under OceanBase, not about one
module, and this table — the manifest's storage for its `script` category — sat
outside its directory and so outside its coverage. That is exactly where the
drift turned up, found by reading a `SHOW CREATE TABLE` rather than by anything
in CI.

## Validation

- `tests/community/core/bot_config_manifest/`, `tests/community/repository/bot/`,
  `tests/community/core/bot_startup_script/`, `tests/community/plugins/local/` —
  1305 passed
- Confirmed the extended contract test actually catches this drift: reverting
  `gmt_create` to `datetime` fails with
  `ac_bot_startup_script.gmt_create is declared datetime, not timestamp`
- Confirmed the DDL parser still reads the table correctly with two `UNIQUE KEY`
  lines — 11 columns parsed, no key line mis-read as a column
- Verified the `DateTime`/`TIMESTAMP` claim by compiling both against the MySQL
  and SQLite dialects rather than asserting it, and verified that widening
  `script_key` does **not** trip `prepare_for_mysql`'s index-prefixing
  (320 of 768 budget chars, `_prefix_lengths` returns `None`)
- Not run: anything requiring OceanBase/MySQL. The suite is SQLite, which has no
  TIMESTAMP/DATETIME distinction and does not parse the OceanBase modifiers —
  which is why these rules are asserted against the DDL as text.

## Compatibility and risk

No application behaviour changes: the column types are declarations, and the
constraint names are not referenced anywhere but the model and the DDL.

The two breaking repairs are applied directly to the affected environments:

```sql
ALTER TABLE `ac_bot_startup_script`
  MODIFY COLUMN `script` mediumtext NOT NULL COMMENT '脚本正文（清空即删行）';

ALTER TABLE `ac_bot_startup_script`
  ADD UNIQUE KEY `uk_tenant_script_key_v2` (`avernet_tenant`, `script_key`) GLOBAL;
```

Neither drops anything. `MODIFY COLUMN` is re-runnable; `ADD UNIQUE KEY` is not
(it fails with "Duplicate key name" once the key exists), which is why these are
applied rather than shipped as a re-runnable script — matching them to #1977's
idempotent repair would need an `information_schema` guard, since there is no
`ADD KEY IF NOT EXISTS`.

Worth checking whether prod carries the same drift: if `pre` was transcribed by
hand, prod likely was too, and the `mediumint` typo would take out startup
scripts there identically.

## Related issues

Same class of finding as #1977, and the same root cause (the DDL review standard
refusing the canonical file, so the table was created by hand).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C5EuqWQKRuw3yL7Rhz4cmd
