### PR TITLE
fix(bcs): include HTTP method in response logs

### DIFF
--- a/src/bcs/crates/adapters/http/bcs-http/src/gateway_trace.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/gateway_trace.rs
@@ -127,13 +127,14 @@ pub async fn observe_request(
     request.headers_mut().insert("x-request-id", header.clone());
     let route = request.extensions().get::<axum::extract::MatchedPath>()
         .map(|route| route.as_str()).unwrap_or("unmatched").to_owned();
+    let method = request.method().clone();
     let mut observation = RequestObservation {
         request_id: request_id.clone(), route,
         started: std::time::Instant::now(), completed: false,
     };
     tracing::info!(target: "bcs_http_access", request_id = %observation.request_id,
         route = %observation.route,
-        method = %request.method(), "http.request.started");
+        method = %method, "http.request.started");
     let mut response = bcs_observability::with_request_context(request_id, next.run(request)).await;
     let elapsed = observation.started.elapsed();
     response.headers_mut().insert("x-request-id", header);
@@ -142,7 +143,7 @@ pub async fn observe_request(
         "upgraded"
     } else if response.status().is_success() { "success" } else { "http_error" };
     tracing::info!(target: "bcs_http_access", request_id = %observation.request_id,
-        route = %observation.route,
+        route = %observation.route, method = %method,
         status = response.status().as_u16(), duration_ms = elapsed.as_secs_f64() * 1000.0,
         outcome,
         "http.request.response_ready");

--- a/src/bcs/crates/adapters/http/bcs-http/tests/request_observations.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/request_observations.rs
@@ -259,11 +259,11 @@ async fn protocol_upgrade_is_not_reported_as_an_http_error() {
     let writer = buffer.clone();
     let subscriber = tracing_subscriber::fmt().json().with_writer(move || writer.clone()).finish();
     async {
-        for status in [StatusCode::SWITCHING_PROTOCOLS, StatusCode::OK, StatusCode::UNAUTHORIZED] {
-            let app = Router::new().route("/ws/bot", post(move || async move { status }))
+        for (status, method) in [(StatusCode::SWITCHING_PROTOCOLS, "GET"), (StatusCode::OK, "PUT"), (StatusCode::UNAUTHORIZED, "POST")] {
+            let app = Router::new().route("/ws/bot", axum::routing::any(move || async move { status }))
                 .layer(middleware::from_fn(bcs_http::gateway_trace::observe_request));
             let request_id = format!("status-{}", status.as_u16());
-            let request = Request::builder().method("POST").uri("/ws/bot")
+            let request = Request::builder().method(method).uri("/ws/bot")
                 .header("x-request-id", &request_id).body(Body::empty()).unwrap();
             let response = app.oneshot(request).await.unwrap();
             assert_eq!(response.status(), status);
@@ -272,9 +272,10 @@ async fn protocol_upgrade_is_not_reported_as_an_http_error() {
     }.with_subscriber(subscriber).await;
     let logs = String::from_utf8(buffer.0.lock().unwrap().clone()).unwrap();
     let events: Vec<serde_json::Value> = logs.lines().map(|line| serde_json::from_str(line).unwrap()).collect();
-    for (status, outcome) in [(101, "upgraded"), (200, "success"), (401, "http_error")] {
+    for (status, outcome, method) in [(101, "upgraded", "GET"), (200, "success", "PUT"), (401, "http_error", "POST")] {
         let event = events.iter().find(|event| event["fields"]["message"] == "http.request.response_ready"
             && event["fields"]["status"] == status).unwrap();
         assert_eq!(event["fields"]["outcome"], outcome);
+        assert_eq!(event["fields"]["method"], method);
     }
 }


### PR DESCRIPTION
## Problem

`http.request.response_ready` includes the route, status, and latency but omits the HTTP method. Requests using different methods on the same route are therefore combined in log-based traffic and latency monitoring unless joined with the request-start log.

## Solution

- Capture the incoming HTTP method before passing the request to the handler.
- Include `method` in the response-ready log and reuse the captured value in the request-start log.
- Extend the existing response observation test to verify GET, PUT, and POST alongside protocol-upgrade, success, and HTTP-error outcomes.

## Validation

- `cargo test --manifest-path src/bcs/Cargo.toml --offline --locked -p bcs-http --test request_observations` — 7 passed.
- `git diff --check upstream/dev...HEAD` — passed.
- Full workspace CI was not run locally; validation was limited to the affected HTTP observation tests.

## Compatibility and risk

Adds one structured log field without changing HTTP responses, routing, status classification, or existing tracing behavior.
