### PR TITLE
fix(clawweb): install dynamic OCB workspace locally

### DIFF
--- a/src/evolverun/clawweb/scripts/start-clawweb.sh
+++ b/src/evolverun/clawweb/scripts/start-clawweb.sh
@@ -121,16 +121,16 @@ if [ "$DATABASE_MODE" = "sqlite" ] && [ -z "${SQLITE_PATH:-}" ]; then
   export SQLITE_PATH="$local_state_dir/engine.db"
 fi
 
-# The OCB workspace links public packages to their real Avernet paths. Install
-# both roots from lockfiles so platform-specific optional dependencies resolve
-# correctly on macOS/Linux and ARM/x64 without relying on existing node_modules.
+# The Avernet workspace has a committed lockfile. The OCB composition workspace
+# intentionally has no committed lockfile because its public workspaces are linked
+# at runtime, so use npm install there to generate/update the local composition lock.
 (
   cd "$clawweb_root"
   npm ci --include=optional --no-audit --no-fund
 )
 
 cd "$ocb_clawweb"
-npm ci --include=optional --no-audit --no-fund
+npm install --include=dev --include=optional --no-audit --no-fund
 npm run build
 
 export CLAWWEB_DEPLOY_PROFILE="internal"


### PR DESCRIPTION
## Summary

Fix ClawWeb local startup when using a dynamically linked composition workspace.

## Problem

The startup script used `npm ci` for both the Avernet workspace and the linked composition workspace. The latter does not maintain a committed lockfile because its workspace dependencies are resolved dynamically, so a stale or missing lockfile could block startup.

## Changes

- Keep `npm ci` for the Avernet workspace with its committed lockfile.
- Use `npm install` for the dynamically linked composition workspace.
- Preserve the existing package-based composition and startup behavior.

## Validation

Verified local startup with Node.js 22:

- Package boundary validation passed.
- All workspace packages built successfully.
- Database connection succeeded.
- ClawWeb started successfully on port `5173`.

## Scope

This change only affects the local startup script. It does not modify business logic, CI behavior, or deployment behavior.