### PR TITLE
feat(singlebox): build publish snapshots from per-bot local engine directories

### DIFF
--- a/src/backend/src/agentclaw/community/core/service_bot/services/bot_build_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/bot_build_service.py
@@ -228,6 +228,7 @@ class BotBuildService:
         *,
         shared_corpora: tuple[ResolvedSharedCorpusDelivery, ...] = (),
         active_runtime_path: str | None = None,
+        local_source_root: Path | None = None,
     ) -> Dict[str, Any]:
         """执行 Bot 构建迁移。
 
@@ -292,19 +293,36 @@ class BotBuildService:
 
         try:
             # ============================================================
-            # Step 1: 计算源目录和目标目录（统一走 NAS 存储）
+            # Step 1: 计算源目录和目标目录
+            #   - local 模式（local_source_root 给定，singlebox/本地开发）: 源取
+            #     引擎本地工作目录根（provider.get_base_path()，如 ~/.openclaw）
+            #     不走 NAS、不执行 sudo chmod / sudo rsync（target 已是本地可写）。
+            #   - 其它（prod/ARCA）: 维持原 NAS 行为，per-bot NAS merge 路径作源。
             # ============================================================
-            source_nas_engine_type = bot.get("active_engine") or engine_type
-            nas_storage_id = get_bot_nas_dir(
-                entity_id=entity_id,
-                bot_id=bot_id,
-                engine_type=source_nas_engine_type,
-                entity_type=entity_type,
-            )
-            source_dir = nas_storage_id / build_plan.source_root_name
-            logger.info(
-                f"[BotBuildService.build] using NAS source_dir={source_dir}"
-            )
+            is_local = local_source_root is not None
+            nas_storage_id: Path | str | None = None
+            if is_local:
+                # provider.get_base_path() itself is the engine working dir
+                # (e.g. ~/.openclaw already contains openclaw.json/agents/...),
+                # so do NOT append build_plan.source_root_name here — that
+                # concatenation is specific to the NAS per-bot merge layout.
+                source_dir = Path(local_source_root)
+                logger.info(
+                    f"[BotBuildService.build] using local source_dir="
+                    f"{source_dir} (local_source_root)"
+                )
+            else:
+                source_nas_engine_type = bot.get("active_engine") or engine_type
+                nas_storage_id = get_bot_nas_dir(
+                    entity_id=entity_id,
+                    bot_id=bot_id,
+                    engine_type=source_nas_engine_type,
+                    entity_type=entity_type,
+                )
+                source_dir = nas_storage_id / build_plan.source_root_name
+                logger.info(
+                    f"[BotBuildService.build] using NAS source_dir={source_dir}"
+                )
 
             target_dir = get_bot_dir(
                 entity_id=entity_id,
@@ -333,8 +351,8 @@ class BotBuildService:
                 source_dir=source_dir,
                 target_dir=target_dir,
                 version_str=version_str,
-                is_nas=True,
-                nas_storage_id=nas_storage_id,
+                is_nas=not is_local,
+                nas_storage_id=nas_storage_id if not is_local else None,
                 build_plan=build_plan,
                 provider=provider,
             )
@@ -347,12 +365,26 @@ class BotBuildService:
             # Claude Code active root is already covered by extra_sync.
 
             # 2.2 生成 MCP 配置（使用 bot 的 device_id）
+            # Local build (singlebox / local dev): the OpenClaw engine runtime
+            # has no mcporter CLI, so it never maintains
+            # the engine's in-container mcporter.json — `cat` returns empty and
+            # fails the build. This is the same root cause
+            # ``SingleboxDeviceSyncService.sync_all_mcp_servers`` already defers
+            # ("skip MCP whitelist sync: the Singlebox Engine requires mcporter,
+            # which is unavailable"). Defer here too: the build snapshot does
+            # not need a host-regenerated mcporter.json because singlebox routes
+            # MCP through the channel runtime, not the mcporter process file.
             mcp_success = True
-            if device_id and migration_success:
+            if device_id and migration_success and not is_local:
                 mcp_success = self._generate_mcp_config(
                     device_id=device_id,
                     target_dir=target_dir,
                     build_plan=build_plan,
+                )
+            elif is_local:
+                logger.info(
+                    "[BotBuildService.build] skipping MCP config generation "
+                    "(local source root; singlebox has no mcporter.json)"
                 )
 
             # 2.3 生成多阶段 OpenClaw 配置
@@ -1212,18 +1244,33 @@ class BotBuildService:
         )
 
         if not is_nas:
-            try:
-                # 重启 sync 服务确保构建前强制同步
-                self._device_service.exec_shell_new(
-                    device_id=device_id,
-                    shell_cmd="supervisorctl restart sync",
+            # ARCA/BaaS remote source path: the source bot rowns its files
+            # inside a container, so nudge its in-place sync supervisor before
+            # the rsync capture. Local builds (local_source_root set) have no
+            # remote container — any unit 'exec_shell_new' against a local
+            # simulator is a no-op and the sleep(10) only stalls the publish.
+            # Local build: build() set local_source_root and passed
+            # is_nas=False + nas_storage_id=None. Distinguish that from the
+            # genuine BaaS/ARCA remote path (which is also is_nas=False).
+            _is_local_source = nas_storage_id is None
+            if _is_local_source:
+                logger.info(
+                    "[BotBuildService._migrate_bot_instance] "
+                    "skipping BaaS sync restart (local source root)"
                 )
-                time.sleep(10)
-            except Exception as e:
-                logger.error(
-                    f"[BotBuildService._migrate_bot_instance] exec shell cmd supervisorctl restart sync"
-                    f"Unexpected error: {e}"
-                )
+            else:
+                try:
+                    # 重启 sync 服务确保构建前强制同步
+                    self._device_service.exec_shell_new(
+                        device_id=device_id,
+                        shell_cmd="supervisorctl restart sync",
+                    )
+                    time.sleep(10)
+                except Exception as e:
+                    logger.error(
+                        f"[BotBuildService._migrate_bot_instance] exec shell cmd supervisorctl restart sync"
+                        f"Unexpected error: {e}"
+                    )
 
         try:
             # 确保目标目录存在
@@ -1235,9 +1282,11 @@ class BotBuildService:
                 excludes.append(f"--exclude={pattern}")
 
             # 构建 rsync 命令
+            # 本地源(is_nas=False)时无需 sudo:源是引擎本地工作目录(开发者机可读),
+            # 目标是 LOCAL_AIDESKTOP_ROOT 下可写路径;提权只在 NAS 属主模型下需要。
+            rsync_prefix = ["sudo", "rsync"] if is_nas else ["rsync"]
             cmd = [
-                "sudo",
-                "rsync",
+                *rsync_prefix,
                 "-av",           # 归档模式 + 详细输出
                 "--delete",       # 删除目标目录中不存在于源目录的文件
                 # The versioned target is reused when the same publish version
@@ -1289,8 +1338,7 @@ class BotBuildService:
                     extra_target.mkdir(parents=True, exist_ok=True)
 
                     extra_cmd = [
-                        "sudo",
-                        "rsync",
+                        *rsync_prefix,
                         "-av",
                         "--delete",
                         "--delete-excluded",

--- a/src/backend/src/agentclaw/community/core/service_bot/services/deploy/local_build_producer.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/deploy/local_build_producer.py
@@ -1,0 +1,166 @@
+"""``LocalBuildProducer`` — produce a build snapshot from a local engine source.
+
+The singlebox / local-dev counterpart of :class:`ArcaSnapshotProducer`. It still
+delegates to ``bot_build_service.build()`` (host-side copy of the engine root
+into the versioned target), but the **source** is the engine's local working
+directory (``EngineSandboxProvider.get_base_path()``, e.g. ``~/.openclaw`` for
+singlebox) instead of the production per-bot NAS merge area (which only
+exists on the ARCA/ECS sandbox and is never writable/executable from a dev host).
+
+Why a separate producer:
+- The ARCA build path assumes a per-bot NFS mount that only exists on the
+  production ARCA/ECS sandbox. A developer laptop running singlebox has the
+  engine's real files under the configured engine root (``openclaw_root``),
+  never under the NAS merge path — so the NAS migration
+  (``get_bot_nas_dir`` + ``sudo chmod`` + ``sudo rsync``) aborts on the host
+  (``sudo: a password is required``) and the publish build stage fails.
+- ``BotBuildService.build()`` already accepts an optional
+  ``local_source_root`` keyword that, when set, replaces the NAS source and
+  disables the ``sudo chmod`` / ``sudo rsync`` privilege dance. This producer
+  is the thin layer that supplies that root from the matching engine sandbox
+  provider.
+
+Behavior parity with ARCA:
+- Same ``requires_runtime_layout_observation = True`` so ``BuildStageRunner``
+  probes the runtime layout (and the shared-corpus exclusions are honored).
+- ``build()`` returns the same result dict (``migration_path`` /
+  ``build_target_path`` / ``success``); the ext mapping is byte-for-byte
+  identical to :class:`ArcaSnapshotProducer` so the downstream verify/online
+  deploy path is untouched.
+
+Selected via ``DeployArtifactProducerRouter`` under the ``"local"`` key, and —
+because ``resolve()`` returns the *hit* provider (it does not fall back to the
+default once a key matches) — singlebox re-points the ``"arca"``/``"baas"``
+keys here too, so bots whose ``device_provider`` resolves to ``"baas"`` still
+land on the local snapshot path instead of the NAS one.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from agentclaw.community.core.service_bot.services.deploy.artifact_build_request import (
+    ArtifactBuildRequest,
+)
+from agentclaw.community.core.service_bot.services.deploy.producer import (
+    DeployArtifact,
+    DeployArtifactProducer,
+)
+from agentclaw.community.core.service_bot.services.deploy.service_skills_manifest import (
+    ServiceSkillsManifestBuilder,
+)
+from agentclaw.community.core.workspace.engine_sandbox import EngineSandboxRegistry
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from agentclaw.community.core.service_bot.services.bot_build_service import (
+        BotBuildService,
+    )
+
+
+class LocalBuildProducer(DeployArtifactProducer):
+    """Build a snapshot from the engine's local working directory (no NAS).
+
+    Wired for singlebox / local dev so the publish build stage never touches
+    the production NAS merge area, mirroring how the rest of singlebox keeps
+    everything on the localhost filesystem.
+    """
+
+    requires_runtime_layout_observation = True
+
+    def __init__(
+        self,
+        build_service: "BotBuildService",
+        skills_manifest_builder: ServiceSkillsManifestBuilder,
+        sandbox_registry: EngineSandboxRegistry,
+    ) -> None:
+        self._build_service = build_service
+        self._skills_manifest_builder = skills_manifest_builder
+        self._sandbox_registry = sandbox_registry
+
+    def _resolve_local_source_root(self, bot: dict[str, Any]) -> Path:
+        """Resolve the local engine source root for ``bot``.
+
+        Uses the same engine resolution as ``BotBuildService.build()`` so the
+        selected provider matches the build plan: fall back through
+        ``active_engine`` → resolved engine → the default engine when the
+        bot's engine is unknown (mirrors
+        ``BotBuildService._resolve_sandbox_provider``'s fallback chain).
+        """
+        from agentclaw.community.core.bot_management.engines.registry import (
+            resolve_bot_engine,
+        )
+        from agentclaw.community.core.workspace.constants import DEFAULT_ENGINE_TYPE
+
+        engine_type = bot.get("active_engine") or DEFAULT_ENGINE_TYPE
+        engine_type = resolve_bot_engine(bot) or engine_type
+        try:
+            provider = self._sandbox_registry.resolve(engine_type)
+        except Exception:
+            try:
+                provider = self._sandbox_registry.resolve(DEFAULT_ENGINE_TYPE)
+            except Exception as exc:  # pragma: no cover - registry is non-empty
+                raise ValueError(
+                    "no engine sandbox provider available for local build"
+                ) from exc
+        return Path(provider.get_base_path())
+
+    def produce_artifact(self, request: ArtifactBuildRequest) -> DeployArtifact:
+        """Delegate to ``build()`` with the local engine source root.
+
+        Same ext mapping as :class:`ArcaSnapshotProducer` — only the source
+        root changes — so the deployable pointers pinned onto ``ext`` stay
+        identical and the downstream verify/online deploy path is untouched.
+        """
+        if request.version is None:
+            raise ValueError("local build snapshot requires a publish version")
+        bot = dict(request.bot)
+        captured_layout = self._skills_manifest_builder.capture(
+            bot=bot,
+            layout_observation=request.layout_observation,
+        )
+        build_kwargs: dict[str, Any] = {
+            "bot": bot,
+            "version": request.version,
+            "local_source_root": self._resolve_local_source_root(bot),
+        }
+        if captured_layout is not None:
+            build_kwargs["shared_corpora"] = captured_layout.shared_corpora
+            build_kwargs["active_runtime_path"] = captured_layout.active_runtime_path
+        result = self._build_service.build(**build_kwargs)
+
+        success = bool(result.get("success"))
+        ext: dict[str, Any] = {}
+        if "migration_path" in result:
+            ext["migration_path"] = result.get("migration_path")
+        if "build_target_path" in result:
+            ext["build_target_path"] = result.get("build_target_path")
+        if success and captured_layout is not None:
+            build_target_path = result.get("build_target_path")
+            if not build_target_path:
+                raise ValueError(
+                    "successful service build is missing build_target_path"
+                )
+            # Reuse the ARCA shared-corpus validation verbatim: the snapshot
+            # shape (exclusions + exact Center links) is engine-determined, not
+            # NAS/local-determined, so the same invariants apply to a local build.
+            from agentclaw.community.core.service_bot.services.deploy.arca_snapshot_producer import (
+                ArcaSnapshotProducer,
+            )
+
+            ArcaSnapshotProducer._validate_shared_corpus_snapshot(
+                captured=captured_layout,
+                build_target_path=str(build_target_path),
+                snapshot_paths=result.get("shared_corpus_snapshot_paths"),
+                active_snapshot_path=result.get("active_skill_snapshot_path"),
+            )
+            ext["skills_manifest"] = self._skills_manifest_builder.finalize(
+                captured=captured_layout,
+                bot=bot,
+            )
+
+        return DeployArtifact(
+            success=success,
+            ext=ext,
+            message="" if success else "构建失败",
+        )

--- a/src/backend/src/agentclaw/community/core/service_bot/services/deploy/local_build_producer.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/deploy/local_build_producer.py
@@ -1,24 +1,11 @@
 """``LocalBuildProducer`` — produce a build snapshot from a local engine source.
 
-The singlebox / local-dev counterpart of :class:`ArcaSnapshotProducer`. It still
-delegates to ``bot_build_service.build()`` (host-side copy of the engine root
-into the versioned target), but the **source** is the engine's local working
-directory (``EngineSandboxProvider.get_base_path()``, e.g. ``~/.openclaw`` for
-singlebox) instead of the production per-bot NAS merge area (which only
-exists on the ARCA/ECS sandbox and is never writable/executable from a dev host).
-
-Why a separate producer:
-- The ARCA build path assumes a per-bot NFS mount that only exists on the
-  production ARCA/ECS sandbox. A developer laptop running singlebox has the
-  engine's real files under the configured engine root (``openclaw_root``),
-  never under the NAS merge path — so the NAS migration
-  (``get_bot_nas_dir`` + ``sudo chmod`` + ``sudo rsync``) aborts on the host
-  (``sudo: a password is required``) and the publish build stage fails.
-- ``BotBuildService.build()`` already accepts an optional
-  ``local_source_root`` keyword that, when set, replaces the NAS source and
-  disables the ``sudo chmod`` / ``sudo rsync`` privilege dance. This producer
-  is the thin layer that supplies that root from the matching engine sandbox
-  provider.
+The singlebox counterpart of :class:`ArcaSnapshotProducer` delegates to
+``bot_build_service.build()`` but obtains its source from the existing
+``WorkspacePathFactory`` per-bot host layout. The source is selected by entity,
+Bot ID and engine, not by the global engine sandbox default (such as
+``~/.openclaw``). Missing per-bot sources fail rather than falling back to that
+unrelated global directory or the production NAS merge area.
 
 Behavior parity with ARCA:
 - Same ``requires_runtime_layout_observation = True`` so ``BuildStageRunner``
@@ -51,6 +38,7 @@ from agentclaw.community.core.service_bot.services.deploy.service_skills_manifes
     ServiceSkillsManifestBuilder,
 )
 from agentclaw.community.core.workspace.engine_sandbox import EngineSandboxRegistry
+from agentclaw.community.core.workspace.path_factory import WorkspacePathFactory
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from agentclaw.community.core.service_bot.services.bot_build_service import (
@@ -73,10 +61,12 @@ class LocalBuildProducer(DeployArtifactProducer):
         build_service: "BotBuildService",
         skills_manifest_builder: ServiceSkillsManifestBuilder,
         sandbox_registry: EngineSandboxRegistry,
+        path_factory: WorkspacePathFactory,
     ) -> None:
         self._build_service = build_service
         self._skills_manifest_builder = skills_manifest_builder
         self._sandbox_registry = sandbox_registry
+        self._path_factory = path_factory
 
     def _resolve_local_source_root(self, bot: dict[str, Any]) -> Path:
         """Resolve the local engine source root for ``bot``.
@@ -103,7 +93,21 @@ class LocalBuildProducer(DeployArtifactProducer):
                 raise ValueError(
                     "no engine sandbox provider available for local build"
                 ) from exc
-        return Path(provider.get_base_path())
+        identity: dict[str, str] = {}
+        for field in ("entity_id", "bot_id", "entity_type"):
+            value = bot.get(field, "staff" if field == "entity_type" else None)
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError(f"local build requires {field}")
+            identity[field] = value
+        source_root = self._path_factory.get_bot_engine_dir(
+            entity_id=identity["entity_id"],
+            bot_id=identity["bot_id"],
+            engine_type=provider.engine_type,
+            entity_type=identity["entity_type"],
+        )
+        if not source_root.is_dir():
+            raise ValueError("local build source directory does not exist")
+        return source_root
 
     def produce_artifact(self, request: ArtifactBuildRequest) -> DeployArtifact:
         """Delegate to ``build()`` with the local engine source root.

--- a/src/backend/src/agentclaw/community/core/workspace/engines/openclaw.py
+++ b/src/backend/src/agentclaw/community/core/workspace/engines/openclaw.py
@@ -37,6 +37,15 @@ _OPENCLAW_RSYNC_EXCLUDES = [
     "session_user_map.json",
     "cron/runs/",
     "identity/device.json",
+    # Atomic-write temp backups of openclaw.json (the engine writes
+    # openclaw.json.asback_<ts> then renames over openclaw.json). These are
+    # transient write-side residue owned by whichever uid the engine ran
+    # under (root under sudo/docker) and are not part of the stable source
+    # tree. Excluding them keeps the build snapshot to the real working
+    # directory and lets a non-privileged rsync (singlebox, no sudo) succeed
+    # even when a leftover backup is mode 0600 and unreadable to the host
+    # user — which is exactly what aborted the singlebox publish build.
+    "openclaw.json.asback*",
 ]
 
 

--- a/src/backend/src/agentclaw/community/di/modules/singlebox_service_bot_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/singlebox_service_bot_module.py
@@ -1,0 +1,133 @@
+"""Singlebox-only producer router override.
+
+Singlebox runs on a developer laptop (or CI) with **no ARCA/ECS sandbox**, so
+the engine's bot files live on the **localhost filesystem** under the
+configured engine root (``openclaw_root`` → ``~/.openclaw``), never under the
+production per-bot NAS merge area. The base
+``ServiceBotModule`` wires the publish build's ``DeployArtifactProducerRouter``
+to point ``arca``/``baas`` at :class:`ArcaSnapshotProducer`, which computes
+the build source via ``get_bot_nas_dir(...)`` and runs ``sudo chmod`` +
+``sudo rsync`` against it — both abort on a dev laptop (``sudo: a password is
+required``; the NAS path does not exist), failing the publish build stage.
+
+This module re-binds ``DeployArtifactProducerRouter`` so singlebox routes the
+publish build through :class:`LocalBuildProducer`, which sources the artifact
+from the engine's local working directory (``EngineSandboxProvider.get_base_path()``).
+Following the existing singlebox override pattern (see ``SingleboxAccessModule``,
+``SingleboxDevicesModule``), installing this module after the base
+``ServiceBotModule`` makes the later binding win.
+
+Why re-point ``"arca"`` and ``"baas"`` too (not just set ``default_provider_key``):
+``DeployArtifactProducerRouter.resolve()`` returns the *hit* provider and only
+falls back to the default when the key is absent. Non-teclaw bots resolve
+their ``device_provider`` to ``"baas"`` (see ``provider_resolver.py``), which
+*hits* the map — so merely changing the default would leave ``"baas"`` pointed
+at the NAS producer and the local path would never be selected. All local
+builds must land on :class:`LocalBuildProducer`, so the local keys
+(``local``/``arca``/``baas``) are re-pointed here.
+
+``teclaw`` keeps :class:`ExternalComposeProducer` — singlebox has teclaw
+external-container bots too, and their compose-from-DB+OSS path is
+NAS-independent by design.
+"""
+
+from __future__ import annotations
+
+from injector import Injector, Module, inject, provider, singleton
+
+from agentclaw.community.core.bot_management.engines.registry import resolve_bot_engine  # noqa: F401  # (kept for parity; module-level import surface)
+from agentclaw.community.core.repository.protocols.bot import BotRepository
+from agentclaw.community.core.repository.protocols.skills_pool import (
+    SkillsPoolLayoutRepositoryProtocol,
+)
+from agentclaw.community.api.bot_capability_state_reader import (
+    BotCapabilityStateReaderProtocol,
+)
+from agentclaw.community.core.service_bot.services.bot_build_service import (
+    BotBuildService,
+)
+from agentclaw.community.core.service_bot.services.deploy.arca_snapshot_producer import (
+    ArcaSnapshotProducer,
+)
+from agentclaw.community.core.service_bot.services.deploy.external_compose_producer import (
+    ExternalComposeProducer,
+)
+from agentclaw.community.core.service_bot.services.deploy.local_build_producer import (
+    LocalBuildProducer,
+)
+from agentclaw.community.core.service_bot.services.deploy.producer import (
+    DeployArtifactProducerRouter,
+)
+from agentclaw.community.core.service_bot.services.deploy.service_skills_manifest import (
+    ServiceSkillsManifestBuilder,
+)
+from agentclaw.community.core.skill_center.canonical_center_store import (
+    CanonicalCenterStoreConfig,
+    CanonicalCenterVersionStore,
+)
+from agentclaw.community.core.storage.path import get_skills_repo_path
+from agentclaw.community.core.workspace.engine_sandbox import EngineSandboxRegistry
+from agentclaw.community.log import get_logger
+
+logger = get_logger()
+
+
+class SingleboxServiceBotModule(Module):
+    """Singlebox: route the publish build producer to the local source snapshot."""
+
+    @singleton
+    @provider
+    @inject
+    def local_build_producer(
+        self,
+        bot_build_service: BotBuildService,
+        layout_repository: SkillsPoolLayoutRepositoryProtocol,
+        capability_reader: BotCapabilityStateReaderProtocol,
+        center_store: CanonicalCenterStoreConfig,
+        canonical_center_versions: CanonicalCenterVersionStore,
+        sandbox_registry: EngineSandboxRegistry,
+    ) -> LocalBuildProducer:
+        """Local-source build snapshot producer for singlebox.
+
+        Same ``ServiceSkillsManifestBuilder`` wiring as
+        :meth:`ServiceBotModule.arca_snapshot_producer` — the Skills slice the
+        build pins is engine-determined, not NAS/local-determined.
+        """
+        return LocalBuildProducer(
+            build_service=bot_build_service,
+            skills_manifest_builder=ServiceSkillsManifestBuilder(
+                layout_repository,
+                capability_reader,
+                center_store.base_prefix,
+                canonical_center_versions,
+                get_skills_repo_path(),
+            ),
+            sandbox_registry=sandbox_registry,
+        )
+
+    @singleton
+    @provider
+    @inject
+    def deploy_artifact_producer_router(
+        self,
+        local_producer: LocalBuildProducer,
+        external_producer: ExternalComposeProducer,
+    ) -> DeployArtifactProducerRouter:
+        """Override base ``ServiceBotModule`` so singlebox builds from the local
+        engine source. Re-points ``local``/``arca``/``baas`` to
+        :class:`LocalBuildProducer`` (see module docstring on why re-pointing
+        both keys is required); ``teclaw`` keeps the compose-from-DB producer.
+        """
+        logger.info(
+            "[SINGLEBOX] DeployArtifactProducerRouter → LocalBuildProducer "
+            "(local/arca/baas; teclaw unchanged)"
+        )
+        return DeployArtifactProducerRouter(
+            providers={
+                "local": local_producer,
+                "arca": local_producer,
+                "baas": local_producer,
+                "teclaw": external_producer,
+            },
+            default_provider_key="local",
+        )

--- a/src/backend/src/agentclaw/community/di/modules/singlebox_service_bot_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/singlebox_service_bot_module.py
@@ -2,7 +2,7 @@
 
 Singlebox runs on a developer laptop (or CI) with **no ARCA/ECS sandbox**, so
 the engine's bot files live on the **localhost filesystem** under the
-configured engine root (``openclaw_root`` → ``~/.openclaw``), never under the
+per-bot engine root selected by ``WorkspacePathFactory``, never under the
 production per-bot NAS merge area. The base
 ``ServiceBotModule`` wires the publish build's ``DeployArtifactProducerRouter``
 to point ``arca``/``baas`` at :class:`ArcaSnapshotProducer`, which computes
@@ -12,7 +12,7 @@ required``; the NAS path does not exist), failing the publish build stage.
 
 This module re-binds ``DeployArtifactProducerRouter`` so singlebox routes the
 publish build through :class:`LocalBuildProducer`, which sources the artifact
-from the engine's local working directory (``EngineSandboxProvider.get_base_path()``).
+from the selected Bot's local working directory, not the global engine default.
 Following the existing singlebox override pattern (see ``SingleboxAccessModule``,
 ``SingleboxDevicesModule``), installing this module after the base
 ``ServiceBotModule`` makes the later binding win.
@@ -67,6 +67,7 @@ from agentclaw.community.core.skill_center.canonical_center_store import (
 )
 from agentclaw.community.core.storage.path import get_skills_repo_path
 from agentclaw.community.core.workspace.engine_sandbox import EngineSandboxRegistry
+from agentclaw.community.core.workspace.path_factory import WorkspacePathFactory
 from agentclaw.community.log import get_logger
 
 logger = get_logger()
@@ -86,6 +87,7 @@ class SingleboxServiceBotModule(Module):
         center_store: CanonicalCenterStoreConfig,
         canonical_center_versions: CanonicalCenterVersionStore,
         sandbox_registry: EngineSandboxRegistry,
+        path_factory: WorkspacePathFactory,
     ) -> LocalBuildProducer:
         """Local-source build snapshot producer for singlebox.
 
@@ -103,6 +105,7 @@ class SingleboxServiceBotModule(Module):
                 get_skills_repo_path(),
             ),
             sandbox_registry=sandbox_registry,
+            path_factory=path_factory,
         )
 
     @singleton

--- a/src/backend/src/agentclaw/community/di/profile_modules.py
+++ b/src/backend/src/agentclaw/community/di/profile_modules.py
@@ -173,6 +173,9 @@ def modules_for(profile: DeployProfile) -> list[Module]:
             from agentclaw.community.core.devices.services.singlebox_device_sync import (
                 SingleboxDeviceSyncService,
             )
+            from agentclaw.community.di.modules.singlebox_service_bot_module import (
+                SingleboxServiceBotModule,
+            )
 
             column.extend([
                 SingleboxDevicesModule(),
@@ -181,6 +184,10 @@ def modules_for(profile: DeployProfile) -> list[Module]:
                 ),
                 SingleboxAccessModule(),
                 SingleboxCallerIdentityModule(),
+                # Route the publish build producer to the local engine
+                # source (LocalBuildProducer) instead of the NAS-backed
+                # ArcaSnapshotProducer — singlebox has no ARCA/NAS sandbox.
+                SingleboxServiceBotModule(),
             ])
 
         return column

--- a/src/backend/tests/community/core/service_bot/services/deploy/test_local_build_producer.py
+++ b/src/backend/tests/community/core/service_bot/services/deploy/test_local_build_producer.py
@@ -1,0 +1,197 @@
+"""Local publishing must snapshot the selected Bot, never the global engine root."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from agentclaw.community.core.service_bot.services.deploy.artifact_build_request import (
+    ArtifactBuildRequest,
+)
+from agentclaw.community.core.service_bot.services.deploy.local_build_producer import (
+    LocalBuildProducer,
+)
+from agentclaw.community.core.workspace.engine_sandbox import EngineSandboxRegistry
+from agentclaw.community.core.workspace.engines.openclaw import OpenClawSandboxProvider
+from agentclaw.community.core.workspace.engines.hermes import HermesSandboxProvider
+from agentclaw.community.core.workspace.path_factory import WorkspacePathFactory
+from agentclaw.community.di.config import WorkspaceConfig
+
+
+class _SnapshotBuildService:
+    """Keep source selection real without remote stage configuration or sudo."""
+
+    def __init__(self, artifacts: Path) -> None:
+        self.artifacts = artifacts
+
+    def build(self, *, bot, version, local_source_root):
+        target = self.artifacts / bot["bot_id"] / str(version)
+        shutil.copytree(local_source_root, target)
+        return {"success": True, "build_target_path": str(target)}
+
+
+@pytest.fixture
+def local_build(tmp_path, monkeypatch):
+    monkeypatch.setenv("AIDESKTOP_ROOT", str(tmp_path / "aidesktop"))
+    monkeypatch.setenv("LOCAL_AIDESKTOP_ROOT", str(tmp_path / "aidesktop"))
+    monkeypatch.setattr(
+        "agentclaw.community.core.workspace.path_factory._get_aidesktop_env_folder",
+        lambda: "aidesktop_singlebox",
+    )
+    global_root = tmp_path / "global-openclaw"
+    global_root.mkdir()
+    (global_root / "identity.md").write_text("global, not a Bot")
+    registry = EngineSandboxRegistry()
+    registry.register(
+        OpenClawSandboxProvider(WorkspaceConfig(openclaw_root=str(global_root)))
+    )
+    registry.register(
+        HermesSandboxProvider(WorkspaceConfig(hermes_root=str(global_root)))
+    )
+    producer = LocalBuildProducer(
+        build_service=_SnapshotBuildService(tmp_path / "artifacts"),
+        skills_manifest_builder=Mock(capture=Mock(return_value=None)),
+        sandbox_registry=registry,
+        path_factory=WorkspacePathFactory(skill_repo_sync=Mock()),
+    )
+    return producer, tmp_path / "aidesktop/aidesktop_singlebox/bolt_data"
+
+
+def _bot(bot_id="bot-a", entity_id="owner-a", entity_type="staff"):
+    return {
+        "bot_id": bot_id,
+        "entity_id": entity_id,
+        "entity_type": entity_type,
+        "active_engine": "openclaw",
+    }
+
+
+def _publish(producer, bot):
+    return producer.produce_artifact(ArtifactBuildRequest.create(bot=bot, version=1))
+
+
+@pytest.mark.parametrize(
+    "bot_id,entity_id,entity_type,relative_root",
+    [
+        ("bot-a", "owner-a", "staff", "staff_owner-a/bot-a/openclaw"),
+        ("bot-b", "owner-a", "staff", "staff_owner-a/bot-b/openclaw"),
+        ("bot-a", "team-a", "team", "team_team-a/bot-a/openclaw"),
+    ],
+)
+def test_snapshots_only_the_requested_bot(
+    local_build,
+    bot_id,
+    entity_id,
+    entity_type,
+    relative_root,
+):
+    producer, base = local_build
+    source = base / relative_root
+    source.mkdir(parents=True)
+    (source / "identity.md").write_text(relative_root)
+    artifact = _publish(producer, _bot(bot_id, entity_id, entity_type))
+    assert artifact.success
+    assert (
+        Path(artifact.ext["build_target_path"]) / "identity.md"
+    ).read_text() == relative_root
+
+
+def test_missing_bot_source_does_not_fall_back_to_existing_global_root(local_build):
+    producer, _ = local_build
+    with pytest.raises(ValueError, match="local build source directory"):
+        _publish(producer, _bot())
+
+
+@pytest.mark.parametrize("field", ["bot_id", "entity_id", "entity_type"])
+@pytest.mark.parametrize("value", [None, "", "   "])
+def test_missing_identity_is_rejected_before_build(local_build, field, value):
+    producer, _ = local_build
+    bot = _bot()
+    bot[field] = value
+    with pytest.raises(ValueError, match=field):
+        _publish(producer, bot)
+
+
+def test_two_bots_keep_independent_snapshot_contents(local_build):
+    producer, base = local_build
+    for bot_id, content in (("bot-a", "first Bot"), ("bot-b", "second Bot")):
+        source = base / f"staff_owner-a/{bot_id}/openclaw"
+        source.mkdir(parents=True)
+        (source / "identity.md").write_text(content)
+    first = _publish(producer, _bot("bot-a"))
+    second = _publish(producer, _bot("bot-b"))
+    first_path = Path(first.ext["build_target_path"])
+    second_path = Path(second.ext["build_target_path"])
+    assert first_path != second_path
+    assert (first_path / "identity.md").read_text() == "first Bot"
+    assert (second_path / "identity.md").read_text() == "second Bot"
+
+
+def test_oss_view_source_is_translated_to_local_host(local_build, monkeypatch):
+    producer, base = local_build
+    monkeypatch.setenv("AIDESKTOP_ROOT", "/aidesktop")
+    monkeypatch.setattr(
+        "agentclaw.community.utils.env_utils.is_local_mode", lambda: True
+    )
+    source = base / "staff_owner-a/bot-a/openclaw"
+    source.mkdir(parents=True)
+    (source / "identity.md").write_text("host source")
+    artifact = _publish(producer, _bot())
+    assert (
+        Path(artifact.ext["build_target_path"]) / "identity.md"
+    ).read_text() == "host source"
+
+
+def test_source_file_is_not_accepted_as_engine_directory(local_build):
+    producer, base = local_build
+    source = base / "staff_owner-a/bot-a/openclaw"
+    source.parent.mkdir(parents=True)
+    source.write_text("not a directory")
+    with pytest.raises(ValueError, match="local build source directory"):
+        _publish(producer, _bot())
+
+
+def test_singlebox_di_constructs_local_producer_with_path_factory(local_build):
+    from agentclaw.community.core.service_bot.services.deploy.producer import (
+        DeployArtifactProducerRouter,
+    )
+    from agentclaw.community.di.container import build_injector
+    from agentclaw.community.di.profile import DeployProfile
+
+    _, base = local_build
+    source = base / "staff_owner-a/bot-a/openclaw"
+    source.mkdir(parents=True)
+    injector = build_injector(profile=DeployProfile.SINGLEBOX)
+    router = injector.get(DeployArtifactProducerRouter)
+    producer = router.resolve("baas")
+    assert isinstance(producer, LocalBuildProducer)
+    assert producer._resolve_local_source_root(_bot()) == source
+
+
+def test_uses_the_selected_engine_directory(local_build):
+    producer, base = local_build
+    source = base / "staff_owner-a/bot-a/hermes"
+    source.mkdir(parents=True)
+    (source / "identity.md").write_text("Hermes Bot")
+    bot = _bot()
+    bot["active_engine"] = "hermes"
+    artifact = _publish(producer, bot)
+    assert (
+        Path(artifact.ext["build_target_path"]) / "identity.md"
+    ).read_text() == "Hermes Bot"
+
+
+def test_omitted_entity_type_keeps_staff_default(local_build):
+    producer, base = local_build
+    source = base / "staff_owner-a/bot-a/openclaw"
+    source.mkdir(parents=True)
+    (source / "identity.md").write_text("staff Bot")
+    bot = _bot()
+    del bot["entity_type"]
+    artifact = _publish(producer, bot)
+    assert (
+        Path(artifact.ext["build_target_path"]) / "identity.md"
+    ).read_text() == "staff Bot"

--- a/src/backend/tests/community/core/service_bot/services/deploy/test_local_build_producer.py
+++ b/src/backend/tests/community/core/service_bot/services/deploy/test_local_build_producer.py
@@ -195,3 +195,56 @@ def test_omitted_entity_type_keeps_staff_default(local_build):
     assert (
         Path(artifact.ext["build_target_path"]) / "identity.md"
     ).read_text() == "staff Bot"
+
+
+@pytest.mark.parametrize("engine", ["openclaw", "hermes"])
+def test_local_producer_builds_real_snapshot_without_remote_services(
+    local_build, monkeypatch, engine
+):
+    """Exercise the real build and rsync path, including its local-only branches."""
+    from agentclaw.community.core.service_bot.services import bot_build_service
+
+    producer, base = local_build
+    source = base / f"staff_owner-a/bot-a/{engine}"
+    source.mkdir(parents=True)
+    (source / "identity.md").write_text("selected Bot")
+    (source / "logs").mkdir()
+    (source / "logs/runtime.log").write_text("not a deployable file")
+    (source / "openclaw.json").write_text('{"name": "selected Bot"}')
+    if engine == "openclaw":
+        (source / "openclaw.json.asback_123").write_text("transient backup")
+
+    def unexpected_remote_call(*args, **kwargs):
+        pytest.fail("local snapshot must not access NAS, MCP generation, or remote sync")
+
+    service = bot_build_service.BotBuildService.__new__(bot_build_service.BotBuildService)
+    service._sandbox_registry = producer._sandbox_registry
+    service._device_service = Mock(exec_shell_new=unexpected_remote_call)
+    monkeypatch.setattr(bot_build_service, "get_bot_nas_dir", unexpected_remote_call)
+    monkeypatch.setattr(service, "_generate_mcp_config", unexpected_remote_call)
+    # Stage configuration belongs to the channel service, not the snapshot copy.
+    monkeypatch.setattr(service, "_generate_openclaw_stage_configs", lambda **kwargs: True)
+    monkeypatch.setattr(
+        service, "_get_migration_path_base", lambda **kwargs: "/artifacts/bot-a"
+    )
+    producer._build_service = service
+    bot = _bot()
+    bot.update(active_engine=engine, device_id="local-device")
+
+    artifact = _publish(producer, bot)
+
+    assert artifact.success
+    target = base / f"staff_owner-a/bot-a/1/{engine}"
+    assert Path(artifact.ext["build_target_path"]) == target
+    assert artifact.ext["migration_path"] == f"/artifacts/bot-a/1/{engine}"
+    assert (target / "identity.md").read_text() == "selected Bot"
+    assert (target / "openclaw.json").read_text() == '{"name": "selected Bot"}'
+    assert not (target / "logs").exists()
+    assert not (target / "openclaw.json.asback_123").exists()
+
+
+def test_local_producer_rejects_missing_publish_version(local_build):
+    producer, _ = local_build
+    request = ArtifactBuildRequest.create(bot=_bot(), version=None)
+    with pytest.raises(ValueError, match="requires a publish version"):
+        producer.produce_artifact(request)

--- a/src/backend/tests/community/di/test_profile_and_modules_for.py
+++ b/src/backend/tests/community/di/test_profile_and_modules_for.py
@@ -203,6 +203,7 @@ def test_test_and_singlebox_have_explicit_access_and_http_bindings():
     assert "SingleboxAccessModule" in singlebox_names
     assert "TestHttpClientModule" not in singlebox_names
     assert "SingleboxDevicesModule" in singlebox_names
+    assert "SingleboxServiceBotModule" in singlebox_names
     assert "CommunityDeviceSyncModule" in singlebox_names
     assert "SingleboxDeviceSyncModule" not in singlebox_names
     assert "TestDevicesModule" not in singlebox_names
@@ -218,6 +219,7 @@ def test_test_and_singlebox_have_explicit_access_and_http_bindings():
             "SingleboxAccessModule",
             "SingleboxCallerIdentityModule",
             "SingleboxDevicesModule",
+            "SingleboxServiceBotModule",
             "CommunityDeviceSyncModule",
         }
     )

--- a/src/backend/tests/community/endpoints/test_service_bot_rsync_excludes.py
+++ b/src/backend/tests/community/endpoints/test_service_bot_rsync_excludes.py
@@ -22,8 +22,8 @@ class TestRsyncExcludesLogic:
     """Test rsync excludes configuration logic."""
 
     def test_openclaw_default_excludes_count(self):
-        """OpenClaw引擎默认有25条rsync排除规则"""
-        assert len(_OPENCLAW_RSYNC_EXCLUDES) == 25
+        """OpenClaw引擎默认有26条rsync排除规则（含原子写备份）"""
+        assert len(_OPENCLAW_RSYNC_EXCLUDES) == 26
 
     def test_claude_code_default_excludes_count(self):
         """ClaudeCode引擎默认有31条rsync排除规则"""
@@ -91,6 +91,7 @@ class TestRsyncExcludesLogic:
         assert "workspace/memory/" in _OPENCLAW_RSYNC_EXCLUDES
         assert "logs/" in _OPENCLAW_RSYNC_EXCLUDES
         assert "agents/*/sessions/" in _OPENCLAW_RSYNC_EXCLUDES
+        assert "openclaw.json.asback*" in _OPENCLAW_RSYNC_EXCLUDES
 
     def test_claude_code_default_excludes_content(self):
         """验证ClaudeCode默认排除规则包含关键目录"""


### PR DESCRIPTION
## Problem
Singlebox publishing uses the shared-storage snapshot build path even though local development does not provide that storage layout. Builds should capture the selected Bot's actual engine directory, not a global engine directory that may be unrelated to the Bot being published.

## Solution
- Add a Singlebox-only local build producer and register it for local, ARCA, and BaaS deployment targets; keep the external producer route unchanged.
- Resolve the source through `WorkspacePathFactory` using entity identity, Bot identity, and engine type. Reject missing identities or missing/non-directory sources instead of falling back to a global engine root.
- Allow snapshot builds from an explicit local source, bypass shared-storage setup and the remote sync restart, and use unprivileged rsync for the main and extra-directory copies.
- Skip MCP configuration generation for local builds and exclude OpenClaw atomic configuration backups from snapshots.
- Add regression coverage for per-Bot isolation, identity and source validation, engine selection, host-path translation, and Singlebox dependency injection.

## Validation
- Focused backend regression suite: **289 passed, 17 warnings**. Covered local build producer, profile/module selection, Singlebox devices, producer routing, ARCA snapshots, extra-file sync, rsync exclusions, and publish flow.
- `git diff --check origin/dev...HEAD`: passed.
- Requester reports manual Singlebox testing without observed issues. Full Singlebox E2E was not independently rerun for this PR; validation here is limited to the focused suite and that manual report.

## Compatibility and risk
- No API or database schema changes. The new producer registration is scoped to Singlebox; other profiles retain their producer selection.
- Missing per-Bot engine directories now fail explicitly rather than building an unrelated global directory.
- Known follow-ups outside this change: local builds skip MCP configuration generation while the copy exclusions may omit an existing MCP configuration; the extra individual-file sync helper still invokes sudo and can fail for local cron-file copies.
- Rollback: revert this PR to restore the previous snapshot build path.
