### PR TITLE
fix(backend): inject AGENTCLAW_DEFAULT_TAG into eval container env and support eval bot deployment w the latest built.

### DIFF
--- a/src/backend/src/agentclaw/community/core/repository/implementations/publishing/bot_publish.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/publishing/bot_publish.py
@@ -356,6 +356,25 @@ class BotPublishRepository(
             record = row.to_record() if row else None
         return self._resolve_record(record)
 
+    def get_latest_built_by_source_bot_id(
+        self,
+        source_bot_id: str,
+        env: str,
+    ) -> Optional[BotPublishRecord]:
+        with self._db.orm_session() as db:
+            row = (
+                db.query(self.Model)
+                .filter(
+                    self.Model.source_bot_id == source_bot_id,
+                    self.Model.status == PublishStatus.BUILT.value,
+                    self.Model.env == env,
+                )
+                .order_by(self.Model.id.desc())
+                .first()
+            )
+            record = row.to_record() if row else None
+        return self._resolve_record(record)
+
     def get_by_last_pub_id(
         self,
         last_pub_id: int,

--- a/src/backend/src/agentclaw/community/core/repository/protocols/publishing.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/publishing.py
@@ -246,6 +246,27 @@ class BotPublishRepositoryProtocol(Protocol):
         ...
 
     @abstractmethod
+    def get_latest_built_by_source_bot_id(
+        self,
+        source_bot_id: str,
+        env: str,
+    ) -> Optional[BotPublishRecord]:
+        """Get the latest status=built publish record by source_bot_id (owner-agnostic).
+
+        Used by the Eval environment to anchor the latest draft (built) version
+        rather than the latest online (success) version. Deliberately NOT filtered
+        by owner_id for the same reason as get_latest_success_by_source_bot_id.
+
+        Args:
+            source_bot_id: source bot_id
+            env: environment
+
+        Returns:
+            The latest built publish record, or None if not found.
+        """
+        ...
+
+    @abstractmethod
     def get_by_last_pub_id(
         self,
         last_pub_id: int,

--- a/src/backend/src/agentclaw/community/core/service_bot/README.md
+++ b/src/backend/src/agentclaw/community/core/service_bot/README.md
@@ -62,6 +62,7 @@ internal_dependencies:
   - agentclaw.community.plugin_api.approval_workflow           # antprocess approval workflow for publish approval
   - agentclaw.community.core.devices.services.device_filesystem    # teclaw build-time file promotion (TeclawFilePromotion)
   - agentclaw.community.plugin_api.engine_ext_client
+  - agentclaw.community.plugin_api.eval_env             # DYNAMIC_ENV_TAG_KEY injected into eval container extra_envs
   - agentclaw.community.plugin_api.http_client
   - agentclaw.community.plugin_api.models
   - agentclaw.community.plugin_api.object_storage           # teclaw promotion stages files to OSS

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/eval_publish_mixin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/eval_publish_mixin.py
@@ -14,6 +14,7 @@ from agentclaw.community.core.service_bot.services.deploy.service_publish_env im
     service_publish_extra_envs,
     service_publish_template_config,
 )
+from agentclaw.community.plugin_api.eval_env import DYNAMIC_ENV_TAG_KEY
 from agentclaw.community.core.service_bot.services.publish_flow.errors import (
     PublishFlowServiceError,
 )
@@ -110,6 +111,11 @@ class EvalPublishMixin:
         )
 
         async def _issue():
+            # 注入评测环境容器环境变量，使容器内进程可通过 os.environ 感知区标识
+            eval_envs = dict(service_publish_extra_envs(publish_record.ext, bot))
+            if default_tag:
+                eval_envs[DYNAMIC_ENV_TAG_KEY] = default_tag
+
             release_kwargs: dict[str, Any] = dict(
                 bot=bot,
                 user_id=owner_id,
@@ -119,7 +125,7 @@ class EvalPublishMixin:
                 version=str(publish_record.version or 1),
                 delivery=delivery,
                 ext_info=ext_info,
-                extra_envs=service_publish_extra_envs(publish_record.ext, bot),
+                extra_envs=eval_envs,
                 docker_image=image_pin.docker_image,
                 template_config=service_publish_template_config(bot),
             )

--- a/src/backend/tests/community/architecture/test_module_boundaries.py
+++ b/src/backend/tests/community/architecture/test_module_boundaries.py
@@ -120,7 +120,10 @@ _ACTIVE_SIGNIFICANT_MODULES: frozenset[str] = frozenset(
 # are not yet reflected in module README metadata. This keeps the unit test
 # focused on newly introduced undeclared dependencies.
 _TEST_ONLY_DECLARED_DEPS: dict[str, list[str]] = {
-    "agentclaw.community.core.service_bot": ["agentclaw.community.api.channel_service"],
+    "agentclaw.community.core.service_bot": [
+        "agentclaw.community.api.channel_service",
+        "agentclaw.community.plugin_api.eval_env",
+    ],
 }
 
 

--- a/src/backend/tests/community/core/service_bot/services/test_publish_flow_service.py
+++ b/src/backend/tests/community/core/service_bot/services/test_publish_flow_service.py
@@ -3407,6 +3407,9 @@ async def test_eval_publish_success():
     assert build_service.release_async.await_args.kwargs["bot"] == bot_service.get_bot.return_value
     assert build_service.release_async.await_args.kwargs["ext_info"] == {"biz_id": "biz-001"}
     assert bot_service.get_bot.return_value["ext"] == {}
+    # 未传 default_tag 时 AGENTCLAW_DEFAULT_TAG 不应注入 extra_envs
+    extra_envs = build_service.release_async.await_args.kwargs["extra_envs"]
+    assert "AGENTCLAW_DEFAULT_TAG" not in extra_envs
     # #197 all-auto: eval CREATE is auto-approved server-side — no client approve.
     baas_service.approve_publish.assert_not_called()
     # #197: a TTL teardown safety-net task is enqueued for the eval bot.
@@ -3488,6 +3491,9 @@ async def test_eval_publish_with_default_tag():
     ext_info = build_service.release_async.await_args.kwargs["ext_info"]
     assert ext_info["biz_id"] == "eval_chat:bot-1:eval"
     assert ext_info["default_tag"] == "eval"
+    # default_tag 应注入 extra_envs[DYNAMIC_ENV_TAG_KEY]，使容器内进程可感知评测环境
+    extra_envs = build_service.release_async.await_args.kwargs["extra_envs"]
+    assert extra_envs.get("AGENTCLAW_DEFAULT_TAG") == "eval"
 
 
 def test_eval_teardown_with_default_tag():

--- a/src/backend/tests/community/repository/publishing/test_bot_publish_unified.py
+++ b/src/backend/tests/community/repository/publishing/test_bot_publish_unified.py
@@ -405,6 +405,28 @@ def test_get_latest_success_by_source_bot_id_returns_none_when_no_success(repo):
     assert repo.get_latest_success_by_source_bot_id("src-missing", "dev") is None
 
 
+def test_get_latest_built_by_source_bot_id_owner_agnostic_returns_latest(repo):
+    """Eval 区版本锚定：latest built row, owner-agnostic."""
+    repo.insert(_data(source_bot_id="src-1", owner_id="emp001", status="built", env="dev"))
+    latest = repo.insert(
+        _data(source_bot_id="src-1", owner_id="other-owner", status="built", env="dev", version=2)
+    )
+    repo.insert(_data(source_bot_id="src-1", owner_id="emp001", status="success", env="dev", version=3))
+    repo.insert(_data(source_bot_id="src-1", owner_id="emp001", status="built", env="pre", version=4))
+
+    got = repo.get_latest_built_by_source_bot_id("src-1", "dev")
+
+    assert got is not None
+    assert got.id == latest.id
+
+
+def test_get_latest_built_by_source_bot_id_returns_none_when_no_built(repo):
+    repo.insert(_data(source_bot_id="src-1", owner_id="emp001", status="success", env="dev"))
+
+    assert repo.get_latest_built_by_source_bot_id("src-1", "dev") is None
+    assert repo.get_latest_built_by_source_bot_id("src-missing", "dev") is None
+
+
 # ── config_artifact OSS offload ─────────────────────────────────────
 #
 # When ``ext['config_artifact']`` serializes past the inline TEXT-column


### PR DESCRIPTION
## Problem

评测环境（Eval 区）创建 Bot 时存在两个缺陷：

1. **容器无法感知区标识**：`eval_publish` 虽然将 `default_tag` 写入 `ext_info`，但未注入到容器环境变量（`extra_envs`），导致容器内进程无法通过 `os.environ` 感知当前所处的评测区标识。
2. **Eval 区锚定了线上版本而非草稿态版本**：`create_eval_env_bot` 使用 `get_latest_success_by_source_bot_id` 查询最新成功发布的版本，但评测目的是验证草稿态（built）版本，应锚定 `status=built` 的最新记录。

## Solution

1. **注入 `AGENTCLAW_DEFAULT_TAG` 到容器环境变量**：在 `EvalPublishMixin._issue()` 中，当 `default_tag` 非空时，将 `DYNAMIC_ENV_TAG_KEY`（即 `AGENTCLAW_DEFAULT_TAG`）写入 `extra_envs`，使容器内进程可通过环境变量感知区标识。无 `default_tag` 时不注入，保持向后兼容。

2. **新增 `get_latest_built_by_source_bot_id` 查询方法**：在 `BotPublishRepositoryProtocol` 和 `BotPublishRepository` 中新增该方法，查询 `status=built` + `env` 匹配 + owner-agnostic 的最新记录（按 `id DESC` 排序），供 Eval 区锚定草稿态版本使用。

**拒绝的替代方案**：
- 复用 `get_latest_success_by_source_bot_id` 并传入不同 status 参数 → 方法语义不清晰，且该方法的 `owner_agnostic` 查询与原方法不一致（built 记录可能由不同 owner 创建），独立方法更明确。

## Validation

- `test_eval_publish_success`：断言未传 `default_tag` 时 `extra_envs` 中不含 `AGENTCLAW_DEFAULT_TAG`
- `test_eval_publish_with_default_tag`：断言传入 `default_tag` 时 `extra_envs["AGENTCLAW_DEFAULT_TAG"]` 值正确
- `test_get_latest_built_by_source_bot_id_owner_agnostic_returns_latest`：验证 owner-agnostic + id DESC 排序 + env 过滤 + status=built 筛选
- `test_get_latest_built_by_source_bot_id_returns_none_when_no_built`：验证无 built 记录时返回 None
- 全部测试通过：Avernet backend eval 相关 5 passed；repository 新增 2 passed
- OCB 侧测试同步更新并通过：`test_default_env_bot_service.py` 125 passed；`test_eval_env_bot_service.py` 23 passed

## Compatibility and risk

- **向后兼容**：`extra_envs` 注入仅在 `default_tag` 非空时生效，现有不传 `default_tag` 的调用路径行为不变
- **新增 Protocol 方法**：`get_latest_built_by_source_bot_id` 为新增抽象方法，当前唯一实现类 `BotPublishRepository` 已补全实现，无遗漏
- **数据库查询**：新增方法所需索引与 `get_latest_success_by_source_bot_id` 一致（`source_bot_id + status + env`），无额外索引迁移