### PR TITLE
feat(frontend): export workspace open core updates

### DIFF
--- a/src/frontend-nextgen/OPEN_CORE_MANIFEST.json
+++ b/src/frontend-nextgen/OPEN_CORE_MANIFEST.json
@@ -1,6 +1,6 @@
 {
   "sourceRepository": "teamclaw",
-  "sourceCommit": "d5870a22c37b7f4f7bf79054940c5c8ad9b646e4",
+  "sourceCommit": "96704eb96f71ce603612a6c81d63b7b23a9dffb0",
   "sourceDirty": false,
   "exportSchemaVersion": 1,
   "target": "src/frontend-nextgen",

--- a/src/frontend-nextgen/config/routes.ts
+++ b/src/frontend-nextgen/config/routes.ts
@@ -19,6 +19,8 @@ export const routes = [
       { path: '/workspace', component: '@/pages/Workspace' },
       { path: '/work/my-task', component: '@/pages/MyTask' },
       { path: '/workspace/invite/:type/:token', component: '@/pages/Workspace/InviteAcceptPanel' },
+      // BCN 协作会话外链落地页：判定参与方式后 replace 至 /workspace 协作群深链。
+      { path: '/workspace/bcn/chat/detail', component: '@/pages/Workspace/BcnChatDetail' },
       { path: '/collaboration-square', redirect: '/collaboration-square/bots' },
       { path: '/collaboration-square/bots', component: '@/pages/CollaborationSquare/Bots' },
       { path: '/collaboration-square/groups', component: '@/pages/CollaborationSquare/Groups' },

--- a/src/frontend-nextgen/src/components/Admin/SpaceMemberList/AddMembersModal.tsx
+++ b/src/frontend-nextgen/src/components/Admin/SpaceMemberList/AddMembersModal.tsx
@@ -1,0 +1,157 @@
+// 添加成员多选模态：搜索员工 → 多选 chip 集（选中不清空、可逐个移除）→ 共享角色 → 批量提交。
+// 下拉对 已是成员/自己/本批次已选 三类置灰去重。部分失败时把 failed 子集回填为 chip 集，
+// 模态保持打开供重试；全部成功则清选 + 复位 + 关闭。成功者由 hook 经 refreshMembers 拉进列表。
+import type { SearchedUser } from '@/capabilities';
+import {
+  Button,
+  CaptionText,
+  Modal,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalTitle,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  ValueText,
+} from '@/components/ui';
+import { Card } from '@/components/ui/Card';
+import type { SpaceMember } from '@/domain/admin/models';
+import { X } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { UserSearchDropdown } from './UserSearchDropdown';
+
+export interface AddMembersModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** 当前已是成员列表（下拉中置灰「已添加」）。 */
+  members: SpaceMember[];
+  /** 当前操作者 userId（下拉置灰，避免加自己）；null=未取得身份。 */
+  currentUid?: string | null;
+  /** 批量添加：多选 chip + 共享角色，返回 {succeeded, failed} 供本模态做部分失败重试回填。 */
+  onAddMembers: (
+    users: SearchedUser[],
+    role: 'ADMIN' | 'MEMBER',
+  ) => void | Promise<{ succeeded: SpaceMember[]; failed: { userId: string; userName?: string; reason: string }[] } | undefined>;
+  addMembersLoading?: boolean;
+  addMembersDisabledReason?: string;
+}
+
+export function AddMembersModal({
+  open,
+  onOpenChange,
+  members,
+  currentUid,
+  onAddMembers,
+  addMembersLoading = false,
+  addMembersDisabledReason,
+}: AddMembersModalProps) {
+  const [selectedUsers, setSelectedUsers] = useState<SearchedUser[]>([]);
+  const [newRole, setNewRole] = useState<'ADMIN' | 'MEMBER'>('MEMBER');
+
+  // 已是成员 ∪ 自己 ∪ 本批次已选 → 下拉置灰，避免重复添加 / 加自己 / 重选
+  const disabledUserIds = useMemo(() => {
+    const set = new Set<string>(members.map((m) => m.userId));
+    if (currentUid) set.add(currentUid);
+    selectedUsers.forEach((u) => set.add(u.userId));
+    return set;
+  }, [members, currentUid, selectedUsers]);
+
+  const removeChip = (userId: string) => {
+    setSelectedUsers((prev) => prev.filter((u) => u.userId !== userId));
+  };
+
+  // 批量提交：部分失败回填 failed 子集（模态保持打开供重试）；全成功清选 + 复位 + 关闭。
+  const submitAdd = async () => {
+    if (selectedUsers.length === 0 || addMembersLoading) return;
+    const result = await onAddMembers(selectedUsers, newRole);
+    if (result && result.failed.length > 0) {
+      // 把失败项还原为可重试的 chip（以 userName 作 nickName，保持展示一致）
+      setSelectedUsers(
+        result.failed.map((f) => ({ userId: f.userId, displayName: f.userName ?? f.userId, nickName: f.userName })),
+      );
+      return;
+    }
+    setSelectedUsers([]);
+    setNewRole('MEMBER');
+    onOpenChange(false);
+  };
+
+  return (
+    <Modal open={open} onOpenChange={onOpenChange}>
+      <ModalContent size="sm" className="max-w-[420px]">
+        <ModalHeader>
+          <ModalTitle>添加成员</ModalTitle>
+        </ModalHeader>
+        <div className="space-y-4 py-2">
+          <div className="space-y-2">
+            <CaptionText as="label">搜索员工</CaptionText>
+            {/* 多选：选中不清空，追加到 chip 集；下拉对 已成员/自己/本批次已选 三类置灰去重 */}
+            <UserSearchDropdown
+              disabledUserIds={disabledUserIds}
+              onSelect={(u) =>
+                setSelectedUsers((prev) => (prev.some((p) => p.userId === u.userId) ? prev : [...prev, u]))
+              }
+              disabled={addMembersLoading}
+            />
+            {selectedUsers.length > 0 && (
+              <ul className="m-0 flex flex-wrap gap-2 list-none p-0">
+                {selectedUsers.map((u) => (
+                  <li key={u.userId}>
+                    <Card className="flex items-center gap-2 rounded-full bg-muted/30 px-2.5 py-1 shadow-sm">
+                      <span className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-primary text-[10px] font-medium text-primary-foreground">
+                        {(u.nickName || u.realName || u.userId || '?').charAt(0).toUpperCase()}
+                      </span>
+                      <ValueText as="span" className="min-w-0 truncate text-xs">
+                        {u.nickName ? `${u.nickName}(${u.userId})` : u.userId}
+                      </ValueText>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        aria-label="取消选择"
+                        className="h-5 w-5 text-muted-foreground"
+                        onClick={() => removeChip(u.userId)}
+                      >
+                        <X size={12} />
+                      </Button>
+                    </Card>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+          <div className="space-y-2">
+            <CaptionText as="label">分配角色</CaptionText>
+            <Select value={newRole} onValueChange={(v) => setNewRole(v as 'ADMIN' | 'MEMBER')}>
+              <SelectTrigger className="h-9 w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="MEMBER">成员</SelectItem>
+                <SelectItem value="ADMIN">管理员</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+        <ModalFooter>
+          <Button variant="ghost" size="sm" onClick={() => onOpenChange(false)} disabled={addMembersLoading}>
+            取消
+          </Button>
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={() => void submitAdd()}
+            disabled={selectedUsers.length === 0 || addMembersLoading}
+            title={addMembersDisabledReason}
+          >
+            {addMembersLoading ? '添加中…' : `添加 ${selectedUsers.length} 人`}
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}
+
+export default AddMembersModal;

--- a/src/frontend-nextgen/src/components/Admin/SpaceMemberList/index.tsx
+++ b/src/frontend-nextgen/src/components/Admin/SpaceMemberList/index.tsx
@@ -2,37 +2,19 @@
 // - 已加入且可管理：顶部右侧「添加成员」按钮；角色可改/可删；无底部提示。
 // - 未加入团队空间：顶部右侧「可申请」文字；最右下角「申请加入」按钮；最左下角提示文案(上方横线)。
 // - 个人空间：无顶部按钮；最左下角提示文案(上方横线)。
-// 单行渲染下沉到 SpaceMemberRow；角色变更直接执行（PRD 交互，无二次确认）。
+// 单行渲染下沉到 SpaceMemberRow；添加成员多选模态下沉到 AddMembersModal；角色变更直接执行（PRD 交互，无二次确认）。
 import type { SearchedUser } from '@/capabilities';
-import {
-  Button,
-  CaptionText,
-  ConfirmDialog,
-  Empty,
-  Modal,
-  ModalContent,
-  ModalFooter,
-  ModalHeader,
-  ModalTitle,
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-  Skeleton,
-  TableHeaderText,
-  ValueText,
-} from '@/components/ui';
+import { Button, CaptionText, ConfirmDialog, Empty, Skeleton, TableHeaderText } from '@/components/ui';
 import { Card } from '@/components/ui/Card';
 import type { Space, SpaceMember } from '@/domain/admin/models';
 import { adminService } from '@/services/admin';
 import { readUserId } from '@/services/admin/userIdentity';
-import { Plus, User, Users, X } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import { Plus, User, Users } from 'lucide-react';
+import { useState } from 'react';
 import { SpaceJoinForm } from '../SpaceJoinForm';
 import { Tag } from '../Tag';
+import { AddMembersModal } from './AddMembersModal';
 import { SpaceMemberRow } from './SpaceMemberRow';
-import { UserSearchDropdown } from './UserSearchDropdown';
 
 // clawweb=Avernet 暂无 DELETE /openapi/v1/bots/spaces/{id} 接口；UI 入口隐藏，后端补接口时翻 true。
 const DELETE_SPACE_SUPPORTED = false;
@@ -41,7 +23,14 @@ export interface SpaceMemberListProps {
   space: Space;
   members: SpaceMember[];
   loading: boolean;
-  onAddMember: (userId: string, role: 'ADMIN' | 'MEMBER', userName?: string) => void | Promise<void>;
+  /** 批量添加成员（多选 chip + 共享角色）。返回 {succeeded, failed} 供模态做部分失败重试回填；可省返回。 */
+  onAddMembers: (
+    users: SearchedUser[],
+    role: 'ADMIN' | 'MEMBER',
+  ) => void | Promise<{ succeeded: SpaceMember[]; failed: { userId: string; userName?: string; reason: string }[] } | undefined>;
+  /** 批量添加 in-flight 加载态（来自 hook）；用于按钮禁用 + 加载文案。 */
+  addMembersLoading?: boolean;
+  addMembersDisabledReason?: string;
   onRemoveMember: (userId: string) => void | Promise<void>;
   onUpdateRole: (userId: string, role: 'ADMIN' | 'MEMBER') => void | Promise<void>;
   onDeleteSpace?: (spaceId: number | string) => void | Promise<void>;
@@ -52,7 +41,9 @@ export function SpaceMemberList({
   space,
   members,
   loading,
-  onAddMember,
+  onAddMembers,
+  addMembersLoading = false,
+  addMembersDisabledReason,
   onRemoveMember,
   onUpdateRole,
   onDeleteSpace,
@@ -67,29 +58,8 @@ export function SpaceMemberList({
   const joinableTeam = !isMember && space.spaceType === 'TEAM' && space.joinStatus !== 'APPLYING';
   const [addOpen, setAddOpen] = useState(false);
   const [joinOpen, setJoinOpen] = useState(false);
-  const [selectedUser, setSelectedUser] = useState<SearchedUser | null>(null);
-  const [newRole, setNewRole] = useState<'ADMIN' | 'MEMBER'>('MEMBER');
 
   const lastOwner = members.filter((m) => m.role === 'ADMIN').length <= 1;
-
-  // 添加成员下拉中禁用已有成员 + 当前用户（避免重复添加 / 加自己）
-  const disabledUserIds = useMemo(() => {
-    const set = new Set<string>(members.map((m) => m.userId));
-    if (currentUid) set.add(currentUid);
-    return set;
-  }, [members, currentUid]);
-
-  const submitAdd = async () => {
-    if (!selectedUser) return;
-    const { userId } = selectedUser;
-    // 花名随被加成员写入成员表：nickName 即花名；缺失时退到 displayName（仅当其非工号，避免把工号误写成花名）。
-    const userName =
-      selectedUser.nickName || (selectedUser.displayName !== userId ? selectedUser.displayName : undefined);
-    await onAddMember(userId, newRole, userName);
-    setSelectedUser(null);
-    setNewRole('MEMBER');
-    setAddOpen(false);
-  };
 
   // 顶部右侧：已加入可管理→添加成员按钮；未加入团队→「可申请」文字；个人空间→空
   const topRight = manageable ? (
@@ -201,66 +171,17 @@ export function SpaceMemberList({
       {/* 底部：状态化提示 + 申请加入按钮 */}
       {bottomBar}
 
-      {/* 添加成员 Modal */}
+      {/* 添加成员多选模态：条件挂载保证每次打开都是 fresh 状态（selectedUsers=[]） */}
       {addOpen && (
-        <Modal open={addOpen} onOpenChange={setAddOpen}>
-          <ModalContent size="sm" className="max-w-[420px]">
-            <ModalHeader>
-              <ModalTitle>添加成员</ModalTitle>
-            </ModalHeader>
-            <div className="space-y-4 py-2">
-              <div className="space-y-2">
-                <CaptionText as="label">搜索员工</CaptionText>
-                <UserSearchDropdown
-                  disabledUserIds={disabledUserIds}
-                  onSelect={setSelectedUser}
-                  disabled={!!selectedUser}
-                />
-                {selectedUser && (
-                  <Card className="flex items-center gap-2 rounded-lg bg-muted/30 px-3 py-2 shadow-sm">
-                    <span className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-primary text-xs font-medium text-primary-foreground">
-                      {(selectedUser.nickName || selectedUser.realName || selectedUser.userId || '?')
-                        .charAt(0)
-                        .toUpperCase()}
-                    </span>
-                    <ValueText as="span" className="min-w-0 flex-1 truncate">
-                      {selectedUser.nickName ? `${selectedUser.nickName}(${selectedUser.userId})` : selectedUser.userId}
-                    </ValueText>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      aria-label="取消选择"
-                      className="h-6 w-6 text-muted-foreground"
-                      onClick={() => setSelectedUser(null)}
-                    >
-                      <X size={14} />
-                    </Button>
-                  </Card>
-                )}
-              </div>
-              <div className="space-y-2">
-                <CaptionText as="label">分配角色</CaptionText>
-                <Select value={newRole} onValueChange={(v) => setNewRole(v as 'ADMIN' | 'MEMBER')}>
-                  <SelectTrigger className="h-9 w-full">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="MEMBER">成员</SelectItem>
-                    <SelectItem value="ADMIN">管理员</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-            </div>
-            <ModalFooter>
-              <Button variant="ghost" size="sm" onClick={() => setAddOpen(false)}>
-                取消
-              </Button>
-              <Button variant="primary" size="sm" onClick={() => void submitAdd()} disabled={!selectedUser}>
-                添加
-              </Button>
-            </ModalFooter>
-          </ModalContent>
-        </Modal>
+        <AddMembersModal
+          open={addOpen}
+          onOpenChange={setAddOpen}
+          members={members}
+          currentUid={currentUid}
+          onAddMembers={onAddMembers}
+          addMembersLoading={addMembersLoading}
+          addMembersDisabledReason={addMembersDisabledReason}
+        />
       )}
 
       {/* 申请加入 Modal（未加入团队时） */}

--- a/src/frontend-nextgen/src/components/CollaborationSquare/CreateGroupSessionModal/index.tsx
+++ b/src/frontend-nextgen/src/components/CollaborationSquare/CreateGroupSessionModal/index.tsx
@@ -1,8 +1,10 @@
 import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
-import { Modal, ModalContent, ModalDescription, ModalFooter, ModalHeader, ModalTitle } from '@/components/ui/Modal';
+import { Modal, ModalContent, ModalHeader, ModalTitle } from '@/components/ui/Modal';
 import { Textarea } from '@/components/ui/Textarea';
 import type { PublicGroup } from '@/domain/collaborationSquare/types';
+import { MessagesSquare } from 'lucide-react';
+import type { FormEvent } from 'react';
 import { useEffect, useState } from 'react';
 
 /** 创建公开协作群会话的表单值（对应接口 body：title + input.query）。 */
@@ -23,6 +25,8 @@ export interface CreateGroupSessionModalProps {
  * 「公开协作群 → 创建新会话」表单弹窗：收集「会话名称」(title) 与「协作目标」(input.query)，
  * 提交后由上层 Hook 调 POST /openapi/v1/collaboration/groups/{group_id}/sessions 并跳转。
  *
+ * 表单样式对齐「创建云端 Bot」（CreateBotModal）：图标题头 + label 包裹字段 +
+ * 必填星号 + 字数计数器 + 行内 secondary 取消/primary 提交；不再展示描述提示文案。
  * 仅 UI：表单状态本地维护，提交与跳转编排交给 Hook（Component → Hook → Service 分层）。
  */
 export function CreateGroupSessionModal({ open, group, loading, onClose, onSubmit }: CreateGroupSessionModalProps) {
@@ -41,56 +45,69 @@ export function CreateGroupSessionModal({ open, group, loading, onClose, onSubmi
   const trimmedQuery = query.trim();
   const canSubmit = !loading && trimmedTitle !== '' && trimmedQuery !== '';
 
-  const handleSubmit = () => {
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault();
     if (!canSubmit) return;
     onSubmit({ title: trimmedTitle, query: trimmedQuery });
   };
 
   return (
     <Modal open={open} onOpenChange={(next) => !next && onClose()}>
-      <ModalContent size="sm">
-        <ModalHeader>
-          <ModalTitle>{group ? `在「${group.name}」创建新会话` : '创建新会话'}</ModalTitle>
-          <ModalDescription>填写会话名称与协作目标，创建后跳转到该会话。</ModalDescription>
+      <ModalContent size="sm" aria-describedby={undefined} className="p-4">
+        <ModalHeader className="flex-row items-center gap-2.5 space-y-0">
+          <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-primary text-primary-foreground">
+            <MessagesSquare aria-hidden className="size-5" />
+          </div>
+          <div className="min-w-0">
+            <ModalTitle className="text-base leading-6">
+              {group ? `在「${group.name}」创建新会话` : '创建新会话'}
+            </ModalTitle>
+          </div>
         </ModalHeader>
-        <div className="space-y-4">
-          <div className="space-y-2">
-            <label htmlFor="create-session-title" className="m-0 text-sm font-medium text-foreground">
-              会话名称
-            </label>
+        <form className="space-y-5" onSubmit={handleSubmit}>
+          <label className="block space-y-2 text-xs font-medium text-foreground">
+            <span className="flex items-center justify-between gap-2">
+              <span>
+                会话名称 <span className="text-destructive">*</span>
+              </span>
+              <span className="text-[10px] font-normal text-muted-foreground">{title.length}/100</span>
+            </span>
             <Input
-              id="create-session-title"
-              value={title}
-              onChange={(event) => setTitle(event.target.value)}
-              placeholder="请输入会话名称"
-              maxLength={100}
-              disabled={loading}
               autoFocus
-            />
-          </div>
-          <div className="space-y-2">
-            <label htmlFor="create-session-query" className="m-0 text-sm font-medium text-foreground">
-              协作目标
-            </label>
-            <Textarea
-              id="create-session-query"
-              value={query}
-              onChange={(event) => setQuery(event.target.value)}
-              placeholder="请描述本会话希望达成的协作目标"
-              rows={4}
-              maxLength={2000}
+              value={title}
+              maxLength={100}
+              placeholder="请输入会话名称"
               disabled={loading}
+              className="focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring/30 focus-visible:ring-offset-0"
+              onChange={(event) => setTitle(event.target.value)}
             />
+          </label>
+          <label className="block space-y-2 text-xs font-medium text-foreground">
+            <span className="flex items-center justify-between gap-2">
+              <span>
+                协作目标 <span className="text-destructive">*</span>
+              </span>
+              <span className="text-[10px] font-normal text-muted-foreground">{query.length}/2000</span>
+            </span>
+            <Textarea
+              rows={4}
+              value={query}
+              maxLength={2000}
+              placeholder="请描述本会话希望达成的协作目标"
+              disabled={loading}
+              className="focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring/30 focus-visible:ring-offset-0"
+              onChange={(event) => setQuery(event.target.value)}
+            />
+          </label>
+          <div className="flex items-center justify-end gap-2">
+            <Button type="button" variant="secondary" disabled={loading} onClick={onClose}>
+              取消
+            </Button>
+            <Button type="submit" loading={loading} disabled={!canSubmit}>
+              创建会话
+            </Button>
           </div>
-        </div>
-        <ModalFooter>
-          <Button variant="ghost" onClick={onClose} disabled={loading}>
-            取消
-          </Button>
-          <Button onClick={handleSubmit} loading={loading} disabled={!canSubmit}>
-            创建会话
-          </Button>
-        </ModalFooter>
+        </form>
       </ModalContent>
     </Modal>
   );

--- a/src/frontend-nextgen/src/components/CollaborationSquare/GroupMembersModal/index.tsx
+++ b/src/frontend-nextgen/src/components/CollaborationSquare/GroupMembersModal/index.tsx
@@ -11,6 +11,36 @@ interface GroupMembersModalProps {
   onClose: () => void;
 }
 
+/**
+ * 角色 → 中文标签与色调，按群类型归一（与「对话协作」成员管理 card 一致）：
+ * 自由聊天/自定义协同 driver→群主；任务协作 manager→主节点、worker→从节点；其余一律「成员」（默认蓝）。
+ */
+function getRoleBadge(role: string, typeLabel?: string): { label: string; tone: 'purple' | 'primary' } {
+  if (typeLabel === '任务协作') {
+    if (role === 'manager') return { label: '主节点', tone: 'purple' };
+    if (role === 'worker') return { label: '从节点', tone: 'primary' };
+    return { label: '成员', tone: 'primary' };
+  }
+  if (role === 'driver') return { label: '群主', tone: 'purple' };
+  return { label: '成员', tone: 'primary' };
+}
+
+/** 与 MemberList 一致的首字母圆标头像：bot 主色软底、human brand 软底。 */
+function MemberAvatar({ member }: { member: PublicGroupMember }) {
+  const symbol = member.displayName?.trim().charAt(0) || '?';
+  return (
+    <div
+      className={
+        member.type === 'bot'
+          ? 'grid size-8 flex-none place-items-center rounded-full bg-primary/10 text-xs font-semibold text-primary shadow-sm'
+          : 'grid size-8 flex-none place-items-center rounded-full bg-brand/15 text-xs font-medium text-brand shadow-sm'
+      }
+    >
+      {symbol}
+    </div>
+  );
+}
+
 export function GroupMembersModal({ open, group, members, loading, onClose }: GroupMembersModalProps) {
   return (
     <Modal open={open} onOpenChange={(next) => !next && onClose()}>
@@ -28,18 +58,28 @@ export function GroupMembersModal({ open, group, members, loading, onClose }: Gr
           <p className="m-0 text-sm leading-6 text-muted-foreground">暂无成员信息。</p>
         ) : (
           <div className="space-y-2">
-            {members.map((member) => (
-              <div
-                key={member.id}
-                className="flex items-center justify-between gap-3 rounded-lg border border-border p-3"
-              >
-                <div className="min-w-0">
-                  <p className="m-0 truncate text-sm font-medium text-foreground">{member.displayName}</p>
-                  <p className="m-0 mt-1 text-xs text-muted-foreground">{member.type === 'human' ? '用户' : 'Bot'}</p>
+            {members.map((member) => {
+              const roleBadge = getRoleBadge(member.role, group?.typeLabel);
+              return (
+                <div
+                  key={member.id}
+                  className="flex items-center gap-2 rounded-lg border border-border bg-card p-2 shadow-sm"
+                >
+                  <MemberAvatar member={member} />
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center">
+                      <span className="max-w-full truncate text-sm font-semibold text-foreground">
+                        {member.displayName}
+                      </span>
+                    </div>
+                    <div className="mt-1 flex flex-wrap items-center gap-1.5">
+                      <Badge tone="primary">{member.type === 'bot' ? 'Bot' : '用户'}</Badge>
+                      <Badge tone={roleBadge.tone}>{roleBadge.label}</Badge>
+                    </div>
+                  </div>
                 </div>
-                <Badge>{member.role}</Badge>
-              </div>
-            ))}
+              );
+            })}
           </div>
         )}
       </ModalContent>

--- a/src/frontend-nextgen/src/components/ui/Badge.tsx
+++ b/src/frontend-nextgen/src/components/ui/Badge.tsx
@@ -1,7 +1,7 @@
 import { cn } from '@/utils/cn';
 import React from 'react';
 
-type Tone = 'neutral' | 'primary' | 'success' | 'warning' | 'error' | 'outline';
+type Tone = 'neutral' | 'primary' | 'success' | 'warning' | 'error' | 'outline' | 'purple';
 const tones: Record<Tone, string> = {
   // D3: token 迁到 shadcn 软色模式 (bg-X/10 text-X)，保历史软徽章观感；沿用 `tone` API 零 callsite 改动。
   neutral: 'bg-muted text-muted-foreground',
@@ -10,6 +10,7 @@ const tones: Record<Tone, string> = {
   warning: 'bg-warning/10 text-warning',
   error: 'bg-destructive/10 text-destructive',
   outline: 'border border-border text-foreground',
+  purple: 'bg-purple/10 text-purple',
 };
 
 export function Badge({

--- a/src/frontend-nextgen/src/global.css
+++ b/src/frontend-nextgen/src/global.css
@@ -46,6 +46,7 @@
   --success: 142 71% 45%;
   --warning: 38 92% 50%;
   --info: 199 89% 48%;
+  --purple: 272 81% 56%; /* 管理角色标签紫（群主/主节点），purple-600 #9333ea */
   --brand: 221.2 83.2% 53.3%; /* 经典科技蓝 #2563eb，与 --primary 保持一致 */
 
   --border: 240 5.9% 90%;
@@ -133,6 +134,7 @@
   --success: 142 71% 45%;
   --warning: 38 92% 50%;
   --info: 199 89% 48%;
+  --purple: 272 81% 56%;
   --brand: 221.7 100% 65%; /* D2: 暗色 brand 提亮 */
 
   --border: 240 3.7% 15.9%;
@@ -177,6 +179,7 @@
   --color-warning: hsl(var(--warning));
   --color-error: hsl(var(--destructive));
   --color-info: hsl(var(--info));
+  --color-purple: hsl(var(--purple));
   --color-brand: hsl(var(--brand));
 
   --color-border: hsl(var(--border));

--- a/src/frontend-nextgen/src/hooks/useAdmin.ts
+++ b/src/frontend-nextgen/src/hooks/useAdmin.ts
@@ -1,8 +1,10 @@
 // useAdmin：空间列表搜索（防抖）/ 类型筛选 / 分页 / 创建团队空间 / 打开详情拉成员 /
-// 成员增删改 / 申请加入。编排 store + adminService，错误 toast（经统一 notify 入口）。
+// 申请加入。编排 store + adminService，错误 toast（经统一 notify 入口）。成员增删改（含批量添加）
+// 下沉到 useSpaceMemberActions，避免本 Hook 超文件体积阈值（Hook ≤ 250 行）。
 import { notifyError, notifySuccess } from '@/components/ui/notify';
 import type { Space } from '@/domain/admin/models';
 import { sortSpacesByDisplayOrder } from '@/domain/spaceContext';
+import { useSpaceMemberActions } from '@/hooks/useSpaceMemberActions';
 import { adminService } from '@/services/admin';
 import { useAdminStore } from '@/stores/adminStore';
 import { shouldMuteNonAuthedToast } from '@/utils/loginToastGate';
@@ -36,6 +38,8 @@ export function useAdmin() {
   } = useAdminStore();
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const keywordRef = useRef(keyword);
+  // 成员增删改（含批量添加 Promise.allSettled 聚合）编排下沉到此子 Hook。
+  const memberActions = useSpaceMemberActions({ currentSpace, setMembers });
 
   const fetchList = useCallback(
     async (override?: { keyword?: string; spaceType?: typeof spaceType; pageNo?: number; pageSize?: number }) => {
@@ -152,54 +156,6 @@ export function useAdmin() {
     [closeSpaceDetail, fetchList],
   );
 
-  const refreshMembers = useCallback(async () => {
-    if (!currentSpace?.spaceId) return;
-    const r = await adminService.listMembers(currentSpace.spaceId);
-    if (!r.error) setMembers(r.data?.items ?? []);
-  }, [currentSpace, setMembers]);
-
-  const addMember = useCallback(
-    async (userId: string, role: 'ADMIN' | 'MEMBER' = 'MEMBER', userName?: string) => {
-      if (!currentSpace?.spaceId) return;
-      const r = await adminService.addMember(currentSpace.spaceId, userId, role, userName);
-      if (r.error) {
-        notifyError(r.error.message, { title: '添加成员失败', requestId: r.error.requestId });
-        return;
-      }
-      notifySuccess('成员已添加');
-      void refreshMembers();
-    },
-    [currentSpace, refreshMembers],
-  );
-
-  const removeMember = useCallback(
-    async (userId: string) => {
-      if (!currentSpace?.spaceId) return;
-      const r = await adminService.removeMember(currentSpace.spaceId, userId);
-      if (r.error) {
-        notifyError(r.error.message, { title: '移除成员失败', requestId: r.error.requestId });
-        return;
-      }
-      notifySuccess('成员已移除');
-      void refreshMembers();
-    },
-    [currentSpace, refreshMembers],
-  );
-
-  const updateRole = useCallback(
-    async (userId: string, role: 'ADMIN' | 'MEMBER') => {
-      if (!currentSpace?.spaceId) return;
-      const r = await adminService.updateRole(currentSpace.spaceId, userId, role);
-      if (r.error) {
-        notifyError(r.error.message, { title: '修改角色失败', requestId: r.error.requestId });
-        return;
-      }
-      notifySuccess('角色已更新');
-      void refreshMembers();
-    },
-    [currentSpace, refreshMembers],
-  );
-
   const requestJoin = useCallback(
     async (spaceId: number | string, reason: string) => {
       const r = await adminService.requestJoin(spaceId, reason);
@@ -240,9 +196,12 @@ export function useAdmin() {
     openSpaceDetail,
     closeSpaceDetail,
     deleteSpace,
-    addMember,
-    removeMember,
-    updateRole,
+    addMember: memberActions.addMember,
+    addMembers: memberActions.addMembers,
+    addMembersLoading: memberActions.addMembersLoading,
+    addMembersDisabledReason: memberActions.addMembersDisabledReason,
+    removeMember: memberActions.removeMember,
+    updateRole: memberActions.updateRole,
     requestJoin,
     fetchList,
   };

--- a/src/frontend-nextgen/src/hooks/useSpaceMemberActions.ts
+++ b/src/frontend-nextgen/src/hooks/useSpaceMemberActions.ts
@@ -1,0 +1,127 @@
+// 空间成员增删改 Hook：refreshMembers / addMember / addMembers(批量) /
+// removeMember / updateRole 编排 adminService + toast。批量添加：Promise.allSettled 聚合在
+// service 层完成（design D2 按 envelope {error} 归属）；本 Hook 只做 toast/refresh/加载态编排：
+//   - 文案 design D6（全成功 notifySuccess；混合/全失败 notifyError 聚合）
+//   - 单次 refreshMembers
+//   - in-flight 期间以 addingMembersRef 同步阻断重入（防双击/重复提交）；addMembersLoading 暴露给 Component
+// 被 useAdmin 组合，避免 useAdmin 超文件体积阈值（Hook ≤ 250 行）。
+import { notifyError, notifySuccess } from '@/components/ui/notify';
+import type { SearchedUser } from '@/capabilities';
+import type { Space, SpaceMember } from '@/domain/admin/models';
+import { adminService } from '@/services/admin';
+import { useCallback, useRef, useState } from 'react';
+
+export interface UseSpaceMemberActionsArgs {
+  /** 当前打开的空间；其 spaceId 驱动成员增删改请求。 */
+  currentSpace: Space | null;
+  /** store 写入成员列表（refreshMembers 后同步成功计入项）。 */
+  setMembers: (members: SpaceMember[]) => void;
+}
+
+export interface SpaceMemberActions {
+  refreshMembers: () => Promise<void>;
+  addMember: (userId: string, role?: 'ADMIN' | 'MEMBER', userName?: string) => Promise<void>;
+  addMembers: (users: SearchedUser[], role?: 'ADMIN' | 'MEMBER') => Promise<
+    { succeeded: SpaceMember[]; failed: { userId: string; userName?: string; reason: string }[] } | undefined
+  >;
+  removeMember: (userId: string) => Promise<void>;
+  updateRole: (userId: string, role: 'ADMIN' | 'MEMBER') => Promise<void>;
+  addMembersLoading: boolean;
+  addMembersDisabledReason: string | undefined;
+}
+
+export function useSpaceMemberActions({ currentSpace, setMembers }: UseSpaceMemberActionsArgs): SpaceMemberActions {
+  // 批量添加 in-flight 同步重入阻断用 ref（useState 异步，无法挡同一 tick 内的重入/双击）。
+  const addingMembersRef = useRef(false);
+  const [addingMembers, setAddingMembers] = useState(false);
+
+  const refreshMembers = useCallback(async () => {
+    if (!currentSpace?.spaceId) return;
+    const r = await adminService.listMembers(currentSpace.spaceId);
+    if (!r.error) setMembers(r.data?.items ?? []);
+  }, [currentSpace, setMembers]);
+
+  const addMember = useCallback(
+    async (userId: string, role: 'ADMIN' | 'MEMBER' = 'MEMBER', userName?: string) => {
+      if (!currentSpace?.spaceId) return;
+      const r = await adminService.addMember(currentSpace.spaceId, userId, role, userName);
+      if (r.error) {
+        notifyError(r.error.message, { title: '添加成员失败', requestId: r.error.requestId });
+        return;
+      }
+      notifySuccess('成员已添加');
+      void refreshMembers();
+    },
+    [currentSpace, refreshMembers],
+  );
+
+  const addMembers = useCallback(
+    async (users: SearchedUser[], role: 'ADMIN' | 'MEMBER' = 'MEMBER') => {
+      if (!currentSpace?.spaceId) return;
+      if (users.length === 0 || addingMembersRef.current) return;
+      addingMembersRef.current = true;
+      setAddingMembers(true);
+      try {
+        const items = users.map((u) => ({
+          userId: u.userId,
+          // 花名优先 nickName；其次 displayName（非工号时）；其余不传，避免把工号误写成花名。
+          userName: u.nickName || (u.displayName !== u.userId ? u.displayName : undefined),
+        }));
+        const r = await adminService.addMembersBatch(currentSpace.spaceId, items, role);
+        const ok = r.succeeded.length;
+        const fail = r.failed.length;
+        if (fail === 0) {
+          notifySuccess(`已添加 ${ok} 名成员`);
+        } else {
+          const detail = r.failed.map((f) => `${f.userName ?? f.userId}(${f.reason})`).join('、');
+          notifyError(`${ok}/${ok + fail} 添加成功；${fail} 名失败：${detail}`, { title: '添加成员部分失败' });
+        }
+        // 成员表需同步成功计入项 → 一次 refresh 把成功者拉进列表。
+        void refreshMembers();
+        return r;
+      } finally {
+        addingMembersRef.current = false;
+        setAddingMembers(false);
+      }
+    },
+    [currentSpace, refreshMembers],
+  );
+
+  const removeMember = useCallback(
+    async (userId: string) => {
+      if (!currentSpace?.spaceId) return;
+      const r = await adminService.removeMember(currentSpace.spaceId, userId);
+      if (r.error) {
+        notifyError(r.error.message, { title: '移除成员失败', requestId: r.error.requestId });
+        return;
+      }
+      notifySuccess('成员已移除');
+      void refreshMembers();
+    },
+    [currentSpace, refreshMembers],
+  );
+
+  const updateRole = useCallback(
+    async (userId: string, role: 'ADMIN' | 'MEMBER') => {
+      if (!currentSpace?.spaceId) return;
+      const r = await adminService.updateRole(currentSpace.spaceId, userId, role);
+      if (r.error) {
+        notifyError(r.error.message, { title: '修改角色失败', requestId: r.error.requestId });
+        return;
+      }
+      notifySuccess('角色已更新');
+      void refreshMembers();
+    },
+    [currentSpace, refreshMembers],
+  );
+
+  return {
+    refreshMembers,
+    addMember,
+    addMembers,
+    removeMember,
+    updateRole,
+    addMembersLoading: addingMembers,
+    addMembersDisabledReason: addingMembers ? '正在添加成员…' : undefined,
+  };
+}

--- a/src/frontend-nextgen/src/pages/Admin/Spaces/index.tsx
+++ b/src/frontend-nextgen/src/pages/Admin/Spaces/index.tsx
@@ -30,7 +30,9 @@ export function AdminSpacesView() {
     openSpaceDetail,
     closeSpaceDetail,
     deleteSpace,
-    addMember,
+    addMembers,
+    addMembersLoading,
+    addMembersDisabledReason,
     removeMember,
     updateRole,
     requestJoin,
@@ -149,7 +151,9 @@ export function AdminSpacesView() {
                 space={currentSpace}
                 members={members}
                 loading={membersLoading}
-                onAddMember={addMember}
+                onAddMembers={addMembers}
+                addMembersLoading={addMembersLoading}
+                addMembersDisabledReason={addMembersDisabledReason}
                 onRemoveMember={removeMember}
                 onUpdateRole={updateRole}
                 onRequestJoin={(s, reason) => void requestJoin(s.spaceId, reason)}

--- a/src/frontend-nextgen/src/pages/Workspace/BcnChatDetail.tsx
+++ b/src/frontend-nextgen/src/pages/Workspace/BcnChatDetail.tsx
@@ -1,0 +1,40 @@
+import { Button, Empty, Spin } from '@/components/ui';
+import { useBcnChatDetailRedirect } from '@/pages/Workspace/hooks/useBcnChatDetailRedirect';
+import { useNavigate } from 'react-router-dom';
+
+/**
+ * BcnChatDetail —— BCN 协作会话外链落地页（纯 view）。
+ *
+ * /workspace/bcn/chat/detail?id={groupId}&bot_uuid={currentUser}&session={sessionId}
+ * 参数解析、参与方式判定（固定群成员/仅参与临时会话）与重定向全部经
+ * `useBcnChatDetailRedirect` 下发；组件不直接 import service，保持分层约束。
+ * 对齐 InviteAcceptPanel 落地页范式。
+ */
+export function BcnChatDetail() {
+  const { status } = useBcnChatDetailRedirect();
+  const navigate = useNavigate();
+
+  if (status === 'invalid') {
+    return (
+      <div className="flex min-h-64 items-center justify-center py-14">
+        <Empty
+          title="链接参数不完整"
+          description="缺少协作群或会话标识（id / session），无法定位到目标会话。"
+          action={
+            <Button variant="secondary" size="sm" onClick={() => navigate('/workspace')}>
+              返回对话协作
+            </Button>
+          }
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-64 items-center justify-center py-14">
+      <Spin tip="正在打开协作会话…" />
+    </div>
+  );
+}
+
+export default BcnChatDetail;

--- a/src/frontend-nextgen/src/pages/Workspace/components/ManagePanel/MemberList.tsx
+++ b/src/frontend-nextgen/src/pages/Workspace/components/ManagePanel/MemberList.tsx
@@ -1,8 +1,8 @@
-import { Badge, Button, Skeleton } from '@/components/ui';
+import { Badge, Button, IconButton, Skeleton } from '@/components/ui';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import type { GroupView, IdentityView, ParticipantView } from '@/domain/collaboration';
 import { resolveAuthenticatedDisplayName } from '@/domain/userIdentity';
-import { Plus, UserMinus } from 'lucide-react';
+import { Plus, Trash2 } from 'lucide-react';
 import { useState } from 'react';
 import { AddMemberDialog } from './AddMemberDialog';
 
@@ -24,21 +24,19 @@ export interface MemberListProps {
   onRemove: (actorId: string) => Promise<boolean>;
 }
 
-const MEMBER_TAG_CLASS = 'text-[10px]';
-
-function getRoleLabel(participant: ParticipantView, groupKind: GroupView['kind']): string | null {
+/** 角色标签：自由聊天/自定义协同 driver→群主；任务协作 manager→主节点、worker→从节点；其余一律「成员」。 */
+function getRoleLabel(participant: ParticipantView, groupKind: GroupView['kind']): string {
   if (groupKind === 'task_master_slave') {
-    if (participant.kind !== 'bot') return null;
     if (participant.role === 'manager') return '主节点';
     if (participant.role === 'worker') return '从节点';
-    return null;
+    return '成员';
   }
-  return participant.role === 'driver' ? '群主' : null;
+  return participant.role === 'driver' ? '群主' : '成员';
 }
 
 function getModeLabel(participant: ParticipantView): string | null {
   if (participant.kind === 'bot') {
-    if (participant.mode === 'auto') return '自由';
+    if (participant.mode === 'auto') return '自动';
     if (participant.mode === 'muted') return '禁言';
     return null;
   }
@@ -47,13 +45,26 @@ function getModeLabel(participant: ParticipantView): string | null {
   return null;
 }
 
+/** 角色标签色：群主/主节点（管理角色）紫；从节点/成员走默认蓝。 */
+function getRoleTone(participant: ParticipantView, groupKind: GroupView['kind']): 'purple' | 'primary' {
+  if (groupKind === 'task_master_slave') return participant.role === 'manager' ? 'purple' : 'primary';
+  return participant.role === 'driver' ? 'purple' : 'primary';
+}
+
+/** 状态标签色：自动/参与绿，禁言/旁观灰。 */
+function getModeTone(participant: ParticipantView): 'success' | 'neutral' {
+  if (participant.kind === 'bot') return participant.mode === 'auto' ? 'success' : 'neutral';
+  return participant.mode === 'present' ? 'success' : 'neutral';
+}
+
 function Avatar({ participant }: { participant: ParticipantView }) {
   const symbol = participant.name?.trim().charAt(0) || '?';
   return (
     <div
       className={
         participant.kind === 'bot'
-          ? 'grid size-8 flex-none place-items-center rounded-full bg-foreground text-xs font-medium text-background shadow-sm'
+          ? // bot 图标对齐 Bot 工坊信息列首字母圆标：主色软底（bg-primary/10 + text-primary）。
+            'grid size-8 flex-none place-items-center rounded-full bg-primary/10 text-xs font-semibold text-primary shadow-sm'
           : 'grid size-8 flex-none place-items-center rounded-full bg-brand/15 text-xs font-medium text-brand shadow-sm'
       }
     >
@@ -133,19 +144,12 @@ export function MemberList({
                   <div className="flex items-center">
                     <span className="max-w-full truncate text-sm font-semibold text-foreground">{displayName}</span>
                   </div>
+                  {/* 标签分类型着色（Badge 默认字号）：成员类型默认蓝；群主/主节点紫；自动/参与绿；禁言/旁观灰。 */}
                   <div className="mt-1 flex flex-wrap items-center gap-1.5">
-                    <Badge className={MEMBER_TAG_CLASS} tone={participant.kind === 'bot' ? 'primary' : 'neutral'}>
-                      {participant.kind === 'bot' ? 'Bot' : '用户'}
-                    </Badge>
-                    {getRoleLabel(participant, groupKind) ? (
-                      <Badge className={MEMBER_TAG_CLASS} tone="warning">
-                        {getRoleLabel(participant, groupKind)}
-                      </Badge>
-                    ) : null}
+                    <Badge tone="primary">{participant.kind === 'bot' ? 'Bot' : '用户'}</Badge>
+                    <Badge tone={getRoleTone(participant, groupKind)}>{getRoleLabel(participant, groupKind)}</Badge>
                     {showMode && getModeLabel(participant) ? (
-                      <Badge className={MEMBER_TAG_CLASS} tone="neutral">
-                        {getModeLabel(participant)}
-                      </Badge>
+                      <Badge tone={getModeTone(participant)}>{getModeLabel(participant)}</Badge>
                     ) : null}
                   </div>
                 </div>
@@ -157,10 +161,12 @@ export function MemberList({
                     confirmVariant="destructive"
                     onConfirm={() => void onRemove(participant.actorId)}
                   >
-                    <Button variant="ghost" size="sm" className="shrink-0 text-muted-foreground hover:text-destructive">
-                      <UserMinus className="h-4 w-4" />
-                      移除
-                    </Button>
+                    <IconButton
+                      label="移除成员"
+                      icon={<Trash2 className="h-4 w-4" aria-hidden />}
+                      size="sm"
+                      className="shrink-0 text-destructive hover:bg-destructive/10 hover:text-destructive"
+                    />
                   </ConfirmDialog>
                 )}
               </div>

--- a/src/frontend-nextgen/src/pages/Workspace/hooks/sessionMapRequests.utils.ts
+++ b/src/frontend-nextgen/src/pages/Workspace/hooks/sessionMapRequests.utils.ts
@@ -58,3 +58,16 @@ export function normalizePage(data: GroupSessionPage | SessionView[], fallbackOf
   }
   return data;
 }
+
+/** 清掉指定群的陈旧会话缓存（ref+state 同步更新）：重拉窗口内自动选中/陈旧选中兜底不消费旧数据。 */
+export function dropGroupCache(
+  rawByGroupIdRef: SessionMapRef,
+  setRawByGroupId: Dispatch<SetStateAction<SessionMap>>,
+  gid: string,
+): void {
+  if (rawByGroupIdRef.current[gid] === undefined) return;
+  const next = { ...rawByGroupIdRef.current };
+  delete next[gid];
+  rawByGroupIdRef.current = next;
+  setRawByGroupId(next);
+}

--- a/src/frontend-nextgen/src/pages/Workspace/hooks/useBcnChatDetailRedirect.ts
+++ b/src/frontend-nextgen/src/pages/Workspace/hooks/useBcnChatDetailRedirect.ts
@@ -1,0 +1,59 @@
+import { isSameHumanIdentity } from '@/domain/userIdentity';
+import { groupService } from '@/services/workspace/groupService';
+import { history, useSearchParams } from '@umijs/max';
+import { useEffect, useState } from 'react';
+
+export type BcnChatDetailStatus = 'redirecting' | 'invalid';
+
+/**
+ * 参与方式判定：bot_uuid 命中群固定成员名册（loadGroupDetail participants）→ direct，
+ * 否则 session_only。以下情形返回 null（降级为不带 membership 参数，
+ * 由 workspace useSelectedGroupDetail 在列表加载完成后自动纠正视角）：
+ * - bot_uuid 缺失；
+ * - `bcs_grp_` 前缀的 BCS 群（交由 workspace BCS 前缀路由承接）；
+ * - 群详情接口失败。
+ */
+async function resolveMembership(groupId: string, botUuid: string | null): Promise<'direct' | 'session_only' | null> {
+  if (!botUuid || groupId.startsWith('bcs_grp_')) return null;
+  try {
+    const res = await groupService.loadGroupDetail(groupId);
+    if (!res.ok) return null;
+    const inRoster = (res.data.participants ?? []).some(
+      (p) => p.actorId === botUuid || isSameHumanIdentity(p.actorId, botUuid, p.kind),
+    );
+    return inRoster ? 'direct' : 'session_only';
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * useBcnChatDetailRedirect —— BCN 外链落地（/workspace/bcn/chat/detail?id=&bot_uuid=&session=）：
+ * 判定参与方式后 history.replace 到 workspace 协作群深链
+ * （?tab=group&group=&session=[&membership=]），身份定位（切回用户身份）由 workspace
+ * 既有一次性外链同步承担（session= 无 bot= 分支）。落地页不进历史栈（replace）。
+ */
+export function useBcnChatDetailRedirect(): { status: BcnChatDetailStatus } {
+  const [searchParams] = useSearchParams();
+  const groupId = searchParams.get('id')?.trim() || null;
+  const botUuid = searchParams.get('bot_uuid')?.trim() || null;
+  const sessionId = searchParams.get('session')?.trim() || null;
+  const [status] = useState<BcnChatDetailStatus>(groupId && sessionId ? 'redirecting' : 'invalid');
+
+  useEffect(() => {
+    if (!groupId || !sessionId) return;
+    let cancelled = false;
+    void (async () => {
+      const params = new URLSearchParams({ tab: 'group', group: groupId, session: sessionId });
+      const membership = await resolveMembership(groupId, botUuid);
+      if (membership) params.set('membership', membership);
+      if (cancelled) return;
+      history.replace(`/workspace?${params.toString()}`);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [groupId, botUuid, sessionId]);
+
+  return { status };
+}

--- a/src/frontend-nextgen/src/pages/Workspace/hooks/useCollabPanel.ts
+++ b/src/frontend-nextgen/src/pages/Workspace/hooks/useCollabPanel.ts
@@ -71,6 +71,12 @@ export function useCollabPanel(
     [identities],
   );
   const humanIdentityId = authenticatedUserId ?? humanIdentity?.id ?? null;
+  // 加入/退出会话与「去发言」切换身份用的 actor id：必须优先 store 人类身份 id
+  //（= mine 接口 human 条目的 bot_id，形如 human_xxx）。authenticatedUserId 是规范化
+  // OpenAPI user_id（无 human_ 前缀），放进 participants/{actor} 路径参数或
+  // setActiveIdentity（按身份 id 精确匹配）都会落空。匹配会话成员仍用 humanIdentityId
+  //（isSameHumanIdentity 两侧归一化，前缀无关）。
+  const humanActorId = humanIdentity?.id ?? authenticatedUserId ?? null;
   const humanIdentityName = authenticatedUserName?.trim() || humanIdentity?.displayName || '';
   const setActiveIdentity = useWorkspaceStore((s) => s.setActiveIdentity);
 
@@ -102,7 +108,9 @@ export function useCollabPanel(
   }, [humanIdentityId, session]);
   const humanJoined = human?.mode === 'present';
   const humanAbsent = human?.mode === 'absent';
-  const humanName = (human?.name ?? humanIdentityName) || (activeIdentity?.kind === 'user' ? activeIdentity.displayName : '用户协作身份');
+  const humanName =
+    (human?.name ?? humanIdentityName) ||
+    (activeIdentity?.kind === 'user' ? activeIdentity.displayName : '用户协作身份');
 
   // 切到用户身份并落到当前群会话。setActiveIdentity 会恢复该身份上次记忆的
   // 视图/选中态（可能停留在某个单聊页），若不显式覆盖 view 与选中态，
@@ -117,13 +125,13 @@ export function useCollabPanel(
   }, []);
 
   const switchToHuman = useCallback(() => {
-    if (!humanIdentityId) {
+    if (!humanActorId) {
       toast.error('未找到用户身份，请稍后重试');
       return;
     }
-    setActiveIdentity(humanIdentityId);
+    setActiveIdentity(humanActorId);
     if (session) openGroupSessionAsHuman(session);
-  }, [humanIdentityId, openGroupSessionAsHuman, session, setActiveIdentity]);
+  }, [humanActorId, openGroupSessionAsHuman, session, setActiveIdentity]);
 
   const setBotMode = useCallback(
     async (mode: 'auto' | 'muted') => {
@@ -140,7 +148,7 @@ export function useCollabPanel(
 
   const joinSession = useCallback(async (): Promise<boolean> => {
     if (!session) return false;
-    const actorId = human?.actorId ?? humanIdentityId;
+    const actorId = human?.actorId ?? humanActorId;
     if (!actorId) {
       toast.error('未找到用户身份，请稍后重试');
       return false;
@@ -149,21 +157,21 @@ export function useCollabPanel(
     try {
       const ok = await updateMemberMode(session.sessionId, actorId, 'present');
       if (ok) {
-        if (humanIdentityId) setActiveIdentity(humanIdentityId);
+        if (humanActorId) setActiveIdentity(humanActorId);
         openGroupSessionAsHuman(session);
       }
       return ok;
     } finally {
       setJoining(false);
     }
-  }, [human, humanIdentityId, openGroupSessionAsHuman, session, setActiveIdentity, updateMemberMode]);
+  }, [human, humanActorId, openGroupSessionAsHuman, session, setActiveIdentity, updateMemberMode]);
 
   const leaveSession = useCallback(async (): Promise<boolean> => {
     if (!session) return false;
-    const actorId = human?.actorId ?? humanIdentityId;
+    const actorId = human?.actorId ?? humanActorId;
     if (!actorId) return false;
     return updateMemberMode(session.sessionId, actorId, 'absent');
-  }, [human, humanIdentityId, session, updateMemberMode]);
+  }, [human, humanActorId, session, updateMemberMode]);
 
   // bot 视角恒显;human 视角 absent 时显示加入条;human 视角 present 时显示「在会话中隐身」条。
   const humanAbsentOnly = !isBotViewer && !!session && humanAbsent;
@@ -179,7 +187,7 @@ export function useCollabPanel(
     humanJoined,
     humanName,
     humanAvatarUrl: human?.avatarUrl,
-    canSwitchToHuman: !!humanIdentityId,
+    canSwitchToHuman: !!humanActorId,
     switchingBotMode,
     joining,
     setBotMode,

--- a/src/frontend-nextgen/src/pages/Workspace/hooks/useExpandedGroupSessionRequests.ts
+++ b/src/frontend-nextgen/src/pages/Workspace/hooks/useExpandedGroupSessionRequests.ts
@@ -1,20 +1,23 @@
 import type { GroupSessionPage, SessionView } from '@/domain/collaboration';
 import { groupService } from '@/services/workspace/groupService';
 import { shouldMuteNonAuthedToast } from '@/utils/loginToastGate';
-import { useEffect, type Dispatch, type MutableRefObject, type SetStateAction } from 'react';
+import { useEffect, useRef, type Dispatch, type MutableRefObject, type SetStateAction } from 'react';
 import { toast } from 'sonner';
+import { dropGroupCache } from './sessionMapRequests.utils';
 
 interface ExpandedGroupSessionRequestsOptions {
   activeIdentityId: string | null;
   expandedGroupIds: string[];
   groupId: string | null;
   rawByGroupId: Record<string, SessionView[]>;
+  rawByGroupIdRef: MutableRefObject<Record<string, SessionView[]>>;
   inFlightRef: MutableRefObject<Map<string, number>>;
   identityEpochRef: MutableRefObject<number>;
   beginGroupRequest: (groupId: string) => number;
   isCurrentRequest: (groupId: string, version: number, epoch: number) => boolean;
   replaceGroupPage: (groupId: string, data: GroupSessionPage | SessionView[]) => void;
   setErrorByGroupId: Dispatch<SetStateAction<Record<string, string>>>;
+  setRawByGroupId: Dispatch<SetStateAction<Record<string, SessionView[]>>>;
 }
 
 export function useExpandedGroupSessionRequests({
@@ -22,17 +25,29 @@ export function useExpandedGroupSessionRequests({
   expandedGroupIds,
   groupId,
   rawByGroupId,
+  rawByGroupIdRef,
   inFlightRef,
   identityEpochRef,
   beginGroupRequest,
   isCurrentRequest,
   replaceGroupPage,
   setErrorByGroupId,
+  setRawByGroupId,
 }: ExpandedGroupSessionRequestsOptions) {
+  const prevExpandedRef = useRef<Set<string>>(new Set());
   useEffect(() => {
     if (!activeIdentityId) return;
+    const prev = prevExpandedRef.current;
+    const next = new Set(expandedGroupIds);
+    prevExpandedRef.current = next;
     for (const gid of expandedGroupIds) {
-      if (gid === groupId || rawByGroupId[gid] !== undefined || inFlightRef.current.has(gid)) continue;
+      // 重新展开（点击群 tab）必重拉最新列表：缓存可能残留当前角色已离开的会话。
+      // 非 transition 时维持原去重语义（选中群由选中路径负责、已缓存不重复拉）。
+      const justExpanded = !prev.has(gid);
+      if (!justExpanded && (gid === groupId || rawByGroupId[gid] !== undefined)) continue;
+      if (inFlightRef.current.has(gid)) continue;
+      // 选中群重拉前清掉陈旧缓存：自动选中/陈旧选中兜底在窗口期不消费旧数据。
+      if (gid === groupId) dropGroupCache(rawByGroupIdRef, setRawByGroupId, gid);
       const requestEpoch = identityEpochRef.current;
       const requestVersion = beginGroupRequest(gid);
       inFlightRef.current.set(gid, requestVersion);
@@ -68,7 +83,9 @@ export function useExpandedGroupSessionRequests({
     inFlightRef,
     isCurrentRequest,
     rawByGroupId,
+    rawByGroupIdRef,
     replaceGroupPage,
     setErrorByGroupId,
+    setRawByGroupId,
   ]);
 }

--- a/src/frontend-nextgen/src/pages/Workspace/hooks/useGroupManagement.ts
+++ b/src/frontend-nextgen/src/pages/Workspace/hooks/useGroupManagement.ts
@@ -5,6 +5,7 @@ import { groupMemberService } from '@/services/workspace/groupMemberService';
 import { groupService } from '@/services/workspace/groupService';
 import type { DomainResult } from '@/services/workspace/identityService';
 import { invitationService } from '@/services/workspace/invitationService';
+import { useWorkspaceStore } from '@/stores/workspaceStore';
 import { useCallback, useEffect, useState } from 'react';
 import { toast } from 'sonner';
 
@@ -115,6 +116,12 @@ export function useGroupManagement(
         return false;
       }
       toast.success('已退出协作群');
+      // 退出后群对当前身份不再可见：选中仍指向它时清空（对齐 dissolveGroup 收尾）。
+      // 否则群列表刷新后 useSelectedGroupDetail 会把「选中群不在 direct 列表」误判为
+      // 深链临时视角场景，把侧栏筛选错切到「仅参与临时会话」（session_only）。
+      if (useWorkspaceStore.getState().selectedGroupId === groupId) {
+        useWorkspaceStore.getState().selectGroup(null);
+      }
       return true;
     },
     [groupId],

--- a/src/frontend-nextgen/src/pages/Workspace/hooks/useGroupSessions.ts
+++ b/src/frontend-nextgen/src/pages/Workspace/hooks/useGroupSessions.ts
@@ -50,6 +50,7 @@ export function useGroupSessions(groupId: string | null, expandedGroupIds: strin
     errorByGroupId,
     loadMoreErrorByGroupId,
     identityEpochRef,
+    rawByGroupIdRef,
   } = useSessionMap(groupId, expandedGroupIds, activeIdentityId);
 
   // 会话成员详情补齐与 mode 更新(从本 Hook 拆出以控体积,详见 useSessionMemberSync)。
@@ -72,9 +73,12 @@ export function useGroupSessions(groupId: string | null, expandedGroupIds: strin
   useEffect(() => {
     if (!groupId || sessionViews.length === 0) return;
     if (useWorkspaceStore.getState().selectedSessionId) return;
-    const first = sessionViews[0];
+    // 以 ref 为准消费最新缓存：点击群 tab 触发的重拉会在同一 commit 内先清掉陈旧缓存
+    //（ref 同步更新、state 下一帧才到），闭包里的 sessionViews 可能仍是旧列表，
+    // 直接消费会自动选中当前角色已离开的会话，导致右栏对其发起请求而报错。
+    const first = (rawByGroupIdRef.current[groupId] ?? [])[0];
     if (first) selectSession(first.sessionId);
-  }, [groupId, sessionViews, selectSession]);
+  }, [groupId, rawByGroupIdRef, sessionViews, selectSession]);
 
   // 收藏状态来源于后端 sessions 列表返回的 collected 字段（映射为 SessionView.favorite）。
   // 收藏过滤已下沉到 GroupItem（每群独立 tab），这里仅暴露收藏 ID 给组件层。

--- a/src/frontend-nextgen/src/pages/Workspace/hooks/useSessionLeave.ts
+++ b/src/frontend-nextgen/src/pages/Workspace/hooks/useSessionLeave.ts
@@ -3,6 +3,7 @@ import { sessionService } from '@/services/workspace/sessionService';
 import { useWorkspaceStore } from '@/stores/workspaceStore';
 import { useCallback } from 'react';
 import { toast } from 'sonner';
+import { markSessionGone } from './useStaleSessionFallback';
 
 /** 从 map 中移除会话并校正选中态（删除/退出共用）。 */
 function removeSessionAndFixSelection(
@@ -32,6 +33,8 @@ export function useSessionMutations(
         toast.error(res.error.friendlyMessage);
         return false;
       }
+      // 登记「已知删除」：陈旧选中兜底/成员详情补齐不再对其发起必然失败的详情反查。
+      markSessionGone(sessionId);
       removeSessionAndFixSelection(applyMapUpdate, selectSession, sessionId);
       toast.success('会话已删除');
       return true;
@@ -46,6 +49,8 @@ export function useSessionMutations(
         toast.error(res.error.friendlyMessage);
         return false;
       }
+      // 登记「已知退出」：陈旧选中兜底/成员详情补齐不再对其发起必然失败的详情反查。
+      markSessionGone(sessionId);
       removeSessionAndFixSelection(applyMapUpdate, selectSession, sessionId);
       toast.success('已退出会话');
       return true;

--- a/src/frontend-nextgen/src/pages/Workspace/hooks/useSessionMap.ts
+++ b/src/frontend-nextgen/src/pages/Workspace/hooks/useSessionMap.ts
@@ -45,6 +45,8 @@ export interface UseSessionMapResult {
   loadMoreSessions: (gid: string) => Promise<void>;
   /** 身份代际：切换身份时递增，供外部丢弃在途旧身份响应。 */
   identityEpochRef: MutableRefObject<number>;
+  /** 最新缓存 ref（重拉窗口清缓存时同步更新）：自动选中消费它避免命中同 commit 陈旧列表。 */
+  rawByGroupIdRef: MutableRefObject<Record<string, SessionView[]>>;
 }
 
 /**
@@ -208,5 +210,6 @@ export function useSessionMap(
     loadMoreErrorByGroupId,
     loadMoreSessions,
     identityEpochRef,
+    rawByGroupIdRef,
   };
 }

--- a/src/frontend-nextgen/src/pages/Workspace/hooks/useSessionMapRequests.ts
+++ b/src/frontend-nextgen/src/pages/Workspace/hooks/useSessionMapRequests.ts
@@ -1,10 +1,11 @@
 import { groupService } from '@/services/workspace/groupService';
 import { useCallback, useEffect, useRef } from 'react';
 import {
-  type UseSessionMapRequestsOptions,
+  dropGroupCache,
   normalizePage,
   notifyError,
   SESSION_PAGE_SIZE,
+  type UseSessionMapRequestsOptions,
 } from './sessionMapRequests.utils';
 import { useExpandedGroupSessionRequests } from './useExpandedGroupSessionRequests';
 
@@ -30,15 +31,27 @@ export function useSessionMapRequests({
 }: UseSessionMapRequestsOptions) {
   // 用 epoch+gid 做已拉标记：epoch 变化（身份切换清空缓存）时旧标记失效，重新拉。
   const lastLoadedKeyRef = useRef<string>('');
+  const prevGroupIdRef = useRef<string | null>(null);
   useEffect(() => {
     if (!groupId || !activeIdentityId) return;
     const key = `${identityEpochRef.current}:${groupId}`;
+    // 切回已加载过的群（groupId transition）必须重拉最新列表：缓存里可能残留当前角色
+    // 已离开/被移除的会话，复用会让自动选中命中陈旧会话，右栏随之对其发起请求而报错。
+    const isGroupTransition = prevGroupIdRef.current !== groupId;
+    prevGroupIdRef.current = groupId;
     // 仅在 groupId 或 epoch 变化时拉取，避免 effect 因其他依赖变化重复拉同一群。
     if (key === lastLoadedKeyRef.current) return;
-    if (rawByGroupIdRef.current[groupId] !== undefined || inFlightRef.current.has(groupId)) {
+    if (inFlightRef.current.has(groupId)) {
       lastLoadedKeyRef.current = key;
       return;
     }
+    if (!isGroupTransition && rawByGroupIdRef.current[groupId] !== undefined) {
+      lastLoadedKeyRef.current = key;
+      return;
+    }
+    // 重拉前先清掉该群陈旧缓存：重拉窗口内列表回到未加载态（骨架），
+    // 自动选中/陈旧选中兜底都不会消费旧数据；新结果到达后整体替换。
+    dropGroupCache(rawByGroupIdRef, setRawByGroupId, groupId);
     let cancelled = false;
     const requestEpoch = identityEpochRef.current;
     const requestVersion = beginGroupRequest(groupId);
@@ -83,10 +96,12 @@ export function useSessionMapRequests({
     identityEpochRef,
     inFlightRef,
     isCurrentRequest,
+    rawByGroupIdRef,
     replaceGroupPage,
     setErrorByGroupId,
     setLoadMoreErrorByGroupId,
     setIsLoading,
+    setRawByGroupId,
   ]);
 
   useExpandedGroupSessionRequests({
@@ -94,12 +109,14 @@ export function useSessionMapRequests({
     expandedGroupIds,
     groupId,
     rawByGroupId,
+    rawByGroupIdRef,
     inFlightRef,
     identityEpochRef,
     beginGroupRequest,
     isCurrentRequest,
     replaceGroupPage,
     setErrorByGroupId,
+    setRawByGroupId,
   });
 
   const reloadGroup = useCallback(

--- a/src/frontend-nextgen/src/pages/Workspace/hooks/useSessionMemberSync.ts
+++ b/src/frontend-nextgen/src/pages/Workspace/hooks/useSessionMemberSync.ts
@@ -4,6 +4,7 @@ import { sessionService } from '@/services/workspace/sessionService';
 import { useCallback, useEffect, useRef } from 'react';
 import { toast } from 'sonner';
 import { replaceSessionInMap } from './sessionMapPatch';
+import { isSessionKnownGone } from './useStaleSessionFallback';
 
 function notifyError(err: DomainError): void {
   toast.error(err.friendlyMessage);
@@ -67,6 +68,11 @@ export function useSessionMemberSync(
   useEffect(() => {
     pendingDetailRef.current = null;
     if (!selectedSessionId) {
+      return;
+    }
+    // 已知退出/删除的会话不再补齐详情（当前角色已非参与者，请求必然失败报错）；
+    // 陈旧选中兜底会直接把选中轮换到有效会话。
+    if (isSessionKnownGone(selectedSessionId)) {
       return;
     }
     let cancelled = false;

--- a/src/frontend-nextgen/src/pages/Workspace/hooks/useStaleSessionFallback.ts
+++ b/src/frontend-nextgen/src/pages/Workspace/hooks/useStaleSessionFallback.ts
@@ -4,9 +4,27 @@ import { useWorkspaceStore } from '@/stores/workspaceStore';
 import { useEffect, useRef, type MutableRefObject } from 'react';
 
 /**
+ * 「已知退出/删除」登记：UI 退出（leaveSession）/删除（deleteSession）成功的会话 id。
+ * 当前角色已不是参与者，任何以其为目标的详情反查都必然失败（协议层还会全局报错），
+ * 故陈旧选中兜底与成员详情补齐对登记 id 跳过请求、直接轮换/放弃。
+ * SPA 生命周期内存即可：整页刷新后登记清空，未知场景由「静默反查」兜底
+ *（sessionService.getSessionDetail 失败时取消协议层默认提示）。
+ */
+const knownGoneSessionIds = new Set<string>();
+
+export function markSessionGone(sessionId: string): void {
+  knownGoneSessionIds.add(sessionId);
+}
+
+export function isSessionKnownGone(sessionId: string): boolean {
+  return knownGoneSessionIds.has(sessionId);
+}
+
+/**
  * useStaleSessionFallback —— 陈旧选中兜底（从 useGroupSessions 拆出以控体积）：
  * 列表加载完成后，记忆的选中会话可能不在列表中（被删/成员视角变化/超出已加载分页）。
  * 先反查详情：仍存在 → 前置补入列表保持选中；不存在 → 回落首条或清空。
+ * 已登记「已知退出/删除」的会话不反查（必然失败），直接回落。
  * 每个 sessionId 只兜底一次；响应返回时校验身份代际与选中态，避免竞态劫持。
  */
 export function useStaleSessionFallback(
@@ -26,6 +44,13 @@ export function useStaleSessionFallback(
     if (!current || triedRef.current.has(current)) return;
     if ((rawByGroupId[groupId] ?? []).some((s) => s.sessionId === current)) return;
     triedRef.current.add(current);
+    // 已知退出/删除：跳过必然失败的反查，直接回落首条或清空。
+    if (knownGoneSessionIds.has(current)) {
+      if (useWorkspaceStore.getState().selectedSessionId !== current) return;
+      const latest = rawByGroupId[groupId] ?? [];
+      selectSession(latest[0]?.sessionId ?? null);
+      return;
+    }
     const epoch = identityEpochRef.current;
     void sessionService.getSessionDetail(current).then((res) => {
       // 身份已切换：旧身份的响应不得回填新列表，也不得改动选中。

--- a/src/frontend-nextgen/src/services/admin/adminService.ts
+++ b/src/frontend-nextgen/src/services/admin/adminService.ts
@@ -46,6 +46,27 @@ export interface SpaceServiceResult<T> {
   error?: ServiceError;
 }
 
+/** 批量添加成员入参项（与单发 addMember 的 userId + 可选花名一致）。 */
+export interface BatchMemberInput {
+  userId: string;
+  /** 被加成员花名，逐项透传为单发 body 的 member_user_name（不共享、不丢失）。 */
+  userName?: string;
+}
+
+/** 批量添加中单个失败项：携带重试所需最小信息（userId + 花名）与后端原因。 */
+export interface BatchMemberFailure {
+  userId: string;
+  userName?: string;
+  /** 后端 message 或回退「请求异常」（业务失败透传后端 message；网络异常无可读 message 时回退）。 */
+  reason: string;
+}
+
+/** 批量添加结果：成功成员集合 + 失败项集合（供上层 toast 聚合与失败重试）。 */
+export interface BatchMembersResult {
+  succeeded: SpaceMember[];
+  failed: BatchMemberFailure[];
+}
+
 // 从后端信封 body 直接读取可读 message（不沿用 extractErrorMessage：后者面向 error 形状，
 // 会优先下钻 .data，对信封不适用）。
 function envelopeMessage(data: unknown): string {
@@ -186,6 +207,38 @@ export const adminService = {
     } catch (e) {
       return { error: toServiceError(e) };
     }
+  },
+
+  /**
+   * 批量添加成员（v1 纯前端聚合，design D1）：Promise.allSettled 并行调用单发 addMember，
+   * 按 envelope {error} 归属成功/失败——业务失败（已是成员/无权限等）在 service 层是
+   * resolve({error}) 而非 reject，故聚合必检 value.error；仅按 rejected 判定会把业务
+   * 失败静默误算为成功（design D2）。无 React 依赖、不抛错、不调 toast；
+   * 失败仅落入 failed 供上层 toast 聚合与失败重试。不新增后端批量端点。
+   */
+  async addMembersBatch(
+    spaceId: number | string,
+    items: BatchMemberInput[],
+    role: 'ADMIN' | 'MEMBER' = 'MEMBER',
+  ): Promise<BatchMembersResult> {
+    if (items.length === 0) return { succeeded: [], failed: [] };
+    const settled = await Promise.allSettled(
+      items.map((item) => this.addMember(spaceId, item.userId, role, item.userName)),
+    );
+    const succeeded: SpaceMember[] = [];
+    const failed: BatchMemberFailure[] = [];
+    settled.forEach((res, i) => {
+      const item = items[i];
+      // fulfilled 且无业务 error 且有数据 → 成功；其余（业务失败 resolve{error} / 网络 reject）→ 失败。
+      if (res.status === 'fulfilled' && !res.value.error && res.value.data) {
+        succeeded.push(res.value.data);
+        return;
+      }
+      // rejected（addMember 实际不 reject，兜底）→「请求异常」；业务失败无 message →「请求异常」。
+      const reason = res.status === 'fulfilled' ? res.value.error?.message || '请求异常' : '请求异常';
+      failed.push({ userId: item.userId, ...(item.userName ? { userName: item.userName } : {}), reason });
+    });
+    return { succeeded, failed };
   },
 
   /** 删除成员（path 为被删成员 userId；user_id 为操作者）。 */

--- a/src/frontend-nextgen/src/services/workspace/groupExecuteService.ts
+++ b/src/frontend-nextgen/src/services/workspace/groupExecuteService.ts
@@ -63,17 +63,21 @@ export interface BcsGroupDetailRaw {
  * BCS 群会话列表（sessions-only）：仅 GET /groups/{id}/sessions，不拉群详情。
  * 供 useSessionMap 选中/展开群填充会话——选中群不再触发 GET /groups/{id} 详情请求，
  * 群详情仅在管理面板（查看/编辑）时按需拉取（见 loadBcsGroupDetail）。兼容历史 BCS raw 字段。
+ * view_bot_id 语义与通用端点一致：当前身份 mine bot_id（bot_id 原始值，含 human_ 前缀形态），
+ * 供后端按当前角色视角过滤会话；缺省（无身份）时省略参数。
  */
 export async function loadBcsGroupSessions(
   groupId: string,
   pageOpts: SessionPageOpts = {},
+  viewBotId?: string,
 ): Promise<DomainResult<GroupSessionPage>> {
   try {
     const base = '/openapi/v1/collaboration';
     const offset = pageOpts.offset ?? 0;
     const limit = pageOpts.limit ?? 10;
+    const viewParam = viewBotId ? `&view_bot_id=${encodeURIComponent(viewBotId)}` : '';
     const sResp = await fetch(
-      `${base}/groups/${encodeURIComponent(groupId)}/sessions?offset=${offset}&limit=${limit}`,
+      `${base}/groups/${encodeURIComponent(groupId)}/sessions?offset=${offset}&limit=${limit}${viewParam}`,
       {
         credentials: 'include',
       },
@@ -115,12 +119,15 @@ export async function loadBcsGroupSessions(
  *
  * 兼容历史 BCS raw 字段，同时接受 OpenAPI envelope.data，避免 execute 链路依赖本地服务。
  */
-export async function loadBcsGroupDetail(groupId: string): Promise<DomainResult<GroupView>> {
+export async function loadBcsGroupDetail(groupId: string, viewBotId?: string): Promise<DomainResult<GroupView>> {
   try {
     const base = '/openapi/v1/collaboration';
+    const viewParam = viewBotId ? `&view_bot_id=${encodeURIComponent(viewBotId)}` : '';
     const [dResp, sResp] = await Promise.all([
       fetch(`${base}/groups/${encodeURIComponent(groupId)}`, { credentials: 'include' }),
-      fetch(`${base}/groups/${encodeURIComponent(groupId)}/sessions?offset=0&limit=50`, { credentials: 'include' }),
+      fetch(`${base}/groups/${encodeURIComponent(groupId)}/sessions?offset=0&limit=50${viewParam}`, {
+        credentials: 'include',
+      }),
     ]);
     if (!dResp.ok) {
       return { ok: false, error: toDomainError('GROUP_MISSING', '该协作群不存在或已被删除。') };
@@ -169,10 +176,10 @@ export async function loadBcsGroupDetail(groupId: string): Promise<DomainResult<
 }
 
 /** 是否为 BCS(execute) 群:内存标记(会话内建群时 markBcsGroup 写入)命中,或 groupId 按 `bcs_grp_` 前缀约定命中。
- *  新开页 `target=_blank` 全新挂载时 `bcsGroupIds` 内存态为空(非持久化),仅靠标记会把既有 BCS 群误判为预发群 →
- *  走通用端点时带 `view_bot_id=人类 me id`,以身份受限的视角拉不回会话 → 右栏"请选择或创建一个会话"。
- *  前缀兜底保证 BCS 群始终走 BCS 路径(不带 view_bot_id),与 ViewSessionButton / NodeListView / taskPanelMapper
- *  判定单/群的口径(`bcs_grp_` 前缀)对齐(后端建群 group_id 即 `bcs_grp_<uuid>`)。 */
+ *  新开页 `target=_blank` 全新挂载时 `bcsGroupIds` 内存态为空(非持久化),仅靠标记会把既有 BCS 群误判为预发群。
+ *  前缀兜底保证 BCS 群始终走 BCS raw-fetch 旁路(ACE 登录体处理 + 历史字段兼容),与 ViewSessionButton /
+ *  NodeListView / taskPanelMapper 判定单/群的口径(`bcs_grp_` 前缀)对齐(后端建群 group_id 即 `bcs_grp_<uuid>`)。
+ *  view_bot_id 两条路径语义一致:当前身份 mine bot_id,缺省时省略。 */
 function isBcsGroupId(groupId: string): boolean {
   return Boolean(useWorkspaceStore.getState().bcsGroupIds[groupId]) || groupId.startsWith('bcs_grp_');
 }
@@ -184,7 +191,7 @@ export async function loadGroupDetailOrBcs(
   viewBotId: string | undefined,
   loadGroupDetail: (id: string, vid?: string) => Promise<DomainResult<GroupView>>,
 ): Promise<DomainResult<GroupView>> {
-  return isBcsGroupId(groupId) ? loadBcsGroupDetail(groupId) : loadGroupDetail(groupId, viewBotId);
+  return isBcsGroupId(groupId) ? loadBcsGroupDetail(groupId, viewBotId) : loadGroupDetail(groupId, viewBotId);
 }
 
 /** 选中/展开群填充会话列表的统一入口：BCS 群走 loadBcsGroupSessions，
@@ -201,7 +208,7 @@ export async function loadGroupSessionsOrBcs(
   const existingRequest = groupSessionRequestsInFlight.get(requestKey);
   if (existingRequest) return existingRequest;
   const request = (
-    isBcsGroup ? loadBcsGroupSessions(groupId, pageOpts) : loadGroupSessions(groupId, viewBotId, pageOpts)
+    isBcsGroup ? loadBcsGroupSessions(groupId, pageOpts, viewBotId) : loadGroupSessions(groupId, viewBotId, pageOpts)
   ).finally(() => {
     if (groupSessionRequestsInFlight.get(requestKey) === request) {
       groupSessionRequestsInFlight.delete(requestKey);

--- a/src/frontend-nextgen/src/services/workspace/sessionService.ts
+++ b/src/frontend-nextgen/src/services/workspace/sessionService.ts
@@ -14,6 +14,7 @@ import {
   updateSessionMemberMode,
 } from '@/services/backendApi/collaboration/sessionController';
 import { triggerAceLoginRedirect } from '@/services/backendApi/httpClient';
+import { useErrorNotifyStore } from '@/stores/errorNotifyStore';
 import { useWorkspaceStore } from '@/stores/workspaceStore';
 import type { DomainError, DomainResult } from './identityService';
 import { mapBcsSessionItem, mapSessionListItem, type BcsSessionRaw } from './mappers';
@@ -142,7 +143,11 @@ export const sessionService = {
     try {
       const resp = await getSession(sessionId);
       return { ok: true, data: mapSessionListItem(resp.data!) };
-    } catch {
+    } catch (err) {
+      // 详情查询均为读侧静默用途（成员补齐 / 陈旧选中兜底探测 / 邀请与深链反查），调用方自行处理失败；
+      // 取消协议层默认全局提示，避免对已退出/已删除会话的「必然失败」反查变成用户可见报错。
+      const toastKey = (err as { toastKey?: string })?.toastKey;
+      if (toastKey) useErrorNotifyStore.getState().cancel(toastKey);
       return {
         ok: false,
         error: toDomainError('SESSION_DETAIL_FAILED', '加载会话详情失败，请稍后重试。'),

--- a/src/frontend-nextgen/test/collaborationSquarePage.test.tsx
+++ b/src/frontend-nextgen/test/collaborationSquarePage.test.tsx
@@ -177,7 +177,9 @@ describe('collaboration square accessible UI', () => {
     );
     expect(memberHtml).toContain('用户');
     expect(memberHtml).not.toContain('Human');
-    expect(memberHtml).toContain('参与者');
+    // 角色标签按群类型归一化：自由聊天群非 driver 的未知 role（如「参与者」）统一展示「成员」。
+    expect(memberHtml).toContain('成员');
+    expect(memberHtml).not.toContain('参与者');
   });
 
   test('公开 Bot 页面保留名称搜索与智能搜索入口', () => {

--- a/src/frontend-nextgen/test/components/Admin/SpaceMemberList.batch.test.tsx
+++ b/src/frontend-nextgen/test/components/Admin/SpaceMemberList.batch.test.tsx
@@ -1,0 +1,229 @@
+/** @jest-environment jsdom */
+// SpaceMemberList 批量多选模态：chip 列表、计数按钮、去重（已是成员/已选入本批次/自己）、
+// in-flight 禁用、部分失败重试。经 extendCapabilities 注入可信搜索目录驱动真实 UserSearchDropdown
+// （该下拉内部行为已由 UserSearchDropdown.test.tsx 覆盖，这里聚焦父级 chip 管理）。
+// 关键：useUserSearch 300ms 防抖 → 必须用 findByRole（自轮询等渲染）而非同步 getByRole。
+import { extendCapabilities } from '@/capabilities';
+import { SpaceMemberList } from '@/components/Admin/SpaceMemberList';
+import type { SearchedUser } from '@/capabilities';
+import type { Space, SpaceMember } from '@/domain/admin/models';
+import { readUserId } from '@/services/admin/userIdentity';
+import '@testing-library/jest-dom';
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+
+jest.mock('@/services/admin/userIdentity'); // readUserId 自动 mock（固定自己=工号 'self'）
+const readUserIdMock = readUserId as unknown as jest.Mock;
+
+const mockSearch = jest.fn();
+
+const CANDIDATES: SearchedUser[] = [
+  { userId: 'a', displayName: 'A', nickName: '花A' },
+  { userId: 'b', displayName: 'B', nickName: '花B' },
+  { userId: 'c', displayName: 'C', nickName: '花C' },
+  { userId: 'm1', displayName: 'M', nickName: '成员一' },
+  { userId: 'self', displayName: 'S', nickName: '我自己' },
+];
+
+const space = {
+  spaceId: 100,
+  spaceCode: 's',
+  spaceName: 'x',
+  spaceType: 'TEAM',
+  memberCount: 1,
+  ownerCount: 1,
+  botCount: 0,
+  gmtModified: '',
+  currentUserRole: 'ADMIN',
+} as unknown as Space;
+
+function mem(userId: string): SpaceMember {
+  return { userId, userName: userId, role: 'ADMIN', botPermissionCount: 0, isCreator: false, gmtModified: '' } as SpaceMember;
+}
+
+interface BatchResult {
+  succeeded: SpaceMember[];
+  failed: { userId: string; userName?: string; reason: string }[];
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  readUserIdMock.mockReturnValue('self');
+  mockSearch.mockReset();
+  mockSearch.mockResolvedValue(CANDIDATES);
+  extendCapabilities({
+    getUserSearchCapability: () => ({ status: 'available', value: { search: mockSearch } }),
+  });
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+/** 打开模态 + 触发搜索（5 名候选随后渲染）。 */
+async function openAndSearch(): Promise<void> {
+  fireEvent.click(screen.getByRole('button', { name: '添加成员' }));
+  const input = (await screen.findByLabelText('搜索员工')) as HTMLInputElement;
+  fireEvent.change(input, { target: { value: 'aa' } });
+}
+
+/**
+ * 选某个候选。首次（retype=false）下拉已开；第 2/3 次（retype=true）前先重新键入触发搜索，
+ * 并用 findByRole 自轮询等 300ms 防抖后的候选渲染（同步 getByRole 会在防抖完成前抛错）。
+ */
+async function pickCandidate(re: RegExp, retype = false): Promise<void> {
+  if (retype) {
+    const input = screen.getByLabelText('搜索员工') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'aa' } });
+  }
+  const opt = await screen.findByRole('button', { name: re }, { timeout: 3000 });
+  fireEvent.click(opt);
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+function submitButton(): HTMLButtonElement {
+  // 排除「添加成员」开关按钮（其 name 固定为「添加成员」无数字）；只匹配「添加 N 人」或加载态「添加中」。
+  return screen.getByRole('button', { name: /添加\s+\d+\s+人|添加中/ }) as HTMLButtonElement;
+}
+
+function chipRemoveButtons(): HTMLElement[] {
+  return screen.getAllByLabelText('取消选择');
+}
+
+describe('SpaceMemberList 批量多选模态', () => {
+  it('已是成员/自己 初始即在下拉中禁用；选中 A 后 A 变为禁用且按钮计数为「添加 1 人」', async () => {
+    render(
+      <SpaceMemberList
+        space={space}
+        members={[mem('m1')]}
+        loading={false}
+        onAddMembers={jest.fn()}
+        onRemoveMember={jest.fn()}
+        onUpdateRole={jest.fn()}
+      />,
+    );
+    await openAndSearch();
+
+    // m1、self 初始禁用（已是成员 / 自己）
+    const m1Opt = await screen.findByRole('button', { name: /成员一\(m1\)/ });
+    expect(m1Opt).toBeDisabled();
+    const selfOpt = await screen.findByRole('button', { name: /我自己\(self\)/ });
+    expect(selfOpt).toBeDisabled();
+
+    // 选 A → chip + 计数
+    fireEvent.click(await screen.findByRole('button', { name: /花A\(a\)/ }));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(submitButton()).toHaveTextContent('添加 1 人');
+    expect(submitButton()).toBeEnabled();
+
+    // 重键：A 已在下拉中禁用（已选入本批次）；B 仍可选
+    const input = screen.getByLabelText('搜索员工') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'aa' } });
+    await screen.findByRole('button', { name: /花A\(a\)/ });
+    expect(screen.getByRole('button', { name: /花A\(a\)/ })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /花B\(b\)/ })).toBeEnabled();
+  });
+
+  it('连续选 A/B/C → 按钮「添加 3 人」；逐个移除至空 → 按钮禁用（计数 0）', async () => {
+    render(
+      <SpaceMemberList
+        space={space}
+        members={[]}
+        loading={false}
+        onAddMembers={jest.fn()}
+        onRemoveMember={jest.fn()}
+        onUpdateRole={jest.fn()}
+      />,
+    );
+    await openAndSearch();
+    await pickCandidate(/花A\(a\)/);
+    await pickCandidate(/花B\(b\)/, true);
+    await pickCandidate(/花C\(c\)/, true);
+
+    expect(submitButton()).toHaveTextContent('添加 3 人');
+    expect(chipRemoveButtons()).toHaveLength(3);
+
+    // 移除 A、B、C → 计数归 0、按钮禁用
+    for (let i = 0; i < 3; i++) {
+      fireEvent.click(screen.getAllByLabelText('取消选择')[0]);
+      await act(async () => {
+        await Promise.resolve();
+      });
+    }
+    expect(submitButton()).toHaveTextContent('添加 0 人');
+    expect(submitButton()).toBeDisabled();
+  });
+
+  it('in-flight（addMembersLoading=true）→ 提交按钮禁用且呈现加载态', async () => {
+    render(
+      <SpaceMemberList
+        space={space}
+        members={[]}
+        loading={false}
+        onAddMembers={jest.fn()}
+        addMembersLoading={true}
+        addMembersDisabledReason="正在添加成员…"
+        onRemoveMember={jest.fn()}
+        onUpdateRole={jest.fn()}
+      />,
+    );
+    await openAndSearch();
+    fireEvent.click(await screen.findByRole('button', { name: /花A\(a\)/ }));
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const btn = submitButton();
+    expect(btn).toBeDisabled();
+    expect(btn.textContent ?? '').toMatch(/添加中/);
+  });
+
+  it('部分失败重试：提交返回 failed[B] → chips 回填为 [B] → 再次提交仅以 B 调 onAddMembers', async () => {
+    const onAddMembers = jest.fn(async (users: SearchedUser[]): Promise<BatchResult | undefined> => {
+      const hasB = users.some((u) => u.userId === 'b');
+      if (!hasB) return { succeeded: [mem('a')], failed: [] };
+      return { succeeded: [mem('a')], failed: [{ userId: 'b', userName: '花B', reason: '已是成员' }] };
+    });
+    render(
+      <SpaceMemberList
+        space={space}
+        members={[]}
+        loading={false}
+        onAddMembers={onAddMembers}
+        onRemoveMember={jest.fn()}
+        onUpdateRole={jest.fn()}
+      />,
+    );
+    await openAndSearch();
+    await pickCandidate(/花A\(a\)/);
+    await pickCandidate(/花B\(b\)/, true);
+
+    expect(submitButton()).toHaveTextContent('添加 2 人');
+    await act(async () => {
+      fireEvent.click(submitButton());
+    });
+    await screen.findByText(/花B\(b\)/); // 等回填 chip 出现
+    expect(onAddMembers).toHaveBeenCalledTimes(1);
+    expect(onAddMembers).toHaveBeenNthCalledWith(
+      1,
+      expect.arrayContaining([expect.objectContaining({ userId: 'a' }), expect.objectContaining({ userId: 'b' })]),
+      'MEMBER',
+    );
+
+    // 回填后：成功者 A 移除；失败者 B 为唯一 chip，按钮「添加 1 人」
+    expect(chipRemoveButtons()).toHaveLength(1);
+    expect(submitButton()).toHaveTextContent('添加 1 人');
+
+    // 再次提交 → 仅以 B 调用
+    await act(async () => {
+      fireEvent.click(submitButton());
+    });
+    await screen.findByText(/花B\(b\)/); // B chip 仍在
+    expect(onAddMembers).toHaveBeenCalledTimes(2);
+    expect(onAddMembers).toHaveBeenNthCalledWith(2, [expect.objectContaining({ userId: 'b' })], 'MEMBER');
+  });
+});

--- a/src/frontend-nextgen/test/components/CollaborationSquare/CreateGroupSessionModal.test.tsx
+++ b/src/frontend-nextgen/test/components/CollaborationSquare/CreateGroupSessionModal.test.tsx
@@ -1,0 +1,50 @@
+/** @jest-environment jsdom */
+import { CreateGroupSessionModal } from '@/components/CollaborationSquare/CreateGroupSessionModal';
+import type { PublicGroup } from '@/domain/collaborationSquare/types';
+import { describe, expect, it, jest } from '@jest/globals';
+import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/jest-globals';
+import { render, screen } from '@testing-library/react';
+
+const group = {
+  id: 'g1',
+  name: '产品共创群',
+  ownerBotName: '群主助手',
+  ownerUserName: '示例用户',
+  typeLabel: '自由聊天',
+  memberCount: 2,
+  goal: '推进产品共创',
+  memberListVisibility: 'visible' as const,
+  canCreateSession: true,
+} as PublicGroup;
+
+function renderModal() {
+  return render(
+    <CreateGroupSessionModal open group={group} loading={false} onClose={jest.fn()} onSubmit={jest.fn()} />,
+  );
+}
+
+describe('CreateGroupSessionModal（对齐「创建云端 Bot」表单样式）', () => {
+  it('不再展示「填写会话名称与协作目标…」描述提示', () => {
+    renderModal();
+    expect(screen.queryByText('填写会话名称与协作目标，创建后跳转到该会话。')).toBeNull();
+  });
+
+  it('字段为 label 包裹 + 必填星号 + 字数计数器', () => {
+    renderModal();
+    expect(screen.getByText('会话名称', { exact: false })).toBeInTheDocument();
+    expect(screen.getByText('协作目标', { exact: false })).toBeInTheDocument();
+    expect(screen.getByText('0/100')).toBeInTheDocument();
+    expect(screen.getByText('0/2000')).toBeInTheDocument();
+    // 两个必填字段均有红色星号标记。
+    expect(screen.getAllByText('*').length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('底部按钮：取消为 secondary 线框，提交为「创建会话」且空表单禁用', () => {
+    renderModal();
+    expect(screen.getByRole('button', { name: '取消' })).toHaveClass('border-input');
+    const submit = screen.getByRole('button', { name: '创建会话' });
+    expect(submit).toBeDisabled();
+    expect(submit).toHaveClass('bg-primary');
+  });
+});

--- a/src/frontend-nextgen/test/components/CollaborationSquare/GroupMembersModal.test.tsx
+++ b/src/frontend-nextgen/test/components/CollaborationSquare/GroupMembersModal.test.tsx
@@ -1,0 +1,83 @@
+/** @jest-environment jsdom */
+import { GroupMembersModal } from '@/components/CollaborationSquare/GroupMembersModal';
+import type { PublicGroup, PublicGroupMember } from '@/domain/collaborationSquare/types';
+import { describe, expect, it, jest } from '@jest/globals';
+import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/jest-globals';
+import { render, screen } from '@testing-library/react';
+
+function makeGroup(typeLabel: string): PublicGroup {
+  return {
+    id: 'g1',
+    name: '产品共创群',
+    ownerBotName: '群主助手',
+    ownerUserName: '示例用户',
+    typeLabel,
+    memberCount: 3,
+    goal: '推进产品共创',
+    memberListVisibility: 'visible' as const,
+    canCreateSession: true,
+  } as PublicGroup;
+}
+
+function member(overrides: Partial<PublicGroupMember> & { id: string }): PublicGroupMember {
+  return { displayName: '成员', type: 'bot', role: 'member', ...overrides } as PublicGroupMember;
+}
+
+function renderMembers(members: PublicGroupMember[], typeLabel = '自由聊天') {
+  return render(
+    <GroupMembersModal open group={makeGroup(typeLabel)} members={members} loading={false} onClose={jest.fn()} />,
+  );
+}
+
+describe('GroupMembersModal（成员卡片对齐「对话协作」成员管理 card 样式）', () => {
+  it('成员卡片：首字母圆标头像 + 名称 + 第二行类型/角色徽章（无移除等操作按钮）', () => {
+    renderMembers([member({ id: 'b1', displayName: '驱动Bot', type: 'bot', role: 'driver' })]);
+    // bot 头像：主色软底圆标（与 MemberList 一致）。
+    expect(screen.getByText('驱')).toHaveClass('bg-primary/10', 'text-primary', 'rounded-full');
+    // 类型徽章默认蓝；自由聊天群 driver → 「群主」紫色。
+    expect(screen.getByText('Bot')).toHaveClass('bg-primary/10', 'text-primary');
+    expect(screen.getByText('群主')).toHaveClass('bg-purple/10', 'text-purple');
+    // 无移除/管理按钮。
+    expect(screen.queryByRole('button', { name: /移除/ })).toBeNull();
+  });
+
+  it('自由聊天群：driver→群主，其余角色（member/manager/未知值）一律「成员」默认蓝', () => {
+    renderMembers([
+      member({ id: 'u1', displayName: '示例用户', type: 'human', role: 'member' }),
+      member({ id: 'b2', displayName: '管理Bot', role: 'manager' }),
+      member({ id: 'b3', displayName: '执行Bot', role: 'worker' }),
+    ]);
+    expect(screen.getByText('示')).toHaveClass('bg-brand/15', 'text-brand');
+    expect(screen.getByText('用户')).toHaveClass('bg-primary/10', 'text-primary');
+    // 非 driver 全部展示「成员」。
+    expect(screen.getAllByText('成员').length).toBe(3);
+    expect(screen.getAllByText('成员')[0]).toHaveClass('bg-primary/10', 'text-primary');
+    expect(screen.queryByText('主节点')).toBeNull();
+    expect(screen.queryByText('从节点')).toBeNull();
+  });
+
+  it('任务协作群：manager→主节点（紫）、worker→从节点（默认蓝），其余一律「成员」', () => {
+    renderMembers(
+      [
+        member({ id: 'b1', displayName: '主节点Bot', role: 'manager' }),
+        member({ id: 'b2', displayName: '从节点Bot', role: 'worker' }),
+        member({ id: 'b3', displayName: '驱动Bot', role: 'driver' }),
+        member({ id: 'u1', displayName: '示例用户', type: 'human', role: 'member' }),
+      ],
+      '任务协作',
+    );
+    expect(screen.getByText('主节点')).toHaveClass('bg-purple/10', 'text-purple');
+    expect(screen.getByText('从节点')).toHaveClass('bg-primary/10', 'text-primary');
+    // driver 与 member 在任务协作群都不是特殊角色 → 「成员」。
+    expect(screen.getAllByText('成员').length).toBe(2);
+  });
+
+  it('后端返回中文角色值等未知 role 也归一为「成员」', () => {
+    renderMembers([member({ id: 'u2', displayName: '示例用户', type: 'human', role: '参与者' })]);
+    expect(screen.getByText('成员')).toBeInTheDocument();
+    expect(screen.queryByText('参与者')).toBeNull();
+    expect(screen.getByText('用户')).toBeInTheDocument();
+    expect(screen.queryByText('Human')).toBeNull();
+  });
+});

--- a/src/frontend-nextgen/test/hooks/useAdmin.batch.test.tsx
+++ b/src/frontend-nextgen/test/hooks/useAdmin.batch.test.tsx
@@ -1,0 +1,215 @@
+/** @jest-environment jsdom */
+// useAdmin.addMembers 编排测试：聚合 toast（经 sonner toast.error/.success spy）/ 单次 refresh /
+// 加载态 / 同一 tick 重入阻断 / 失败子集重试。沿用既有 useAdmin.test.tsx 的 mock 口径
+// （auto-mock @/services/admin barrel；notify 不 mock，spy 真实 sonner，断言 toast 入参）。
+import type { SearchedUser } from '@/capabilities';
+import { useAdmin } from '@/hooks/useAdmin';
+import { adminService } from '@/services/admin';
+import type { SpaceMember } from '@/domain/admin/models';
+import { useAdminStore } from '@/stores/adminStore';
+import { useExternalAuthStore } from '@/stores/externalAuthStore';
+import { useLoginStrategyStore } from '@/stores/loginStrategyStore';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+jest.mock('@/services/admin');
+// notify 不 mock：notifyError(msg,{title}) → toast.error(title,{description:msg,duration})，
+// notifySuccess(msg) → toast.success(msg,{duration})。spy 真实 sonner，断言 title/description。
+const { toast } = jest.requireActual('sonner') as typeof import('sonner');
+const toastError = jest.spyOn(toast, 'error').mockImplementation(() => 'err' as any);
+const toastSuccess = jest.spyOn(toast, 'success').mockImplementation(() => 'ok' as any);
+
+const as = adminService as unknown as Record<string, jest.Mock<any>>;
+
+const space = { spaceId: 100, spaceCode: 's', spaceName: 'x', spaceType: 'TEAM', memberCount: 0, ownerCount: 0, botCount: 0, gmtModified: '', currentUserRole: 'ADMIN' } as const;
+
+function member(userId: string): SpaceMember {
+  return {
+    userId,
+    userName: userId,
+    role: 'MEMBER',
+    botPermissionCount: 0,
+    isCreator: false,
+    gmtModified: '',
+  } as SpaceMember;
+}
+
+function searchedUser(userId: string, nickName?: string): SearchedUser {
+  return { userId, displayName: nickName ?? userId, nickName } as SearchedUser;
+}
+
+const LIST_OK = { data: { items: [] as SpaceMember[], total: 0, page: 1, pageSize: 20, warnings: [] } };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useAdminStore.getState().reset();
+  useExternalAuthStore.getState().reset();
+  useLoginStrategyStore.getState().setLoginStrategy('ace-gateway'); // 非静默口径
+  useAdminStore.getState().setCurrentSpace(space as any);
+  as.listSpaces.mockResolvedValue(LIST_OK);
+  as.listMembers.mockResolvedValue(LIST_OK);
+});
+
+/** 取 toastError 描述体中的 description 文案（notifyError(msg,{title}) 走 title→description 双行）。 */
+function errorDescription(): string {
+  const opts = toastError.mock.calls[0]?.[1] as { description?: string } | undefined;
+  return opts?.description ?? '';
+}
+
+describe('useAdmin.addMembers：聚合 toast / 单次 refresh / 重入阻断 / 重试', () => {
+  it('全部成功 → toast.success 一次含「已添加 N 名成员」+ refresh 一次 + addMembersBatch 入参正确', async () => {
+    as.addMembersBatch.mockResolvedValue({ succeeded: [member('u1'), member('u2')], failed: [] });
+    const { result } = renderHook(() => useAdmin());
+    await waitFor(() => expect(as.listSpaces).toHaveBeenCalled());
+
+    let r: { succeeded: unknown[] } | undefined;
+    await act(async () => {
+      r = await result.current.addMembers([searchedUser('u1', '花一'), searchedUser('u2')], 'MEMBER');
+    });
+    expect(r?.succeeded).toHaveLength(2);
+
+    expect(toastSuccess).toHaveBeenCalledTimes(1);
+    expect(toastSuccess.mock.calls[0][0]).toBe('已添加 2 名成员');
+    expect(toastError).not.toHaveBeenCalled();
+    // refresh 一次
+    expect(as.listMembers).toHaveBeenCalledTimes(1);
+    // 入参：spaceId + items（逐项 userName 透传）+ role
+    expect(as.addMembersBatch).toHaveBeenCalledWith(
+      100,
+      [
+        { userId: 'u1', userName: '花一' },
+        { userId: 'u2', userName: undefined },
+      ],
+      'MEMBER',
+    );
+  });
+
+  it('部分成功 2/5 → toast.error 一次，title=「添加成员部分失败」且 description 含「2/5」与每名失败原因 + refresh 一次', async () => {
+    as.addMembersBatch.mockResolvedValue({
+      succeeded: [member('u1'), member('u2')],
+      failed: [
+        { userId: 'p', userName: '花名P', reason: '已是成员' },
+        { userId: 'q', userName: '花名Q', reason: '无权限' },
+        { userId: 'r', reason: '请求异常' },
+      ],
+    });
+    const { result } = renderHook(() => useAdmin());
+    await waitFor(() => expect(as.listSpaces).toHaveBeenCalled());
+
+    await act(async () => {
+      await result.current.addMembers(
+        [searchedUser('u1'), searchedUser('u2'), searchedUser('p', '花名P'), searchedUser('q', '花名Q'), searchedUser('r')],
+        'MEMBER',
+      );
+    });
+
+    expect(toastError).toHaveBeenCalledTimes(1);
+    expect(toastError.mock.calls[0][0]).toBe('添加成员部分失败');
+    const desc = errorDescription();
+    expect(desc).toContain('2/5');
+    expect(desc).toContain('花名P(已是成员)');
+    expect(desc).toContain('花名Q(无权限)');
+    expect(desc).toContain('r(请求异常)');
+    expect(toastSuccess).not.toHaveBeenCalled();
+    expect(as.listMembers).toHaveBeenCalledTimes(1);
+  });
+
+  it('全部失败 → toast.error 一次，description 含「0/N」与所有失败项 + 不静默', async () => {
+    as.addMembersBatch.mockResolvedValue({
+      succeeded: [],
+      failed: [
+        { userId: 'p', userName: '花名P', reason: '已是成员' },
+        { userId: 'q', userName: '花名Q', reason: '无权限' },
+      ],
+    });
+    const { result } = renderHook(() => useAdmin());
+    await waitFor(() => expect(as.listSpaces).toHaveBeenCalled());
+
+    await act(async () => {
+      await result.current.addMembers([searchedUser('p', '花名P'), searchedUser('q', '花名Q')], 'ADMIN');
+    });
+
+    expect(toastError).toHaveBeenCalledTimes(1);
+    const desc = errorDescription();
+    expect(desc).toContain('0/2');
+    expect(desc).toContain('花名P(已是成员)');
+    expect(desc).toContain('花名Q(无权限)');
+  });
+
+  it('空批次 → 不调 addMembersBatch、不 toast、不 refresh', async () => {
+    const { result } = renderHook(() => useAdmin());
+    await waitFor(() => expect(as.listSpaces).toHaveBeenCalled());
+
+    await act(async () => {
+      await result.current.addMembers([], 'MEMBER');
+    });
+
+    expect(as.addMembersBatch).not.toHaveBeenCalled();
+    expect(toastSuccess).not.toHaveBeenCalled();
+    expect(toastError).not.toHaveBeenCalled();
+    expect(as.listMembers).not.toHaveBeenCalled();
+  });
+
+  it('in-flight 阻断重入：pending 期间再次调用不新增 addMembersBatch，并暴露 addMembersLoading/disabledReason', async () => {
+    let resolveBatch!: (v: unknown) => void;
+    as.addMembersBatch.mockImplementation(
+      () => new Promise((r) => { resolveBatch = r; }),
+    );
+
+    const { result } = renderHook(() => useAdmin());
+    await waitFor(() => expect(as.listSpaces).toHaveBeenCalled());
+
+    await act(async () => {
+      // 不 await：使其 pending；触发 addingMembersRef + addMembersLoading state。
+      void result.current.addMembers([searchedUser('u1'), searchedUser('u2')], 'MEMBER');
+      await Promise.resolve();
+    });
+    expect(as.addMembersBatch).toHaveBeenCalledTimes(1);
+    expect(result.current.addMembersLoading).toBe(true);
+    expect(result.current.addMembersDisabledReason).toBeTruthy();
+
+    // 同一 tick 重入 → 被同步阻断
+    await act(async () => {
+      await result.current.addMembers([searchedUser('u3')], 'MEMBER');
+    });
+    expect(as.addMembersBatch).toHaveBeenCalledTimes(1); // 仍 1 次
+
+    // 解开 pending → toast + 一次 refresh
+    await act(async () => {
+      resolveBatch({ succeeded: [member('u1'), member('u2')], failed: [] });
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalledTimes(1));
+    expect(toastSuccess.mock.calls[0][0]).toBe('已添加 2 名成员');
+    expect(as.listMembers).toHaveBeenCalledTimes(1);
+    expect(result.current.addMembersLoading).toBe(false);
+  });
+
+  it('失败子集重试：以 failed 子集回填再提交，走同一路径并再次 toast+refresh', async () => {
+    as.addMembersBatch.mockResolvedValueOnce({
+      succeeded: [member('u1')],
+      failed: [{ userId: 'p', userName: '花名P', reason: '已是成员' }],
+    });
+    const { result } = renderHook(() => useAdmin());
+    await waitFor(() => expect(as.listSpaces).toHaveBeenCalled());
+
+    // 首次：1 成功 1 失败
+    await act(async () => {
+      await result.current.addMembers([searchedUser('u1'), searchedUser('p', '花名P')], 'MEMBER');
+    });
+    expect(toastError).toHaveBeenCalledTimes(1);
+    expect(as.addMembersBatch).toHaveBeenCalledTimes(1);
+    expect(as.listMembers).toHaveBeenCalledTimes(1);
+
+    // 重试失败子集（仅 p）
+    as.addMembersBatch.mockResolvedValueOnce({ succeeded: [member('p')], failed: [] });
+
+    await act(async () => {
+      await result.current.addMembers([searchedUser('p', '花名P')], 'MEMBER');
+    });
+    expect(as.addMembersBatch).toHaveBeenCalledWith(100, [{ userId: 'p', userName: '花名P' }], 'MEMBER');
+    expect(toastSuccess.mock.calls[0][0]).toBe('已添加 1 名成员');
+    // 第二次 batch 后又一次 refresh
+    expect(as.listMembers).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/frontend-nextgen/test/pages/Workspace/BcnChatDetail.test.tsx
+++ b/src/frontend-nextgen/test/pages/Workspace/BcnChatDetail.test.tsx
@@ -1,0 +1,42 @@
+/** @jest-environment jsdom */
+import { BcnChatDetail } from '@/pages/Workspace/BcnChatDetail';
+import { useBcnChatDetailRedirect } from '@/pages/Workspace/hooks/useBcnChatDetailRedirect';
+import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/jest-globals';
+import { render, screen } from '@testing-library/react';
+import { readFileSync } from 'node:fs';
+import { useNavigate } from 'react-router-dom';
+
+jest.mock('@umijs/max', () => ({
+  history: { replace: jest.fn() },
+  useSearchParams: jest.fn(),
+}));
+jest.mock('@/pages/Workspace/hooks/useBcnChatDetailRedirect');
+jest.mock('react-router-dom', () => ({ useNavigate: jest.fn() }));
+
+const mockedHook = useBcnChatDetailRedirect as jest.MockedFunction<typeof useBcnChatDetailRedirect>;
+const mockedNavigate = useNavigate as jest.MockedFunction<typeof useNavigate>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedNavigate.mockReturnValue(jest.fn() as unknown as ReturnType<typeof useNavigate>);
+});
+
+it('定位中：展示加载态', () => {
+  mockedHook.mockReturnValue({ status: 'redirecting' });
+  render(<BcnChatDetail />);
+  expect(screen.getByText('正在打开协作会话…')).toBeInTheDocument();
+});
+
+it('参数不完整：空态提示 + 返回对话协作按钮', () => {
+  mockedHook.mockReturnValue({ status: 'invalid' });
+  render(<BcnChatDetail />);
+  expect(screen.getByText('链接参数不完整')).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: '返回对话协作' })).toBeInTheDocument();
+});
+
+it('路由已注册：/workspace/bcn/chat/detail → BcnChatDetail', () => {
+  const routesSource = readFileSync('config/routes.ts', 'utf8');
+  expect(routesSource).toContain("'/workspace/bcn/chat/detail'");
+  expect(routesSource).toContain("'@/pages/Workspace/BcnChatDetail'");
+});

--- a/src/frontend-nextgen/test/pages/Workspace/components/ManagePanel/MemberList.test.tsx
+++ b/src/frontend-nextgen/test/pages/Workspace/components/ManagePanel/MemberList.test.tsx
@@ -54,14 +54,35 @@ describe('MemberList', () => {
     expect(memberRow('bot-driver').textContent).toContain('驱动 Bot');
     expect(memberRow('bot-driver').textContent).toContain('Bot');
     expect(memberRow('bot-driver').textContent).toContain('群主');
-    expect(screen.getByText('Bot')).toHaveClass('text-[10px]');
-    expect(screen.getByText('群主')).toHaveClass('text-[10px]');
+    // 标签分类型着色：成员类型默认蓝（primary），群主/主节点紫（purple），Badge 默认字号。
+    expect(screen.getByText('Bot')).toHaveClass('text-[11px]', 'bg-primary/10', 'text-primary');
+    expect(screen.getByText('群主')).toHaveClass('text-[11px]', 'bg-purple/10', 'text-purple');
+    expect(screen.getByText('Bot')).not.toHaveClass('text-[10px]');
+    // bot 图标对齐 Bot 工坊信息列：主色软底圆形首字母（不再黑底 bg-foreground）。
+    expect(screen.getByText('驱')).toHaveClass('bg-primary/10', 'text-primary', 'font-semibold');
     expect(memberRow('bot-driver').textContent).not.toContain('禁言');
     expect(memberRow('human-member').textContent).toContain('用户');
-    expect(memberRow('human-member').textContent).not.toContain('成员');
+    // 自由聊天群：非 driver 一律展示「成员」（默认蓝）。
+    expect(memberRow('human-member').textContent).toContain('成员');
+    expect(screen.getByText('成员')).toHaveClass('bg-primary/10', 'text-primary');
   });
 
-  it('任务协作群展示主从节点标签，human 成员不展示角色', () => {
+  it('可管理时移除入口为红色垃圾桶图标按钮（无文字）', () => {
+    render(
+      <MemberList
+        participants={[baseParticipant]}
+        canManage
+        onAddMany={jest.fn()}
+        onRemove={jest.fn()}
+        groupKind="free_chat"
+      />,
+    );
+    const removeButton = screen.getByRole('button', { name: '移除成员' });
+    expect(removeButton).toHaveClass('text-destructive');
+    expect(removeButton.textContent).toBe('');
+  });
+
+  it('任务协作群按角色展示主/从节点标签（不区分 bot/human）', () => {
     renderMembers(
       [
         { ...baseParticipant, actorId: 'manager', name: '主节点 Bot', role: 'manager' },
@@ -79,10 +100,14 @@ describe('MemberList', () => {
 
     expect(memberRow('manager').textContent).toContain('主节点');
     expect(memberRow('worker').textContent).toContain('从节点');
-    expect(memberRow('human-manager').textContent).not.toContain('主节点');
+    // 角色映射不区分 bot/human：human 的 manager 同样展示「主节点」。
+    expect(memberRow('human-manager').textContent).toContain('主节点');
+    // 主节点紫；从节点走默认蓝。
+    expect(screen.getAllByText('主节点')[0]).toHaveClass('bg-purple/10', 'text-purple');
+    expect(screen.getByText('从节点')).toHaveClass('bg-primary/10', 'text-primary');
   });
 
-  it('自定义协作群仅展示群主标签', () => {
+  it('自定义协作群：driver→群主，其余展示「成员」', () => {
     renderMembers(
       [
         { ...baseParticipant, actorId: 'driver', role: 'driver' },
@@ -93,7 +118,7 @@ describe('MemberList', () => {
 
     expect(memberRow('driver').textContent).toContain('群主');
     expect(memberRow('consultant').textContent).not.toContain('群主');
-    expect(memberRow('consultant').textContent).not.toContain('成员');
+    expect(memberRow('consultant').textContent).toContain('成员');
   });
 
   it('会话成员第二行按成员类型展示模式标签', () => {
@@ -121,9 +146,14 @@ describe('MemberList', () => {
       { groupKind: 'task_master_slave', showMode: true },
     );
 
-    expect(memberRow('bot-auto').textContent).toContain('自由');
+    expect(memberRow('bot-auto').textContent).toContain('自动');
     expect(memberRow('bot-muted').textContent).toContain('禁言');
     expect(memberRow('human-present').textContent).toContain('参与');
     expect(memberRow('human-absent').textContent).toContain('旁观');
+    // 状态色：自动/参与绿（success），禁言/旁观灰（neutral）。
+    expect(screen.getByText('自动')).toHaveClass('bg-success/10', 'text-success');
+    expect(screen.getByText('参与')).toHaveClass('bg-success/10', 'text-success');
+    expect(screen.getByText('禁言')).toHaveClass('bg-muted', 'text-muted-foreground');
+    expect(screen.getByText('旁观')).toHaveClass('bg-muted', 'text-muted-foreground');
   });
 });

--- a/src/frontend-nextgen/test/pages/Workspace/hooks/useBcnChatDetailRedirect.test.tsx
+++ b/src/frontend-nextgen/test/pages/Workspace/hooks/useBcnChatDetailRedirect.test.tsx
@@ -1,0 +1,92 @@
+/** @jest-environment jsdom */
+import { useBcnChatDetailRedirect } from '@/pages/Workspace/hooks/useBcnChatDetailRedirect';
+import { groupService } from '@/services/workspace/groupService';
+import { renderHook, waitFor } from '@testing-library/react';
+import { history, useSearchParams } from '@umijs/max';
+
+jest.mock('@umijs/max', () => ({
+  history: { replace: jest.fn() },
+  useSearchParams: jest.fn(),
+}));
+jest.mock('@/services/workspace/groupService');
+
+const mockedUseSearchParams = useSearchParams as jest.MockedFunction<typeof useSearchParams>;
+const mockedReplace = history.replace as jest.MockedFunction<typeof history.replace>;
+const svc = groupService as unknown as { loadGroupDetail: jest.Mock<any> };
+
+function mountWith(search: string) {
+  mockedUseSearchParams.mockReturnValue([new URLSearchParams(search), jest.fn()] as unknown as ReturnType<
+    typeof useSearchParams
+  >);
+  return renderHook(() => useBcnChatDetailRedirect());
+}
+
+function groupDetail(participants: Array<{ actorId: string; kind: 'human' | 'bot' }>) {
+  return {
+    ok: true,
+    data: { groupId: 'g1', name: '群', participants } as never,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  svc.loadGroupDetail.mockResolvedValue(
+    groupDetail([
+      { actorId: 'human_327325', kind: 'human' },
+      { actorId: 'bot-x:2088', kind: 'bot' },
+    ]),
+  );
+});
+
+it('bot_uuid 命中群固定成员名册 → membership=direct 重定向', async () => {
+  mountWith('id=g1&bot_uuid=human_327325&session=s1');
+  await waitFor(() =>
+    expect(mockedReplace).toHaveBeenCalledWith('/workspace?tab=group&group=g1&session=s1&membership=direct'),
+  );
+  expect(svc.loadGroupDetail).toHaveBeenCalledWith('g1');
+});
+
+it('bot_uuid 不在名册（仅参与临时会话）→ membership=session_only 重定向', async () => {
+  mountWith('id=g1&bot_uuid=human_999999&session=s1');
+  await waitFor(() =>
+    expect(mockedReplace).toHaveBeenCalledWith('/workspace?tab=group&group=g1&session=s1&membership=session_only'),
+  );
+});
+
+it('bot_uuid 无前缀工号与名册 human_ 前缀归一化匹配 → direct', async () => {
+  mountWith('id=g1&bot_uuid=327325&session=s1');
+  await waitFor(() => expect(mockedReplace).toHaveBeenCalledWith(expect.stringContaining('membership=direct')));
+});
+
+it('群详情接口失败 → 降级为不带 membership（由 workspace 自动纠正）', async () => {
+  svc.loadGroupDetail.mockResolvedValue({ ok: false, error: { friendlyMessage: 'x' } });
+  mountWith('id=g1&bot_uuid=human_327325&session=s1');
+  await waitFor(() => expect(mockedReplace).toHaveBeenCalledWith('/workspace?tab=group&group=g1&session=s1'));
+});
+
+it('缺 bot_uuid → 不调群详情、不带 membership，仍重定向', async () => {
+  mountWith('id=g1&session=s1');
+  await waitFor(() => expect(mockedReplace).toHaveBeenCalledWith('/workspace?tab=group&group=g1&session=s1'));
+  expect(svc.loadGroupDetail).not.toHaveBeenCalled();
+});
+
+it('bcs_grp_ 前缀群 → 不判定参与方式（交由 workspace BCS 路由），直接重定向', async () => {
+  mountWith('id=bcs_grp_abc&bot_uuid=human_327325&session=s1');
+  await waitFor(() => expect(mockedReplace).toHaveBeenCalledWith('/workspace?tab=group&group=bcs_grp_abc&session=s1'));
+  expect(svc.loadGroupDetail).not.toHaveBeenCalled();
+});
+
+it('缺 id 或 session → status=invalid 且不发生跳转', async () => {
+  const { result } = mountWith('bot_uuid=human_327325&session=s1');
+  expect(result.current.status).toBe('invalid');
+  const { result: r2 } = mountWith('id=g1&bot_uuid=human_327325');
+  expect(r2.current.status).toBe('invalid');
+  await waitFor(() => Promise.resolve());
+  expect(mockedReplace).not.toHaveBeenCalled();
+  expect(svc.loadGroupDetail).not.toHaveBeenCalled();
+});
+
+it('参数齐全时进入 redirecting 状态', () => {
+  const { result } = mountWith('id=g1&bot_uuid=human_327325&session=s1');
+  expect(result.current.status).toBe('redirecting');
+});

--- a/src/frontend-nextgen/test/pages/Workspace/hooks/useCollabPanel.test.ts
+++ b/src/frontend-nextgen/test/pages/Workspace/hooks/useCollabPanel.test.ts
@@ -226,3 +226,27 @@ it('切换会话时 human ref 缓存被清空，不串数据', () => {
   // 不应继承上一个会话的 human 状态
   expect(result.current.humanJoined).toBe(false);
 });
+
+it('bot 视角加入会话：human 不在 participants 时用 store 人类身份 id（mine bot_id，含 human_ 前缀）作 actor', async () => {
+  // Open Core OAuth 下 authenticatedUserId 是规范化 user_id（无 human_ 前缀）；
+  // participants/{actor} 路径参数必须是 mine 返回的 human 条目 bot_id（human_xxx）。
+  const session = makeSession([{ actorId: 'b:1', kind: 'bot', name: 'Alpha', role: 'driver', mode: 'auto' }]);
+  const { result } = renderHook(() => useCollabPanel(session, botIdentity, updateMemberMode, '1', '章梧'));
+  let ok = false;
+  await act(async () => {
+    ok = await result.current.joinSession();
+  });
+  expect(ok).toBe(true);
+  expect(updateMemberMode).toHaveBeenCalledWith('s1', 'human_1', 'present');
+  // 加入后切换身份也必须命中 store 身份（规范化 id 精确匹配不到）。
+  expect(useWorkspaceStore.getState().activeIdentityId).toBe('human_1');
+});
+
+it('去发言：authenticatedUserId 无 human_ 前缀时 setActiveIdentity 仍落到 store 人类身份', () => {
+  const session = makeSession([{ actorId: 'human_1', kind: 'human', name: '章梧', role: 'member', mode: 'present' }]);
+  const { result } = renderHook(() => useCollabPanel(session, botIdentity, updateMemberMode, '1', '章梧'));
+  useWorkspaceStore.getState().selectGroup('g1');
+  useWorkspaceStore.getState().selectSession('s1');
+  act(() => result.current.switchToHuman());
+  expect(useWorkspaceStore.getState().activeIdentityId).toBe('human_1');
+});

--- a/src/frontend-nextgen/test/pages/Workspace/hooks/useGroupManagement.test.tsx
+++ b/src/frontend-nextgen/test/pages/Workspace/hooks/useGroupManagement.test.tsx
@@ -1,8 +1,10 @@
 /** @jest-environment jsdom */
 import { useGroupManagement } from '@/pages/Workspace/hooks/useGroupManagement';
 import { channelBindingService } from '@/services/workspace/channelBindingService';
+import { groupMemberService } from '@/services/workspace/groupMemberService';
+import { useWorkspaceStore } from '@/stores/workspaceStore';
 import { expect, it, jest } from '@jest/globals';
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 
 jest.mock('@/services/workspace/channelBindingService');
 jest.mock('@/services/workspace/groupService');
@@ -24,4 +26,40 @@ it('loads dingtalk binding when advanced config is enabled', async () => {
   renderHook(() => useGroupManagement('group-1', jest.fn(), true));
 
   await waitFor(() => expect(channelBinding.loadGroupDingTalkBinding).toHaveBeenCalledWith('group-1'));
+});
+
+it('退出群成功后清掉该群选中：避免列表刷新纠正把筛选误切到「仅参与临时会话」', async () => {
+  // 退出后群对当前身份不再可见；若选中仍指向它，refreshGroups 后 useSelectedGroupDetail
+  // 会把「选中群不在 direct 列表」误判为深链临时视角场景 → membership 被错切 session_only。
+  useWorkspaceStore.getState().resetWorkspace();
+  useWorkspaceStore.getState().selectGroup('group-1');
+  (groupMemberService.leaveGroup as unknown as jest.Mock).mockResolvedValue({ ok: true, data: null });
+
+  const { result } = renderHook(() => useGroupManagement('group-1', jest.fn(), false));
+  let ok = false;
+  await act(async () => {
+    ok = await result.current.leaveGroup('me');
+  });
+
+  expect(ok).toBe(true);
+  expect(useWorkspaceStore.getState().selectedGroupId).toBeNull();
+  expect(useWorkspaceStore.getState().membership).toBe('direct');
+});
+
+it('退出失败不清选中', async () => {
+  useWorkspaceStore.getState().resetWorkspace();
+  useWorkspaceStore.getState().selectGroup('group-1');
+  (groupMemberService.leaveGroup as unknown as jest.Mock).mockResolvedValue({
+    ok: false,
+    error: { code: 'X', friendlyMessage: 'fail', canRetry: false },
+  });
+
+  const { result } = renderHook(() => useGroupManagement('group-1', jest.fn(), false));
+  let ok = true;
+  await act(async () => {
+    ok = await result.current.leaveGroup('me');
+  });
+
+  expect(ok).toBe(false);
+  expect(useWorkspaceStore.getState().selectedGroupId).toBe('group-1');
 });

--- a/src/frontend-nextgen/test/pages/Workspace/hooks/useGroupSessions.multiGroup.test.ts
+++ b/src/frontend-nextgen/test/pages/Workspace/hooks/useGroupSessions.multiGroup.test.ts
@@ -63,7 +63,7 @@ it('loads sessions for every expanded group, keyed by groupId (multi-group expan
   expect(result.current.sessionsByGroupId.g2.map((s) => s.title)).toEqual(['g2会话']);
 });
 
-it('expanding one more group later loads it too; re-expand reuses cache without refetch', async () => {
+it('expanding one more group later loads it too; re-expand refetches the latest list', async () => {
   const { result, rerender } = renderHook(({ expanded }: { expanded: string[] }) => useGroupSessions('g1', expanded), {
     initialProps: { expanded: ['g1'] },
   });
@@ -76,10 +76,11 @@ it('expanding one more group later loads it too; re-expand reuses cache without 
   expect(gs.loadGroupSessionsOrBcs).toHaveBeenCalledWith('g2', 'me');
   const callsAfterExpand = gs.loadGroupSessionsOrBcs.mock.calls.length;
 
-  // 收起再展开 → 命中缓存，不再请求
+  // 收起再展开 → 展开 transition 必重拉最新列表（陈旧缓存可能残留当前角色已离开的会话）。
   rerender({ expanded: ['g1'] });
   rerender({ expanded: ['g1', 'g2'] });
-  expect(gs.loadGroupSessionsOrBcs.mock.calls.length).toBe(callsAfterExpand);
+  await waitFor(() => expect(gs.loadGroupSessionsOrBcs.mock.calls.length).toBe(callsAfterExpand + 1));
+  expect(gs.loadGroupSessionsOrBcs).toHaveBeenLastCalledWith('g2', 'me');
   expect(result.current.sessionsByGroupId.g2).toHaveLength(1);
 });
 

--- a/src/frontend-nextgen/test/pages/Workspace/hooks/useGroupSessions.test.ts
+++ b/src/frontend-nextgen/test/pages/Workspace/hooks/useGroupSessions.test.ts
@@ -467,3 +467,121 @@ it('选中归属其他群（参数群滞后）时兜底不得误清选中', asyn
   });
   expect(useWorkspaceStore.getState().selectedSessionId).toBe('g2-s9');
 });
+
+it('切回已加载过的群：重新拉取会话列表（不复用陈旧缓存）', async () => {
+  gs.loadGroupSessionsOrBcs.mockResolvedValue({ ok: true, data: [session('s1', 'g1', '一号')] });
+  const { rerender } = renderHook(({ gid }: { gid: string | null }) => useGroupSessions(gid), {
+    initialProps: { gid: 'g1' as string | null },
+  });
+  await waitFor(() => expect(gs.loadGroupSessionsOrBcs).toHaveBeenCalledTimes(1));
+  rerender({ gid: 'g2' });
+  await waitFor(() => expect(gs.loadGroupSessionsOrBcs).toHaveBeenCalledTimes(2));
+  // 旧实现：rawByGroupIdRef['g1'] 缓存命中 → 不再请求（停留在 2 次）。
+  rerender({ gid: 'g1' });
+  await waitFor(() => expect(gs.loadGroupSessionsOrBcs).toHaveBeenCalledTimes(3));
+  expect(gs.loadGroupSessionsOrBcs).toHaveBeenLastCalledWith('g1', 'me');
+});
+
+it('收起后重新展开未选中的群：重新拉取会话列表', async () => {
+  gs.loadGroupSessionsOrBcs.mockResolvedValue({ ok: true, data: [session('s1', 'g1', '一号')] });
+  const { rerender } = renderHook(({ expanded }: { expanded: string[] }) => useGroupSessions(null, expanded), {
+    initialProps: { expanded: ['g1'] as string[] },
+  });
+  await waitFor(() => expect(gs.loadGroupSessionsOrBcs).toHaveBeenCalledTimes(1));
+  rerender({ expanded: [] });
+  await act(async () => Promise.resolve());
+  rerender({ expanded: ['g1'] });
+  await waitFor(() => expect(gs.loadGroupSessionsOrBcs).toHaveBeenCalledTimes(2));
+});
+
+it('选中群收起后再次点击其 tab（groupId 未变）：由展开 transition 重拉', async () => {
+  gs.loadGroupSessionsOrBcs.mockResolvedValue({ ok: true, data: [session('s1', 'g1', '一号')] });
+  const { rerender } = renderHook(({ expanded }: { expanded: string[] }) => useGroupSessions('g1', expanded), {
+    initialProps: { expanded: ['g1'] as string[] },
+  });
+  // 首次：选中路径拉取；展开路径因在途去重不重复请求。
+  await waitFor(() => expect(gs.loadGroupSessionsOrBcs).toHaveBeenCalledTimes(1));
+  rerender({ expanded: [] });
+  await act(async () => Promise.resolve());
+  // 旧实现：选中路径 key 未变不拉、展开路径因 gid===groupId 恒跳过 → 停留在 1 次。
+  rerender({ expanded: ['g1'] });
+  await waitFor(() => expect(gs.loadGroupSessionsOrBcs).toHaveBeenCalledTimes(2));
+});
+
+it('重拉窗口清空陈旧缓存：不会自动选中当前角色已离开的会话', async () => {
+  let resolveRefetch: (value: unknown) => void = () => {};
+  gs.loadGroupSessionsOrBcs
+    .mockResolvedValueOnce({ ok: true, data: [session('s-gone', 'g1', '已离开'), session('s2', 'g1', '二号')] })
+    .mockResolvedValueOnce({ ok: true, data: [session('x', 'g2', 'X')] })
+    .mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveRefetch = resolve;
+        }),
+    );
+  const { rerender } = renderHook(({ gid }: { gid: string | null }) => useGroupSessions(gid), {
+    initialProps: { gid: 'g1' as string | null },
+  });
+  await waitFor(() => expect(useWorkspaceStore.getState().selectedSessionId).toBe('s-gone'));
+  rerender({ gid: 'g2' });
+  await waitFor(() => expect(gs.loadGroupSessionsOrBcs).toHaveBeenCalledTimes(2));
+
+  // 模拟再次点击 g1 的 tab：selectGroup 清空选中 + groupId 切回。
+  act(() => {
+    useWorkspaceStore.getState().selectGroup('g1');
+  });
+  rerender({ gid: 'g1' });
+  await waitFor(() => expect(gs.loadGroupSessionsOrBcs).toHaveBeenCalledTimes(3));
+  await act(async () => Promise.resolve());
+  // 旧实现：缓存未清 → 自动选中立即命中陈旧列表首条 s-gone（当前角色已离开 → 右栏请求报错）。
+  expect(useWorkspaceStore.getState().selectedSessionId).not.toBe('s-gone');
+
+  await act(async () => {
+    resolveRefetch({ ok: true, data: [session('s2', 'g1', '二号')] });
+    await Promise.resolve();
+  });
+  await waitFor(() => expect(useWorkspaceStore.getState().selectedSessionId).toBe('s2'));
+});
+
+it('退出会话登记「已知退出」：陈旧选中再指向它时不反查详情，直接轮换', async () => {
+  // 首拉返回 [S, S2]；退出后服务端不再返回 S（重拉只剩 [S2]）。
+  let g1Calls = 0;
+  gs.loadGroupSessionsOrBcs.mockImplementation(async (gid: string) => {
+    if (gid !== 'g1') return { ok: true, data: [session('x', 'g2', 'X')] };
+    g1Calls += 1;
+    return g1Calls === 1
+      ? { ok: true, data: [session('S', 'g1', 'S'), session('S2', 'g1', 'S2')] }
+      : { ok: true, data: [session('S2', 'g1', 'S2')] };
+  });
+  // S 的详情自始失败（当前角色已退出后反查必然报错的形态）。
+  ss.getSessionDetail.mockImplementation(async (sid: string) =>
+    sid === 'S'
+      ? { ok: false, error: { code: 'X', friendlyMessage: 'fail', canRetry: true } }
+      : { ok: true, data: { ...session('S2', 'g1', 'S2'), participants: [] } },
+  );
+  ss.leaveSession.mockResolvedValue({ ok: true, data: null });
+  useWorkspaceStore.getState().selectGroup('g1');
+  const { result, rerender } = renderHook(({ gid }: { gid: string | null }) => useGroupSessions(gid), {
+    initialProps: { gid: 'g1' as string | null },
+  });
+  await waitFor(() => expect(useWorkspaceStore.getState().selectedSessionId).toBe('S'));
+
+  await act(async () => {
+    await result.current.leaveSession('S', 'me');
+  });
+  // 退出成功：从列表移除并轮换选中。
+  expect(useWorkspaceStore.getState().selectedSessionId).toBe('S2');
+  const sCallsBefore = ss.getSessionDetail.mock.calls.filter((c: unknown[]) => c[0] === 'S').length;
+
+  // 模拟陈旧选中再次指向已退出会话（记忆恢复/深链），随后点击群 tab 触发重拉：
+  // 列表到达时兜底不得再发 S 详情请求（已登记已知退出），应直接轮换回有效会话。
+  act(() => {
+    useWorkspaceStore.getState().selectSession('S');
+  });
+  rerender({ gid: 'g2' });
+  await waitFor(() => expect(gs.loadGroupSessionsOrBcs).toHaveBeenCalledTimes(2));
+  rerender({ gid: 'g1' });
+  await waitFor(() => expect(useWorkspaceStore.getState().selectedSessionId).toBe('S2'));
+  const sCallsAfter = ss.getSessionDetail.mock.calls.filter((c: unknown[]) => c[0] === 'S').length;
+  expect(sCallsAfter).toBe(sCallsBefore);
+});

--- a/src/frontend-nextgen/test/services/admin/adminService.batch.test.ts
+++ b/src/frontend-nextgen/test/services/admin/adminService.batch.test.ts
@@ -1,0 +1,163 @@
+/** @jest-environment node */
+// 批量添加成员：Promise.allSettled 聚合 + 按 envelope {error} 归属成功/失败。
+// 关键（design D2）：adminService.addMember 业务失败是 resolve({error}) 而非 reject；
+// 朴素「按 rejected 判失败」会把业务失败静默误判为成功——本用例钉死这一陷阱。
+import { getCapabilities } from '@/capabilities';
+import { adminService } from '@/services/admin/adminService';
+import * as spaceController from '@/services/backendApi/admin/spaceController';
+import { BackendRequestError } from '@/services/backendApi/httpClient';
+import { identityService } from '@/services/workspace/identityService';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+jest.mock('@/services/backendApi/admin/spaceController');
+jest.mock('@/capabilities');
+jest.mock('@/services/workspace/identityService');
+jest.mock('@tc-chat/adapters', () => ({}));
+
+const sc = spaceController as unknown as Record<string, jest.Mock<any>>;
+const getCapabilitiesMock = getCapabilities as unknown as jest.Mock;
+
+/** 固定能力：恒返回给定操作者身份（null = 未就绪）。默认 userId-only（不落 user_name）。 */
+function setUserIdentity(value: { userId: string; displayName?: string | null } | null): void {
+  const capVal = value ? { userId: value.userId, displayName: value.displayName ?? null } : null;
+  getCapabilitiesMock.mockReturnValue({
+    getHumanIdentity: () => ({ status: 'available', value: capVal }),
+  });
+}
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  (identityService.loadIdentities as unknown as jest.Mock<any>).mockResolvedValue({
+    ok: false,
+    error: { code: 'IDENTITY_LOAD_FAILED', friendlyMessage: '', canRetry: true },
+  });
+  setUserIdentity({ userId: '327325', displayName: null });
+});
+
+/**
+ * 按 member_user_id 分派单发 addSpaceMember 的返回：
+ *  - resolve 一个信封（success envelope 或业务失败 envelope）；
+ *  - reject 一个 BackendRequestError（网络异常，且可控制 message 是否可读以验证「请求异常」回退）。
+ */
+function mockAddByUserId(map: Record<string, { resolve?: Record<string, unknown> | null; reject?: BackendRequestError } | null>): void {
+  sc.addSpaceMember.mockImplementation((_spaceId: unknown, body: { member_user_id: string }) => {
+    const entry = map[body.member_user_id];
+    if (!entry || entry.resolve === null || entry.reject) {
+      // reject：无 entry 视为「无可读 message 的 500」→ 验证「请求异常」回退
+      const err =
+        entry?.reject ??
+        new BackendRequestError('', { status: 500, data: {}, apiPath: '/openapi/v1/bots/spaces/10001/members' });
+      return Promise.reject(err);
+    }
+    return Promise.resolve(entry.resolve);
+  });
+}
+
+describe('adminService.addMembersBatch：Promise.allSettled + {error} 归属', () => {
+  it('全部成功 → succeeded 含全部、failed 为空', async () => {
+    mockAddByUserId({
+      ok1: { resolve: { success: true, data: { user_id: 'ok1', role: 'MEMBER' } } },
+      ok2: { resolve: { success: true, data: { user_id: 'ok2', role: 'MEMBER' } } },
+      ok3: { resolve: { success: true, data: { user_id: 'ok3', role: 'MEMBER' } } },
+    });
+    const r = await adminService.addMembersBatch(10001, [{ userId: 'ok1' }, { userId: 'ok2' }, { userId: 'ok3' }], 'MEMBER');
+    expect(r.succeeded.map((m) => m.userId).sort()).toEqual(['ok1', 'ok2', 'ok3']);
+    expect(r.failed).toEqual([]);
+    expect(sc.addSpaceMember).toHaveBeenCalledTimes(3);
+  });
+
+  it('混合：业务失败（已是成员 resolve{error}）与成功并存 → 业务失败计入 failed 不被静默吞为成功', async () => {
+    // ★ D2 陷阱钉死：already 是 resolve({error}) 的业务失败，必须出现在 failed 而非 succeeded
+    mockAddByUserId({
+      ok: { resolve: { success: true, data: { user_id: 'ok', role: 'MEMBER' } } },
+      already: { resolve: { code: 502201, message: '已是成员', data: null, request_id: 'rid-already' } },
+    });
+    const r = await adminService.addMembersBatch(
+      10001,
+      [{ userId: 'ok' }, { userId: 'already', userName: '花名A' }],
+      'MEMBER',
+    );
+    expect(r.succeeded.map((m) => m.userId)).toEqual(['ok']);
+    expect(r.failed).toHaveLength(1);
+    expect(r.failed[0]).toMatchObject({ userId: 'already', userName: '花名A', reason: '已是成员' });
+    // 关键反向断言：业务失败绝不被误算进 succeeded
+    expect(r.succeeded.find((m) => m.userId === 'already')).toBeUndefined();
+  });
+
+  it('网络异常无可读 message → 失败原因回退「请求异常」', async () => {
+    // 5xx + 空 body + 空 message → toServiceError 得 message='' → 聚合回退「请求异常」
+    mockAddByUserId({
+      neterr: { reject: new BackendRequestError('', { status: 500, data: {}, apiPath: '/openapi/v1/bots/spaces/10001/members' }) },
+    });
+    const r = await adminService.addMembersBatch(10001, [{ userId: 'neterr' }], 'MEMBER');
+    expect(r.succeeded).toEqual([]);
+    expect(r.failed[0]).toMatchObject({ userId: 'neterr', reason: '请求异常' });
+  });
+
+  it('网络异常带可读 message → 透传该 message 而非「请求异常」', async () => {
+    mockAddByUserId({
+      neterr: {
+        reject: new BackendRequestError('网关超时', {
+          status: 502,
+          data: { code: 502201, message: '网关超时', data: null, request_id: 'rid-502' },
+          apiPath: '/openapi/v1/bots/spaces/10001/members',
+        }),
+      },
+    });
+    const r = await adminService.addMembersBatch(10001, [{ userId: 'neterr' }], 'MEMBER');
+    expect(r.failed[0].reason).toBe('网关超时');
+  });
+
+  it('全部失败 → succeeded 为空、failed 全员', async () => {
+    mockAddByUserId({
+      already: { resolve: { code: 502201, message: '已是成员', data: null, request_id: 'r1' } },
+      noperm: { resolve: { code: 502201, message: '无权限', data: null, request_id: 'r2' } },
+    });
+    const r = await adminService.addMembersBatch(10001, [{ userId: 'already' }, { userId: 'noperm' }], 'ADMIN');
+    expect(r.succeeded).toEqual([]);
+    expect(r.failed.map((f) => f.reason)).toEqual(['已是成员', '无权限']);
+  });
+
+  it('每项 member_user_name 逐项透传到单发 body（不共享、不丢失）', async () => {
+    mockAddByUserId({
+      named: { resolve: { success: true, data: { user_id: 'named', role: 'MEMBER' } } },
+      plain: { resolve: { success: true, data: { user_id: 'plain', role: 'MEMBER' } } },
+    });
+    await adminService.addMembersBatch(
+      10001,
+      [{ userId: 'named', userName: '花名甲' }, { userId: 'plain' }],
+      'MEMBER',
+    );
+    const calls = sc.addSpaceMember.mock.calls as unknown as [unknown, Record<string, unknown>, Record<string, unknown>][];
+    const namedCall = calls.find((c) => c[1]?.member_user_id === 'named');
+    const plainCall = calls.find((c) => c[1]?.member_user_id === 'plain');
+    expect(namedCall?.[1]).toMatchObject({ member_user_id: 'named', member_user_name: '花名甲', role: 'MEMBER' });
+    expect(plainCall?.[1]).toMatchObject({ member_user_id: 'plain', role: 'MEMBER' });
+    expect(plainCall?.[1]).not.toHaveProperty('member_user_name');
+  });
+
+  it('role 对整批生效（每单发 body 均带同一 role）', async () => {
+    mockAddByUserId({
+      a: { resolve: { success: true, data: { user_id: 'a', role: 'ADMIN' } } },
+      b: { resolve: { success: true, data: { user_id: 'b', role: 'ADMIN' } } },
+    });
+    await adminService.addMembersBatch(10001, [{ userId: 'a' }, { userId: 'b' }], 'ADMIN');
+    const calls = sc.addSpaceMember.mock.calls as unknown as [unknown, Record<string, unknown>, Record<string, unknown>][];
+    expect(calls.every((c) => c[1]?.role === 'ADMIN')).toBe(true);
+    expect(calls.every((c) => c[2]?.user_id === '327325')).toBe(true);
+  });
+
+  it('空批次 → 不发请求、succeeded/failed 均为空', async () => {
+    const r = await adminService.addMembersBatch(10001, [], 'MEMBER');
+    expect(r.succeeded).toEqual([]);
+    expect(r.failed).toEqual([]);
+    expect(sc.addSpaceMember).not.toHaveBeenCalled();
+  });
+
+  it('不抛异常：即使含 reject，整体仍 resolve（失败收口到 failed，不 reject）', async () => {
+    mockAddByUserId({
+      neterr: { reject: new BackendRequestError('', { status: 500, data: {}, apiPath: '/x' }) },
+    });
+    await expect(adminService.addMembersBatch(10001, [{ userId: 'neterr' }], 'MEMBER')).resolves.toBeDefined();
+  });
+});

--- a/src/frontend-nextgen/test/services/workspace/groupService.test.ts
+++ b/src/frontend-nextgen/test/services/workspace/groupService.test.ts
@@ -244,8 +244,8 @@ describe('BCS group routing by bcs_grp_ prefix', () => {
 
   it('routes bcs_grp_ group to BCS fetch path even when in-memory marker is empty (fresh tab)', async () => {
     // 模拟新开页 target=_blank 全新挂载:bcsGroupIds 内存标记为空(非持久化),
-    // 仅靠 groupId 的 bcs_grp_ 前缀兜底应走 BCS 会话端点(不带 view_bot_id),
-    // 不走通用 listGroupSessions(通用端点会带人类 me id,身份受限拉不回会话 → 右栏空态)。
+    // 仅靠 groupId 的 bcs_grp_ 前缀兜底应走 BCS 会话端点(raw-fetch 旁路)。
+    // view_bot_id 语义与通用端点一致：当前身份 mine bot_id，供后端按角色视角过滤会话。
     useWorkspaceStore.setState({ bcsGroupIds: {} });
     global.fetch = jest
       .fn<typeof fetch>()
@@ -256,10 +256,41 @@ describe('BCS group routing by bcs_grp_ prefix', () => {
     expect(sc.listGroupSessions).not.toHaveBeenCalled();
     expect(global.fetch).toHaveBeenCalledTimes(1);
     const calledUrl = (global.fetch as jest.Mock).mock.calls[0][0] as string;
-    expect(calledUrl).toContain('/openapi/v1/collaboration/groups/bcs_grp_abc/sessions?offset=0&limit=10');
+    expect(calledUrl).toContain(
+      '/openapi/v1/collaboration/groups/bcs_grp_abc/sessions?offset=0&limit=10&view_bot_id=human-me',
+    );
     expect(res.ok).toBe(true);
     expect(res.ok && res.data).toMatchObject({ items: [], total: 0, hasMore: false });
     expect(typeof (res.ok && res.data.limit)).toBe('number');
+  });
+
+  it('BCS 群无当前身份时降级：URL 不带 view_bot_id', async () => {
+    useWorkspaceStore.setState({ bcsGroupIds: {} });
+    global.fetch = jest
+      .fn<typeof fetch>()
+      .mockResolvedValue(jsonOk({ code: 200000, message: 'OK', data: { items: [], offset: 0, limit: 10, total: 0 } }));
+
+    await groupService.loadGroupSessionsOrBcs('bcs_grp_abc', undefined);
+
+    const calledUrl = (global.fetch as jest.Mock).mock.calls[0][0] as string;
+    expect(calledUrl).toContain('/groups/bcs_grp_abc/sessions?offset=0&limit=10');
+    expect(calledUrl).not.toContain('view_bot_id');
+  });
+
+  it('BCS 群详情路径：sessions 子请求同样携带 view_bot_id（群详情请求保持不变）', async () => {
+    useWorkspaceStore.setState({ bcsGroupIds: {} });
+    global.fetch = jest.fn<typeof fetch>().mockImplementation(async (url: unknown) => {
+      const u = String(url);
+      if (u.includes('/sessions')) return jsonOk({ code: 200000, message: 'OK', data: { items: [] } });
+      return jsonOk({ code: 200000, message: 'OK', data: { id: 'bcs_grp_abc', name: 'G', participants: [] } });
+    });
+
+    const res = await groupService.loadGroupDetailOrBcs('bcs_grp_abc', 'human-me');
+
+    expect(res.ok).toBe(true);
+    const urls = (global.fetch as jest.Mock).mock.calls.map((c: unknown[]) => String(c[0]));
+    expect(urls.some((u: string) => u.includes('/sessions?') && u.includes('view_bot_id=human-me'))).toBe(true);
+    expect(urls.some((u: string) => u.endsWith('/groups/bcs_grp_abc'))).toBe(true);
   });
 
   it('routes non-prefixed group to generic listGroupSessions path with view_bot_id', async () => {

--- a/src/frontend-nextgen/test/services/workspace/sessionService.test.ts
+++ b/src/frontend-nextgen/test/services/workspace/sessionService.test.ts
@@ -1,6 +1,7 @@
 /** @jest-environment jsdom */
 import * as sessionController from '@/services/backendApi/collaboration/sessionController';
 import { sessionService } from '@/services/workspace/sessionService';
+import { useErrorNotifyStore } from '@/stores/errorNotifyStore';
 import { useWorkspaceStore } from '@/stores/workspaceStore';
 import { beforeEach, expect, it, jest } from '@jest/globals';
 
@@ -260,4 +261,20 @@ it('leaveSession maps 409 to friendly conflict', async () => {
   const res = await sessionService.leaveSession('s1', 'human_1');
   expect(res.ok).toBe(false);
   expect(!res.ok && res.error.code).toBe('SESSION_CONFLICT');
+});
+
+it('getSessionDetail 失败：取消协议层全局错误提示（读侧静默用途，调用方均自行处理失败）', async () => {
+  // 协议层（backendRequest）失败时会 enqueue 默认提示并抛出携带 toastKey 的错误；
+  // 会话详情查询的调用方（成员补齐/陈旧选中兜底探测/深链反查）全部自行静默处理失败，
+  // 已退出/已删除会话的反查「必然失败」不应变成用户可见报错。
+  useErrorNotifyStore.getState().reset();
+  useErrorNotifyStore.getState().enqueue({ toastKey: 'k-detail-1', message: 'boom', apiPath: '/sessions/s1' });
+  sc.getSession.mockRejectedValue(Object.assign(new Error('boom'), { toastKey: 'k-detail-1' }));
+
+  const res = await sessionService.getSessionDetail('s1');
+
+  expect(res.ok).toBe(false);
+  const items = useErrorNotifyStore.getState().drain();
+  expect(items.some((it) => it.toastKey === 'k-detail-1' && it.cancelled)).toBe(true);
+  useErrorNotifyStore.getState().reset();
 });


### PR DESCRIPTION
## Problem
The nextgen open core export is behind the latest TeamClaw workspace updates: admin space member management only supported single-user adds, BCN collaboration chat external links had no dedicated landing page, collaboration square modals lacked consistent form styling, and several workspace session hooks needed member-sync and stale-session refinements.

## Solution
- Synced the open core export to TeamClaw source commit `96704eb9` and updated `OPEN_CORE_MANIFEST.json`.
- Admin space members:
  - Added `AddMembersModal` with multi-select chips, shared role selection, and partial-failure retry (failed users are restored as chips; the modal stays open).
  - Added batch member add API and extracted `useSpaceMemberActions` from `useAdmin` to control hook size.
- BCN chat external links:
  - Added `/workspace/bcn/chat/detail` landing page (`BcnChatDetail`) and `useBcnChatDetailRedirect` to resolve direct vs session-only membership and redirect into the workspace group deep link.
- Collaboration square:
  - Restyled `CreateGroupSessionModal` (icon header, required markers, character counters, form submit) and updated `GroupMembersModal`.
- Workspace hooks: refined expanded group session requests, session leave, session member sync, collab panel, and stale-session fallback behavior.
- Added and updated extensive unit tests for member batch operations, BCN redirect, group sessions, and collaboration square modals.

## Validation
- Mechanical export from TeamClaw source commit `96704eb9` (`sourceDirty: false`); no manual code changes beyond the export.
- Diff scope: `src/frontend-nextgen` (42 files, +1913/-272).
- Did not run frontend unit tests locally; CI will run the frontend gate on this PR.

## Compatibility and risk
- New admin batch-add API call requires the matching backend endpoint or the operation will report an error; single-add flows are unchanged.
- New BCN detail route is additive and redirects to existing workspace deep links; invalid parameters show a friendly empty state.
- Rollback path: revert this PR to restore the previous export.

## Spec
- Open Core export schema: `src/frontend-nextgen/OPEN_CORE_MANIFEST.json` (exportSchemaVersion 1)