### PR TITLE
fix(bcsfuse): include success in worker config responses

### DIFF
--- a/src/bcsfuse/docs/api/api-reference.md
+++ b/src/bcsfuse/docs/api/api-reference.md
@@ -1252,13 +1252,22 @@ curl http://localhost:8765/v1/workers/my-bot-001/profiles/quality \
 
 ```json
 {
+  "success": true,
   "worker_id": "my-bot-001",
+  "fusion_enable": true,
   "config": {
+    "fusion_enable": true,
     "max_concurrent_tasks": 5,
     "timeout_seconds": 30
-  }
+  },
+  "version": 9,
+  "updated_at": "2026-09-07T03:59:00"
 }
 ```
+
+Successful GET and PUT `/v1/workers/{worker_id}/config` responses include
+`success: true`, including when `fusion_enable` is false. Errors retain their
+non-2xx HTTP status and error response.
 
 **Status Codes:**
 

--- a/src/bcsfuse/src/interfaces/api/schemas/worker_management_schemas.py
+++ b/src/bcsfuse/src/interfaces/api/schemas/worker_management_schemas.py
@@ -410,12 +410,18 @@ class WorkerConfigResponse(BaseModel):
     Worker config response.
 
     Attributes:
+        success: Whether the configuration request succeeded
         worker_id: Worker ID
         fusion_enable: Whether fusion is enabled
         config: Full configuration
         version: Config version
         updated_at: Last update timestamp
     """
+
+    success: bool = Field(
+        default=True,
+        description="Whether the configuration request succeeded",
+    )
 
     worker_id: str = Field(
         description="Worker ID",

--- a/src/bcsfuse/tests/contract/test_public_safe_contract_models.py
+++ b/src/bcsfuse/tests/contract/test_public_safe_contract_models.py
@@ -17,6 +17,25 @@ import pytest
 from pydantic import ValidationError
 
 
+@pytest.mark.parametrize("fusion_enable", [True, False])
+def test_worker_config_response_includes_success(fusion_enable):
+    """GET/PUT config responses must satisfy the frontend Worker config contract."""
+    from src.interfaces.api.schemas.worker_management_schemas import WorkerConfigResponse
+
+    response = WorkerConfigResponse(
+        worker_id="test-bot:test-owner",
+        fusion_enable=fusion_enable,
+        config={"fusion_enable": fusion_enable},
+        version=9,
+    ).model_dump(mode="json")
+
+    assert response["success"] is True
+    assert response["fusion_enable"] is fusion_enable
+    assert response["config"] == {"fusion_enable": fusion_enable}
+    assert response["worker_id"] == "test-bot:test-owner"
+    assert response["version"] == 9
+
+
 class TestSchemaModuleImports:
     """Test that all schema modules import successfully."""
 


### PR DESCRIPTION
## Problem
Worker config responses omit `success`, but frontend-nextgen requires it to be a boolean. This causes valid responses with `fusion_enable: true` to fail validation, hiding eligible Bots from fusion mode.

## Solution
Add `success: true` to the shared response model for GET and PUT worker config endpoints. Preserve existing fields and error behavior, and update the API documentation.

No frontend or gateway changes are required.

## Validation
- Added regression coverage for both enabled and disabled fusion configurations.
- All 34 contract model tests passed.
- `git diff --check` and the lint-only pre-push gate passed.
- Live deployment and browser verification have not been performed.