### PR TITLE
fix(bcs): mint typed invite tokens and reject target/path mismatch on join

### DIFF
--- a/src/bcs/crates/application/v1/bcs-app-invitation/src/lib.rs
+++ b/src/bcs/crates/application/v1/bcs-app-invitation/src/lib.rs
@@ -11,8 +11,9 @@
 //! V1 invitation divergence from the legacy `InviteService`:
 //! - Tokens are minted directly with `target_type: Some(Group|Session)` via
 //!   `bcs_domain::invite_token_encode`, so the accept path can route without
-//!   inspecting a join URL. Legacy tokens carry `target_type: None` and are
-//!   rejected by V1 accept.
+//!   inspecting a join URL. The legacy `bcs-http` invite routes also mint
+//!   typed tokens now, so their links are accepted here; only pre-field
+//!   tokens (`target_type: None`) remain rejected by V1 accept.
 //! - V1 `create_*_invitation` mirrors the legacy DM/active-group guards but
 //!   mints tokens directly (the legacy `create_*_invite_token` paths are not
 //!   reused because they emit legacy join URLs).

--- a/src/bcs/crates/application/v1/bcs-app-invitation/tests/v1_invitation_friendship_service.rs
+++ b/src/bcs/crates/application/v1/bcs-app-invitation/tests/v1_invitation_friendship_service.rs
@@ -17,7 +17,7 @@ use bcs_friend::{FriendCore, FriendRequestCore};
 use bcs_group::application::invite::InviteServiceImpl;
 use bcs_group::{GroupCore, MemoryGroupRepo};
 use bcs_relation::RelationCore;
-use bcs_service_api::application::invite::InviteService;
+use bcs_service_api::application::invite::{CreateInviteTokenCommand, InviteService};
 use bcs_service_api::application::session::{CreateOrReactivateCommand, SessionManagementService};
 use bcs_service_api::application::v1::{
     AcceptFriendRequest, AcceptInvitation, ApplicationError, AuthenticatedCaller,
@@ -889,6 +889,88 @@ async fn accept_invitation_legacy_token_without_target_type_rejected() {
         .expect_err("legacy token rejected");
 
     assert_code(error, "invalid_request");
+}
+
+#[tokio::test]
+async fn accept_invitation_accepts_legacy_route_group_token() {
+    // Compatibility: the legacy `bcs-http` invite routes now mint tokens that
+    // carry `target_type`, so a token from `create_group_invite_link` is
+    // accepted and routed by V1 `acceptInvitation`.
+    let fx = Fixture::new().await;
+    fx.add_bot("bot-a").await;
+    fx.store_group("grp-1", "bot-a").await;
+
+    let legacy = fx
+        .invite
+        .create_group_invite_token(CreateInviteTokenCommand {
+            caller_actor_id: Some("bot-a".to_string()),
+            caller_staff_no: None,
+            target_id: "grp-1".to_string(),
+            ttl_seconds: None,
+        })
+        .await
+        .expect("legacy group invite link");
+
+    let result = fx
+        .service
+        .accept_invitation(AcceptInvitation {
+            caller: Fixture::human_principal("staff-9"),
+            token: legacy.invite_token,
+        })
+        .await
+        .expect("V1 accepts the legacy-route group token");
+
+    assert_eq!(result.target_type, InvitationTargetType::Group);
+    assert_eq!(result.target_id, "grp-1");
+    assert!(result.joined);
+
+    let group = fx.groups.get("grp-1").await.expect("group present");
+    let actor = Fixture::human_actor_id("staff-9");
+    assert!(group.participants.iter().any(|p| p.bot_uuid == actor));
+}
+
+#[tokio::test]
+async fn accept_invitation_accepts_legacy_route_session_token() {
+    // Compatibility: a token from the legacy `create_session_invite_link`
+    // route carries `target_type: session` and is accepted by V1
+    // `acceptInvitation`, joining the human to the session.
+    let fx = Fixture::new().await;
+    fx.add_bot("bot-a").await;
+    fx.store_group("grp-1", "bot-a").await;
+    let session_id = fx.create_session("grp-1", "bot-a").await;
+
+    let legacy = fx
+        .invite
+        .create_session_invite_token(CreateInviteTokenCommand {
+            caller_actor_id: Some("bot-a".to_string()),
+            caller_staff_no: None,
+            target_id: session_id.clone(),
+            ttl_seconds: None,
+        })
+        .await
+        .expect("legacy session invite link");
+
+    let result = fx
+        .service
+        .accept_invitation(AcceptInvitation {
+            caller: Fixture::human_principal("staff-9"),
+            token: legacy.invite_token,
+        })
+        .await
+        .expect("V1 accepts the legacy-route session token");
+
+    assert_eq!(result.target_type, InvitationTargetType::Session);
+    assert_eq!(result.target_id, session_id);
+    assert!(result.joined);
+
+    let session = fx
+        .sessions
+        .get(&session_id)
+        .await
+        .expect("session lookup")
+        .expect("session present");
+    let actor = Fixture::human_actor_id("staff-9");
+    assert!(session.participants.iter().any(|p| p.bot_uuid == actor));
 }
 
 #[tokio::test]

--- a/src/bcs/crates/services/bcs-group/src/application/invite.rs
+++ b/src/bcs/crates/services/bcs-group/src/application/invite.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use bcs_service_api::{
     ActorKind, BotRegistryCoreService, GroupCoreService, GroupKind, GroupStatus,
-    Participant, ParticipantMode, ParticipantRole,
+    InviteTargetType, Participant, ParticipantMode, ParticipantRole,
     SessionManagementService,
     SystemMessageEvent, SystemMessageService,
     CreateInviteTokenCommand, InviteService, InviteTokenResult,
@@ -103,7 +103,12 @@ impl InviteServiceImpl {
         ))
     }
 
-    fn make_token(&self, target_id: &str, ttl_seconds: Option<u64>) -> (String, u64) {
+    fn make_token(
+        &self,
+        target_id: &str,
+        ttl_seconds: Option<u64>,
+        target_type: InviteTargetType,
+    ) -> (String, u64) {
         let ttl = ttl_seconds.unwrap_or(self.default_ttl_seconds);
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -114,13 +119,39 @@ impl InviteServiceImpl {
             v: 1,
             id: target_id.to_string(),
             exp,
-            // Legacy tokens carry no target_type; the field is omitted from the
-            // payload JSON so the HMAC and on-wire form stay byte-identical to
-            // pre-field tokens. V1 invite minting overrides this with Some(...).
-            target_type: None,
+            // Newly minted legacy tokens carry target_type so the join
+            // endpoints can reject a token presented to the wrong path and V1
+            // `acceptInvitation` can route without a lookup. Tokens minted
+            // before this field existed decode to `None` and stay accepted by
+            // the legacy join paths (the JSON key is `serde(default)`).
+            target_type: Some(target_type),
         };
         let token = invite_token_encode(&payload, &self.token_secret);
         (token, exp)
+    }
+
+    /// Reject a token whose `target_type` contradicts the join endpoint it is
+    /// presented to (e.g. a session token on `POST /groups/join/{token}`).
+    /// Pre-field legacy tokens decode to `None` and pass: they predate the
+    /// distinction and remain honored on both endpoints as before.
+    fn ensure_target_type(
+        payload: &InviteTokenPayload,
+        expected: InviteTargetType,
+    ) -> Result<(), InviteUseCaseError> {
+        match &payload.target_type {
+            Some(actual) if *actual != expected => Err(InviteUseCaseError::InvalidToken(format!(
+                "invite token targets a {}, not a {}",
+                match actual {
+                    InviteTargetType::Group => "group",
+                    InviteTargetType::Session => "session",
+                },
+                match expected {
+                    InviteTargetType::Group => "group",
+                    InviteTargetType::Session => "session",
+                },
+            ))),
+            _ => Ok(()),
+        }
     }
 
     fn decode_token(&self, token: &str) -> Result<InviteTokenPayload, InviteUseCaseError> {
@@ -186,7 +217,8 @@ impl InviteService for InviteServiceImpl {
         }
 
         self.authorize_group_invite(&cmd, &group).await?;
-        let (token, exp) = self.make_token(&cmd.target_id, cmd.ttl_seconds);
+        let (token, exp) =
+            self.make_token(&cmd.target_id, cmd.ttl_seconds, InviteTargetType::Group);
         let join_url = match &self.group_link_url {
             Some(url) => format!("{}/{}", url.trim_end_matches('/'), token),
             None => {
@@ -221,7 +253,8 @@ impl InviteService for InviteServiceImpl {
         }
 
         self.ensure_session_member(&cmd, &session).await?;
-        let (token, exp) = self.make_token(&cmd.target_id, cmd.ttl_seconds);
+        let (token, exp) =
+            self.make_token(&cmd.target_id, cmd.ttl_seconds, InviteTargetType::Session);
         let join_url = match &self.session_link_url {
             Some(url) => format!("{}/{}", url.trim_end_matches('/'), token),
             None => {
@@ -241,6 +274,7 @@ impl InviteService for InviteServiceImpl {
         cmd: JoinByInviteCommand,
     ) -> Result<JoinByInviteResult, InviteUseCaseError> {
         let payload = self.decode_token(&cmd.token)?;
+        Self::ensure_target_type(&payload, InviteTargetType::Group)?;
         let group_id = &payload.id;
         let group = self.group.get(group_id).await
             .ok_or_else(|| InviteUseCaseError::NotFound(format!("group not found: {}", group_id)))?;
@@ -292,6 +326,7 @@ impl InviteService for InviteServiceImpl {
         cmd: JoinByInviteCommand,
     ) -> Result<JoinByInviteResult, InviteUseCaseError> {
         let payload = self.decode_token(&cmd.token)?;
+        Self::ensure_target_type(&payload, InviteTargetType::Session)?;
         let session_id = &payload.id;
         let session = self.session
             .get(session_id)

--- a/src/bcs/crates/services/bcs-group/tests/invite.rs
+++ b/src/bcs/crates/services/bcs-group/tests/invite.rs
@@ -13,12 +13,13 @@ use bcs_bot::BotCore;
 use bcs_group::application::invite::InviteServiceImpl;
 use bcs_group::{GroupCore, MemoryGroupRepo};
 use bcs_service_api::application::invite::{
-    CreateInviteTokenCommand, InviteService, InviteUseCaseError,
+    CreateInviteTokenCommand, InviteService, InviteUseCaseError, JoinByInviteCommand,
 };
 use bcs_service_api::application::session::{CreateOrReactivateCommand, SessionManagementService};
 use bcs_service_api::port::repo::{GroupRepoPort, NewSessionParams, SessionRepoPort};
 use bcs_service_api::{
-    BotCapabilities, BotRegistryCoreService, Group, GroupCoreService, GroupStrategy, Participant,
+    invite_token_decode_no_expiry, invite_token_encode, BotCapabilities, BotRegistryCoreService,
+    Group, GroupCoreService, GroupStrategy, InviteTargetType, InviteTokenPayload, Participant,
     ParticipantRole, SessionKind,
 };
 use bcs_session::SessionManagementServiceImpl;
@@ -312,4 +313,210 @@ async fn session_invite_token_rejects_human_without_participant_bot() {
         matches!(error, InviteUseCaseError::Forbidden(_)),
         "expected Forbidden, got {error:?}",
     );
+}
+
+#[tokio::test]
+async fn minted_tokens_carry_target_type() {
+    // Newly minted legacy tokens are self-describing: the payload carries
+    // `target_type` so the split join endpoints can reject a token presented
+    // to the wrong path, and V1 `acceptInvitation` can route it directly.
+    let fx = Fixture::new().await;
+    fx.store_group("grp-1", "bot-a").await;
+    let session_id = fx
+        .create_session_with_participants(
+            "grp-1",
+            "bot-a",
+            vec![Participant::bot("bot-a", ParticipantRole::Driver)],
+        )
+        .await;
+
+    let group_token = fx
+        .service
+        .create_group_invite_token(fx.cmd("grp-1", Some("bot-a")))
+        .await
+        .expect("driver may mint a group token");
+    let group_payload =
+        invite_token_decode_no_expiry(&group_token.invite_token, SECRET).expect("decodes");
+    assert_eq!(group_payload.target_type, Some(InviteTargetType::Group));
+
+    let session_token = fx
+        .service
+        .create_session_invite_token(fx.cmd(&session_id, Some("bot-a")))
+        .await
+        .expect("participant may mint a session token");
+    let session_payload =
+        invite_token_decode_no_expiry(&session_token.invite_token, SECRET).expect("decodes");
+    assert_eq!(session_payload.target_type, Some(InviteTargetType::Session));
+}
+
+#[tokio::test]
+async fn session_token_rejected_on_group_join() {
+    // A session invite token presented to `POST /groups/join/{token}` is
+    // rejected instead of being treated as a group id.
+    let fx = Fixture::new().await;
+    fx.store_group("grp-1", "bot-a").await;
+    let session_id = fx
+        .create_session_with_participants(
+            "grp-1",
+            "bot-a",
+            vec![Participant::bot("bot-a", ParticipantRole::Driver)],
+        )
+        .await;
+    let token = fx
+        .service
+        .create_session_invite_token(fx.cmd(&session_id, Some("bot-a")))
+        .await
+        .expect("mint session token");
+
+    let error = fx
+        .service
+        .join_group_by_invite(JoinByInviteCommand {
+            token: token.invite_token,
+            staff_no: "staff-9".to_string(),
+            nick_name: None,
+        })
+        .await
+        .expect_err("session token must not join via the group path");
+
+    assert!(
+        matches!(error, InviteUseCaseError::InvalidToken(_)),
+        "expected InvalidToken, got {error:?}",
+    );
+}
+
+#[tokio::test]
+async fn group_token_rejected_on_session_join() {
+    // A group invite token presented to `POST /sessions/join/{token}` is
+    // rejected instead of being treated as a session id.
+    let fx = Fixture::new().await;
+    fx.store_group("grp-1", "bot-a").await;
+    let token = fx
+        .service
+        .create_group_invite_token(fx.cmd("grp-1", Some("bot-a")))
+        .await
+        .expect("mint group token");
+
+    let error = fx
+        .service
+        .join_session_by_invite(JoinByInviteCommand {
+            token: token.invite_token,
+            staff_no: "staff-9".to_string(),
+            nick_name: None,
+        })
+        .await
+        .expect_err("group token must not join via the session path");
+
+    assert!(
+        matches!(error, InviteUseCaseError::InvalidToken(_)),
+        "expected InvalidToken, got {error:?}",
+    );
+}
+
+#[tokio::test]
+async fn typed_token_joins_matching_target() {
+    // Happy path: the typed tokens still join through their own endpoint.
+    let fx = Fixture::new().await;
+    fx.store_group("grp-1", "bot-a").await;
+    let session_id = fx
+        .create_session_with_participants(
+            "grp-1",
+            "bot-a",
+            vec![Participant::bot("bot-a", ParticipantRole::Driver)],
+        )
+        .await;
+
+    let group_token = fx
+        .service
+        .create_group_invite_token(fx.cmd("grp-1", Some("bot-a")))
+        .await
+        .expect("mint group token");
+    let joined = fx
+        .service
+        .join_group_by_invite(JoinByInviteCommand {
+            token: group_token.invite_token,
+            staff_no: "staff-9".to_string(),
+            nick_name: None,
+        })
+        .await
+        .expect("group token joins via the group path");
+    assert!(joined.joined);
+    assert_eq!(joined.target_type, "group");
+
+    let session_token = fx
+        .service
+        .create_session_invite_token(fx.cmd(&session_id, Some("bot-a")))
+        .await
+        .expect("mint session token");
+    let joined = fx
+        .service
+        .join_session_by_invite(JoinByInviteCommand {
+            token: session_token.invite_token,
+            staff_no: "staff-8".to_string(),
+            nick_name: None,
+        })
+        .await
+        .expect("session token joins via the session path");
+    assert!(joined.joined);
+    assert_eq!(joined.target_type, "session");
+}
+
+#[tokio::test]
+async fn pre_field_legacy_token_still_joins_both_paths() {
+    // Tokens minted before `target_type` existed decode to `None` and keep
+    // working on both legacy join endpoints (already-distributed links must
+    // not break). V1 `acceptInvitation` still rejects them by contract.
+    let fx = Fixture::new().await;
+    fx.store_group("grp-1", "bot-a").await;
+    let session_id = fx
+        .create_session_with_participants(
+            "grp-1",
+            "bot-a",
+            vec![Participant::bot("bot-a", ParticipantRole::Driver)],
+        )
+        .await;
+    let exp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock")
+        .as_secs()
+        + 3600;
+
+    let group_token = invite_token_encode(
+        &InviteTokenPayload {
+            v: 1,
+            id: "grp-1".to_string(),
+            exp,
+            target_type: None,
+        },
+        SECRET,
+    );
+    let joined = fx
+        .service
+        .join_group_by_invite(JoinByInviteCommand {
+            token: group_token,
+            staff_no: "staff-9".to_string(),
+            nick_name: None,
+        })
+        .await
+        .expect("pre-field token still joins the group path");
+    assert!(joined.joined);
+
+    let session_token = invite_token_encode(
+        &InviteTokenPayload {
+            v: 1,
+            id: session_id,
+            exp,
+            target_type: None,
+        },
+        SECRET,
+    );
+    let joined = fx
+        .service
+        .join_session_by_invite(JoinByInviteCommand {
+            token: session_token,
+            staff_no: "staff-8".to_string(),
+            nick_name: None,
+        })
+        .await
+        .expect("pre-field token still joins the session path");
+    assert!(joined.joined);
 }


### PR DESCRIPTION
## Problem

Invite links minted by the legacy `bcs-http` routes (`create_group_invite_link` / `create_session_invite_link`) carry no `target_type` in the token payload. As a result:

- The V1 `POST /openapi/v1/collaboration/invitations/{token}/accept` endpoint rejects them with `invalid_request` ("legacy invitation token without target_type is not supported by V1"), so links shared from the legacy routes cannot be accepted through the V1 API.
- The split legacy join endpoints (`POST /groups/join/{token}` and `POST /sessions/join/{token}`) cannot tell a group token from a session token; a token presented to the wrong path is only caught later by a confusing "group/session not found" lookup.

## Solution

- Legacy minting (`InviteServiceImpl::make_token`) now always embeds `target_type`: `Group` for group invite links, `Session` for session invite links — the same self-describing format V1 already mints.
- `join_group_by_invite` / `join_session_by_invite` validate the decoded `target_type` against the endpoint; a mismatch is rejected as `InvalidToken` (HTTP 401 via the existing bcs-http error mapping) instead of attempting a lookup with the wrong id kind.
- Backward compatibility: tokens minted before this change decode to `target_type: None` (serde default) and are still honored by both legacy join endpoints, so already-distributed links keep working. V1 accept keeps its contract of rejecting untyped tokens, but now accepts fresh legacy-route tokens because they are typed.

## Validation

- New unit tests in `bcs-group/tests/invite.rs` (5): minted tokens carry target_type; session token rejected on group join; group token rejected on session join; typed tokens join their matching endpoint; pre-field untyped tokens still join both legacy paths. 10/10 pass.
- New V1 facade tests in `bcs-app-invitation` (2): legacy-route group/session tokens are accepted via V1 `accept_invitation` and join the target. 36/36 pass.
- HTTP-level e2e `invite_integration` (bootstrap): 5/5 pass.
- `cargo test` for bcs-group and bcs-http: all pass; `cargo check --workspace --all-targets`: clean.