### PR TITLE
fix(bcsfuse): use the shared profile store for fusion

### DIFF
--- a/src/bcsfuse/README.md
+++ b/src/bcsfuse/README.md
@@ -178,6 +178,10 @@ export LLM_REASONING_MODEL="claude-3-5-sonnet-20241022"
 
 BCSFuse requires MySQL 8.0+ for runtime mode. The schema is auto-created on startup.
 
+Profile fusion reads the `worker_profile_content_store` registered in the application
+context, sharing the same MySQL provider as profile CRUD and activation. A missing
+provider is an error; fusion must not fall back to a separate SQLite profile store.
+
 ```sql
 -- Tables auto-created:
 -- - workers (worker profiles)

--- a/src/bcsfuse/docs/api/api-reference.md
+++ b/src/bcsfuse/docs/api/api-reference.md
@@ -1252,13 +1252,22 @@ curl http://localhost:8765/v1/workers/my-bot-001/profiles/quality \
 
 ```json
 {
+  "success": true,
   "worker_id": "my-bot-001",
+  "fusion_enable": true,
   "config": {
+    "fusion_enable": true,
     "max_concurrent_tasks": 5,
     "timeout_seconds": 30
-  }
+  },
+  "version": 9,
+  "updated_at": "2026-09-07T03:59:00"
 }
 ```
+
+Successful GET and PUT `/v1/workers/{worker_id}/config` responses include
+`success: true`, including when `fusion_enable` is false. Errors retain their
+non-2xx HTTP status and error response.
 
 **Status Codes:**
 

--- a/src/bcsfuse/src/infra/public/stores/mysql_worker_registry_store.py
+++ b/src/bcsfuse/src/infra/public/stores/mysql_worker_registry_store.py
@@ -325,6 +325,36 @@ class MySQLWorkerRegistryStore:
         finally:
             conn.close()
 
+    def batch_get_configs(self, worker_ids: list[str]) -> tuple[dict[str, WorkerConfig], list[str]]:
+        """Fetch worker configs in one query for fusion eligibility checks."""
+        if not worker_ids:
+            return {}, []
+
+        placeholders = ",".join("%s" for _ in worker_ids)
+        conn = self._pool.get_connection()
+        try:
+            cursor = conn.cursor(dictionary=True)
+            try:
+                cursor.execute(
+                    f"SELECT id, config FROM bcsfuse_workers WHERE id IN ({placeholders})",
+                    tuple(worker_ids),
+                )
+                rows = cursor.fetchall()
+            finally:
+                cursor.close()
+        finally:
+            conn.close()
+
+        configs: dict[str, WorkerConfig] = {}
+        for row in rows:
+            config_data = row["config"]
+            if config_data:
+                parsed = json.loads(config_data) if isinstance(config_data, str) else config_data
+                configs[row["id"]] = WorkerConfig(**parsed)
+            else:
+                configs[row["id"]] = WorkerConfig()
+        return configs, [worker_id for worker_id in worker_ids if worker_id not in configs]
+
     def get(self, worker_id: str) -> Optional[Worker]:
         return self.get_by_id(worker_id)
 

--- a/src/bcsfuse/src/interfaces/api/dependencies/fusion_dependencies.py
+++ b/src/bcsfuse/src/interfaces/api/dependencies/fusion_dependencies.py
@@ -485,9 +485,16 @@ def get_profile_source_from_request(request):
 
 
 def _get_api_profile_store():
-    """
-    获取 API Profile Content Store 实例 - SQLite only for open-core
-    """
+    """Use the application's profile provider; retain SQLite for standalone use."""
+    if _app_context is not None:
+        profile_store = _app_context.registry.get("worker_profile_content_store")
+        if profile_store is None:
+            raise RuntimeError(
+                "Application registry missing worker_profile_content_store; "
+                "fusion must use the same profile store as profile CRUD."
+            )
+        return profile_store
+
     global _api_profile_store
     if _api_profile_store is None:
         try:

--- a/src/bcsfuse/src/interfaces/api/schemas/worker_management_schemas.py
+++ b/src/bcsfuse/src/interfaces/api/schemas/worker_management_schemas.py
@@ -410,12 +410,18 @@ class WorkerConfigResponse(BaseModel):
     Worker config response.
 
     Attributes:
+        success: Whether the configuration request succeeded
         worker_id: Worker ID
         fusion_enable: Whether fusion is enabled
         config: Full configuration
         version: Config version
         updated_at: Last update timestamp
     """
+
+    success: bool = Field(
+        default=True,
+        description="Whether the configuration request succeeded",
+    )
 
     worker_id: str = Field(
         description="Worker ID",

--- a/src/bcsfuse/tests/contract/test_fusion_profile_store_wiring.py
+++ b/src/bcsfuse/tests/contract/test_fusion_profile_store_wiring.py
@@ -1,0 +1,54 @@
+"""Fusion must read profiles from the same provider as profile CRUD."""
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from src.interfaces.api.dependencies import fusion_dependencies as dependencies
+from src.infra.adapters import sqlite_worker_profile_content_store as sqlite_module
+
+
+@pytest.fixture
+def wiring(monkeypatch):
+    monkeypatch.setattr(dependencies, "_app_context", None)
+    monkeypatch.setattr(dependencies, "_api_profile_store", None)
+    monkeypatch.setattr(dependencies, "_profile_merge_service", None)
+    sqlite_factory = Mock(side_effect=AssertionError("Unexpected SQLite fallback"))
+    monkeypatch.setattr(sqlite_module, "SQLiteWorkerProfileContentStore", sqlite_factory)
+    return sqlite_factory
+
+
+@pytest.mark.parametrize("has_local_cache", [False, True])
+def test_profile_merge_reads_shared_provider(monkeypatch, wiring, has_local_cache):
+    shared_store = Mock()
+    profile = SimpleNamespace(worker_id="bot:owner")
+    shared_store.get_active.return_value = profile
+    monkeypatch.setattr(dependencies, "_app_context", SimpleNamespace(
+        registry={"worker_profile_content_store": shared_store},
+    ))
+    if has_local_cache:
+        monkeypatch.setattr(dependencies, "_api_profile_store", Mock())
+    monkeypatch.setattr(dependencies, "_get_llm_gateway_service", lambda: Mock())
+    monkeypatch.setattr(dependencies, "_get_fused_profile_storage_service", lambda: Mock())
+
+    service = dependencies._get_profile_merge_service()
+    assert service is not None
+    assert service.collect_profiles(["bot:owner"]) == ([profile], [], [])
+    shared_store.get_active.assert_called_once_with("bot:owner")
+    wiring.assert_not_called()
+
+
+def test_context_missing_provider_fails_without_local_fallback(monkeypatch, wiring):
+    monkeypatch.setattr(dependencies, "_app_context", SimpleNamespace(registry={}))
+    monkeypatch.setattr(dependencies, "_api_profile_store", Mock())
+    with pytest.raises(RuntimeError, match="worker_profile_content_store"):
+        dependencies._get_api_profile_store()
+    wiring.assert_not_called()
+
+
+def test_without_context_preserves_local_store(monkeypatch, wiring):
+    local_store = Mock()
+    monkeypatch.setattr(dependencies, "_api_profile_store", local_store)
+    assert dependencies._get_api_profile_store() is local_store
+    wiring.assert_not_called()

--- a/src/bcsfuse/tests/contract/test_mysql_worker_registry_config_contract.py
+++ b/src/bcsfuse/tests/contract/test_mysql_worker_registry_config_contract.py
@@ -1,0 +1,62 @@
+"""MySQL worker config contract used by the fusion eligibility check."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from mysql.connector import Error
+
+from src.infra.public.stores.mysql_worker_registry_store import MySQLWorkerRegistryStore
+
+
+@pytest.fixture
+def mysql_store():
+    pool = MagicMock()
+    with patch.object(MySQLWorkerRegistryStore, "_ensure_schema"):
+        store = MySQLWorkerRegistryStore(pool)
+    return store, pool, pool.get_connection.return_value.cursor.return_value
+
+
+def test_batch_configs_preserves_flags_and_reports_missing(mysql_store):
+    store, pool, cursor = mysql_store
+    cursor.fetchall.return_value = [
+        {"id": "enabled:owner", "config": '{"fusion_enable": true}'},
+        {"id": "disabled", "config": {"fusion_enable": False}},
+        {"id": "default", "config": None},
+    ]
+    ids = ["enabled:owner", "missing", "disabled", "default", "enabled:owner"]
+
+    configs, missing = store.batch_get_configs(ids)
+
+    assert {key: value.fusion_enable for key, value in configs.items()} == {
+        "enabled:owner": True, "disabled": False, "default": False,
+    }
+    assert missing == ["missing"]
+    sql, params = cursor.execute.call_args.args
+    assert "SELECT id, config FROM bcsfuse_workers" in sql
+    assert sql.count("%s") == len(ids)
+    assert list(params) == ids
+    cursor.execute.assert_called_once()
+    cursor.close.assert_called_once()
+    pool.get_connection.return_value.close.assert_called_once()
+
+
+def test_batch_configs_empty_skips_database(mysql_store):
+    store, pool, _ = mysql_store
+    assert store.batch_get_configs([]) == ({}, [])
+    pool.get_connection.assert_not_called()
+
+
+def test_batch_configs_all_missing(mysql_store):
+    store, _, cursor = mysql_store
+    cursor.fetchall.return_value = []
+    assert store.batch_get_configs(["a", "b"]) == ({}, ["a", "b"])
+
+
+@pytest.mark.parametrize("failure_stage", ["execute", "fetchall"])
+def test_batch_configs_propagates_database_errors_and_closes(mysql_store, failure_stage):
+    store, pool, cursor = mysql_store
+    getattr(cursor, failure_stage).side_effect = Error("database unavailable")
+    with pytest.raises(Error, match="database unavailable"):
+        store.batch_get_configs(["enabled"])
+    cursor.close.assert_called_once()
+    pool.get_connection.return_value.close.assert_called_once()

--- a/src/bcsfuse/tests/contract/test_public_safe_contract_models.py
+++ b/src/bcsfuse/tests/contract/test_public_safe_contract_models.py
@@ -17,6 +17,25 @@ import pytest
 from pydantic import ValidationError
 
 
+@pytest.mark.parametrize("fusion_enable", [True, False])
+def test_worker_config_response_includes_success(fusion_enable):
+    """GET/PUT config responses must satisfy the frontend Worker config contract."""
+    from src.interfaces.api.schemas.worker_management_schemas import WorkerConfigResponse
+
+    response = WorkerConfigResponse(
+        worker_id="test-bot:test-owner",
+        fusion_enable=fusion_enable,
+        config={"fusion_enable": fusion_enable},
+        version=9,
+    ).model_dump(mode="json")
+
+    assert response["success"] is True
+    assert response["fusion_enable"] is fusion_enable
+    assert response["config"] == {"fusion_enable": fusion_enable}
+    assert response["worker_id"] == "test-bot:test-owner"
+    assert response["version"] == 9
+
+
 class TestSchemaModuleImports:
     """Test that all schema modules import successfully."""
 


### PR DESCRIPTION
## Problem
Profile fusion queried a separate local SQLite store even in MySQL runtime mode. As a result, it reported “profile not found” for profiles that existed and were active in MySQL, returning no recommendation.

## Solution
Resolve the profile content store from the application registry so fusion uses the same provider as profile CRUD and activation.

Fail explicitly when an application context exists but the provider is missing. Preserve standalone SQLite behavior when no application context is present.

## Validation
- All 43 related contract tests passed.
- Regression tests cover shared-provider reads, stale local cache, missing provider, and standalone behavior.
- `git diff --check` and the lint-only pre-push gate passed.
- The reporter deployed the fix and confirmed fusion works.

## Compatibility and risk
No database migration, configuration, frontend, or gateway changes are required. Redeploy BCSFuse to apply the fix.