### PR TITLE
fix(backend): avoid repeated MCP projection reads and device resolution

### DIFF
--- a/src/backend/src/agentclaw/community/core/mcp/mcp_sync_service_protocol.py
+++ b/src/backend/src/agentclaw/community/core/mcp/mcp_sync_service_protocol.py
@@ -8,7 +8,13 @@ from typing import Any, Protocol, runtime_checkable
 
 @runtime_checkable
 class MCPSyncServiceProtocol(Protocol):
-    """Service API for syncing MCP details to bot devices."""
+    """Service API for syncing MCP details to bot devices.
+
+    ``sync_mcp_details_for_bot`` and ``remove_mcp_detail`` accept an optional
+    ``device_sync``: a caller-resolved DeviceSync for the same Bot and current
+    projection only. When supplied, do not re-resolve the target. Omission
+    retains standalone resolution. Never cache it across requests/retries.
+    """
 
     async def sync_mcp_details(self, *args: Any, **kwargs: Any) -> Any: ...
 

--- a/src/backend/src/agentclaw/community/core/mcp/services/sync_service.py
+++ b/src/backend/src/agentclaw/community/core/mcp/services/sync_service.py
@@ -286,6 +286,7 @@ class MCPSyncService(MCPSyncServiceProtocol):
         bot_id: str,
         entity_id: Optional[str] = None,
         engine_type: Optional[str] = None,
+        device_sync: DeviceSync | None = None,
     ) -> dict[str, Any]:
         """把一批已备齐的 MCP 详情推送到**同一个** bot 的设备。
 
@@ -300,6 +301,8 @@ class MCPSyncService(MCPSyncServiceProtocol):
             user_id: 用户 ID。仅用于 ``build_mcp_sync_payload`` 取该用户的 MCP
                 配置(api_key 等),是 per-user 维度。
             mcp_entries: 待推送的 MCP 详情列表;caller 已备齐,本方法不再回查。
+            device_sync: 本次投影已解析的目标；提供时不再解析或切换设备。
+                省略时保持独立调用的原行为。禁止跨请求复用。
             bot_id: 目标 bot ID——列表内所有 MCP 共用。
             entity_id: bot 所属实体 ID,缺省回退到 ``user_id``。
             engine_type: 引擎类型,默认 ``openclaw``。
@@ -313,19 +316,19 @@ class MCPSyncService(MCPSyncServiceProtocol):
             # 无 MCP 可投递:不必解析设备。allow-list 的声明是 caller 的事。
             return {"success": True}
 
-        try:
-            # resolve_for_bot 同步且内含阻塞 ws-info HTTP + DB 查询,放线程池,
-            # 否则会占住 event loop。
-            ctx = await asyncio.to_thread(
-                self._resolver_provider().resolve_for_bot,
-                bot_id,
-                entity_id or user_id,
-            )
-        except (DeviceNotBoundError, UnknownProviderError):
-            error = f"bot={_bot} 缺少设备连接信息，无法推送 MCP 配置"
-            logger.error("[MCPSyncService] %s", error)
-            return {"success": False, "error": error}
-        plugin = self._device_sync_dispatcher_provider().dispatch(ctx)
+        if device_sync is None:
+            try:
+                ctx = await asyncio.to_thread(
+                    self._resolver_provider().resolve_for_bot,
+                    bot_id,
+                    entity_id or user_id,
+                )
+            except (DeviceNotBoundError, UnknownProviderError):
+                error = f"bot={_bot} 缺少设备连接信息，无法推送 MCP 配置"
+                logger.error("[MCPSyncService] %s", error)
+                return {"success": False, "error": error}
+            device_sync = self._device_sync_dispatcher_provider().dispatch(ctx)
+        plugin = device_sync
 
         _successes, failures = await fan_out_mcp_details(
             mcps=mcp_entries,
@@ -357,6 +360,7 @@ class MCPSyncService(MCPSyncServiceProtocol):
         server_code: str,
         bot_id: str,
         user_id: str,
+        device_sync: DeviceSync | None = None,
     ) -> dict[str, Any]:
         """从指定 bot 的设备上移除单个 MCP。
 
@@ -368,17 +372,21 @@ class MCPSyncService(MCPSyncServiceProtocol):
             bot_id: 目标 bot ID。
             user_id: 用户 ID。
 
+            device_sync: 本次投影的已解析目标；省略时自行解析，不跨请求缓存。
+
         Returns:
             ``{"success": bool, "error": str|None}`` 格式的结果字典。
         """
         _bot = bot_id or "unknown"
-        try:
-            ctx = self._resolver_provider().resolve_for_bot(bot_id, user_id)
-        except (DeviceNotBoundError, UnknownProviderError):
-            error = f"bot={_bot} 缺少设备连接信息，无法移除 MCP {server_code}"
-            logger.error("[MCPSyncService] %s", error)
-            return {"success": False, "error": error}
-        plugin = self._device_sync_dispatcher_provider().dispatch(ctx)
+        if device_sync is None:
+            try:
+                ctx = self._resolver_provider().resolve_for_bot(bot_id, user_id)
+            except (DeviceNotBoundError, UnknownProviderError):
+                error = f"bot={_bot} 缺少设备连接信息，无法移除 MCP {server_code}"
+                logger.error("[MCPSyncService] %s", error)
+                return {"success": False, "error": error}
+            device_sync = self._device_sync_dispatcher_provider().dispatch(ctx)
+        plugin = device_sync
 
         # teclaw 在 sync_remove_mcp 内部重组并投递整产物（compose 反映删除后的状态），
         # arca/baas 走单条移除请求——由插件按容器类型决定。

--- a/src/backend/src/agentclaw/community/core/skill_center/AGENTS.md
+++ b/src/backend/src/agentclaw/community/core/skill_center/AGENTS.md
@@ -80,6 +80,8 @@ Bot 定位必须携带 `owner_id + bot_id`，并保持 Repository 的 tenant/env
 
 命令通过 `ProjectionScope` 表达变化范围；Skill claim/release 携带 MCP dependency candidates，由投影端结合完整有效集合过滤。不要把每次操作都扩大为 `everything()`。启动恢复等确实需要完整重投影的入口可使用它。
 
+一次 MCP 投影通过 Reader `active_capabilities` 同步一次 Installation，返回精确 Skill 与 installed MCP 的 `BotCapabilitySnapshot`，供 Skill Plan 和唯一 Effective MCP collector 共用。快照不包括 Policy MCP、不保证跨表事务快照隔离，不能跨变更、重试或请求缓存；Skill-only 仍使用独立 Skill 读取。Default/exclusion 与完整回刷模式均保留。MCP 配置、移除和完整白名单下发在同一次 `project_mcps` 内复用一个解析后的 `DeviceSync`；不改变下发顺序、失败处理、POST-conflict-update 或 Passport 语义。
+
 ## 4. Local、Repo、Center 的内容身份
 
 - `local://...`：Bot-owned 可变内容，由 Local upload/delete 服务及文件适配器管理；上传协议保留 raw ZIP，同时提供 multipart `files + file_paths` 文件夹上传。GET Bot Skills 的 `source=LOCAL` 仅列出该 Bot 上传资产，`active` 再筛选 Desired State；省略 source 保留完整可达资产列表。

--- a/src/backend/src/agentclaw/community/core/skill_center/capability_state_contract.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/capability_state_contract.py
@@ -100,4 +100,4 @@ class BotCapabilityStateReaderProtocol(Protocol):
         ...
 
 
-__all__ = ["BotCapabilityStateReaderProtocol"]
+__all__ = ["BotCapabilitySnapshot", "BotCapabilityStateReaderProtocol"]

--- a/src/backend/src/agentclaw/community/core/skill_center/capability_state_contract.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/capability_state_contract.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
@@ -10,6 +11,20 @@ if TYPE_CHECKING:
     # package __init__ is still executing, so a module-level import of
     # skills_pool.models here would close an import cycle.
     from agentclaw.community.core.skills_pool.models import RegisteredSkillAsset
+
+
+@dataclass(frozen=True)
+class BotCapabilitySnapshot:
+    """One reader-backed projection input, never cached across mutations.
+
+    This groups reads after one synchronization, not a database isolation
+    guarantee. Policy defaults remain the effective-MCP collector's concern.
+    """
+
+    bot_id: str
+    owner_id: str
+    skills: tuple[RegisteredSkillAsset, ...]
+    installed_mcp_server_codes: frozenset[str]
 
 
 @runtime_checkable
@@ -58,6 +73,20 @@ class BotCapabilityStateReaderProtocol(Protocol):
         bot: Mapping[str, Any] | None = None,
     ) -> tuple[RegisteredSkillAsset, ...]:
         """Flush, then return Runtime-ready assets with exact Center Versions."""
+        ...
+
+    def active_capabilities(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+        bot: Mapping[str, Any] | None = None,
+    ) -> BotCapabilitySnapshot:
+        """Synchronize once, then read exact Skills and installed MCP codes.
+
+        Consume only within the current projection; after a write or retry,
+        obtain a new snapshot. This does not include engine Policy MCPs.
+        """
         ...
 
     def active_mcp_server_codes(

--- a/src/backend/src/agentclaw/community/core/skill_center/services/bot_capability_state_reader.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/bot_capability_state_reader.py
@@ -31,6 +31,7 @@ from agentclaw.community.core.skill_center.version_resolution_contract import (
 )
 from agentclaw.community.core.skills_pool.models import RegisteredSkillAsset
 from agentclaw.community.core.skill_center.bot_capability_state_reader_protocol import BotCapabilityStateReaderProtocol
+from agentclaw.community.core.skill_center.capability_state_contract import BotCapabilitySnapshot
 
 
 logger = get_logger()
@@ -118,6 +119,11 @@ class BotCapabilityStateReader(BotCapabilityStateReaderProtocol):
         self.synchronize_installations(
             bot_id=bot_id, owner_id=owner_id, bot=bot
         )
+        return self._read_skill_assets(bot_id=bot_id, owner_id=owner_id, bot=bot)
+
+    def _read_skill_assets(
+        self, *, bot_id: str, owner_id: str, bot: Mapping[str, Any]
+    ) -> tuple[RegisteredSkillAsset, ...]:
         assets = tuple(
             self._pool_skills.list_bot_installed_assets(
                 env=str(bot["env"]),
@@ -127,6 +133,24 @@ class BotCapabilityStateReader(BotCapabilityStateReaderProtocol):
         )
         return self._version_resolver.resolve_latest_runtime_assets(
             env=str(bot["env"]), assets=assets
+        )
+
+    def active_capabilities(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+        bot: Mapping[str, Any] | None = None,
+    ) -> BotCapabilitySnapshot:
+        bot = self._bot(bot_id=bot_id, owner_id=owner_id, bot=bot)
+        self.synchronize_installations(bot_id=bot_id, owner_id=owner_id, bot=bot)
+        return BotCapabilitySnapshot(
+            bot_id=bot_id,
+            owner_id=owner_id,
+            skills=self._read_skill_assets(bot_id=bot_id, owner_id=owner_id, bot=bot),
+            installed_mcp_server_codes=frozenset(
+                self._repository.list_installed_mcps(bot_id=bot_id, owner_id=owner_id)
+            ),
         )
 
     def active_mcp_server_codes(

--- a/src/backend/src/agentclaw/community/core/skill_center/services/bot_runtime_projector.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/bot_runtime_projector.py
@@ -16,6 +16,7 @@ from agentclaw.community.core.mcp.services.cli_passport_scope import (
     build_passport_resource_scope,
 )
 from agentclaw.community.core.skill_center.capability_state_contract import (
+    BotCapabilitySnapshot,
     BotCapabilityStateReaderProtocol,
 )
 from agentclaw.community.core.repository.protocols.bot import BotRepository
@@ -269,11 +270,16 @@ class BotRuntimeProjector(BotRuntimeProjectorProtocol):
             raise LocalSkillNotFoundError()
         skill_plan_started_at = time.perf_counter()
         try:
+            snapshot = (
+                self._reader.active_capabilities(bot_id=bot_id, owner_id=owner_id, bot=bot)
+                if scope.mcp else None
+            )
             skill_plan = self._build_skill_plan(
                 bot=bot,
                 bot_id=bot_id,
                 owner_id=owner_id,
                 retired_mappings=retired_mappings,
+                snapshot=snapshot,
             )
         except Exception:
             self._log_plan_timing(
@@ -302,7 +308,8 @@ class BotRuntimeProjector(BotRuntimeProjectorProtocol):
             return skill_plan
         capability_plan_started_at = time.perf_counter()
         try:
-            capability_plan = self._build_capability_plan(skill_plan)
+            assert snapshot is not None
+            capability_plan = self._build_capability_plan(skill_plan, snapshot)
         except Exception:
             self._log_plan_timing(
                 stage="build_mcp_plan",
@@ -380,6 +387,7 @@ class BotRuntimeProjector(BotRuntimeProjectorProtocol):
         bot_id: str,
         owner_id: str,
         retired_mappings: Sequence[PoolSkillMapping] = (),
+        snapshot: BotCapabilitySnapshot | None = None,
     ) -> ResolvedSkillPlan:
         engine = str(bot.get("active_engine") or "openclaw")
         service = self._factory.create(
@@ -393,6 +401,7 @@ class BotRuntimeProjector(BotRuntimeProjectorProtocol):
         # over Installation that agrees with Set configuration — the lazy
         # flush every read runs, not a projector-only repair.
         skill_assets = tuple(
+            snapshot.skills if snapshot is not None else
             self._reader.active_skill_assets(bot_id=bot_id, owner_id=owner_id, bot=bot)
         )
         # Reject before querying or writing any external MCP, Passport, or
@@ -412,7 +421,7 @@ class BotRuntimeProjector(BotRuntimeProjectorProtocol):
         )
 
     def _build_capability_plan(
-        self, skill_plan: ResolvedSkillPlan
+        self, skill_plan: ResolvedSkillPlan, snapshot: BotCapabilitySnapshot
     ) -> ResolvedCapabilityPlan:
         bot = skill_plan.bot
         bot_id = skill_plan.bot_id
@@ -456,6 +465,7 @@ class BotRuntimeProjector(BotRuntimeProjectorProtocol):
                 entity_type=bot.get("entity_type") or "staff",
                 engine_type=engine,
                 strict_policy_context=True,
+                capability_snapshot=snapshot,
             )
         except Exception as exc:
             self._log_plan_timing(
@@ -486,30 +496,7 @@ class BotRuntimeProjector(BotRuntimeProjectorProtocol):
             stage="query_passport_clis", bot_id=bot_id, engine=engine,
             started_at=started_at, outcome="success", cli_count=len(effective_cli_items),
         )
-        started_at = time.perf_counter()
-        try:
-            installed_mcp_codes = frozenset(
-                self._repository.list_installed_mcps(
-                    bot_id=bot_id, owner_id=owner_id
-                )
-            )
-        except Exception:
-            self._log_plan_timing(
-                stage="read_installed_mcps",
-                bot_id=bot_id,
-                engine=engine,
-                started_at=started_at,
-                outcome="error",
-            )
-            raise
-        self._log_plan_timing(
-            stage="read_installed_mcps",
-            bot_id=bot_id,
-            engine=engine,
-            started_at=started_at,
-            outcome="success",
-            mcp_count=len(installed_mcp_codes),
-        )
+        installed_mcp_codes = snapshot.installed_mcp_server_codes
         started_at = time.perf_counter()
         try:
             projection = RuntimeProjectionResolver().resolve(

--- a/src/backend/src/agentclaw/community/core/skill_center/services/bot_runtime_projector.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/bot_runtime_projector.py
@@ -401,8 +401,8 @@ class BotRuntimeProjector(BotRuntimeProjectorProtocol):
         # over Installation that agrees with Set configuration — the lazy
         # flush every read runs, not a projector-only repair.
         skill_assets = tuple(
-            snapshot.skills if snapshot is not None else
-            self._reader.active_skill_assets(bot_id=bot_id, owner_id=owner_id, bot=bot)
+            snapshot.skills if snapshot is not None
+            else self._reader.active_skill_assets(bot_id=bot_id, owner_id=owner_id, bot=bot)
         )
         # Reject before querying or writing any external MCP, Passport, or
         # runtime boundary. What an engine's runtime cannot carry is the

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any, Callable, List, Mapping, Optional, TypeVa
 
 from agentclaw.community.core.devices.models import SynlinkMappingInfo
 from agentclaw.community.core.devices.services.device_accessor import DeviceAccessor
+from agentclaw.community.core.devices.services.device_sync import DeviceSync
 
 if TYPE_CHECKING:
     from agentclaw.community.core.repository.protocols.bot import BotRepository
@@ -28,6 +29,7 @@ from agentclaw.community.core.mcp.services.config_service import MCPConfigServic
 from agentclaw.community.core.repository.protocols.skill_center import SkillSetRepository
 from agentclaw.community.core.repository.protocols.skill_center import SkillRepository
 from agentclaw.community.core.skill_center.capability_state_contract import (
+    BotCapabilitySnapshot,
     BotCapabilityStateReaderProtocol,
 )
 from agentclaw.community.core.skill_center.errors import (
@@ -633,12 +635,29 @@ class SkillSetService:
         has to declare the larger one — the declaration is a full replacement,
         so skipping it would leave the device's view of the set behind.
         """
-        if not await self.sync_mcp_delivery(claimed=claimed, released=released):
+        started = time.perf_counter()
+        try:
+            ctx = await asyncio.to_thread(
+                self._resolver.resolve_for_bot,
+                self.bot_id,
+                self.entity_id or self.user_id or "",
+            )
+            device_sync = self._device_sync_dispatcher.dispatch(ctx)
+        except Exception:
+            logger.warning("[project_mcps] device resolution failed bot_id=%s", self.bot_id, exc_info=True)
             return False
-        return await self.sync_mcp_desired_state(server_codes=declared)
+        finally:
+            logger.info("[project_mcps] timing stage=resolve_device bot_id=%s duration_ms=%.3f",
+                        self.bot_id, (time.perf_counter() - started) * 1000)
+        if not await self.sync_mcp_delivery(
+            claimed=claimed, released=released, device_sync=device_sync
+        ):
+            return False
+        return await self.sync_mcp_desired_state(server_codes=declared, device_sync=device_sync)
 
     async def sync_mcp_delivery(
-        self, *, claimed: frozenset[str], released: frozenset[str]
+        self, *, claimed: frozenset[str], released: frozenset[str],
+        device_sync: DeviceSync | None = None,
     ) -> bool:
         """Deliver configuration for newly claimed MCPs, withdraw it for released ones.
 
@@ -683,6 +702,7 @@ class SkillSetService:
                     bot_id=self.bot_id,
                     entity_id=self.entity_id,
                     engine_type=self.engine_type,
+                    **({"device_sync": device_sync} if device_sync is not None else {}),
                 )
                 if not delivery.get("success"):
                     logger.error(
@@ -704,6 +724,7 @@ class SkillSetService:
                     server_code=server_code,
                     bot_id=self.bot_id,
                     user_id=self.entity_id or self.user_id or "",
+                    **({"device_sync": device_sync} if device_sync is not None else {}),
                 )
                 if not removal.get("success"):
                     logger.error(
@@ -721,7 +742,9 @@ class SkillSetService:
             )
             return False
 
-    async def sync_mcp_desired_state(self, *, server_codes: set[str]) -> bool:
+    async def sync_mcp_desired_state(
+        self, *, server_codes: set[str], device_sync: DeviceSync | None = None
+    ) -> bool:
         """Declare the complete MCP allow-list to the Bot runtime.
 
         Declaration is total on purpose: ``sync_all_mcp_servers`` is the
@@ -737,18 +760,20 @@ class SkillSetService:
         try:
             # resolve_for_bot 与 sync_all_mcp_servers 都是同步阻塞调用(前者含
             # ws-info HTTP,后者是设备侧 HTTP),留在协程里会占住 event loop。
-            ctx = await asyncio.to_thread(
-                self._resolver.resolve_for_bot,
-                self.bot_id,
-                self.entity_id or self.user_id or "",
-            )
+            if device_sync is None:
+                ctx = await asyncio.to_thread(
+                    self._resolver.resolve_for_bot,
+                    self.bot_id,
+                    self.entity_id or self.user_id or "",
+                )
+                device_sync = self._device_sync_dispatcher.dispatch(ctx)
             logger.info(
                 "[sync_mcp_desired_state] declaring MCP allow-list: bot_id=%s, mcps=%s",
                 self.bot_id, len(server_codes),
             )
             return bool(
                 await asyncio.to_thread(
-                    self._device_sync_dispatcher.dispatch(ctx).sync_all_mcp_servers,
+                    device_sync.sync_all_mcp_servers,
                     # ``filter_servers`` reads server_code/serverCode off each
                     # entry, so bare strings would silently declare nothing.
                     [{"server_code": code} for code in sorted(server_codes)],
@@ -1686,6 +1711,7 @@ class SkillSetService:
         engine_type: Optional[str] = None,
         *,
         strict_policy_context: bool = False,
+        capability_snapshot: BotCapabilitySnapshot | None = None,
     ) -> List[dict]:
         """Effective MCPs = default policy ∪ installed ∪ Skill dependencies.
 
@@ -1699,6 +1725,10 @@ class SkillSetService:
 
         Args:
             engine_type: Engine type for scoping. Defaults to self.engine_type.
+            capability_snapshot: Reader output for this same Bot and projection.
+                When supplied, reuse its Skills and Installation codes while
+                retaining the canonical Default/exclusion/metadata logic below.
+                Omit for standalone reads; never retain across commands.
         """
         if self._reader is None:
             raise RuntimeError(
@@ -1706,6 +1736,10 @@ class SkillSetService:
                 "capability state reader; construct through "
                 "SkillSetServiceFactory"
             )
+        if capability_snapshot is not None and (
+            capability_snapshot.bot_id != bot_id or capability_snapshot.owner_id != user_id
+        ):
+            raise ValueError("Capability snapshot belongs to a different Bot")
         effective_engine = engine_type if engine_type is not None else self.engine_type
         effective_ext_info = self._run_effective_mcp_stage(
             stage="default_ext_info",
@@ -1794,7 +1828,7 @@ class SkillSetService:
             stage="active_skill_assets",
             bot_id=bot_id,
             engine_type=effective_engine,
-            operation=lambda: self._active_skill_assets(
+            operation=lambda: capability_snapshot.skills if capability_snapshot is not None else self._active_skill_assets(
                 entity_id=entity_id, bot_id=bot_id, user_id=user_id
             ),
             item_count=len,
@@ -1803,7 +1837,7 @@ class SkillSetService:
             stage="installed_mcp_codes",
             bot_id=bot_id,
             engine_type=effective_engine,
-            operation=lambda: self._installed_mcp_codes(
+            operation=lambda: capability_snapshot.installed_mcp_server_codes if capability_snapshot is not None else self._installed_mcp_codes(
                 entity_id=entity_id, bot_id=bot_id, user_id=user_id
             ),
             item_count=len,

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
@@ -644,16 +644,23 @@ class SkillSetService:
             )
             device_sync = self._device_sync_dispatcher.dispatch(ctx)
         except Exception:
-            logger.warning("[project_mcps] device resolution failed bot_id=%s", self.bot_id, exc_info=True)
+            logger.warning(
+                "[project_mcps] device resolution failed bot_id=%s",
+                self.bot_id, exc_info=True,
+            )
             return False
         finally:
-            logger.info("[project_mcps] timing stage=resolve_device bot_id=%s duration_ms=%.3f",
-                        self.bot_id, (time.perf_counter() - started) * 1000)
+            logger.info(
+                "[project_mcps] timing stage=resolve_device bot_id=%s duration_ms=%.3f",
+                self.bot_id, (time.perf_counter() - started) * 1000,
+            )
         if not await self.sync_mcp_delivery(
             claimed=claimed, released=released, device_sync=device_sync
         ):
             return False
-        return await self.sync_mcp_desired_state(server_codes=declared, device_sync=device_sync)
+        return await self.sync_mcp_desired_state(
+            server_codes=declared, device_sync=device_sync
+        )
 
     async def sync_mcp_delivery(
         self, *, claimed: frozenset[str], released: frozenset[str],
@@ -1828,8 +1835,11 @@ class SkillSetService:
             stage="active_skill_assets",
             bot_id=bot_id,
             engine_type=effective_engine,
-            operation=lambda: capability_snapshot.skills if capability_snapshot is not None else self._active_skill_assets(
-                entity_id=entity_id, bot_id=bot_id, user_id=user_id
+            operation=lambda: (
+                capability_snapshot.skills if capability_snapshot is not None
+                else self._active_skill_assets(
+                    entity_id=entity_id, bot_id=bot_id, user_id=user_id
+                )
             ),
             item_count=len,
         )
@@ -1837,8 +1847,11 @@ class SkillSetService:
             stage="installed_mcp_codes",
             bot_id=bot_id,
             engine_type=effective_engine,
-            operation=lambda: capability_snapshot.installed_mcp_server_codes if capability_snapshot is not None else self._installed_mcp_codes(
-                entity_id=entity_id, bot_id=bot_id, user_id=user_id
+            operation=lambda: (
+                capability_snapshot.installed_mcp_server_codes if capability_snapshot is not None
+                else self._installed_mcp_codes(
+                    entity_id=entity_id, bot_id=bot_id, user_id=user_id
+                )
             ),
             item_count=len,
         )

--- a/src/backend/tests/community/core/mcp/services/test_sync_service.py
+++ b/src/backend/tests/community/core/mcp/services/test_sync_service.py
@@ -1092,6 +1092,24 @@ class TestSyncMcpDetailsForBot:
         return [{"server_code": f"mcp.s{i}"} for i in range(n)]
 
     @pytest.mark.asyncio
+    async def test_supplied_device_is_used_for_details_and_removal(self):
+        resolver, dispatcher, plugin = _make_resolver_and_dispatcher()
+        svc = _make_sync_service(resolver=resolver, dispatcher=dispatcher)
+        result = await svc.sync_mcp_details_for_bot(
+            user_id="u1", mcp_entries=self._entries(1), bot_id="bot1", device_sync=plugin
+        )
+        assert result["success"] is True
+        plugin.sync_remove_mcp.return_value = True
+        result = await svc.remove_mcp_detail(
+            user_id="u1", bot_id="bot1", server_code="mcp.old", device_sync=plugin
+        )
+        assert result["success"] is True
+        resolver.resolve_for_bot.assert_not_called()
+        dispatcher.dispatch.assert_not_called()
+        plugin.sync_single_mcp.assert_called_once()
+        plugin.sync_remove_mcp.assert_called_once_with("mcp.old")
+
+    @pytest.mark.asyncio
     async def test_device_is_resolved_once_for_the_whole_batch(self):
         resolver, dispatcher, plugin = _make_resolver_and_dispatcher()
         svc = _make_sync_service(resolver=resolver, dispatcher=dispatcher)

--- a/src/backend/tests/community/core/skill_center/services/test_skill_set_service.py
+++ b/src/backend/tests/community/core/skill_center/services/test_skill_set_service.py
@@ -297,6 +297,7 @@ class TestCollectBotActiveMcps:
     @pytest.mark.parametrize("reuse_snapshot", [False, True])
     def test_collect_excludes_user_excluded_default_mcps(self, caplog, reuse_snapshot):
         from agentclaw.community.core.skill_center.capability_state_contract import BotCapabilitySnapshot
+        from agentclaw.community.core.skills_pool.models import RegisteredSkillAsset
         from agentclaw.community.core.skill_center.services.skill_set_service import SkillSetService
         mock_repo = MagicMock()
         mock_repo.get_all_active_skill_sets.return_value = [
@@ -327,7 +328,15 @@ class TestCollectBotActiveMcps:
         caplog.set_level(logging.INFO)
         with patch.object(svc, "get_set_mcp_servers") as mock_get_mcps:
             mock_get_mcps.return_value = []
-            snapshot = BotCapabilitySnapshot("default", "user1", (), frozenset()) if reuse_snapshot else None
+            snapshot = BotCapabilitySnapshot(
+                "default", "user1",
+                (RegisteredSkillAsset(
+                    skill_id=1, name="center", git_path="center://public-code",
+                    skill_uuid="00000000-0000-4000-8000-000000000001",
+                    sc_version_number="2.0.0", mcp_dependencies=("mcp.dependency",),
+                ),),
+                frozenset({"mcp.installed"}),
+            ) if reuse_snapshot else None
             result = svc.collect_bot_active_mcps(
                 "entity1", "default", "user1", "staff", capability_snapshot=snapshot
             )
@@ -336,6 +345,8 @@ class TestCollectBotActiveMcps:
             svc._reader.active_mcp_server_codes.assert_not_called()
 
         codes = {r["server_code"] for r in result}
+        if reuse_snapshot:
+            assert {"mcp.installed", "mcp.dependency"} <= codes
         assert "mcp.ant.antprocessai.anttaskmcp" not in codes
         messages = [record.getMessage() for record in caplog.records]
         for stage in (

--- a/src/backend/tests/community/core/skill_center/services/test_skill_set_service.py
+++ b/src/backend/tests/community/core/skill_center/services/test_skill_set_service.py
@@ -294,7 +294,9 @@ class TestGetSetMcpServers:
 class TestCollectBotActiveMcps:
     """collect_bot_active_mcps filters out user-excluded default MCPs."""
 
-    def test_collect_excludes_user_excluded_default_mcps(self, caplog):
+    @pytest.mark.parametrize("reuse_snapshot", [False, True])
+    def test_collect_excludes_user_excluded_default_mcps(self, caplog, reuse_snapshot):
+        from agentclaw.community.core.skill_center.capability_state_contract import BotCapabilitySnapshot
         from agentclaw.community.core.skill_center.services.skill_set_service import SkillSetService
         mock_repo = MagicMock()
         mock_repo.get_all_active_skill_sets.return_value = [
@@ -325,7 +327,13 @@ class TestCollectBotActiveMcps:
         caplog.set_level(logging.INFO)
         with patch.object(svc, "get_set_mcp_servers") as mock_get_mcps:
             mock_get_mcps.return_value = []
-            result = svc.collect_bot_active_mcps("entity1", "default", "user1", "staff")
+            snapshot = BotCapabilitySnapshot("default", "user1", (), frozenset()) if reuse_snapshot else None
+            result = svc.collect_bot_active_mcps(
+                "entity1", "default", "user1", "staff", capability_snapshot=snapshot
+            )
+        if reuse_snapshot:
+            svc._reader.active_skill_assets.assert_not_called()
+            svc._reader.active_mcp_server_codes.assert_not_called()
 
         codes = {r["server_code"] for r in result}
         assert "mcp.ant.antprocessai.anttaskmcp" not in codes
@@ -813,6 +821,46 @@ class TestSyncMcpDesiredState:
         plugin.sync_all_mcp_servers.assert_called_once_with(
             [{"server_code": code} for code in sorted(codes)]
         )
+
+    @pytest.mark.asyncio
+    async def test_projection_reuses_device_for_details_and_declaration(self):
+        svc, plugin = self._make_svc()
+        events = []
+
+        async def deliver(**kwargs):
+            assert kwargs["device_sync"] is plugin
+            events.append("details")
+            return {"success": True}
+
+        svc._mcp_sync_service.sync_mcp_details_for_bot.side_effect = deliver
+        plugin.sync_all_mcp_servers.side_effect = lambda _codes: events.append("declare") or True
+        assert await svc.project_mcps(
+            claimed=frozenset({"mcp.new"}), released=frozenset(), declared={"mcp.new"}
+        )
+        assert events == ["details", "declare"]
+        svc._resolver.resolve_for_bot.assert_called_once_with("bot1", "staff_user1")
+        svc._device_sync_dispatcher.dispatch.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_projection_failure_does_not_declare_and_next_call_resolves_again(self):
+        svc, plugin = self._make_svc(delivery={"success": False})
+        for _ in range(2):
+            assert not await svc.project_mcps(
+                claimed=frozenset({"mcp.new"}), released=frozenset(), declared={"mcp.new"}
+            )
+        assert svc._resolver.resolve_for_bot.call_count == 2
+        plugin.sync_all_mcp_servers.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_release_only_reuses_device_and_still_declares_empty_scope(self):
+        svc, plugin = self._make_svc()
+        svc._mcp_sync_service.remove_mcp_detail = AsyncMock(return_value={"success": True})
+        assert await svc.project_mcps(
+            claimed=frozenset(), released=frozenset({"mcp.old"}), declared=set()
+        )
+        assert svc._mcp_sync_service.remove_mcp_detail.await_args.kwargs["device_sync"] is plugin
+        svc._resolver.resolve_for_bot.assert_called_once()
+        plugin.sync_all_mcp_servers.assert_called_once_with([])
 
     @pytest.mark.asyncio
     async def test_declaration_pushes_no_configuration(self):

--- a/src/backend/tests/community/core/skill_center/test_bot_capability_state_reader.py
+++ b/src/backend/tests/community/core/skill_center/test_bot_capability_state_reader.py
@@ -148,6 +148,19 @@ def test_the_implementation_satisfies_the_public_protocol():
     assert isinstance(reader, BotCapabilityStateReaderProtocol)
 
 
+@pytest.mark.parametrize("default_sync_only", [False, True])
+def test_projection_snapshot_synchronizes_once_and_is_not_cached(default_sync_only):
+    reader, repository, pool, bots, versions = _reader(default_sync_only=default_sync_only)
+    first = reader.active_capabilities(bot_id="bot-1", owner_id="owner")
+    assert first.skills[0].skill_id == 1
+    assert first.installed_mcp_server_codes == frozenset({"mcp.weather"})
+    assert len(repository.flush_calls) + len(repository.default_sync_calls) == 1
+    assert len(pool.reads) == len(versions.calls) == len(repository.mcp_reads) == 1
+    second = reader.active_capabilities(bot_id="bot-1", owner_id="owner")
+    assert second == first and second is not first
+    assert len(repository.flush_calls) + len(repository.default_sync_calls) == 2
+
+
 def test_skill_read_flushes_then_answers_from_the_installation_join():
     reader, repository, pool_skills, bots, versions = _reader()
 

--- a/src/backend/tests/community/core/skill_center/test_bot_runtime_projector_timing.py
+++ b/src/backend/tests/community/core/skill_center/test_bot_runtime_projector_timing.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 
 import pytest
+from agentclaw.community.core.skill_center.capability_state_contract import BotCapabilitySnapshot
 
 from agentclaw.community.core.skill_center.runtime_projection_contract import (
     ProjectionScope,
@@ -34,10 +35,18 @@ class _Factory:
 
 class _SkillSetService:
     def collect_bot_active_mcps(self, **_kwargs) -> list[dict]:
+        assert isinstance(_kwargs["capability_snapshot"], BotCapabilitySnapshot)
         return []
 
 
 class _Reader:
+    def __init__(self):
+        self.snapshot_reads = 0
+
+    def active_capabilities(self, **kwargs):
+        self.snapshot_reads += 1
+        return BotCapabilitySnapshot(kwargs["bot_id"], kwargs["owner_id"], (), frozenset())
+
     def active_skill_assets(self, **_kwargs) -> list:
         return []
 
@@ -91,6 +100,7 @@ def test_runtime_projector_logs_skill_and_mcp_plan_timing(caplog) -> None:
     )
 
     assert isinstance(plan, ResolvedCapabilityPlan)
+    assert projector._reader.snapshot_reads == 1
     messages = [record.getMessage() for record in caplog.records]
     for stage in (
         "build_skill_plan",
@@ -98,7 +108,6 @@ def test_runtime_projector_logs_skill_and_mcp_plan_timing(caplog) -> None:
         "resolve_mcp_identity_modes",
         "collect_effective_mcps",
         "query_passport_clis",
-        "read_installed_mcps",
         "resolve_effective_capabilities",
     ):
         assert any(
@@ -115,7 +124,7 @@ def test_runtime_projector_logs_skill_and_mcp_plan_timing(caplog) -> None:
     "stage",
     (
         "resolve_mcp_identity_modes",
-        "read_installed_mcps",
+        "build_skill_plan",
         "resolve_effective_capabilities",
     ),
 )
@@ -130,8 +139,8 @@ def test_runtime_projector_logs_substage_errors(
 
     if stage == "resolve_mcp_identity_modes":
         monkeypatch.setattr(projector, "_resolve_mcp_identity_modes", fail)
-    elif stage == "read_installed_mcps":
-        monkeypatch.setattr(projector._repository, "list_installed_mcps", fail)
+    elif stage == "build_skill_plan":
+        monkeypatch.setattr(projector._reader, "active_capabilities", fail)
     else:
         monkeypatch.setattr(RuntimeProjectionResolver, "resolve", fail)
 

--- a/src/backend/tests/community/core/skill_center/test_skill_set_management_service.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_set_management_service.py
@@ -2231,6 +2231,7 @@ async def test_runtime_projection_mcp_inputs_agree_when_the_union_overlaps():
 
 @pytest.mark.asyncio
 async def test_runtime_reconcile_projects_full_mcp_desired_state():
+    from agentclaw.community.core.skill_center.capability_state_contract import BotCapabilitySnapshot
     factory = _RuntimeFactory()
     passport = _RuntimePassport()
     runtime = BotRuntimeProjector(
@@ -2269,6 +2270,9 @@ async def test_runtime_reconcile_projects_full_mcp_desired_state():
             "entity_type": "staff",
             "engine_type": "openclaw",
             "strict_policy_context": True,
+            "capability_snapshot": BotCapabilitySnapshot(
+                "bot-1", "true-owner", (), frozenset({"mcp.weather"})
+            ),
         }
     ]
     assert passport.calls == [


### PR DESCRIPTION
## Problem

MCP-only capability changes repeatedly synchronize Installation and read the same Skill/MCP inputs while constructing one post-mutation projection. Detail delivery and allow-list declaration also independently resolve the same device, adding serial database and transport work.

## Solution

- Add a reader-backed `BotCapabilitySnapshot`: synchronize once, resolve exact Skill versions, and read installed MCP codes. Reuse this input in Skill/MCP plans and the existing effective-MCP collector.
- Resolve one `DeviceSync` per MCP projection and pass it to detail delivery, removal, and full allow-list declaration. Standalone entry points retain their existing resolution behavior.
- Keep Default policy/exclusion/dependency logic, full/default-only migration modes, write ordering, failure semantics, and POST-conflict-update behavior unchanged.
- Add device-resolution timing. No cross-request cache or asynchronous HTTP contract is introduced.

## Validation

- Focused Reader/Direct/SkillSet/MCP/DI/write-ownership suite: 605 passed.
- Additional architecture, projector conformance, runtime-message and device suites: 318 passed.
- Added coverage for one synchronization per snapshot in both migration modes, fresh snapshots on repeated calls, exact Center dependency/Installation union, same-device delivery/removal/declaration, delivery failure short-circuit, and fresh device resolution on retry.
- Ruff and git diff whitespace checks passed.
- Standards/Spec reviews found no P1/P2 findings.
- Backend full suite and other CI gates are delegated to GitHub CI; no deployed latency improvement is claimed.

## Compatibility and risk

Internal Service API additions only; no HTTP/DDL/config/Engine protocol changes. Snapshot is request-local grouped input, not a transaction-isolation guarantee. Skill-only reads retain their previous scope.

Checked the matching OCB release dispatcher, DI factories and consumer implementations. OCB reuses these Community services and the existing DeviceSync contract; no Corp implementation change was identified. OCB must bump its public submodule after merge before deployment. Enterprise runtime verification remains pending.

## Spec

Implements the two approved optimizations: post-mutation capability snapshot reuse and per-projection MCP device-context reuse. Module maintenance contract updated in `src/backend/src/agentclaw/community/core/skill_center/AGENTS.md`.
