### PR TITLE
docs(ci): clarify per-module Python dependency setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -297,13 +297,24 @@ If you cannot run a required test, state exactly what was not run and why.
 ## Common Commands
 
 ```bash
-# Root Python workspace
+# Root coordination project only (does not install module dependencies)
 uv sync
+
+# Independent Python module environments; run from the repository root
+uv sync --project src/backend --frozen
+uv sync --project src/baas --frozen
+uv sync --project src/engine --frozen
 
 # BCS
 cd src/bcs
 cargo test --workspace
 ```
+
+Backend, BaaS community, and Engine each use a module-local `pyproject.toml`,
+`uv.lock`, and `.venv`. Read [`docs/dependencies.md`](docs/dependencies.md) before
+preparing or smoke-testing one of these Python environments; it lists their
+Python constraints, environment-specific verification commands, and Engine's
+separate test-tool setup.
 
 Frontend public setup is still being finalized. Do not replace unresolved
 public setup gaps with private registry or company-network assumptions.

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -51,6 +51,43 @@ Running `singlebox.sh` also installs the repo-local pre-push hook by setting
 `core.hooksPath=.githooks`. Set `OCB_SKIP_GIT_HOOKS=1` if you need to skip hook
 installation for a one-off command.
 
+## Python module environments
+
+The root `pyproject.toml` is an empty coordination project: its dependency list
+and uv workspace member list are both empty. Consequently, `uv sync` at the
+repository root only prepares the root `.venv`; it does **not** install the
+Backend, BaaS community, or Engine dependencies.
+
+Each Python module is an independent uv project with its own `pyproject.toml`,
+`uv.lock`, and `.venv`. Run the commands below from the repository root. Using
+`uv run --project ...` ensures that verification uses the module environment
+instead of a system Python. `--frozen` also ensures that installation uses the
+committed lockfile without updating it.
+
+| Module | Project path | Python requirement | Install and minimal verification |
+| --- | --- | --- | --- |
+| Backend | `src/backend` | `>=3.12,<3.13` | `uv sync --project src/backend --frozen`<br>`uv run --project src/backend --no-sync python -c "import fastapi, pytest; import agentclaw.community; print(pytest.__version__)"` |
+| BaaS community | `src/baas` | `>=3.12.0,<3.13.0` | `uv sync --project src/baas --frozen`<br>`uv run --project src/baas --no-sync python -c "import fastapi, pytest; import secbaas.community; print(pytest.__version__)"` |
+| Engine | `src/engine` | `>=3.12` (CI uses 3.12) | `uv sync --project src/engine --frozen`<br>`uv run --project src/engine --no-sync python -c "import fastapi; import engine.community; print(fastapi.__version__)"` |
+
+Backend and BaaS declare their test tools in the locked `dev` dependency group,
+which `uv sync` installs by default. Engine declares runtime dependencies only:
+its lockfile does not include pytest or the other test tools. A successful
+Engine sync therefore prepares the runtime environment, not a complete test
+environment. Engine CI supplies its test tools ephemerally; to reproduce that
+tool setup without running the full suite, use:
+
+```bash
+uv run --project src/engine --no-sync \
+  --with pytest-cov --with pytest-asyncio --with socksio \
+  python -c "import pytest, pytest_asyncio, pytest_cov, socksio; print(pytest.__version__)"
+```
+
+The `--with` packages are resolved when the command runs and are not recorded
+in `src/engine/uv.lock`. For full module test and coverage gates, use the
+module-local `scripts/ci_test.sh`; those gates are intentionally outside this
+environment smoke check.
+
 ## Safety rules
 
 - Outside the disclosed `install-tools` Node.js and uv auto-install paths, stop

--- a/docs/dependencies.zh-CN.md
+++ b/docs/dependencies.zh-CN.md
@@ -24,6 +24,39 @@
 
 运行 `singlebox.sh` 时也会安装仓库级 pre-push hook，即设置 `core.hooksPath=.githooks`。如果某次命令需要跳过 hook 安装，可以设置 `OCB_SKIP_GIT_HOOKS=1`。
 
+## Python 模块环境
+
+根目录 `pyproject.toml` 是一个空的协调项目：依赖列表和 uv workspace
+member 列表都为空。因此，在仓库根目录执行 `uv sync` 只会准备根目录
+`.venv`，**不会**安装 Backend、BaaS community 或 Engine 的依赖。
+
+每个 Python 模块都是独立的 uv 项目，各自拥有 `pyproject.toml`、`uv.lock`
+和 `.venv`。以下命令均从仓库根目录执行。使用 `uv run --project ...`
+可确保验证时使用模块环境而非系统 Python；`--frozen` 则确保按已提交的
+lockfile 安装，不更新 lockfile。
+
+| 模块 | 项目路径 | Python 要求 | 安装与最小验证 |
+| --- | --- | --- | --- |
+| Backend | `src/backend` | `>=3.12,<3.13` | `uv sync --project src/backend --frozen`<br>`uv run --project src/backend --no-sync python -c "import fastapi, pytest; import agentclaw.community; print(pytest.__version__)"` |
+| BaaS community | `src/baas` | `>=3.12.0,<3.13.0` | `uv sync --project src/baas --frozen`<br>`uv run --project src/baas --no-sync python -c "import fastapi, pytest; import secbaas.community; print(pytest.__version__)"` |
+| Engine | `src/engine` | `>=3.12`（CI 使用 3.12） | `uv sync --project src/engine --frozen`<br>`uv run --project src/engine --no-sync python -c "import fastapi; import engine.community; print(fastapi.__version__)"` |
+
+Backend 和 BaaS 已在锁定的 `dev` 依赖组中声明测试工具，`uv sync` 默认会
+安装该依赖组。Engine 只声明了运行时依赖；它的 lockfile 不包含 pytest
+或其他测试工具。所以 Engine sync 成功只表示运行时环境已就绪，不代表完整
+测试环境已就绪。Engine CI 会临时提供测试工具；如需在不运行全量测试的
+情况下复现该工具环境，请执行：
+
+```bash
+uv run --project src/engine --no-sync \
+  --with pytest-cov --with pytest-asyncio --with socksio \
+  python -c "import pytest, pytest_asyncio, pytest_cov, socksio; print(pytest.__version__)"
+```
+
+`--with` 包会在命令执行时解析，不会写入 `src/engine/uv.lock`。如需运行完整的
+模块测试与覆盖率门禁，请使用模块自身的 `scripts/ci_test.sh`；这些门禁特意不属于
+本环境冒烟验证的范围。
+
 ## 安全规则
 
 - 除上文已说明的 `install-tools` Node.js / uv 自动安装路径外，执行 `sudo`、全局安装、`brew link --force`、`curl | sh` 或等价的系统级写入前，必须停下确认。


### PR DESCRIPTION
### Motivation

- The repository root `pyproject.toml` is an empty coordination project so running `uv sync` at the root only prepares the root `.venv` and does not install Backend, BaaS community, or Engine dependencies, causing confusion for contributors and cloud agents.  
- Document the correct per-module workflow so developers and automated agents can prepare and verify each module's isolated Python environment reliably.  
- Provide a minimal, reproducible smoke-check for each module that matches how CI runs tests and resolves differences between runtime vs test-tool lockfile expectations.

### Description

- Add a new “Python module environments” section to `docs/dependencies.md` that explains the root project is coordination-only and documents per-module `uv sync`/`uv run` commands for `src/backend`, `src/baas`, and `src/engine`.  
- Add the same guidance in Chinese to `docs/dependencies.zh-CN.md` so bilingual readers have the same instructions.  
- Update `AGENTS.md` Common Commands to distinguish the root coordination environment from independent module environments and point readers to `docs/dependencies.md` for verification commands.  
- Explain Engine’s lockfile semantics (runtime deps only) and include an example `uv run --with ...` invocation that reproduces CI’s ephemeral test-tool resolution for smoke checks.

### Testing

- Ran `uv sync --project src/backend --frozen` and then `uv run --project src/backend --no-sync python -c

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9fa6fa24b88326a9be3871a65936f2)