### PR TITLE
fix(backend): persist verified owner names during bot creation

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/create_with_manifest.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/create_with_manifest.py
@@ -37,6 +37,7 @@ from agentclaw.community.adapters.http.openapi_v1.contracts import (
     Envelope,
 )
 from agentclaw.community.adapters.http.openapi_v1.principal import (
+    OwnerNameDep,
     UserIdDep,
     refuse_app_only_caller,
 )
@@ -143,6 +144,7 @@ async def create_bot_with_manifest(
     body: BotCreateWithManifest,
     request: Request,
     owner_id: UserIdDep,
+    owner_name: OwnerNameDep,
     bot_service: BotServiceProtocol = Injected(BotServiceProtocol),
     bot_repo: BotRepository = Injected(BotRepository),
     passport_plugin: PassportPlugin = Injected(PassportPlugin),
@@ -197,6 +199,7 @@ async def create_bot_with_manifest(
 
     submitted = submit_bot_creation_with_manifest(
         user_id=owner_id,
+        nick_name=owner_name,
         bot_id=bot_id,
         document=body.config_manifest,
         modifier=owner_id,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py
@@ -45,6 +45,7 @@ from agentclaw.community.adapters.http.openapi_v1.dependencies import (
 from agentclaw.community.adapters.http.openapi_v1.log_safe import for_log
 from agentclaw.community.adapters.http.openapi_v1.admission import ActingCaller
 from agentclaw.community.adapters.http.openapi_v1.principal import (
+    OwnerNameDep,
     ActingCallerDep,
     UserIdDep,
     refuse_app_only_caller,
@@ -529,6 +530,7 @@ async def create_bot(
     body: BotCreate,
     request: Request,
     owner_id: UserIdDep,
+    owner_name: OwnerNameDep,
     bot_service: BotServiceProtocol = Injected(BotServiceProtocol),
     bot_repo: BotRepository = Injected(BotRepository),
     passport_plugin: PassportPlugin = Injected(PassportPlugin),
@@ -576,7 +578,7 @@ async def create_bot(
     bot_id = generate_bot_id(owner_id, bot_repo)
     outcome = create_bot_with_authorization(
         user_id=owner_id,
-        nick_name=owner_id,
+        nick_name=owner_name,
         bot_id=bot_id,
         spec=BotCreateSpec(
             entity_id=owner_id,
@@ -1160,6 +1162,7 @@ def _complete_auth_status(
     bot_id: str,
     request: Request,
     owner_id: str,
+    owner_name: str,
     engine: str | None,
     cluster_name: ClusterName | None,
     bot_name: str | None,
@@ -1208,7 +1211,7 @@ def _complete_auth_status(
     try:
         result = complete_bot_authorization(
             user_id=owner_id,
-            nick_name=owner_id,
+            nick_name=owner_name,
             bot_id=bot_id,
             spec=BotCreateSpec(
                 entity_id=owner_id,
@@ -1272,6 +1275,7 @@ async def poll_bot_auth_status(
     body: BotAuthStatusPoll,
     request: Request,
     owner_id: UserIdDep,
+    owner_name: OwnerNameDep,
     bot_service: BotServiceProtocol = Injected(BotServiceProtocol),
     passport_plugin: PassportPlugin = Injected(PassportPlugin),
     auth_rel_plugin: AuthRelationshipPlugin = Injected(AuthRelationshipPlugin),
@@ -1306,6 +1310,7 @@ async def poll_bot_auth_status(
         bot_id=bot_id,
         request=request,
         owner_id=owner_id,
+        owner_name=owner_name,
         engine=body.engine,
         cluster_name=body.cluster_name,
         bot_name=body.bot_name,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/deprecated/auth_status.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/deprecated/auth_status.py
@@ -39,7 +39,7 @@ from agentclaw.community.adapters.http.openapi_v1.contracts import (
     BotIdPath,
     Envelope,
 )
-from agentclaw.community.adapters.http.openapi_v1.principal import UserIdDep
+from agentclaw.community.adapters.http.openapi_v1.principal import OwnerNameDep, UserIdDep
 from agentclaw.community.adapters.http.openapi_v1.responses import envelope_errors
 from agentclaw.community.api.bot_service import BotServiceProtocol
 from agentclaw.community.core.bot_inventory.protocols import (
@@ -60,6 +60,7 @@ async def get_bot_auth_status(
     bot_id: BotIdPath,
     request: Request,
     owner_id: UserIdDep,
+    owner_name: OwnerNameDep,
     engine: Annotated[
         str | None,
         Query(
@@ -131,6 +132,7 @@ async def get_bot_auth_status(
         bot_id=bot_id,
         request=request,
         owner_id=owner_id,
+        owner_name=owner_name,
         engine=engine,
         cluster_name=cluster_name,
         bot_name=bot_name,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/principal.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/principal.py
@@ -277,6 +277,21 @@ async def require_user_id(
 UserIdDep = Annotated[str, Depends(require_user_id)]
 
 
+async def require_owner_name(
+    user_id: UserIdDep,
+    principal: Annotated[Principal, Depends(require_principal)],
+) -> str:
+    """Use the verified owner's display name, retaining the ID fallback."""
+    user = getattr(principal, "user", None)
+    # COSEC: delegated callers must not lend their identity to another owner.
+    if user is not None and user.id == user_id and user.display_name:
+        return user.display_name.strip() or user_id
+    return user_id
+
+
+OwnerNameDep = Annotated[str, Depends(require_owner_name)]
+
+
 async def require_acting_caller(
     request: Request,
     principal: Annotated[Principal, Depends(require_principal)],

--- a/src/backend/src/agentclaw/community/core/bot_management/README.md
+++ b/src/backend/src/agentclaw/community/core/bot_management/README.md
@@ -85,3 +85,16 @@ internal_dependencies:
 ### Change impact
 
 Highest-fanout domain — 12+ other core domains import it. BotService signature changes ripple widely. Repository protocol changes break the corresponding plugin_impl repos.
+
+## Owner display name on OpenAPI creation
+
+OpenAPI creation supplies the matching verified gateway user's nonblank
+`display_name` as `nick_name`, stripping surrounding whitespace. When no matching
+user display name is available, the owner ID remains the fallback. The existing
+`ac_bots.owner_name` column persists this value; catalog search projects it
+without substituting the entity ID.
+
+Create-with-manifest freezes `nick_name` in the durable job's `spec` at submission,
+so background completion does not depend on request identity context. Jobs queued
+before this field was introduced remain readable and fall back to their `user_id`.
+This requires no database migration and does not backfill historical Bot rows.

--- a/src/backend/src/agentclaw/community/core/bot_management/create_flow.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/create_flow.py
@@ -574,6 +574,7 @@ class ManifestCreationSubmitted:
 def submit_bot_creation_with_manifest(
     *,
     user_id: str,
+    nick_name: str,
     bot_id: str,
     document: str,
     modifier: str,
@@ -653,6 +654,7 @@ def submit_bot_creation_with_manifest(
     # can.
     try:
         return _apply_and_hand_off(
+            nick_name=nick_name,
             manifest_seam=manifest_seam,
             passport_plugin=passport_plugin,
             skill_set_factory=skill_set_factory,
@@ -676,6 +678,7 @@ def _apply_and_hand_off(
     passport_plugin: PassportPlugin,
     skill_set_factory: SkillSetServiceFactory,
     user_id: str,
+    nick_name: str,
     bot_id: str,
     entity_id: str,
     bot_name: str | None,
@@ -740,7 +743,7 @@ def _apply_and_hand_off(
         entity_id=entity_id,
         user_id=user_id,
         document_owner=user_id,
-        spec=creation_spec_to_payload(spec, context),
+        spec={**creation_spec_to_payload(spec, context), "nick_name": nick_name},
         iframe_url=iframe_url,
         redirect_url=redirect_url,
     )
@@ -827,7 +830,8 @@ def complete_manifest_creation(
     user_id = str(job_payload["user_id"])
     return complete_bot_authorization(
         user_id=user_id,
-        nick_name=user_id,
+        # Tasks submitted before owner-name propagation contain no nickname.
+        nick_name=job_payload["spec"].get("nick_name", user_id),
         bot_id=str(job_payload["bot_id"]),
         spec=spec,
         context=context,

--- a/src/backend/tests/community/core/bot_management/test_create_flow_with_manifest.py
+++ b/src/backend/tests/community/core/bot_management/test_create_flow_with_manifest.py
@@ -82,6 +82,7 @@ def _submit(seam, apply_result=None, passport=None):
     skill_set_factory = MagicMock()
     skill_set_factory.create.return_value.get_bot_mcp_codes.return_value = []
     outcome = submit_bot_creation_with_manifest(
+        nick_name="Test Owner",
         user_id="u1",
         bot_id="b_1",
         document=_DOCUMENT,

--- a/src/backend/tests/community/endpoints/test_openapi_bot_owner_name.py
+++ b/src/backend/tests/community/endpoints/test_openapi_bot_owner_name.py
@@ -1,0 +1,156 @@
+"""Trusted display names survive creation and durable manifest completion."""
+
+import jwt
+import pytest
+from fastapi.testclient import TestClient
+
+from agentclaw.community.adapters.http.openapi_v1.dependencies import PRINCIPAL_HEADER
+from agentclaw.community.core.bot_public.catalog_metadata import (
+    BotCatalogAddress,
+    BotCatalogMetadata,
+    BotCatalogMetadataPage,
+    BotCatalogMetadataServiceProtocol,
+)
+from agentclaw.community.core.repository.protocols.bot import BotRepository
+from tests.community.framework import bind_overrides
+from tests.community.endpoints.test_openapi_bot_auth_status import (
+    _KEY,
+    _OWNER,
+    _principal,
+    _seed_for_completion,
+)
+from tests.community.endpoints.test_openapi_create_with_manifest import _Worker
+
+
+@pytest.fixture
+def client(app_with_testing_modules):
+    return TestClient(app_with_testing_modules)
+
+
+@pytest.mark.parametrize("flow", ["create", "post-auth", "get-auth", "manifest"])
+@pytest.mark.parametrize(
+    ("display_name", "expected"),
+    [("  张三  ", "张三"), (None, _OWNER), ("", _OWNER), ("   ", _OWNER)],
+)
+def test_creation_persists_verified_owner_name(
+    client, world, flow, display_name, expected
+):
+    _seed_for_completion(world)
+    claims = jwt.decode(_principal(), _KEY, algorithms=["HS256"], audience="backend")
+    claims["principals"][0]["subject"]["display_name"] = display_name
+    headers = {PRINCIPAL_HEADER: jwt.encode(claims, _KEY, algorithm="HS256")}
+    params = {"user_id": _OWNER}
+    body = {
+        "engine": "openclaw",
+        "bot_name": "Owner Name Bot",
+        "bot_desc": "owner regression",
+        "cluster_name": "ACRA",
+        "bot_type": "personal",
+    }
+    bot_id = "owner-name-bot"
+    if flow == "create":
+        response = client.post(
+            "/openapi/v1/bots", params=params, headers=headers, json=body
+        )
+    elif flow == "manifest":
+        response = client.post(
+            "/openapi/v1/bots/with-manifest",
+            params=params,
+            headers=headers,
+            json={**body, "config_manifest": "schema_version: 1\n"},
+        )
+    elif flow == "post-auth":
+        response = client.post(
+            f"/openapi/v1/bots/{bot_id}/auth-status",
+            params=params,
+            headers=headers,
+            json=body,
+        )
+    else:
+        response = client.get(
+            f"/openapi/v1/bots/{bot_id}/auth-status",
+            params={**params, **body},
+            headers=headers,
+        )
+    assert response.status_code in (200, 201, 202), response.text
+    if flow in ("create", "manifest"):
+        bot_id = response.json()["data"]["bot_id"]
+    if flow == "manifest":
+        # Drive authorization until persistence, without waiting for a container.
+        worker = _Worker(world)
+        for _ in range(8):
+            worker.turn()
+            if world.get(BotRepository).get_by_id_and_entity(bot_id, _OWNER):
+                break
+    row = world.get(BotRepository).get_by_id_and_entity(bot_id, _OWNER)
+    assert row is not None, response.text
+    assert row["owner_name"] == expected
+    assert row["owner_id"] == _OWNER
+    assert row["entity_id"] == _OWNER
+
+    def catalog_metadata(_self, **_kwargs):
+        return BotCatalogMetadataPage(
+            total=1,
+            items=[BotCatalogMetadata(BotCatalogAddress(bot_id, _OWNER), kind="bot")],
+        )
+
+    bind_overrides(
+        world,
+        BotCatalogMetadataServiceProtocol,
+        {"search_public_bot_metadata": catalog_metadata},
+    )
+    catalog = client.get("/openapi/v1/bots/catalog/search", headers=headers)
+    assert catalog.status_code == 200, catalog.text
+    items = catalog.json()["data"]["items"]
+    assert len(items) == 1
+    assert items[0]["owner_name"] == expected
+    assert items[0]["entity_id"] == _OWNER
+
+
+def test_manifest_completion_accepts_pre_upgrade_job_without_nickname(world):
+    from agentclaw.community.core.bot_management.create_flow import (
+        complete_manifest_creation,
+    )
+    from agentclaw.community.core.bot_management.services.bot_service import BotService
+    from agentclaw.community.plugin_api.auth_relationship import AuthRelationshipPlugin
+    from agentclaw.community.plugin_api.passport import PassportPlugin
+
+    _seed_for_completion(world)
+    complete_manifest_creation(
+        {
+            "user_id": _OWNER,
+            "bot_id": "legacy-owner-name-bot",
+            "spec": {
+                "entity_id": _OWNER,
+                "engine_type": "openclaw",
+                "bot_type": "personal",
+                "bot_name": "Legacy Job Bot",
+                "template_validation_mode": "public",
+                "deployment_mode": "cloud",
+                "space_kind": "personal",
+            },
+        },
+        bot_service=world.get(BotService),
+        passport_plugin=world.get(PassportPlugin),
+        auth_rel_plugin=world.get(AuthRelationshipPlugin),
+        provision=False,
+    )
+    row = world.get(BotRepository).get_by_id_and_entity("legacy-owner-name-bot", _OWNER)
+    assert row["owner_name"] == _OWNER
+
+
+def test_create_rejects_owner_id_different_from_verified_user(client, world):
+    _seed_for_completion(world)
+    response = client.post(
+        "/openapi/v1/bots",
+        params={"user_id": "another-owner"},
+        headers={PRINCIPAL_HEADER: _principal()},
+        json={
+            "engine": "openclaw",
+            "bot_name": "Wrong Owner Bot",
+            "bot_desc": "identity boundary",
+            "cluster_name": "ACRA",
+            "bot_type": "personal",
+        },
+    )
+    assert response.status_code == 403, response.text


### PR DESCRIPTION
## Problem

`GET /openapi/v1/bots/catalog/search` returns the owner's entity ID as `owner_name` even when the verified gateway identity includes a display name. OpenAPI creation and authorization completion passed the owner ID as `nick_name`, and the creation service persisted that value in `ac_bots.owner_name`. The catalog correctly projected the incorrectly stored value. Durable create-with-manifest completion had the same issue.

## Solution

- Resolve the owner's nonblank, trimmed `display_name` from the existing verified gateway principal, only when its user ID matches the authorized owner.
- Pass the resolved name through ordinary creation and both POST and legacy GET authorization completion.
- Freeze the name in the create-with-manifest job specification and reuse it during background completion.
- Preserve the owner-ID fallback for missing/blank display names and jobs submitted before this change.
- Add regression tests exercising real creation, database persistence, and catalog projection, plus old-job compatibility and cross-user rejection. Only external BaaS/catalog edges are stubbed.

## Validation

- Before the fix, the four named-owner creation paths failed with the stored owner ID instead of the display name; the 12 missing/blank-name cases passed.
- Final focused regression suite: **18 passed**.
- Expanded OpenAPI, endpoint, bot-management, catalog, gateway-principal, manifest, and architecture suites: **4140 passed, 2 skipped, 47 warnings**.
- Ruff on changed Python files and `git diff --check`: passed.
- PR title validator: passed.
- Full Backend CI gate: **17790 passed, 60 skipped, 679 warnings**; line coverage **88.76%**, changed-line coverage **100% (7/7)**. Existing environment dependencies were reused (`BACKEND_CI_SKIP_INSTALL=1`); no test or coverage threshold was disabled.
- Changed-file Python SAST block scan: passed.
- Full pre-push was attempted with `OCB_PRE_PUSH_RUN_CI=1`, base `origin/REL20260908`. The Singlebox gate could not start its instrumented stack because `cargo-llvm-cov` is not installed. Singlebox E2E and runtime coverage are **not verified**.
- The requester explicitly approved opening this as a **Draft PR** with the local Singlebox tooling limitation recorded as an exception. This is not a claim that the full gate passed or approval to merge without the required checks.

## Compatibility and risk

- No request/response schema, database schema, or authorization-policy change.
- Existing Bot rows are not backfilled. A missing display name still intentionally falls back to the owner ID.
- Old queued jobs remain readable. New job specifications contain an additive nickname field.
- Rollback: revert this commit; no data migration is required. Existing stored names are retained.

## Spec

The persistence and durable-job compatibility behavior is documented in `src/backend/src/agentclaw/community/core/bot_management/README.md`.
