### PR TITLE
fix(frontend): sync friend bot workspace behavior

### DIFF
--- a/src/frontend-nextgen/OPEN_CORE_MANIFEST.json
+++ b/src/frontend-nextgen/OPEN_CORE_MANIFEST.json
@@ -1,6 +1,6 @@
 {
   "sourceRepository": "teamclaw",
-  "sourceCommit": "bccac60ecf92d4f591e02cfb8bb1d455b917a4b1",
+  "sourceCommit": "4c2bf71f8f30fbcc426d29f1c0f2873b71e217cf",
   "sourceDirty": false,
   "exportSchemaVersion": 1,
   "target": "src/frontend-nextgen",

--- a/src/frontend-nextgen/src/domain/collaborationSquare/types.ts
+++ b/src/frontend-nextgen/src/domain/collaborationSquare/types.ts
@@ -213,6 +213,11 @@ export interface OpenBotConversationResult {
   sessionId: string;
 }
 
+/** 打开 Bot 单聊的附加选项：目标 Bot 归登录用户所有时不传 f_user_id（仅好友 Bot 传）。 */
+export interface OpenBotConversationOptions {
+  isOwnedByLoggedInUser?: boolean;
+}
+
 /** 创建公开协作群会话的表单入参（OpenAPI POST /groups/{group_id}/sessions body）。 */
 export interface CreateGroupSessionPayload {
   /** 会话名称（接口 body.title）。 */

--- a/src/frontend-nextgen/src/hooks/useCollaborationSquare.ts
+++ b/src/frontend-nextgen/src/hooks/useCollaborationSquare.ts
@@ -166,7 +166,9 @@ export function useCollaborationSquare(resource: SquareResource) {
         void runBusy(
           busyKey,
           async () => {
-            const result = await collaborationSquareBotService.openBotConversation(bot.id, humanBotContext);
+            const result = await collaborationSquareBotService.openBotConversation(bot.id, humanBotContext, {
+              isOwnedByLoggedInUser: Boolean(bot.isOwnedByLoggedInUser),
+            });
             history.push(getCollaborationBotConversationUrl(bot.id, result.sessionId));
           },
           bot.id,

--- a/src/frontend-nextgen/src/pages/Workspace/GroupWorkspaceArea.tsx
+++ b/src/frontend-nextgen/src/pages/Workspace/GroupWorkspaceArea.tsx
@@ -65,6 +65,15 @@ export function GroupWorkspaceArea({
   const selectedGroup = ws.selectedGroup;
   const canManage = ws.canManageGroup;
 
+  // 管理面板打开期间跟随选中群补拉详情：打开面板（齿轮/「…」菜单）或面板保持打开时切群，
+  // 都会为新选中群拉取 participants 等详情；否则列表项 participants 为空且 participantCount>0，
+  // 「群成员管理」card 会一直停留在「加载中…」。面板关闭时不拉取（保持按需拉取约定）。
+  const { selectedGroupId, reloadSelectedGroup } = ws;
+  React.useEffect(() => {
+    if (activePanel !== 'manage' || !selectedGroupId) return;
+    void reloadSelectedGroup(selectedGroupId);
+  }, [activePanel, selectedGroupId, reloadSelectedGroup]);
+
   const handleDissolve = () => {
     if (!ws.selectedGroupId) return;
     void ws.dissolveGroup(ws.selectedGroupId);
@@ -107,18 +116,13 @@ export function GroupWorkspaceArea({
   const handleShareSession = () => sessionManage.createShare();
   const handleCreateSession = (groupId: string) => void sessions.createSessionIn(groupId);
   const handleCreateGroup = () => createGroupDialog.openModal();
-  // 侧栏「…」菜单：群管理（选中该群并打开管理面板，按需拉取群详情）。
+  // 侧栏「…」菜单：群管理（选中该群并打开管理面板；详情由上方 effect 按需补拉）。
   const handleManageGroup = (groupId: string) => {
     ws.onSelectGroup(groupId);
     setActivePanel('manage');
-    // 列表项不含 participants/owner/driver，打开管理（查看/编辑）时补齐群详情。
-    void ws.reloadSelectedGroup(groupId);
   };
-  // 头部齿轮切面板：打开群管理时按需拉取当前选中群详情。
+  // 头部齿轮切面板：打开群管理时详情由上方 effect 按需补拉。
   const handleTogglePanel = (panel: GroupPanelKind) => {
-    if (panel === 'manage' && activePanel !== 'manage' && ws.selectedGroupId) {
-      void ws.reloadSelectedGroup(ws.selectedGroupId);
-    }
     setActivePanel(panel);
   };
   const handleManageSession = (groupId: string, sessionId: string) => {
@@ -276,9 +280,7 @@ export function GroupWorkspaceArea({
           sessionId={sessions.selectedSession.sessionId}
           sessionName={sessions.selectedSession.title}
           participants={sessions.selectedSession.participants}
-          authenticatedUser={
-            userIdentityId ? { userId: userIdentityId, name: userIdentityName } : null
-          }
+          authenticatedUser={userIdentityId ? { userId: userIdentityId, name: userIdentityName } : null}
           onClose={() => setActivePanel('none')}
         />
       )}

--- a/src/frontend-nextgen/src/pages/Workspace/hooks/useBotSessionMap.ts
+++ b/src/frontend-nextgen/src/pages/Workspace/hooks/useBotSessionMap.ts
@@ -2,10 +2,11 @@ import { appendUnique } from '@/services/workspace/botSessionHelpers';
 import type { BotChatSessionView, ChatBotView } from '@/services/workspace/botSessionService';
 import { BOT_SESSION_PAGE_SIZE, botSessionService } from '@/services/workspace/botSessionService';
 import { useWorkspaceStore } from '@/stores/workspaceStore';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 
 import type { BotSessionPageMeta, UseBotSessionMapResult } from './useBotSessionMap.types';
 import { errorBotPageMeta, hasMoreForPage, successBotPageMeta } from './useBotSessionMap.utils';
+import { useExpandedBotLoader } from './useExpandedBotLoader';
 export type { BotSessionPageMeta, UseBotSessionMapResult } from './useBotSessionMap.types';
 
 /** 以 botId 键控缓存各 bot 会话；首屏及追加均使用 10 条，身份切换清缓存。 */
@@ -78,19 +79,8 @@ export function useBotSessionMap(
     [syncLoadingState],
   );
 
-  useEffect(() => {
-    if (!activeIdentityId) return;
-    for (const bot of chatBots) {
-      if (
-        !bot.chatable ||
-        bot.isAgentCodingBot ||
-        !expandedBotIds.includes(bot.botId) ||
-        loadedRef.current.has(bot.botId)
-      )
-        continue;
-      void loadFirstPage(bot, activeIdentityId);
-    }
-  }, [activeIdentityId, chatBots, expandedBotIds, loadFirstPage]);
+  // 展开 transition 必重拉最新会话列表；持续展开按 loadedRef 去重（实现见 useExpandedBotLoader）。
+  useExpandedBotLoader(chatBots, expandedBotIds, activeIdentityId, loadFirstPage, loadedRef);
 
   const updateBotSessions = useCallback(
     (botId: string, fn: (list: BotChatSessionView[]) => BotChatSessionView[]) =>

--- a/src/frontend-nextgen/src/pages/Workspace/hooks/useBotSessions.ts
+++ b/src/frontend-nextgen/src/pages/Workspace/hooks/useBotSessions.ts
@@ -64,12 +64,13 @@ export function useBotSessions(
   }, [expandedBotIds, rawByBotId, selectedBotSessionId, selectBotSession]);
   const openSession = useCallback(
     (botId: string, sessionId: string) => {
-      // 确保 bot 已展开
-      if (!useWorkspaceStore.getState().expandedBotIds[botId]) toggleBotExpandedFromMap(botId);
+      if (!useWorkspaceStore.getState().expandedBotIds[botId]) {
+        toggleBotExpandedFromMap(botId, chatBots.find((b) => b.botId === botId)?.isFriendBot ? 'friend' : 'mine');
+      }
       selectBotSession(sessionId);
       useWorkspaceStore.getState().bumpHistoryRefresh();
     },
-    [toggleBotExpandedFromMap, selectBotSession],
+    [chatBots, toggleBotExpandedFromMap, selectBotSession],
   );
   const createSession = useCallback(
     async (bot: ChatBotView, title?: string): Promise<BotChatSessionView | null> => {

--- a/src/frontend-nextgen/src/pages/Workspace/hooks/useExpandedBotLoader.ts
+++ b/src/frontend-nextgen/src/pages/Workspace/hooks/useExpandedBotLoader.ts
@@ -1,0 +1,32 @@
+import type { ChatBotView } from '@/services/workspace/botSessionService';
+import type { MutableRefObject } from 'react';
+import { useEffect, useRef } from 'react';
+
+/**
+ * 展开 bot 的会话首屏懒加载（从 useBotSessionMap 抽出以守行数预算）：
+ * - bot 从「未展开 → 展开」的 transition 必然重拉首页——切换 bot 时拿到最新会话列表
+ *   （并发去重由 loadFirstPage 内 inFlightRef 承担；旧数据保留展示，成功后整体替换，无骨架闪烁）；
+ * - 持续展开的 bot 依赖 loadedRef 去重（chatBots 数组刷新等不重复请求），未加载成功过的允许重试。
+ * 身份切换的清缓存/在途失效由 useBotSessionMap 渲染期重置负责，本 hook 不感知代际。
+ */
+export function useExpandedBotLoader(
+  chatBots: ChatBotView[],
+  expandedBotIds: string[],
+  activeIdentityId: string | null,
+  loadFirstPage: (bot: ChatBotView, userId: string) => Promise<void>,
+  loadedRef: MutableRefObject<Set<string>>,
+): void {
+  const prevExpandedRef = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    if (!activeIdentityId) return;
+    const prev = prevExpandedRef.current;
+    const next = new Set(expandedBotIds);
+    prevExpandedRef.current = next;
+    for (const bot of chatBots) {
+      if (!bot.chatable || bot.isAgentCodingBot || !next.has(bot.botId)) continue;
+      const justExpanded = !prev.has(bot.botId);
+      if (loadedRef.current.has(bot.botId) && !justExpanded) continue;
+      void loadFirstPage(bot, activeIdentityId);
+    }
+  }, [activeIdentityId, chatBots, expandedBotIds, loadFirstPage, loadedRef]);
+}

--- a/src/frontend-nextgen/src/pages/Workspace/hooks/useFriendBotSectionSync.ts
+++ b/src/frontend-nextgen/src/pages/Workspace/hooks/useFriendBotSectionSync.ts
@@ -1,0 +1,21 @@
+import type { ChatBotView } from '@/services/workspace/botSessionService';
+import { useWorkspaceStore } from '@/stores/workspaceStore';
+import { useEffect } from 'react';
+
+/**
+ * 好友 bot 列表就绪后，纠正已展开好友 bot 的分区归属为 'friend'。
+ * 冷启动深链（?bot=好友bot）在展开时无法判定归属，store 缺省记 'mine'，
+ * 会让侧栏好友分区判定为折叠（expanded 需 sectionKey==='friend'）而看不到会话列表。
+ * 仅纠正「已展开且归属不是 friend」的项；未展开的好友 bot 与 mine 分区 bot 不受影响。
+ */
+export function useFriendBotSectionSync(friendBots: ChatBotView[]): void {
+  useEffect(() => {
+    if (friendBots.length === 0) return;
+    const store = useWorkspaceStore.getState();
+    for (const bot of friendBots) {
+      if (store.expandedBotIds[bot.botId] && store.expandedBotSectionKey[bot.botId] !== 'friend') {
+        store.setBotExpandedSection(bot.botId, 'friend');
+      }
+    }
+  }, [friendBots]);
+}

--- a/src/frontend-nextgen/src/pages/Workspace/hooks/useFriendBots.ts
+++ b/src/frontend-nextgen/src/pages/Workspace/hooks/useFriendBots.ts
@@ -3,6 +3,7 @@ import type { ChatBotView } from '@/services/workspace/botSessionService';
 import { splitBotId } from '@/services/workspace/botSessionService';
 import { collaborationCandidateService } from '@/services/workspace/collaborationCandidateService';
 import { useCallback, useEffect, useState } from 'react';
+import { useFriendBotSectionSync } from './useFriendBotSectionSync';
 
 export interface UseFriendBotsResult {
   friendBots: ChatBotView[];
@@ -92,6 +93,9 @@ export function useFriendBots(
   }, [activeIdentityId, isUserIdentity, enabled, reloadNonce]);
 
   const reload = useCallback(() => setReloadNonce((current) => current + 1), []);
+
+  // 列表就绪后纠正已展开好友 bot 的分区归属（冷启动深链缺省记 'mine' 会让好友行折叠、列表不可见）。
+  useFriendBotSectionSync(friendBots);
 
   return { friendBots, isLoading, error, reload };
 }

--- a/src/frontend-nextgen/src/pages/Workspace/hooks/useWorkspacePage.ts
+++ b/src/frontend-nextgen/src/pages/Workspace/hooks/useWorkspacePage.ts
@@ -94,8 +94,12 @@ export function useWorkspacePage(): UseWorkspacePageResult {
       if (user && store.activeIdentityId !== user.id) store.setActiveIdentityId(user.id);
       const workspace = useWorkspaceStore.getState();
       workspace.setView('chat');
+      // 已展开时保留 store 的分区归属（侧栏点击路径已写入 'friend'/'mine'）：本 effect 会在
+      // URL 回写（useChatUrlSync）后随 botParam 变化重跑，无条件覆盖 'mine' 会让好友 bot 行
+      // 被好友分区判定为折叠（expanded 需 sectionKey==='friend'），已加载的会话列表随之消失。
+      // 冷启动深链新展开走 store 缺省 'mine'，好友 bot 由 useFriendBotSectionSync 在列表就绪后纠正。
       if (!workspace.expandedBotIds[botParam]) workspace.toggleBotExpanded(botParam);
-      workspace.setBotExpandedSection(botParam, 'mine');
+      else if (!workspace.expandedBotSectionKey[botParam]) workspace.setBotExpandedSection(botParam, 'mine');
       if (sessionParam && workspace.selectedBotSessionId !== sessionParam) {
         workspace.selectBotSession(sessionParam);
         workspace.bumpHistoryRefresh();

--- a/src/frontend-nextgen/src/services/collaborationSquare/collaborationSquareApiAdapter.ts
+++ b/src/frontend-nextgen/src/services/collaborationSquare/collaborationSquareApiAdapter.ts
@@ -6,6 +6,7 @@ import type {
   FriendRequestActor,
   FriendRequestResult,
   HumanBotActionContext,
+  OpenBotConversationOptions,
   OpenBotConversationResult,
   PublicBot,
   PublicBotDiscoveryQuery,
@@ -187,7 +188,11 @@ export class CollaborationSquareApiAdapter implements CollaborationSquareGateway
     }
   }
 
-  async openBotConversation(botId: string, context: HumanBotActionContext): Promise<OpenBotConversationResult> {
+  async openBotConversation(
+    botId: string,
+    context: HumanBotActionContext,
+    options?: OpenBotConversationOptions,
+  ): Promise<OpenBotConversationResult> {
     try {
       const { realBotId, ownerId } = splitBotId(botId);
       if (!realBotId || !context.userId.trim())
@@ -197,7 +202,8 @@ export class CollaborationSquareApiAdapter implements CollaborationSquareGateway
         {
           user_id: context.userId,
           ...(ownerId ? { owner_id: ownerId } : {}),
-          f_user_id: context.userId,
+          // f_user_id 仅好友 Bot 会话需要；目标 Bot 归登录用户所有（自有 Bot）时不得携带。
+          ...(options?.isOwnedByLoggedInUser ? {} : { f_user_id: context.userId }),
         },
         {},
       );

--- a/src/frontend-nextgen/src/services/collaborationSquare/collaborationSquareGateway.ts
+++ b/src/frontend-nextgen/src/services/collaborationSquare/collaborationSquareGateway.ts
@@ -4,6 +4,7 @@ import type {
   FriendRequestActor,
   FriendRequestResult,
   HumanBotActionContext,
+  OpenBotConversationOptions,
   OpenBotConversationResult,
   PublicBot,
   PublicBotDiscoveryQuery,
@@ -36,7 +37,11 @@ export interface CollaborationSquareGateway {
     friendRequestBotId?: string,
     fromActor?: FriendRequestActor,
   ): Promise<FriendRequestResult>;
-  openBotConversation(botId: string, context: HumanBotActionContext): Promise<OpenBotConversationResult>;
+  openBotConversation(
+    botId: string,
+    context: HumanBotActionContext,
+    options?: OpenBotConversationOptions,
+  ): Promise<OpenBotConversationResult>;
   listGroupPage(query?: PublicGroupSearchQuery, signal?: AbortSignal): Promise<CollaborationSquarePage<PublicGroup>>;
   listGroups(query?: PublicGroupSearchQuery, signal?: AbortSignal): Promise<PublicGroup[]>;
   listGroupMembers(groupId: string, signal?: AbortSignal): Promise<PublicGroupMember[]>;

--- a/src/frontend-nextgen/src/services/collaborationSquare/collaborationSquareService.ts
+++ b/src/frontend-nextgen/src/services/collaborationSquare/collaborationSquareService.ts
@@ -2,6 +2,7 @@ import type {
   BotCatalogViewer,
   FriendRequestActor,
   HumanBotActionContext,
+  OpenBotConversationOptions,
   PublicBotDiscoveryQuery,
   PublicBotSearchQuery,
   PublicGroupSearchQuery,
@@ -118,8 +119,10 @@ export class CollaborationSquareService {
     );
   }
 
-  openBotConversation(botId: string, context: HumanBotActionContext) {
-    return this.runTargetAction(`conversation:${botId}`, () => this.gateway.openBotConversation(botId, context));
+  openBotConversation(botId: string, context: HumanBotActionContext, options?: OpenBotConversationOptions) {
+    return this.runTargetAction(`conversation:${botId}`, () =>
+      this.gateway.openBotConversation(botId, context, options),
+    );
   }
 
   createGroupSession(groupId: string, context?: HumanBotActionContext, options?: { title?: string; query?: string }) {

--- a/src/frontend-nextgen/src/shell/SpaceSwitcher.tsx
+++ b/src/frontend-nextgen/src/shell/SpaceSwitcher.tsx
@@ -10,7 +10,11 @@ import type { Space } from '@/domain/admin/models';
 import { refreshSpaceContext, switchSpaceContext, useSpaceContext } from '@/hooks/useSpaceContext';
 import { cn } from '@/utils/cn';
 import { CheckCircle, ChevronDown, Loader2, User, Users } from 'lucide-react';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
+
+// 打开气泡的刷新节流窗口：窗口内复用 store 现有列表，避免反复开合连打 GET /spaces?page_size=100。
+// plan.md D7「下次打开切换器时刷新」的兜底仍生效，远端变更最迟一个窗口后可见。
+const REFRESH_THROTTLE_MS = 60_000;
 
 function SpaceIcon({ type, className }: { type: Space['spaceType']; className?: string }) {
   // 个人=紫 User(text-brand)，团队=蓝 Users(text-primary)，与 SpaceCard 图标配色一致
@@ -56,6 +60,7 @@ function SpaceRow({ space, active, onSelect }: { space: Space; active: boolean; 
 
 export function SpaceSwitcher() {
   const [open, setOpen] = useState(false);
+  const lastRefreshAt = useRef(0);
   const currentSpace = useSpaceContext((s) => s.currentSpace);
   const currentSpaceId = useSpaceContext((s) => s.currentSpaceId);
   const spaces = useSpaceContext((s) => s.spaces);
@@ -67,10 +72,14 @@ export function SpaceSwitcher() {
     setOpen(false);
   };
 
-  // 每次打开气泡都重拉最新空间列表（成员变更/新空间可能发生在上次初始化之后）
+  // 打开气泡时按 REFRESH_THROTTLE_MS 节流重拉（成员变更/新空间可能发生在上次初始化之后）
   const onOpenChange = (next: boolean) => {
     setOpen(next);
-    if (next) void refreshSpaceContext();
+    if (!next) return;
+    const now = Date.now();
+    if (now - lastRefreshAt.current < REFRESH_THROTTLE_MS) return;
+    lastRefreshAt.current = now;
+    void refreshSpaceContext();
   };
 
   // 列表排序：个人空间置顶，团队按 gmtModified 倒序（与空间管理页一致）

--- a/src/frontend-nextgen/test/hooks/useCollaborationSquare.test.tsx
+++ b/src/frontend-nextgen/test/hooks/useCollaborationSquare.test.tsx
@@ -662,7 +662,7 @@ describe('useCollaborationSquare Bot Search', () => {
       await Promise.resolve();
     });
 
-    expect(openConversation).toHaveBeenCalledWith(bot.id, humanContext);
+    expect(openConversation).toHaveBeenCalledWith(bot.id, humanContext, { isOwnedByLoggedInUser: false });
     expect(legacyConversation).not.toHaveBeenCalled();
     expect(history.push).toHaveBeenCalledWith('/workspace?tab=chat&bot=bot-1%3A2088&session=session-1');
 
@@ -688,7 +688,7 @@ describe('useCollaborationSquare Bot Search', () => {
     });
 
     expect(requestFriendship).not.toHaveBeenCalled();
-    expect(openConversation).toHaveBeenCalledWith(bot.id, humanContext);
+    expect(openConversation).toHaveBeenCalledWith(bot.id, humanContext, { isOwnedByLoggedInUser: true });
     expect(history.push).toHaveBeenCalledWith('/workspace?tab=chat&bot=owned-bot&session=session-owned');
 
     unmount();

--- a/src/frontend-nextgen/test/pages/Workspace/GroupWorkspaceAreaManagePanel.test.tsx
+++ b/src/frontend-nextgen/test/pages/Workspace/GroupWorkspaceAreaManagePanel.test.tsx
@@ -1,0 +1,199 @@
+/**
+ * @jest-environment jsdom
+ *
+ * 覆盖 GroupWorkspaceArea 的群管理面板详情补拉编排：
+ * 面板保持打开时切换选中群，必须为新群重新拉取群详情（reloadSelectedGroup），
+ * 否则「群成员管理」card 因 participants 为空 + participantCount>0 永远显示「加载中…」。
+ */
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/jest-globals';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+const baseGroup = {
+  groupId: 'g1',
+  name: '主站群',
+  kind: 'free_chat' as const,
+  status: 'active' as const,
+  participants: [],
+  sessions: [],
+  lastMessageAt: 1,
+  createdAt: 1,
+  participantCount: 2,
+  isPublic: false,
+  deliveryPolicy: 'send_to_driver' as const,
+};
+
+// 可变 mock 状态：测试内切换 selectedGroupId 后 rerender，模拟侧栏切群。
+const mockState: { selectedGroupId: string | null } = { selectedGroupId: 'g1' };
+const mockReloadSelectedGroup = jest.fn();
+const mockOnSelectGroup = jest.fn();
+
+const mockStore = {
+  sessionTabsByGroup: {},
+  setSessionTabForGroup: jest.fn(),
+  selectGroup: jest.fn(),
+  membership: 'direct' as const,
+};
+
+jest.mock('@/stores/workspaceStore', () => ({
+  useWorkspaceStore: (selector?: (s: typeof mockStore) => unknown) => (selector ? selector(mockStore) : mockStore),
+}));
+jest.mock('@/services/workspace/sessionService', () => ({ sessionService: { getSessionDetail: jest.fn() } }));
+jest.mock('sonner', () => ({ toast: { info: jest.fn(), error: jest.fn(), success: jest.fn() } }));
+
+jest.mock('@/pages/Workspace/hooks/useGroupWorkspace', () => ({
+  useGroupWorkspace: () => ({
+    groups: [baseGroup],
+    expandedGroupIds: {} as Record<string, true>,
+    selectedGroupId: mockState.selectedGroupId,
+    selectedGroup: baseGroup,
+    canManageGroup: { allowed: true },
+    isLoadingGroups: false,
+    groupSearchText: '',
+    setGroupSearchText: jest.fn(),
+    kindFilter: 'all' as const,
+    setKindFilter: jest.fn(),
+    membership: 'direct' as const,
+    setMembership: jest.fn(),
+    sortMode: 'createdAt' as const,
+    setSortMode: jest.fn(),
+    toggleGroupExpanded: jest.fn(),
+    onSelectGroup: mockOnSelectGroup,
+    dissolveGroup: jest.fn(),
+    refreshGroups: jest.fn(),
+    retryGroups: jest.fn(),
+    groupsError: null,
+    reloadSelectedGroup: mockReloadSelectedGroup,
+    activeIdentity: null,
+    activeIdentityId: null,
+    identities: [],
+    canDissolveGroup: { allowed: false },
+  }),
+}));
+jest.mock('@/pages/Workspace/hooks/useGroupSessions', () => ({
+  useGroupSessions: () => ({
+    sessionsByGroupId: {},
+    hasMoreSessionsByGroupId: {},
+    totalSessionsByGroupId: {},
+    isLoadingMoreSessionsByGroupId: {},
+    loadMoreSessions: jest.fn(),
+    errorByGroupId: {},
+    loadMoreErrorByGroupId: {},
+    reloadGroup: jest.fn(),
+    selectedSession: null,
+    selectedSessionId: null,
+    openSession: jest.fn(),
+    createSessionIn: jest.fn(),
+    leaveSession: jest.fn(),
+    updateMemberMode: jest.fn(),
+    applySessionUpdate: jest.fn(),
+    favoriteSessionIds: [],
+    sessionSearchText: '',
+    setSessionSearchText: jest.fn(),
+    toggleFavorite: jest.fn(),
+    renameSession: jest.fn(),
+    deleteSession: jest.fn(),
+  }),
+}));
+jest.mock('@/pages/Workspace/hooks/useGroupChat', () => ({ useGroupChat: () => ({}) }));
+jest.mock('@/pages/Workspace/hooks/useGroupManagement', () => ({ useGroupManagement: () => ({}) }));
+jest.mock('@/pages/Workspace/hooks/useSessionManagement', () => ({ useSessionManagement: () => ({}) }));
+jest.mock('@/pages/Workspace/hooks/useGroupCreateDialog', () => ({
+  useGroupCreateDialog: () => ({ open: false, openModal: jest.fn(), closeModal: jest.fn(), handleCreated: jest.fn() }),
+}));
+jest.mock('@/pages/Workspace/hooks/useOpenDefaultGroupSession', () => ({
+  useOpenDefaultGroupSession: () => jest.fn(),
+}));
+
+// GroupChatPane 桩件：暴露一个按钮触发 onTogglePanel('manage')，模拟齿轮打开管理面板。
+jest.mock('@/pages/Workspace/components/GroupChatPane', () => ({
+  GroupChatPane: ({ onTogglePanel }: { onTogglePanel: (panel: string) => void }) => (
+    <div data-testid="group-chat-pane">
+      <button type="button" onClick={() => onTogglePanel('manage')}>
+        打开管理面板
+      </button>
+    </div>
+  ),
+}));
+jest.mock('@/pages/Workspace/components/GroupChatPane/SessionFilesModal', () => ({
+  SessionFilesModal: () => null,
+}));
+jest.mock('@/pages/Workspace/components/GroupMembersPanelSlot', () => ({
+  GroupMembersPanelSlot: () => null,
+}));
+jest.mock('@/pages/Workspace/components/Modals/CreateGroupModal', () => ({
+  CreateGroupModal: () => null,
+}));
+jest.mock('@/pages/Workspace/components/WorkspaceManagePanels', () => ({
+  WorkspaceManagePanels: () => null,
+}));
+jest.mock('@/pages/Workspace/components/GroupSidebar', () => {
+  const actual = jest.requireActual<typeof import('@/pages/Workspace/components/GroupSidebar')>(
+    '@/pages/Workspace/components/GroupSidebar',
+  );
+  return { ...actual, GroupSidebar: () => <aside data-testid="in-flow-group-sidebar" /> };
+});
+
+const { GroupWorkspaceArea } =
+  require('@/pages/Workspace/GroupWorkspaceArea') as typeof import('@/pages/Workspace/GroupWorkspaceArea');
+
+function renderArea() {
+  return render(
+    <GroupWorkspaceArea
+      view="group"
+      onViewChange={jest.fn()}
+      availableViews={['chat', 'group']}
+      mobileListOpen={false}
+      onCloseMobileList={jest.fn()}
+    />,
+  );
+}
+
+describe('GroupWorkspaceArea 管理面板打开期间切群补拉详情', () => {
+  beforeEach(() => {
+    mockState.selectedGroupId = 'g1';
+    mockReloadSelectedGroup.mockClear();
+  });
+
+  it('打开管理面板时为当前选中群拉取详情', () => {
+    renderArea();
+    fireEvent.click(screen.getByRole('button', { name: '打开管理面板' }));
+    expect(mockReloadSelectedGroup).toHaveBeenCalledWith('g1');
+  });
+
+  it('面板保持打开时切换选中群，为新群重新拉取详情', () => {
+    const view = renderArea();
+    fireEvent.click(screen.getByRole('button', { name: '打开管理面板' }));
+    mockReloadSelectedGroup.mockClear();
+
+    // 模拟侧栏切群：选中群变为 g2（真实场景中 onSelectGroup 写 store 后 selectedGroupId 变化）。
+    mockState.selectedGroupId = 'g2';
+    view.rerender(
+      <GroupWorkspaceArea
+        view="group"
+        onViewChange={jest.fn()}
+        availableViews={['chat', 'group']}
+        mobileListOpen={false}
+        onCloseMobileList={jest.fn()}
+      />,
+    );
+
+    expect(mockReloadSelectedGroup).toHaveBeenCalledWith('g2');
+  });
+
+  it('面板未打开时切换选中群不拉取详情（保持按需拉取约定）', () => {
+    const view = renderArea();
+    mockState.selectedGroupId = 'g3';
+    view.rerender(
+      <GroupWorkspaceArea
+        view="group"
+        onViewChange={jest.fn()}
+        availableViews={['chat', 'group']}
+        mobileListOpen={false}
+        onCloseMobileList={jest.fn()}
+      />,
+    );
+    expect(mockReloadSelectedGroup).not.toHaveBeenCalled();
+  });
+});

--- a/src/frontend-nextgen/test/pages/Workspace/hooks/useBotSessions.test.ts
+++ b/src/frontend-nextgen/test/pages/Workspace/hooks/useBotSessions.test.ts
@@ -325,3 +325,55 @@ it('兜底反查在途时用户已切换选中：失败回调不得劫持新选�
   });
   expect(useWorkspaceStore.getState().selectedBotSessionId).toBe('s1');
 });
+
+const friendBot: ChatBotView = {
+  botId: 'botfriend:999',
+  realBotId: 'botfriend',
+  ownerId: '999',
+  displayName: '好友Bot',
+  online: true,
+  chatable: true,
+  isFriendBot: true,
+};
+
+it('展开「好友 Bot」分类下的 bot：按 isFriendBot 调用会话列表接口（服务层据此附带 f_user_id）', async () => {
+  useWorkspaceStore.getState().setView('chat');
+  const { result } = renderHook(() => useBotSessions([friendBot], ['botfriend:999'], 'human_327325', false));
+  // 懒加载必须以好友 bot 实体（isFriendBot=true、realBotId 拆分）与当前用户 id 调用 listSessionsPage；
+  // 服务层 withFriendBotRequestParams 据此在 GET /openapi/v1/bots/{realBotId}/sessions 上附带 f_user_id。
+  await waitFor(() => expect(svc.listSessionsPage).toHaveBeenCalledWith(friendBot, 'human_327325', 1, 10));
+  const [calledBot] = svc.listSessionsPage.mock.calls[0];
+  expect(calledBot.isFriendBot).toBe(true);
+  expect(calledBot.realBotId).toBe('botfriend');
+  expect(result.current.sessionsByBotId['botfriend:999']).toBeDefined();
+});
+
+it('openSession 好友 bot：展开时分区归属记为 friend（缺省 mine 会让侧栏好友分区折叠）', async () => {
+  useWorkspaceStore.getState().setView('chat');
+  const { result } = renderHook(() => useBotSessions([friendBot], [], 'human_327325', false));
+  act(() => {
+    result.current.openSession('botfriend:999', 's1');
+  });
+  expect(useWorkspaceStore.getState().expandedBotIds['botfriend:999']).toBe(true);
+  expect(useWorkspaceStore.getState().expandedBotSectionKey['botfriend:999']).toBe('friend');
+});
+
+it('收起后重新展开 bot：每次切换 bot 都重新拉取最新会话列表', async () => {
+  const { rerender } = renderHook(
+    ({ expanded }: { expanded: string[] }) => useBotSessions([bot], expanded, 'human-1'),
+    {
+      initialProps: { expanded: [] as string[] },
+    },
+  );
+  await act(async () => Promise.resolve());
+  expect(svc.listSessionsPage).not.toHaveBeenCalled();
+
+  rerender({ expanded: ['b:1'] });
+  await waitFor(() => expect(svc.listSessionsPage).toHaveBeenCalledTimes(1));
+
+  // 收起再展开（= 切换到别的 bot 再切回来）：必须重新请求获取最新列表。
+  rerender({ expanded: [] });
+  await act(async () => Promise.resolve());
+  rerender({ expanded: ['b:1'] });
+  await waitFor(() => expect(svc.listSessionsPage).toHaveBeenCalledTimes(2));
+});

--- a/src/frontend-nextgen/test/pages/Workspace/hooks/useCollabPanel.test.ts
+++ b/src/frontend-nextgen/test/pages/Workspace/hooks/useCollabPanel.test.ts
@@ -48,12 +48,26 @@ it('多个 human 成员时只选择与当前认证用户 ID 匹配的成员', ()
     { actorId: 'human_other', kind: 'human', name: '其他成员', role: 'member', mode: 'present' },
     { actorId: 'human_1', kind: 'human', name: '章梧', role: 'member', mode: 'absent' },
   ]);
-  const { result } = renderHook(() =>
-    useCollabPanel(session, botIdentity, updateMemberMode, 'human_1', '认证用户'),
-  );
+  const { result } = renderHook(() => useCollabPanel(session, botIdentity, updateMemberMode, 'human_1', '认证用户'));
 
   expect(result.current.human?.actorId).toBe('human_1');
   expect(result.current.humanName).toBe('章梧');
+});
+
+it('用户身份视角 + 多个 human 成员：LeaveBar 显示当前用户名而非其他成员', () => {
+  useWorkspaceStore.getState().setActiveIdentity(humanIdentity.id);
+  // 群里两个 human：其他成员排在前且 present，当前用户排在后且 present。
+  const session = makeSession([
+    { actorId: 'human_other', kind: 'human', name: '其他成员', role: 'member', mode: 'present' },
+    { actorId: 'human_1', kind: 'human', name: '章梧', role: 'member', mode: 'present' },
+  ]);
+  const { result } = renderHook(() => useCollabPanel(session, humanIdentity, updateMemberMode, 'human_1', '章梧'));
+  // 用户视角 present → 渲染 LeaveBar（isHumanViewer），显示的必须是当前用户，而非数组首个 human。
+  expect(result.current.human?.actorId).toBe('human_1');
+  expect(result.current.humanName).toBe('章梧');
+  expect(result.current.humanJoined).toBe(true);
+  expect(result.current.humanAbsentOnly).toBe(false);
+  expect(result.current.botActorId).toBeNull();
 });
 
 it('setBotMode 调用 updateMemberMode 并携带 bot actorId', async () => {

--- a/src/frontend-nextgen/test/pages/Workspace/hooks/useFriendBotSectionSync.test.ts
+++ b/src/frontend-nextgen/test/pages/Workspace/hooks/useFriendBotSectionSync.test.ts
@@ -1,0 +1,61 @@
+/** @jest-environment jsdom */
+import { useFriendBotSectionSync } from '@/pages/Workspace/hooks/useFriendBotSectionSync';
+import type { ChatBotView } from '@/services/workspace/botSessionService';
+import { useWorkspaceStore } from '@/stores/workspaceStore';
+import { beforeEach, expect, it } from '@jest/globals';
+import { act, renderHook } from '@testing-library/react';
+
+const friendBot: ChatBotView = {
+  botId: 'botfriend:999',
+  realBotId: 'botfriend',
+  ownerId: '999',
+  displayName: '好友Bot',
+  online: true,
+  chatable: true,
+  isFriendBot: true,
+};
+
+beforeEach(() => {
+  useWorkspaceStore.getState().resetWorkspace();
+});
+
+it('好友列表就绪后：已展开但分区被记为 mine 的好友 bot 纠正为 friend', async () => {
+  // 冷启动深链 ?bot=好友bot：展开时无法判定归属，store 缺省记 'mine'，
+  // 好友分区 expanded 判定（需 ==='friend'）失败 → 行折叠、会话列表不可见。
+  useWorkspaceStore.getState().toggleBotExpanded('botfriend:999');
+  expect(useWorkspaceStore.getState().expandedBotSectionKey['botfriend:999']).toBe('mine');
+
+  renderHook(() => useFriendBotSectionSync([friendBot]));
+  await act(async () => Promise.resolve());
+
+  expect(useWorkspaceStore.getState().expandedBotSectionKey['botfriend:999']).toBe('friend');
+});
+
+it('未展开的好友 bot 与 mine 分区 bot 不受影响', async () => {
+  // 'b:1' 是「我的 bot」（不在好友列表内），展开后归属应保持 'mine'。
+  useWorkspaceStore.getState().toggleBotExpanded('b:1');
+
+  renderHook(() => useFriendBotSectionSync([friendBot]));
+  await act(async () => Promise.resolve());
+
+  const s = useWorkspaceStore.getState();
+  expect(s.expandedBotSectionKey['b:1']).toBe('mine');
+  expect(s.expandedBotIds['botfriend:999']).toBeUndefined();
+  expect(s.expandedBotSectionKey['botfriend:999']).toBeUndefined();
+});
+
+it('用户手动展开为 friend 分区后不被重复改写', async () => {
+  useWorkspaceStore.getState().toggleBotExpanded('botfriend:999');
+  useWorkspaceStore.getState().setBotExpandedSection('botfriend:999', 'friend');
+
+  const { rerender } = renderHook(({ bots }: { bots: ChatBotView[] }) => useFriendBotSectionSync(bots), {
+    initialProps: { bots: [friendBot] },
+  });
+  await act(async () => Promise.resolve());
+  // 收起后好友列表刷新（新数组引用）不得把 bot 重新展开或改写分区。
+  useWorkspaceStore.getState().toggleBotExpanded('botfriend:999');
+  rerender({ bots: [{ ...friendBot }] });
+  await act(async () => Promise.resolve());
+
+  expect(useWorkspaceStore.getState().expandedBotIds['botfriend:999']).toBeUndefined();
+});

--- a/src/frontend-nextgen/test/pages/Workspace/hooks/useWorkspacePage.botOnly.test.tsx
+++ b/src/frontend-nextgen/test/pages/Workspace/hooks/useWorkspacePage.botOnly.test.tsx
@@ -46,6 +46,34 @@ it('bot-only 单聊 URL 恢复用户身份并展开对应 Bot', async () => {
   expect(sessionService.getSessionDetail).not.toHaveBeenCalled();
 });
 
+it('已展开的好友 bot：URL 回写触发回填时不得把分区归属覆盖成 mine（否则好友行折叠、会话列表不可见）', async () => {
+  // 复现链路：点击好友 bot（分区 'friend'）→ 自动选中首会话 → useChatUrlSync 写回 ?bot=&session=
+  // → URL→Store effect 因 botParam 变化重跑。旧实现无条件 setBotExpandedSection(bot,'mine')
+  // → 好友分区 expanded 判定（需 ==='friend'）失败 → 行折叠、已加载的会话列表消失。
+  mockedUseSearchParams.mockReturnValue([
+    new URLSearchParams('tab=chat&bot=fr:9&session=s1'),
+    jest.fn(),
+  ] as unknown as ReturnType<typeof useSearchParams>);
+  useWorkspaceStore.setState({
+    identities: [{ id: 'human_2088', kind: 'user', displayName: '我', online: true }],
+    activeIdentityId: 'human_2088',
+    view: 'chat',
+    expandedBotIds: { 'fr:9': true },
+    expandedBotSectionKey: { 'fr:9': 'friend' },
+  });
+
+  const { rerender } = renderHook(() => useWorkspacePage());
+  await act(async () => Promise.resolve());
+  // 模拟 URL 回写后的重渲染（searchParams 变化 → effect 重跑）。
+  rerender();
+  await act(async () => Promise.resolve());
+
+  const state = useWorkspaceStore.getState();
+  expect(state.expandedBotIds['fr:9']).toBe(true);
+  expect(state.expandedBotSectionKey['fr:9']).toBe('friend');
+  expect(state.selectedBotSessionId).toBe('s1');
+});
+
 it('协作群外链 session= 仍会把身份切回用户并选中群/会话（保留邀请/外链直达行为）', async () => {
   mockedUseSearchParams.mockReturnValue([
     new URLSearchParams('tab=group&group=g1&session=s1'),

--- a/src/frontend-nextgen/test/services/collaborationSquare/collaborationSquareApiAdapter.test.ts
+++ b/src/frontend-nextgen/test/services/collaborationSquare/collaborationSquareApiAdapter.test.ts
@@ -754,6 +754,20 @@ describe('CollaborationSquareApiAdapter', () => {
     );
   });
 
+  it('omits f_user_id when the target Bot is owned by the logged-in user', async () => {
+    mockedCreateBotSession.mockResolvedValue({
+      code: 200000,
+      data: { session_id: 'session-owned' } as never,
+    });
+
+    await expect(
+      new CollaborationSquareApiAdapter().openBotConversation('bot-1:2088', humanContext, {
+        isOwnedByLoggedInUser: true,
+      }),
+    ).resolves.toEqual({ sessionId: 'session-owned' });
+    expect(mockedCreateBotSession).toHaveBeenCalledWith('bot-1', { user_id: '327325', owner_id: '2088' }, {});
+  });
+
   it('rejects a session response without session_id as a protocol error', async () => {
     mockedCreateBotSession.mockResolvedValue({ code: 200000, data: {} as never });
 


### PR DESCRIPTION
## Problem
The nextgen open core export was behind the latest TeamClaw friend-bot workspace fixes. Deep-linked friend bots (`?bot=...`) could be recorded under the wrong sidebar section and appear collapsed, switching bots did not always refresh their first page of sessions, the group manage panel could stay stuck loading member details after opening or switching groups, and opening the space switcher repeatedly refetched the full space list.

## Solution
- Synced the open core export to TeamClaw source commit `4c2bf71f` and updated `OPEN_CORE_MANIFEST.json`.
- Extracted `useExpandedBotLoader`: expanded bots reload their first page on the collapsed-to-expanded transition; continuously expanded bots are deduplicated.
- Added `useFriendBotSectionSync`: once the friend bot list is ready, expanded friend bots with a wrong section key are corrected to `friend`, fixing deep-link visibility.
- Passed `isOwnedByLoggedInUser` through `openBotConversation` so friend bot conversations respect ownership context.
- Group manage panel detail loading now runs from an effect: opening the panel or switching groups while it is open fetches participants/owner details; closed panels stay lazy.
- Throttled `SpaceSwitcher` list refresh to once per 60 seconds while opening the bubble.
- Added and updated unit tests covering bot session loading, friend section sync, group manage panel refetch, bot-only workspace, and collaboration square adapter ownership handling.

## Validation
- Mechanical export from TeamClaw source commit `4c2bf71f` (`sourceDirty: false`); no manual code changes beyond the export.
- Diff scope: `src/frontend-nextgen` (21 files, +495/-43).
- Did not run frontend unit tests locally; CI will run the frontend gate on this PR.

## Compatibility and risk
- No public API contract changes; behavior changes are frontend-internal.
- Space switcher remote changes may take up to 60 seconds to appear when reopening the bubble within the throttle window.
- Rollback path: revert this PR to restore the previous export.

## Spec
- Open Core export schema: `src/frontend-nextgen/OPEN_CORE_MANIFEST.json` (exportSchemaVersion 1)