### PR TITLE
feat(baas): allow scale_bot to target specific device UUIDs on SCALE_DOWN

### DIFF
--- a/src/baas/src/secbaas/community/adapters/web/routers/bot_service/management_router.py
+++ b/src/baas/src/secbaas/community/adapters/web/routers/bot_service/management_router.py
@@ -11,7 +11,7 @@ Endpoints:
 - GET /api/v1/bots/{bot_uuid} - Get bot details
 - POST /api/v1/bots/{bot_uuid}/destroy - Destroy bot
 - POST /api/v1/bots/{bot_uuid}/update - Update bot
-- POST /api/v1/bots/{bot_uuid}/scale - Scale bot devices
+- POST /api/v1/bots/{bot_uuid}/scale - Scale bot devices (optional device_uuids for targeted SCALE_DOWN)
 - POST /api/v1/bots/{bot_uuid}/restart - Restart bot
 - POST /api/v1/bots/{bot_uuid}/update-devices - Update specified bot devices
 - GET /api/v1/bots/{bot_uuid}/sessions - List bot sessions
@@ -94,9 +94,21 @@ class UpdateBotRequest(BaseModel):
 
 
 class ScaleBotRequest(BaseRequest):
-    """Scale bot request."""
+    """Scale bot request.
 
-    target_count: int = Field(..., ge=1, le=100)
+    ``target_count`` is always required. When ``device_uuids`` is also
+    provided, SCALE_DOWN destroys exactly those devices and
+    ``target_count`` must equal
+    ``current_count - len(device_uuids)``.
+    """
+
+    target_count: int = Field(
+        ...,
+        ge=1,
+        le=100,
+        description="Target device count (required). When device_uuids is "
+        "supplied, must equal current_count - len(device_uuids).",
+    )
     operator: str = Field(..., min_length=1, max_length=64)
     auto_approve_publish: bool = Field(
         default=False,
@@ -105,6 +117,13 @@ class ScaleBotRequest(BaseRequest):
     config: BotConfig | None = Field(
         default=None,
         description="Bot configuration for the scale publish workflow (merged with existing config; not persisted to DB)",
+    )
+    device_uuids: list[str] | None = Field(
+        default=None,
+        min_length=1,
+        description="Optional explicit list of device UUIDs to destroy during "
+        "SCALE_DOWN. When set, target_count must equal "
+        "current_count - len(device_uuids).",
     )
 
 
@@ -430,15 +449,33 @@ async def scale_bot(
     Initiates scaling through publish workflow.
     Returns bot info with target_count and publish_id for workflow tracking.
     """
-    result = await service.scale_bot(
-        tenant=tenant,
-        bot_uuid=bot_uuid,
-        target_count=request.target_count,
-        operator=request.operator,
-        request_id=request.request_id,
-        auto_approve_publish=request.auto_approve_publish,
-        bot_config=request.config,
-    )
+    try:
+        result = await service.scale_bot(
+            tenant=tenant,
+            bot_uuid=bot_uuid,
+            target_count=request.target_count,
+            operator=request.operator,
+            request_id=request.request_id,
+            auto_approve_publish=request.auto_approve_publish,
+            bot_config=request.config,
+            device_uuids=request.device_uuids,
+        )
+    except BotNotFoundError:
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "error_code": "BOT_NOT_FOUND",
+                "message": f"Bot not found: {bot_uuid}",
+            },
+        )
+    except ValueError as e:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error_code": "INVALID_REQUEST",
+                "message": str(e),
+            },
+        )
     return ApiResponse(data=result)
 
 

--- a/src/baas/src/secbaas/community/adapters/web/routers/bot_service/management_router.py
+++ b/src/baas/src/secbaas/community/adapters/web/routers/bot_service/management_router.py
@@ -97,9 +97,10 @@ class ScaleBotRequest(BaseRequest):
     """Scale bot request.
 
     ``target_count`` is always required. When ``device_uuids`` is also
-    provided, SCALE_DOWN destroys exactly those devices and
-    ``target_count`` must equal
-    ``current_count - len(device_uuids)``.
+    provided (and non-empty), SCALE_DOWN destroys exactly those devices
+    and ``target_count`` must equal
+    ``current_count - len(device_uuids)``. An empty list is treated the
+    same as ``None`` (count-based scaling).
     """
 
     target_count: int = Field(
@@ -120,9 +121,9 @@ class ScaleBotRequest(BaseRequest):
     )
     device_uuids: list[str] | None = Field(
         default=None,
-        min_length=1,
         description="Optional explicit list of device UUIDs to destroy during "
-        "SCALE_DOWN. When set, target_count must equal "
+        "SCALE_DOWN. Empty list is treated the same as None (count-based "
+        "scaling). When non-empty, target_count must equal "
         "current_count - len(device_uuids).",
     )
 

--- a/src/baas/src/secbaas/community/api/bot_manage/_protocols.py
+++ b/src/baas/src/secbaas/community/api/bot_manage/_protocols.py
@@ -150,8 +150,19 @@ class BotManageService(Protocol):
         request_id: str,
         auto_approve_publish: bool = False,
         bot_config: BotConfig | None = None,
+        device_uuids: list[str] | None = None,
     ) -> ScaleBotResponse:
-        """Scale Bot to target device count (SCALE_UP or SCALE_DOWN)."""
+        """Scale Bot to target device count (SCALE_UP or SCALE_DOWN).
+
+        ``target_count`` is always required. When ``device_uuids`` is
+        also supplied, it must satisfy ``target_count ==
+        current_count - len(device_uuids)`` and the operation targets
+        exactly those devices for SCALE_DOWN destruction.
+        ``device_uuids`` is rejected on SCALE_UP.
+
+        When ``device_uuids`` is omitted, behavior is unchanged:
+        SCALE_DOWN destroys the oldest ACTIVE devices.
+        """
         ...
 
     async def update_bot(

--- a/src/baas/src/secbaas/community/api/bot_manage/_protocols.py
+++ b/src/baas/src/secbaas/community/api/bot_manage/_protocols.py
@@ -155,13 +155,14 @@ class BotManageService(Protocol):
         """Scale Bot to target device count (SCALE_UP or SCALE_DOWN).
 
         ``target_count`` is always required. When ``device_uuids`` is
-        also supplied, it must satisfy ``target_count ==
+        also supplied (and non-empty), it must satisfy ``target_count ==
         current_count - len(device_uuids)`` and the operation targets
         exactly those devices for SCALE_DOWN destruction.
-        ``device_uuids`` is rejected on SCALE_UP.
+        ``device_uuids`` is rejected on SCALE_UP. An empty list is
+        treated the same as ``None`` (count-based scaling).
 
-        When ``device_uuids`` is omitted, behavior is unchanged:
-        SCALE_DOWN destroys the oldest ACTIVE devices.
+        When ``device_uuids`` is omitted or empty, behavior is
+        unchanged: SCALE_DOWN destroys the oldest ACTIVE devices.
         """
         ...
 

--- a/src/baas/src/secbaas/community/api/publish_manage/_models.py
+++ b/src/baas/src/secbaas/community/api/publish_manage/_models.py
@@ -135,7 +135,7 @@ class PublishConfig(BaseModel):
     # UPDATE-specific: ID of the new PENDING bot record created during create_publish
     target_bot_id: int | None = None
 
-    # UPDATE_DEVICE-specific: explicit list of device UUIDs to update
+    # UPDATE_DEVICE and SCALE_DOWN: explicit list of device UUIDs targeted by this publish
     target_device_uuids: list[str] | None = None
 
     # auto_approve: when True, manual /approve calls are rejected; only internal loop drives gates

--- a/src/baas/src/secbaas/community/core/service/bot_manage/_bot_management_service.py
+++ b/src/baas/src/secbaas/community/core/service/bot_manage/_bot_management_service.py
@@ -730,7 +730,8 @@ class DefaultBotManagementService(BotManageService):
         operation targets exactly those devices for SCALE_DOWN. In that
         case ``target_count`` must equal
         ``current_count - len(unique_device_uuids)``. ``device_uuids`` is
-        rejected on SCALE_UP.
+        rejected on SCALE_UP. An empty list is treated the same as
+        ``None`` (count-based scaling).
 
         When ``bot_config`` is provided, its non-None fields are merged with
         the bot's existing extra_config and consumed by the publish workflow

--- a/src/baas/src/secbaas/community/core/service/bot_manage/_bot_management_service.py
+++ b/src/baas/src/secbaas/community/core/service/bot_manage/_bot_management_service.py
@@ -36,6 +36,7 @@ from secbaas.community.api.device_manage import (
     DeployConfig,
     DeviceInfo,
     DeviceListResponse,
+    DeviceStatus,
 )
 from secbaas.community.api.health_check.bot import (
     BotHealthCheckerService as BotHealthCheckerServiceProtocol,
@@ -717,12 +718,19 @@ class DefaultBotManagementService(BotManageService):
         request_id: str,
         auto_approve_publish: bool = False,
         bot_config: BotConfig | None = None,
+        device_uuids: list[str] | None = None,
     ) -> ScaleBotResponse:
         """Scale Bot to target device count (SCALE_UP or SCALE_DOWN).
 
         Creates appropriate publish for capacity adjustment:
         - target_count > current: SCALE_UP adding devices
         - target_count < current: SCALE_DOWN removing devices
+
+        When ``device_uuids`` is provided alongside ``target_count``, the
+        operation targets exactly those devices for SCALE_DOWN. In that
+        case ``target_count`` must equal
+        ``current_count - len(unique_device_uuids)``. ``device_uuids`` is
+        rejected on SCALE_UP.
 
         When ``bot_config`` is provided, its non-None fields are merged with
         the bot's existing extra_config and consumed by the publish workflow
@@ -742,6 +750,9 @@ class DefaultBotManagementService(BotManageService):
                                   without manual intervention (default: False)
             bot_config: Optional bot configuration to merge with existing
                         config for the scale publish workflow
+            device_uuids: Optional explicit list of device UUIDs to destroy
+                          during SCALE_DOWN. When set, target_count must
+                          equal current_count - len(device_uuids).
 
         Returns:
             ScaleBotResponse with bot info, target_count and publish_id
@@ -769,14 +780,57 @@ class DefaultBotManagementService(BotManageService):
         if bot.status == BotStatus.DESTROYING.value:
             raise ValueError("Cannot scale bot in DESTROYING status")
 
+        # Get current device count (fetched once, reused for validation)
+        device_repo = self._device_repo
+        devices = device_repo.list_by_bot_id(
+            bot_id=bot.id, tenant=tenant, env=env
+        )
+        current_count = len(devices)
+
+        # Validate device_uuids if provided
+        unique_device_uuids: list[str] | None = None
+        if device_uuids:
+            unique_device_uuids = list(dict.fromkeys(device_uuids))
+            if not unique_device_uuids:
+                raise ValueError(
+                    "device_uuids must contain at least one valid UUID"
+                )
+
+            bot_device_map = {d.device_uuid: d for d in devices}
+
+            invalid_uuids = [
+                uuid
+                for uuid in unique_device_uuids
+                if uuid not in bot_device_map
+            ]
+            if invalid_uuids:
+                raise ValueError(
+                    f"Device(s) not found or not belonging to bot {bot_uuid}: "
+                    f"{invalid_uuids}"
+                )
+
+            non_active_uuids = [
+                uuid
+                for uuid in unique_device_uuids
+                if bot_device_map[uuid].status != DeviceStatus.ACTIVE.value
+            ]
+            if non_active_uuids:
+                raise ValueError(
+                    f"Device(s) not ACTIVE, cannot scale down: {non_active_uuids}"
+                )
+
+            # target_count is required and must be consistent with device_uuids.
+            derived_target = current_count - len(unique_device_uuids)
+            if target_count != derived_target:
+                raise ValueError(
+                    f"target_count ({target_count}) does not match "
+                    f"current_count - len(device_uuids) ({derived_target})"
+                )
+
         # Validate target_count >= 1
         if target_count < 1:
             raise ValueError(f"Target count must be at least 1, got {target_count}")
 
-        # Get current device count
-        device_repo = self._device_repo
-        devices = device_repo.list_by_bot_id(bot_id=bot.id, tenant=tenant, env=env)
-        current_count = len(devices)
         logger.info(
             f"[scale_bot] bot_id={bot.id} current_count={current_count} "
             f"target_count={target_count} delta={target_count - current_count}"
@@ -793,6 +847,12 @@ class DefaultBotManagementService(BotManageService):
             publish_type = PublishType.SCALE_UP
         else:
             publish_type = PublishType.SCALE_DOWN
+
+        # Reject device_uuids on scale-up
+        if publish_type == PublishType.SCALE_UP and unique_device_uuids:
+            raise ValueError(
+                "device_uuids cannot be combined with SCALE_UP"
+            )
 
         # Resolve config for PublishConfig
         # Pattern matches update_devices merge at lines 1133-1151:
@@ -836,6 +896,7 @@ class DefaultBotManagementService(BotManageService):
                 bot_config.callback_timeout_seconds if bot_config is not None else None
             )
             or DEFAULT_CALLBACK_TIMEOUT_SECONDS,
+            target_device_uuids=unique_device_uuids,
         )
         publish = await self._publish_service.create_publish(
             tenant=tenant,
@@ -848,7 +909,8 @@ class DefaultBotManagementService(BotManageService):
 
         logger.info(
             f"[scale_bot] publish created: publish_id={publish.id} "
-            f"type={publish_type.value} target={target_count} current={current_count} config={scale_config}"
+            f"type={publish_type.value} target={target_count} current={current_count} "
+            f"target_device_uuids={unique_device_uuids} config={scale_config}"
         )
 
         # Auto-approve publish stage gates when requested

--- a/src/baas/src/secbaas/community/core/service/publish_manage/_publish_service.py
+++ b/src/baas/src/secbaas/community/core/service/publish_manage/_publish_service.py
@@ -1073,10 +1073,52 @@ class DefaultPublishService(PublishService):
                 [d for d in all_devices if d.status == DeviceStatus.ACTIVE.value],
                 key=lambda d: d.id,
             )
+
+            publish_repo = self._publish_repo
+            publish_record = publish_repo.get_by_id(
+                publish_id, tenant=tenant, env=env
+            )
+            target_uuids: list[str] = []
+            if publish_record and publish_record.extra_config:
+                try:
+                    cfg = PublishConfig.model_validate(
+                        publish_record.extra_config
+                    )
+                    target_uuids = cfg.target_device_uuids or []
+                except Exception:
+                    logger.warning(
+                        f"[create_device_records] Failed to parse "
+                        f"target_device_uuids for SCALE_DOWN "
+                        f"publish_id={publish_id}"
+                    )
+
+            if target_uuids:
+                target_set = set(target_uuids)
+                present_uuids = {d.device_uuid for d in eligible_devices}
+                missing = target_set - present_uuids
+                if missing:
+                    raise ValueError(
+                        f"Requested SCALE_DOWN devices not ACTIVE/owned: "
+                        f"{sorted(missing)}"
+                    )
+                eligible_devices = [
+                    d for d in eligible_devices if d.device_uuid in target_set
+                ]
+                expected_scale_amount = sum(
+                    b.batch_capacity for b in batch_records
+                )
+                if len(eligible_devices) != expected_scale_amount:
+                    raise ValueError(
+                        f"SCALE_DOWN target_device_uuids count "
+                        f"({len(eligible_devices)}) != scale_amount "
+                        f"({expected_scale_amount})"
+                    )
+
             event_type = PublishEventType.DESTROY.value
             logger.info(
                 f"[create_device_records] SCALE_DOWN publish_id={publish_id} "
                 f"found {len(eligible_devices)} ACTIVE devices"
+                + (f" targeted={target_uuids}" if target_uuids else "")
             )
 
         elif publish_type == PublishType.DESTROY:

--- a/src/baas/tests/e2e/asgi/baseline/test_async_device_hooks_for_scale_down.py
+++ b/src/baas/tests/e2e/asgi/baseline/test_async_device_hooks_for_scale_down.py
@@ -177,3 +177,168 @@ class TestScaleDownNoHook:
             )
 
         await cleanup_bot(api, bot["bot_uuid"])
+
+
+# ── Explicit device_uuids ────────────────────────────────────────────────────
+
+
+async def _scale_down_bot_with_device_uuids(
+    api: APITestHelper, bot_uuid: str, target_count: int, device_uuids: list[str]
+) -> int | None:
+    """Scale down bot with explicit device_uuids, return publish_id or None."""
+    resp = await api.client.post(
+        api.bot_url(bot_uuid) + "/scale",
+        params=api.params(),
+        json={
+            "target_count": target_count,
+            "device_uuids": device_uuids,
+            "operator": "e2e-test",
+            "request_id": uuid.uuid4().hex,
+        },
+    )
+    assert resp.status_code == 200
+    return resp.json()["data"].get("publish_id")
+
+
+async def _get_bot_devices(api: APITestHelper, bot_uuid: str) -> list[dict]:
+    """Fetch bot devices via HTTP, return list of device dicts from the response."""
+    resp = await api.client.get(
+        api.bot_devices_url(bot_uuid), params=api.params()
+    )
+    assert resp.status_code == 200
+    devices_data = resp.json()["data"]
+    all_devices: list[dict] = []
+    for entry in devices_data:
+        all_devices.extend(entry.get("items", []))
+    return all_devices
+
+
+class TestScaleDownWithDeviceUuids:
+    """SCALE_DOWN with explicit device_uuids: targeted destruction with hooks."""
+
+    @pytest.mark.asyncio
+    async def test_scale_down_with_explicit_device_uuids(
+        self, api: APITestHelper, unique_id: str
+    ) -> None:
+        """3 devices, scale down by device_uuids=[d1, d2]: only d1, d2 destroyed."""
+        bot = await create_and_activate_bot(
+            api, f"scaledn-duid-1d-{unique_id}", device_count=3
+        )
+        bot_uuid = bot["bot_uuid"]
+
+        all_devices = await _get_bot_devices(api, bot_uuid)
+        active_devices = [d for d in all_devices if d.get("status") == "ACTIVE"]
+        assert len(active_devices) == 3, (
+            f"Expected 3 ACTIVE devices, got {len(active_devices)}: {all_devices}"
+        )
+
+        target_devices = active_devices[:2]
+        target_uuids = [d["device_uuid"] for d in target_devices]
+        # Progress endpoint exposes the internal device id (not device_uuid);
+        # capture both so we can match across the two responses.
+        target_ids = {d["id"] for d in target_devices}
+        keep_uuid = active_devices[2]["device_uuid"]
+
+        publish_id = await _scale_down_bot_with_device_uuids(
+            api, bot_uuid, target_count=1, device_uuids=target_uuids
+        )
+        if not publish_id:
+            pytest.skip("No publish_id returned from scale down")
+
+        code = await approve_publish(api, publish_id)
+        assert code == 200
+
+        status = await wait_for_publish_status(
+            api, publish_id, {"SUCCESS"}, timeout_seconds=0.5
+        )
+        assert status == "SUCCESS", f"Expected SUCCESS, got {status}"
+
+        # before_destroy_cmd_hook must fire for exactly the targeted devices.
+        # Progress devices report device_id (internal), so match against ids.
+        devices = await get_devices_from_progress(api, publish_id)
+        progress_device_ids = {d.get("device_id") for d in devices}
+        assert progress_device_ids == target_ids, (
+            f"Expected progress to contain only device ids {target_ids}, "
+            f"got {progress_device_ids}"
+        )
+
+        for device in devices:
+            result_msg = device.get("result_message")
+            if result_msg and result_msg.startswith("{"):
+                hook_data = assert_result_message_has_hook_data(result_msg)
+                assert "stdout" in hook_data
+
+        # Remaining ACTIVE device count must match target_count (3 - 2 = 1).
+        remaining_devices = await _get_bot_devices(api, bot_uuid)
+        remaining_active = [
+            d for d in remaining_devices if d.get("status") == "ACTIVE"
+        ]
+        assert len(remaining_active) == 1, (
+            f"Expected 1 ACTIVE device after scale down, got "
+            f"{len(remaining_active)}: {remaining_active}"
+        )
+        assert remaining_active[0]["device_uuid"] == keep_uuid
+
+        await cleanup_bot(api, bot["bot_uuid"])
+
+    @pytest.mark.asyncio
+    async def test_scale_down_with_explicit_device_uuids_preserves_others(
+        self, api: APITestHelper, unique_id: str
+    ) -> None:
+        """4 devices, scale down by device_uuids=[d2, d4]: d1 and d3 remain ACTIVE."""
+        bot = await create_and_activate_bot(
+            api, f"scaledn-duid-2d-{unique_id}", device_count=4
+        )
+        bot_uuid = bot["bot_uuid"]
+
+        all_devices = await _get_bot_devices(api, bot_uuid)
+        active_devices = [d for d in all_devices if d.get("status") == "ACTIVE"]
+        assert len(active_devices) == 4, (
+            f"Expected 4 ACTIVE devices, got {len(active_devices)}: {all_devices}"
+        )
+
+        target_uuids = [
+            active_devices[1]["device_uuid"],
+            active_devices[3]["device_uuid"],
+        ]
+        target_ids = {active_devices[1]["id"], active_devices[3]["id"]}
+        preserve_uuids = {
+            active_devices[0]["device_uuid"],
+            active_devices[2]["device_uuid"],
+        }
+
+        publish_id = await _scale_down_bot_with_device_uuids(
+            api, bot_uuid, target_count=2, device_uuids=target_uuids
+        )
+        if not publish_id:
+            pytest.skip("No publish_id returned from scale down")
+
+        code = await approve_publish(api, publish_id)
+        assert code == 200
+
+        status = await wait_for_publish_status(
+            api, publish_id, {"SUCCESS"}, timeout_seconds=0.5
+        )
+        assert status == "SUCCESS", f"Expected SUCCESS, got {status}"
+
+        # Publish must process exactly the targeted devices (match by device id).
+        devices = await get_devices_from_progress(api, publish_id)
+        progress_device_ids = {d.get("device_id") for d in devices}
+        assert progress_device_ids == target_ids, (
+            f"Expected progress to contain only device ids {target_ids}, "
+            f"got {progress_device_ids}"
+        )
+
+        # Devices 1 and 3 must remain ACTIVE.
+        remaining_devices = await _get_bot_devices(api, bot_uuid)
+        remaining_active_uuids = {
+            d["device_uuid"]
+            for d in remaining_devices
+            if d.get("status") == "ACTIVE"
+        }
+        assert preserve_uuids.issubset(remaining_active_uuids), (
+            f"Expected preserved devices {preserve_uuids} to remain ACTIVE, "
+            f"got {remaining_active_uuids}"
+        )
+
+        await cleanup_bot(api, bot["bot_uuid"])

--- a/src/baas/tests/e2e/asgi/baseline/test_scale_lifecycle_with_device_uuids.py
+++ b/src/baas/tests/e2e/asgi/baseline/test_scale_lifecycle_with_device_uuids.py
@@ -182,15 +182,16 @@ class TestScaleLifecycleWithDeviceUuids:
             f"Expected scale-down publish SUCCESS, got {status}"
         )
 
-        # 4a. The two targeted devices must now be DESTROYED.
+        # 4a. The two targeted devices must be gone from the listing.
+        # destroy_device_by_uuid soft-deletes (is_deleted=1) before setting
+        # status=RELEASED, so list_by_bot_id (which filters is_deleted=0)
+        # never returns them. Assert absence rather than status.
         all_devices = await _get_bot_devices(api, bot_uuid)
-        destroyed_devices = [
-            d for d in all_devices if d.get("status") == "DESTROYED"
-        ]
-        destroyed_uuids = {d["device_uuid"] for d in destroyed_devices}
-        assert destroyed_uuids == set(device_uuids_to_destroy), (
-            f"Expected exactly {set(device_uuids_to_destroy)} to be DESTROYED, "
-            f"got {destroyed_uuids}"
+        all_device_uuids = {d["device_uuid"] for d in all_devices}
+        assert not (set(device_uuids_to_destroy) & all_device_uuids), (
+            f"Targeted devices {set(device_uuids_to_destroy)} should be "
+            f"absent from the bot device listing after scale down, "
+            f"got {all_device_uuids}"
         )
 
         # 4b. The two original devices must remain ACTIVE.

--- a/src/baas/tests/e2e/asgi/baseline/test_scale_lifecycle_with_device_uuids.py
+++ b/src/baas/tests/e2e/asgi/baseline/test_scale_lifecycle_with_device_uuids.py
@@ -1,0 +1,213 @@
+"""E2E lifecycle test: create → scale up → scale down with device_uuids → verify.
+
+Full flow:
+1. Create bot with 2 devices
+2. Scale up to 4 devices (with async hook callbacks)
+3. Scale down by specifying 2 device_uuids to destroy
+4. Verify final state: correct 2 devices destroyed, correct 2 remain ACTIVE
+
+Requires:
+- Service running with PAAS_MOCK_MODE=true (just restart-mock)
+"""
+
+import uuid
+
+import pytest
+
+from tests.e2e.asgi.conftest import (
+    APITestHelper,
+    approve_publish,
+    cleanup_bot,
+    create_and_activate_bot,
+    get_devices_from_progress,
+    send_callbacks_for_hook_devices,
+    wait_for_publish_status,
+)
+
+pytestmark = [pytest.mark.e2e_asgi]
+
+
+# ── Helpers (inlined per existing test-file convention) ──────────────────────
+
+
+async def _scale_up_bot(
+    api: APITestHelper, bot_uuid: str, target_count: int
+) -> int | None:
+    """Scale up bot, return publish_id or None."""
+    resp = await api.client.post(
+        api.bot_url(bot_uuid) + "/scale",
+        params=api.params(),
+        json={
+            "target_count": target_count,
+            "operator": "e2e-test",
+            "request_id": uuid.uuid4().hex,
+        },
+    )
+    assert resp.status_code == 200
+    return resp.json()["data"].get("publish_id")
+
+
+async def _scale_down_bot_with_device_uuids(
+    api: APITestHelper, bot_uuid: str, target_count: int, device_uuids: list[str]
+) -> int | None:
+    """Scale down bot with explicit device_uuids, return publish_id or None."""
+    resp = await api.client.post(
+        api.bot_url(bot_uuid) + "/scale",
+        params=api.params(),
+        json={
+            "target_count": target_count,
+            "device_uuids": device_uuids,
+            "operator": "e2e-test",
+            "request_id": uuid.uuid4().hex,
+        },
+    )
+    assert resp.status_code == 200
+    return resp.json()["data"].get("publish_id")
+
+
+async def _get_bot_devices(api: APITestHelper, bot_uuid: str) -> list[dict]:
+    """Fetch bot devices via HTTP, return list of device dicts from the response."""
+    resp = await api.client.get(
+        api.bot_devices_url(bot_uuid), params=api.params()
+    )
+    assert resp.status_code == 200
+    devices_data = resp.json()["data"]
+    all_devices: list[dict] = []
+    for entry in devices_data:
+        all_devices.extend(entry.get("items", []))
+    return all_devices
+
+
+# ── Lifecycle test ────────────────────────────────────────────────────────────
+
+
+class TestScaleLifecycleWithDeviceUuids:
+    """Full lifecycle: create → scale up → scale down with device_uuids."""
+
+    @pytest.mark.asyncio
+    async def test_create_scale_up_scale_down_with_device_uuids_lifecycle(
+        self, api: APITestHelper, unique_id: str
+    ) -> None:
+        """Exercise full bot scaling lifecycle with explicit device_uuids on scale down.
+
+        Steps:
+        1. Create bot with 2 devices → verify 2 ACTIVE
+        2. Scale up to 4 devices (async hook callbacks) → verify 4 ACTIVE
+        3. Pick the 2 devices added during scale-up as destroy targets
+        4. Scale down with device_uuids=[new1, new2] → verify they are
+           DESTROYED, the original 2 remain ACTIVE, total ACTIVE == 2
+        5. Cleanup
+        """
+        # ── Step 1: Create a bot with 2 devices ──────────────────────────────
+        bot = await create_and_activate_bot(
+            api, f"lifecycle-duid-{unique_id}", device_count=2
+        )
+        bot_uuid = bot["bot_uuid"]
+
+        all_devices = await _get_bot_devices(api, bot_uuid)
+        active_devices = [d for d in all_devices if d.get("status") == "ACTIVE"]
+        assert len(active_devices) == 2, (
+            f"Expected 2 ACTIVE devices after create, got "
+            f"{len(active_devices)}: {active_devices}"
+        )
+
+        # Capture the 2 original device UUIDs (must survive scale down later)
+        original_device_uuids = {
+            d["device_uuid"] for d in active_devices
+        }
+
+        # ── Step 2: Scale up from 2 to 4 devices ─────────────────────────────
+        publish_id = await _scale_up_bot(api, bot_uuid, target_count=4)
+        assert publish_id is not None, "Scale up must return a publish_id"
+
+        code = await approve_publish(api, publish_id)
+        assert code == 200, f"Approve scale-up publish failed: {code}"
+
+        # SCALE_UP uses after_create_cmd_hook (async, callback-driven)
+        await send_callbacks_for_hook_devices(api, publish_id)
+
+        status = await wait_for_publish_status(
+            api, publish_id, {"SUCCESS"}, timeout_seconds=0.5
+        )
+        assert status == "SUCCESS", (
+            f"Expected scale-up publish SUCCESS, got {status}"
+        )
+
+        all_devices = await _get_bot_devices(api, bot_uuid)
+        active_devices = [d for d in all_devices if d.get("status") == "ACTIVE"]
+        assert len(active_devices) == 4, (
+            f"Expected 4 ACTIVE devices after scale up, got "
+            f"{len(active_devices)}: {active_devices}"
+        )
+
+        # ── Step 3: Identify the 2 devices added during scale-up ─────────────
+        scale_up_added_uuids = {
+            d["device_uuid"]
+            for d in active_devices
+            if d["device_uuid"] not in original_device_uuids
+        }
+        assert len(scale_up_added_uuids) == 2, (
+            f"Expected 2 newly added devices after scale up, got "
+            f"{len(scale_up_added_uuids)}: {scale_up_added_uuids} "
+            f"(original={original_device_uuids})"
+        )
+        device_uuids_to_destroy = sorted(scale_up_added_uuids)
+
+        # Sanity check: the surviving set must be the original two
+        surviving_uuids = {
+            d["device_uuid"]
+            for d in active_devices
+            if d["device_uuid"] in original_device_uuids
+        }
+        assert surviving_uuids == original_device_uuids, (
+            f"Original devices {original_device_uuids} should all still be "
+            f"ACTIVE before scale down, got {surviving_uuids}"
+        )
+
+        # ── Step 4: Scale down by explicit device_uuids ────────────────────────
+        publish_id = await _scale_down_bot_with_device_uuids(
+            api, bot_uuid, target_count=2, device_uuids=device_uuids_to_destroy
+        )
+        assert publish_id is not None, "Scale down must return a publish_id"
+
+        # SCALE_DOWN uses before_destroy_cmd_hook (synchronous, inline):
+        # no callback needed — the hook runs before PaaS destroy.
+        code = await approve_publish(api, publish_id)
+        assert code == 200, f"Approve scale-down publish failed: {code}"
+
+        status = await wait_for_publish_status(
+            api, publish_id, {"SUCCESS"}, timeout_seconds=0.5
+        )
+        assert status == "SUCCESS", (
+            f"Expected scale-down publish SUCCESS, got {status}"
+        )
+
+        # 4a. The two targeted devices must now be DESTROYED.
+        all_devices = await _get_bot_devices(api, bot_uuid)
+        destroyed_devices = [
+            d for d in all_devices if d.get("status") == "DESTROYED"
+        ]
+        destroyed_uuids = {d["device_uuid"] for d in destroyed_devices}
+        assert destroyed_uuids == set(device_uuids_to_destroy), (
+            f"Expected exactly {set(device_uuids_to_destroy)} to be DESTROYED, "
+            f"got {destroyed_uuids}"
+        )
+
+        # 4b. The two original devices must remain ACTIVE.
+        remaining_active = [
+            d for d in all_devices if d.get("status") == "ACTIVE"
+        ]
+        remaining_active_uuids = {d["device_uuid"] for d in remaining_active}
+        assert remaining_active_uuids == original_device_uuids, (
+            f"Expected original devices {original_device_uuids} to remain "
+            f"ACTIVE, got {remaining_active_uuids}"
+        )
+
+        # 4c. Total ACTIVE count must be exactly 2.
+        assert len(remaining_active) == 2, (
+            f"Expected exactly 2 ACTIVE devices after scale down, got "
+            f"{len(remaining_active)}: {remaining_active}"
+        )
+
+        # ── Step 5: Cleanup ──────────────────────────────────────────────────
+        await cleanup_bot(api, bot_uuid)

--- a/src/baas/tests/integration/core/service/test_bot_management_service.py
+++ b/src/baas/tests/integration/core/service/test_bot_management_service.py
@@ -1481,3 +1481,201 @@ class TestBotManagementServiceIntegration:
         assert stored_config.deploy_config is not None
         assert stored_config.deploy_config.docker_image == "scale-img:v2"
         assert stored_config.deploy_config.ttl_in_minutes == 120
+
+    @pytest.mark.asyncio
+    async def test_scale_bot_workflow_with_device_uuids(
+        self,
+        bot_repository,
+        device_repository,
+        shared_bot_setup,
+        created_bot_ids,
+        created_device_ids,
+        created_publish_ids,
+    ):
+        """Scale down with explicit device_uuids targets exactly those devices.
+
+        - Create a bot with 3 ACTIVE devices
+        - Scale down via device_uuids targeting the first 2 devices
+        - Assert: publish created, target_count = 1 (matches 3 - 2 = 1)
+        - Assert: publish record stores target_device_uuids = [uuid1, uuid2]
+        - Assert: uuid3 is NOT in target_device_uuids (it remains)
+        """
+        from secbaas.community.api.publish_manage import PublishConfig
+
+        # Create a fresh bot with 3 ACTIVE devices
+        bot_uuid = generate_uuid()
+        bot_id = bot_repository.insert_bot(
+            bot_uuid=bot_uuid,
+            tenant=FIXED_TENANT_NAME,
+            env=TEST_ENV,
+            domain="test_domain",
+            creator="test_user",
+            modifier="test_user",
+            status=BotStatus.ACTIVE.value,
+            name="Scale With Device UUIDs Bot",
+            description="Bot for scale down with device_uuids",
+            template_uuid=None,
+            replica_desired=3,
+            replica_minimum=1,
+            replica_maximum=10,
+            auto_scaling_enabled=0,
+            sla_grade="standard",
+            extra_config={},
+        )
+        created_bot_ids.append(bot_id)
+
+        rel_repo = get_container().repository.bot_device_rel_repository()
+
+        # Create 3 ACTIVE devices and track their UUIDs
+        device_uuids: list[str] = []
+        for _ in range(3):
+            d_uuid = generate_uuid()
+            d_id = device_repository.insert_device(
+                device_uuid=d_uuid,
+                tenant=FIXED_TENANT_NAME,
+                env=TEST_ENV,
+                domain="test_domain",
+                creator="test_user",
+                modifier="test_user",
+                status=DeviceStatus.ACTIVE.value,
+                provider_type="Sigma",
+                provider_device_id=None,
+                provider_device_props={},
+                extra_config={},
+            )
+            created_device_ids.append(d_id)
+            rel_repo.insert_rel(
+                bot_id=bot_id,
+                device_uuid=d_uuid,
+                tenant=FIXED_TENANT_NAME,
+                env=TEST_ENV,
+                domain="test_domain",
+                creator="test_user",
+                modifier="test_user",
+            )
+            device_uuids.append(d_uuid)
+
+        target_uuids = device_uuids[:2]
+        remaining_uuid = device_uuids[2]
+
+        with patch.object(
+            DefaultTenantManageService,
+            "get_tenant_by_name",
+            return_value=create_mock_tenant_response(),
+        ):
+            result = await _bms().scale_bot(
+                tenant=FIXED_TENANT_NAME,
+                bot_uuid=bot_uuid,
+                target_count=1,
+                device_uuids=target_uuids,
+                operator="test_user",
+                request_id=uuid4().hex,
+            )
+
+        # Publish must be created successfully
+        assert result is not None
+        assert result.publish_id is not None
+        # target_count = current_count - len(device_uuids) = 3 - 2 = 1
+        assert result.target_count == 1
+        assert result.bot_uuid == bot_uuid
+        created_publish_ids.append(result.publish_id)
+
+        # Read the publish record and verify target_device_uuids.
+        # The integration test does not execute the publish (matching the
+        # existing test_scale_bot_workflow pattern); asserting the publish
+        # record stores the right target_device_uuids proves the targeting
+        # reached the persistence layer.
+        publish_repo = get_container().repository.publish_repository()
+        publish = publish_repo.get_by_id(
+            result.publish_id, tenant=FIXED_TENANT_NAME, env=TEST_ENV
+        )
+        assert publish is not None
+        stored_config = PublishConfig.model_validate(publish.extra_config)
+        assert stored_config.target_device_uuids is not None
+        assert set(stored_config.target_device_uuids) == set(target_uuids)
+        # The device not in device_uuids must NOT be marked for destruction.
+        assert remaining_uuid not in stored_config.target_device_uuids
+
+    @pytest.mark.asyncio
+    async def test_scale_bot_with_device_uuids_validates_against_real_repo(
+        self,
+        bot_repository,
+        device_repository,
+        shared_bot_setup,
+        created_bot_ids,
+        created_device_ids,
+    ):
+        """Scale down with device_uuids referencing a foreign device raises ValueError.
+
+        - Create bot A with one ACTIVE device (uuid-a)
+        - Attempt to scale down bot A with device_uuids=["uuid-from-other-bot"]
+        - Assert: ValueError raised because device does not belong to bot A.
+
+        Uses the real DI container and SQLite-backed repositories so the
+        validation hits the real device/relationship lookup.
+        """
+        bot_uuid = generate_uuid()
+        bot_id = bot_repository.insert_bot(
+            bot_uuid=bot_uuid,
+            tenant=FIXED_TENANT_NAME,
+            env=TEST_ENV,
+            domain="test_domain",
+            creator="test_user",
+            modifier="test_user",
+            status=BotStatus.ACTIVE.value,
+            name="UUID Validation Bot",
+            description="Bot for device_uuids validation test",
+            template_uuid=None,
+            replica_desired=1,
+            replica_minimum=1,
+            replica_maximum=10,
+            auto_scaling_enabled=0,
+            sla_grade="standard",
+            extra_config={},
+        )
+        created_bot_ids.append(bot_id)
+
+        # Create one ACTIVE device owned by this bot
+        own_device_uuid = generate_uuid()
+        own_device_id = device_repository.insert_device(
+            device_uuid=own_device_uuid,
+            tenant=FIXED_TENANT_NAME,
+            env=TEST_ENV,
+            domain="test_domain",
+            creator="test_user",
+            modifier="test_user",
+            status=DeviceStatus.ACTIVE.value,
+            provider_type="Sigma",
+            provider_device_id=None,
+            provider_device_props={},
+            extra_config={},
+        )
+        created_device_ids.append(own_device_id)
+        rel_repo = get_container().repository.bot_device_rel_repository()
+        rel_repo.insert_rel(
+            bot_id=bot_id,
+            device_uuid=own_device_uuid,
+            tenant=FIXED_TENANT_NAME,
+            env=TEST_ENV,
+            domain="test_domain",
+            creator="test_user",
+            modifier="test_user",
+        )
+
+        # A device UUID that does not belong to this bot
+        foreign_device_uuid = generate_uuid()
+
+        with patch.object(
+            DefaultTenantManageService,
+            "get_tenant_by_name",
+            return_value=create_mock_tenant_response(),
+        ):
+            with pytest.raises(ValueError, match="not found or not belonging to bot"):
+                await _bms().scale_bot(
+                    tenant=FIXED_TENANT_NAME,
+                    bot_uuid=bot_uuid,
+                    target_count=1,
+                    device_uuids=[foreign_device_uuid],
+                    operator="test_user",
+                    request_id=uuid4().hex,
+                )

--- a/src/baas/tests/unit/adapters/web/test_bot_management_router.py
+++ b/src/baas/tests/unit/adapters/web/test_bot_management_router.py
@@ -1128,6 +1128,65 @@ async def test_scale_bot_with_device_uuids_unknown_bot_returns_404(mock_service)
     assert detail["error_code"] == "BOT_NOT_FOUND"
 
 
+@pytest.mark.asyncio
+async def test_scale_bot_with_empty_device_uuids_list_passes_empty(mock_service):
+    """POST /{bot_uuid}/scale with ``device_uuids: []`` is accepted by the
+    request model (no ``min_length`` constraint) and forwarded as-is to the
+    service, mirroring legacy count-based behavior."""
+    now = datetime.now(tz=UTC)
+    scale_resp = ScaleBotResponse(
+        id=1,
+        bot_uuid="BOT-001",
+        tenant="test_tenant",
+        env="dev",
+        domain="default",
+        is_deleted=0,
+        creator="user1",
+        modifier="op",
+        status="ACTIVE",
+        name="test-bot",
+        description=None,
+        template_uuid="TMPL-001",
+        replica_desired=3,
+        replica_minimum=1,
+        replica_maximum=10,
+        auto_scaling_enabled=0,
+        sla_grade="standard",
+        gmt_create=now,
+        gmt_modified=now,
+        config=None,
+        devices=[],
+        target_count=2,
+        publish_id=405,
+        request_id="a" * 32,
+    )
+    mock_service.scale_bot.return_value = scale_resp
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/api/v1/bots/BOT-001/scale?tenant=test_tenant",
+            json={
+                "operator": "op",
+                "request_id": "a" * 32,
+                "target_count": 2,
+                "device_uuids": [],
+            },
+        )
+
+    assert resp.status_code == 200
+    mock_service.scale_bot.assert_awaited_once_with(
+        tenant="test_tenant",
+        bot_uuid="BOT-001",
+        target_count=2,
+        operator="op",
+        request_id="a" * 32,
+        auto_approve_publish=False,
+        bot_config=None,
+        device_uuids=[],
+    )
+
+
 # ==================== POST /{bot_uuid}/restart — restart_bot ====================
 
 
@@ -1817,6 +1876,19 @@ class TestScaleBotRequest:
         assert req.target_count == 1
         assert req.operator == "op"
         assert req.device_uuids == ["uuid-1"]
+
+    def test_empty_device_uuids_list_accepted(self):
+        from secbaas.community.adapters.web.routers.bot_service.management_router import (
+            ScaleBotRequest,
+        )
+
+        req = ScaleBotRequest(
+            target_count=1,
+            operator="op",
+            request_id="a" * 32,
+            device_uuids=[],
+        )
+        assert req.device_uuids == []
 
 
 class TestRestartBotRequest:

--- a/src/baas/tests/unit/adapters/web/test_bot_management_router.py
+++ b/src/baas/tests/unit/adapters/web/test_bot_management_router.py
@@ -906,6 +906,7 @@ async def test_scale_bot_success(mock_service):
         request_id="a" * 32,
         auto_approve_publish=False,
         bot_config=None,
+        device_uuids=None,
     )
 
 
@@ -965,6 +966,7 @@ async def test_scale_bot_with_auto_approve(mock_service):
         request_id="a" * 32,
         auto_approve_publish=True,
         bot_config=None,
+        device_uuids=None,
     )
 
 
@@ -1016,7 +1018,114 @@ async def test_scale_bot_scale_down(mock_service):
         request_id="a" * 32,
         auto_approve_publish=False,
         bot_config=None,
+        device_uuids=None,
     )
+
+
+@pytest.mark.asyncio
+async def test_scale_bot_with_device_uuids_success(mock_service):
+    """POST /{bot_uuid}/scale with device_uuids targets specific devices and returns 200."""
+    now = datetime.now(tz=UTC)
+    scale_resp = ScaleBotResponse(
+        id=1,
+        bot_uuid="BOT-001",
+        tenant="test_tenant",
+        env="dev",
+        domain="default",
+        is_deleted=0,
+        creator="user1",
+        modifier="op",
+        status="ACTIVE",
+        name="test-bot",
+        description=None,
+        template_uuid="TMPL-001",
+        replica_desired=3,
+        replica_minimum=1,
+        replica_maximum=10,
+        auto_scaling_enabled=0,
+        sla_grade="standard",
+        gmt_create=now,
+        gmt_modified=now,
+        config=None,
+        devices=[],
+        target_count=1,
+        publish_id=404,
+        request_id="a" * 32,
+    )
+    mock_service.scale_bot.return_value = scale_resp
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/api/v1/bots/BOT-001/scale?tenant=test_tenant",
+            json={
+                "operator": "op",
+                "request_id": "a" * 32,
+                "target_count": 1,
+                "device_uuids": ["uuid-2", "uuid-3"],
+            },
+        )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["data"]["publish_id"] == 404
+    assert data["data"]["target_count"] == 1
+    mock_service.scale_bot.assert_awaited_once_with(
+        tenant="test_tenant",
+        bot_uuid="BOT-001",
+        target_count=1,
+        operator="op",
+        request_id="a" * 32,
+        auto_approve_publish=False,
+        bot_config=None,
+        device_uuids=["uuid-2", "uuid-3"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_scale_bot_with_device_uuids_unknown_returns_400(mock_service):
+    """POST /{bot_uuid}/scale with unknown device_uuids surfaces ValueError as 400 INVALID_REQUEST."""
+    mock_service.scale_bot.side_effect = ValueError(
+        "Device(s) not found or not belonging to bot BOT-001: ['unknown-uuid']"
+    )
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/api/v1/bots/BOT-001/scale?tenant=test_tenant",
+            json={
+                "operator": "op",
+                "request_id": "a" * 32,
+                "target_count": 2,
+                "device_uuids": ["unknown-uuid"],
+            },
+        )
+
+    assert resp.status_code == 400
+    detail = resp.json()["detail"]
+    assert detail["error_code"] == "INVALID_REQUEST"
+
+
+@pytest.mark.asyncio
+async def test_scale_bot_with_device_uuids_unknown_bot_returns_404(mock_service):
+    """POST /{bot_uuid}/scale with unknown bot_uuid surfaces BotNotFoundError as 404 BOT_NOT_FOUND."""
+    mock_service.scale_bot.side_effect = BotNotFoundError("BOT-MISSING")
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/api/v1/bots/BOT-MISSING/scale?tenant=test_tenant",
+            json={
+                "operator": "op",
+                "request_id": "a" * 32,
+                "target_count": 2,
+                "device_uuids": ["uuid-1"],
+            },
+        )
+
+    assert resp.status_code == 404
+    detail = resp.json()["detail"]
+    assert detail["error_code"] == "BOT_NOT_FOUND"
 
 
 # ==================== POST /{bot_uuid}/restart — restart_bot ====================
@@ -1693,6 +1802,21 @@ class TestScaleBotRequest:
         req = ScaleBotRequest(target_count=5, operator="op", request_id="a" * 32)
         assert req.target_count == 5
         assert req.operator == "op"
+
+    def test_valid_request_with_device_uuids(self):
+        from secbaas.community.adapters.web.routers.bot_service.management_router import (
+            ScaleBotRequest,
+        )
+
+        req = ScaleBotRequest(
+            target_count=1,
+            operator="op",
+            request_id="a" * 32,
+            device_uuids=["uuid-1"],
+        )
+        assert req.target_count == 1
+        assert req.operator == "op"
+        assert req.device_uuids == ["uuid-1"]
 
 
 class TestRestartBotRequest:

--- a/src/baas/tests/unit/core/service/bot_manage/test_bot_management_service.py
+++ b/src/baas/tests/unit/core/service/bot_manage/test_bot_management_service.py
@@ -16,7 +16,7 @@ from secbaas.community.api.bot_manage import (
     UpdateDevicesResponse,
 )
 from secbaas.community.api.bot_runtime import BotNotFoundError
-from secbaas.community.api.device_manage import DeployConfig
+from secbaas.community.api.device_manage import DeployConfig, DeviceStatus
 from secbaas.community.api.device_manage._models import ResourceSpecification
 from secbaas.community.api.publish_manage import (
     DEFAULT_CALLBACK_TIMEOUT_SECONDS,
@@ -2443,6 +2443,294 @@ class TestScaleBotDown:
             call_kwargs = mock_publish_service.create_publish.call_args.kwargs
             assert call_kwargs["publish_type"] == PublishType.SCALE_DOWN
             assert call_kwargs["config"].replica_desired == 1
+
+
+class TestScaleBotWithDeviceUuids:
+    """Tests for scale_bot when ``device_uuids`` is supplied.
+
+    Mirrors ``TestScaleBotDown`` for the targeted SCALE_DOWN path: the
+    service must validate the supplied UUIDs against the bot's active device
+    map, derive (or cross-check) target_count, and forward the deduped
+    UUID list to the publish via ``PublishConfig.target_device_uuids``.
+    """
+
+    def _make_bot_response(self) -> MagicMock:
+        """Build a 3-device ACTIVE bot (id=1, BOT-001, replica_desired=3)."""
+        mock_bot = MagicMock()
+        mock_bot.id = 1
+        mock_bot.bot_uuid = "BOT-001"
+        mock_bot.status = BotStatus.ACTIVE.value
+        mock_bot.model_dump = MagicMock(
+            return_value={
+                "id": 1,
+                "bot_uuid": "BOT-001",
+                "tenant": "test_tenant",
+                "env": "dev",
+                "domain": "default",
+                "is_deleted": 0,
+                "creator": "user1",
+                "modifier": "user1",
+                "status": BotStatus.ACTIVE.value,
+                "name": "Test Bot",
+                "description": None,
+                "template_uuid": None,
+                "replica_desired": 3,
+                "replica_minimum": 1,
+                "replica_maximum": 10,
+                "auto_scaling_enabled": 0,
+                "sla_grade": "standard",
+                "gmt_create": "2024-01-01T00:00:00",
+                "gmt_modified": "2024-01-01T00:00:00",
+                "config": None,
+            }
+        )
+        return mock_bot
+
+    def _make_device(self, device_uuid: str, status: str | None = None) -> MagicMock:
+        """Build a single mock device record with the given device_uuid and status."""
+        d = MagicMock()
+        d.device_uuid = device_uuid
+        d.status = status if status is not None else DeviceStatus.ACTIVE.value
+        d.provider_device_id = f"sandbox-{device_uuid}@0"
+        d.provider_type = "ARCA"
+        d.gmt_create = "2024-01-01T00:00:00"
+        return d
+
+    def _make_service(
+        self, devices: list[MagicMock] | None = None
+    ) -> tuple[
+        "BotManagementService",
+        MagicMock,
+        MagicMock,
+        list[MagicMock],
+    ]:
+        """Wire a service with a 3-ACTIVE-device bot by default.
+
+        Returns ``(service, mock_publish_service, mock_device_repo, devices)``
+        so individual tests can drive further assertions on any of them.
+        """
+        if devices is None:
+            devices = [
+                self._make_device("uuid-1"),
+                self._make_device("uuid-2"),
+                self._make_device("uuid-3"),
+            ]
+        mock_device_repo = MagicMock()
+        mock_device_repo.list_by_bot_id.return_value = devices
+
+        mock_publish = MagicMock()
+        mock_publish.id = 555
+
+        mock_publish_service = MagicMock()
+        mock_publish_service.create_publish = AsyncMock(return_value=mock_publish)
+
+        service = _make_service(
+            device_repo=mock_device_repo,
+            publish_service=mock_publish_service,
+        )
+        return service, mock_publish_service, mock_device_repo, devices
+
+    @pytest.mark.asyncio
+    async def test_scale_down_with_device_uuids_success(self):
+        """device_uuids + consistent target_count creates a SCALE_DOWN publish
+        with target_device_uuids populated and replica_desired derived."""
+        service, mock_publish_service, _, _ = self._make_service()
+
+        with patch.object(
+            service,
+            "get_bot",
+            new_callable=AsyncMock,
+            return_value=self._make_bot_response(),
+        ):
+            result = await service.scale_bot(
+                tenant="test_tenant",
+                bot_uuid="BOT-001",
+                operator="user1",
+                request_id="test-request-id-12345678901234567890",
+                target_count=1,
+                device_uuids=["uuid-2", "uuid-3"],
+            )
+
+            assert result.publish_id == 555
+            assert result.target_count == 1
+            call_kwargs = mock_publish_service.create_publish.call_args.kwargs
+            assert call_kwargs["publish_type"] == PublishType.SCALE_DOWN
+            assert call_kwargs["config"].replica_desired == 1
+            assert call_kwargs["config"].target_device_uuids == ["uuid-2", "uuid-3"]
+
+    @pytest.mark.asyncio
+    async def test_scale_down_with_device_uuids_count_mismatch(self):
+        """When target_count != current_count - len(device_uuids), ValueError."""
+        service, _, _, _ = self._make_service()
+
+        with patch.object(
+            service,
+            "get_bot",
+            new_callable=AsyncMock,
+            return_value=self._make_bot_response(),
+        ):
+            with pytest.raises(
+                ValueError,
+                match="target_count .* does not match current_count - len\\(device_uuids\\)",
+            ):
+                await service.scale_bot(
+                    tenant="test_tenant",
+                    bot_uuid="BOT-001",
+                    operator="user1",
+                    request_id="test-request-id-12345678901234567890",
+                    target_count=3,  # current(3) - len(2) = 1, not 3
+                    device_uuids=["uuid-2", "uuid-3"],
+                )
+
+    @pytest.mark.asyncio
+    async def test_scale_down_with_device_uuids_unknown_uuid(self):
+        """A device UUID absent from the bot's device map raises ValueError."""
+        service, _, _, _ = self._make_service()
+
+        with patch.object(
+            service,
+            "get_bot",
+            new_callable=AsyncMock,
+            return_value=self._make_bot_response(),
+        ):
+            with pytest.raises(
+                ValueError,
+                match="not found or not belonging to bot",
+            ):
+                await service.scale_bot(
+                    tenant="test_tenant",
+                    bot_uuid="BOT-001",
+                    operator="user1",
+                    request_id="test-request-id-12345678901234567890",
+                    target_count=2,
+                    device_uuids=["unknown-uuid", "uuid-2"],
+                )
+
+    @pytest.mark.asyncio
+    async def test_scale_down_with_device_uuids_non_active(self):
+        """A device UUID whose device status is not ACTIVE raises ValueError."""
+        devices = [
+            self._make_device("uuid-1"),
+            self._make_device("uuid-2", status=DeviceStatus.FAILED.value),
+            self._make_device("uuid-3"),
+        ]
+        service, _, _, _ = self._make_service(devices=devices)
+
+        with patch.object(
+            service,
+            "get_bot",
+            new_callable=AsyncMock,
+            return_value=self._make_bot_response(),
+        ):
+            with pytest.raises(ValueError, match="not ACTIVE, cannot scale down"):
+                await service.scale_bot(
+                    tenant="test_tenant",
+                    bot_uuid="BOT-001",
+                    operator="user1",
+                    request_id="test-request-id-12345678901234567890",
+                    target_count=2,
+                    device_uuids=["uuid-2"],
+                )
+
+    @pytest.mark.asyncio
+    async def test_scale_down_with_device_uuids_belongs_to_other_bot(self):
+        """A device UUID belonging to another bot is not in this bot's device map,
+        so it is reported as unknown (the device_repo only returns this bot's devices)."""
+        service, _, _, _ = self._make_service()
+
+        with patch.object(
+            service,
+            "get_bot",
+            new_callable=AsyncMock,
+            return_value=self._make_bot_response(),
+        ):
+            with pytest.raises(
+                ValueError,
+                match="not found or not belonging to bot",
+            ):
+                await service.scale_bot(
+                    tenant="test_tenant",
+                    bot_uuid="BOT-001",
+                    operator="user1",
+                    request_id="test-request-id-12345678901234567890",
+                    target_count=2,
+                    device_uuids=["other-bot-uuid-1"],
+                )
+
+    @pytest.mark.asyncio
+    async def test_scale_down_with_device_uuids_duplicate_deduped(self):
+        """Duplicate device UUIDs are deduped (order preserved) before being
+        forwarded in target_device_uuids and used for consistency check."""
+        service, mock_publish_service, _, _ = self._make_service()
+
+        with patch.object(
+            service,
+            "get_bot",
+            new_callable=AsyncMock,
+            return_value=self._make_bot_response(),
+        ):
+            await service.scale_bot(
+                tenant="test_tenant",
+                bot_uuid="BOT-001",
+                operator="user1",
+                request_id="test-request-id-12345678901234567890",
+                target_count=1,  # 3 - len(deduped=2) = 1
+                device_uuids=["uuid-2", "uuid-2", "uuid-3"],
+            )
+
+            call_kwargs = mock_publish_service.create_publish.call_args.kwargs
+            assert call_kwargs["publish_type"] == PublishType.SCALE_DOWN
+            assert call_kwargs["config"].target_device_uuids == ["uuid-2", "uuid-3"]
+            assert call_kwargs["config"].replica_desired == 1  # 3 - 2
+
+    @pytest.mark.asyncio
+    async def test_scale_down_with_device_uuids_scale_up_rejected(self):
+        """Combining device_uuids with an explicit target_count above current_count
+        is rejected (device_uuids are exclusively a SCALE_DOWN mechanism)."""
+        service, _, _, _ = self._make_service()
+
+        with patch.object(
+            service,
+            "get_bot",
+            new_callable=AsyncMock,
+            return_value=self._make_bot_response(),
+        ):
+            with pytest.raises(ValueError):
+                await service.scale_bot(
+                    tenant="test_tenant",
+                    bot_uuid="BOT-001",
+                    operator="user1",
+                    request_id="test-request-id-12345678901234567890",
+                    target_count=5,  # > current_count(3)
+                    device_uuids=["uuid-1"],
+                )
+
+    @pytest.mark.asyncio
+    async def test_scale_down_without_device_uuids_backward_compatible(self):
+        """Omitting device_uuids preserves the legacy path: target_device_uuids
+        on the publish config is None."""
+        service, mock_publish_service, _, _ = self._make_service()
+
+        with patch.object(
+            service,
+            "get_bot",
+            new_callable=AsyncMock,
+            return_value=self._make_bot_response(),
+        ):
+            result = await service.scale_bot(
+                tenant="test_tenant",
+                bot_uuid="BOT-001",
+                operator="user1",
+                request_id="test-request-id-12345678901234567890",
+                target_count=1,  # Scale from 3 to 1
+            )
+
+            assert result.publish_id == 555
+            assert result.target_count == 1
+            call_kwargs = mock_publish_service.create_publish.call_args.kwargs
+            assert call_kwargs["publish_type"] == PublishType.SCALE_DOWN
+            assert call_kwargs["config"].replica_desired == 1
+            assert call_kwargs["config"].target_device_uuids is None
 
 
 class TestListBotsStatusFilter:

--- a/src/baas/tests/unit/core/service/bot_manage/test_bot_management_service.py
+++ b/src/baas/tests/unit/core/service/bot_manage/test_bot_management_service.py
@@ -2732,6 +2732,34 @@ class TestScaleBotWithDeviceUuids:
             assert call_kwargs["config"].replica_desired == 1
             assert call_kwargs["config"].target_device_uuids is None
 
+    async def test_scale_down_with_empty_device_uuids_list_behaves_like_none(self):
+        """An empty ``device_uuids`` list is treated the same as ``None``:
+        no targeted destruction — the publish config's
+        ``target_device_uuids`` is ``None``."""
+        service, mock_publish_service, _, _ = self._make_service()
+
+        with patch.object(
+            service,
+            "get_bot",
+            new_callable=AsyncMock,
+            return_value=self._make_bot_response(),
+        ):
+            result = await service.scale_bot(
+                tenant="test_tenant",
+                bot_uuid="BOT-001",
+                operator="user1",
+                request_id="test-request-id-12345678901234567890",
+                target_count=1,  # Scale from 3 to 1
+                device_uuids=[],
+            )
+
+            assert result.publish_id == 555
+            assert result.target_count == 1
+            call_kwargs = mock_publish_service.create_publish.call_args.kwargs
+            assert call_kwargs["publish_type"] == PublishType.SCALE_DOWN
+            assert call_kwargs["config"].replica_desired == 1
+            assert call_kwargs["config"].target_device_uuids is None
+
 
 class TestListBotsStatusFilter:
     """Tests for BotManagementService.list_bots with status filter"""

--- a/src/baas/tests/unit/core/service/publish_manage/test_publish_service_coverage.py
+++ b/src/baas/tests/unit/core/service/publish_manage/test_publish_service_coverage.py
@@ -1117,6 +1117,143 @@ class TestCreateDeviceRecordsForPublish:
         call_kwargs = svc._publish_record_repo.insert_record.call_args.kwargs
         assert call_kwargs["extra_config"] is None
 
+    def test_scale_down_with_target_device_uuids_filters_eligible(self):
+        """SCALE_DOWN with target_device_uuids filters ACTIVE devices to the requested set."""
+        svc = _make_service()
+        bot = _make_bot_record()
+        svc._device_repo.list_by_bot_id.return_value = [
+            _make_device(id=1, device_uuid="uuid-a", status="ACTIVE"),
+            _make_device(id=2, device_uuid="uuid-b", status="ACTIVE"),
+            _make_device(id=3, device_uuid="uuid-c", status="ACTIVE"),  # filtered out
+        ]
+        # target_device_uuids live on the persisted publish record's extra_config.
+        pub = _make_publish_record(
+            extra_config={"target_device_uuids": ["uuid-a", "uuid-b"]}
+        )
+        svc._publish_repo.get_by_id.return_value = pub
+        batch = _make_batch_record(batch_capacity=2)
+
+        with patch(
+            "secbaas.community.core.service.publish_manage._publish_service.get_current_env",
+            return_value="test",
+        ):
+            svc._create_device_records_for_publish(
+                tenant="t",
+                env="test",
+                publish_id=1,
+                publish_type=PublishType.SCALE_DOWN,
+                bot_record=bot,
+                batch_records=[batch],
+                operator="op",
+            )
+
+        assert svc._publish_record_repo.insert_record.call_count == 2
+        inserted_device_ids = [
+            call.kwargs["device_id"]
+            for call in svc._publish_record_repo.insert_record.call_args_list
+        ]
+        assert sorted(inserted_device_ids) == [1, 2]
+        assert 3 not in inserted_device_ids
+
+    def test_scale_down_with_target_device_uuids_missing_uuid_raises(self):
+        """SCALE_DOWN raises ValueError when a requested UUID is not ACTIVE/owned."""
+        svc = _make_service()
+        bot = _make_bot_record()
+        svc._device_repo.list_by_bot_id.return_value = [
+            _make_device(id=1, device_uuid="uuid-a", status="ACTIVE"),
+            _make_device(id=2, device_uuid="uuid-b", status="ACTIVE"),
+        ]
+        pub = _make_publish_record(
+            extra_config={"target_device_uuids": ["uuid-a", "nonexistent"]}
+        )
+        svc._publish_repo.get_by_id.return_value = pub
+        batch = _make_batch_record(batch_capacity=2)
+
+        with patch(
+            "secbaas.community.core.service.publish_manage._publish_service.get_current_env",
+            return_value="test",
+        ):
+            with pytest.raises(ValueError, match="nonexistent"):
+                svc._create_device_records_for_publish(
+                    tenant="t",
+                    env="test",
+                    publish_id=1,
+                    publish_type=PublishType.SCALE_DOWN,
+                    bot_record=bot,
+                    batch_records=[batch],
+                    operator="op",
+                )
+
+    def test_scale_down_with_target_device_uuids_count_mismatch_raises(self):
+        """SCALE_DOWN raises ValueError when target count != batch capacity (scale_amount)."""
+        svc = _make_service()
+        bot = _make_bot_record()
+        svc._device_repo.list_by_bot_id.return_value = [
+            _make_device(id=1, device_uuid="uuid-a", status="ACTIVE"),
+            _make_device(id=2, device_uuid="uuid-b", status="ACTIVE"),
+            _make_device(id=3, device_uuid="uuid-c", status="ACTIVE"),
+        ]
+        # scale_amount = batch_capacity = 2, but target_uuids has 3 entries.
+        pub = _make_publish_record(
+            extra_config={"target_device_uuids": ["uuid-a", "uuid-b", "uuid-c"]}
+        )
+        svc._publish_repo.get_by_id.return_value = pub
+        batch = _make_batch_record(batch_capacity=2)
+
+        with patch(
+            "secbaas.community.core.service.publish_manage._publish_service.get_current_env",
+            return_value="test",
+        ):
+            with pytest.raises(ValueError, match="scale_amount"):
+                svc._create_device_records_for_publish(
+                    tenant="t",
+                    env="test",
+                    publish_id=1,
+                    publish_type=PublishType.SCALE_DOWN,
+                    bot_record=bot,
+                    batch_records=[batch],
+                    operator="op",
+                )
+
+    def test_scale_down_without_target_device_uuids_oldest_active_behavior(self):
+        """SCALE_DOWN without target_device_uuids preserves oldest-ACTIVE selection (by id)."""
+        svc = _make_service()
+        bot = _make_bot_record()
+        # Devices deliberately out of id order to verify sort-by-id before slicing.
+        svc._device_repo.list_by_bot_id.return_value = [
+            _make_device(id=3, device_uuid="uuid-c", status="ACTIVE"),
+            _make_device(id=1, device_uuid="uuid-a", status="ACTIVE"),
+            _make_device(id=2, device_uuid="uuid-b", status="ACTIVE"),
+        ]
+        # No target_device_uuids on persisted record → old behavior (None becomes {}).
+        pub = _make_publish_record(extra_config=None)
+        svc._publish_repo.get_by_id.return_value = pub
+        # Oldest 2 ACTIVE devices by id should be selected (ids 1 and 2).
+        batch = _make_batch_record(batch_capacity=2)
+
+        with patch(
+            "secbaas.community.core.service.publish_manage._publish_service.get_current_env",
+            return_value="test",
+        ):
+            svc._create_device_records_for_publish(
+                tenant="t",
+                env="test",
+                publish_id=1,
+                publish_type=PublishType.SCALE_DOWN,
+                bot_record=bot,
+                batch_records=[batch],
+                operator="op",
+            )
+
+        assert svc._publish_record_repo.insert_record.call_count == 2
+        inserted_device_ids = [
+            call.kwargs["device_id"]
+            for call in svc._publish_record_repo.insert_record.call_args_list
+        ]
+        # Oldest ACTIVE devices (ids 1, 2) selected over id=3.
+        assert sorted(inserted_device_ids) == [1, 2]
+        assert 3 not in inserted_device_ids
+
 
 # ====================================================================
 # _get_current_stage / _get_pending_batches / _check_all_batches_complete


### PR DESCRIPTION
## Problem

The BaaS `scale_bot` SCALE_DOWN operation only supports count-based scaling: the caller provides `target_count` and the publish service destroys the N oldest ACTIVE devices. Operators have no way to specify **which** devices to destroy.

This creates problems in production:

- **Device-affinity workloads**: certain devices hold stateful sessions or warm caches that should be preserved. Count-based destruction may pick exactly the devices an operator wanted to keep.
- **Draining specific hosts**: when a specific sandbox host is degraded or scheduled for maintenance, operators need to destroy only the devices on that host — not arbitrary oldest devices.
- **Debugging specific devices**: when a device shows anomalous behavior, the cleanest remediation is to destroy and recreate that specific device, not a random subset.
- **Planned migrations**: when moving devices from one pool to another, operators need to remove specific devices by UUID, not by age.

## Solution

Add an optional `device_uuids: list[str] | None` parameter to `scale_bot` (protocol, service, router, `ScaleBotRequest`). When supplied:

1. The service validates each UUID belongs to the bot and is `ACTIVE` (mirroring the `update_devices` validation pattern).
2. The service validates `target_count == current_count - len(unique_device_uuids)` — `target_count` stays **required** so the type contract stays tight (`int`, not `int | None`).
3. The publish service re-validates against the persisted publish record (defense-in-depth).
4. `device_uuids` is rejected on SCALE_UP (`target_count >= current_count`) — it is exclusively a SCALE_DOWN mechanism.

When `device_uuids` is omitted, behavior is unchanged: oldest ACTIVE devices are destroyed.

**Rejected alternative — make `target_count` optional when `device_uuids` is supplied** (derivable as `current_count - len(device_uuids)`). Reverted because:

- It widens the type contract to `int | None` for no real caller benefit.
- Every existing caller already provides `target_count`.
- The cross-check catches stale-count bugs in callers that fetched device UUIDs from a slightly stale view of the bot.

Reuses the existing `PublishConfig.target_device_uuids` field (already used by `UPDATE_DEVICE`), so no DB migration and no new publish type.

## Validation

- 10 service unit tests, 4 router unit tests, 4 publish service unit tests
- 2 integration tests (real SQLite-backed repo)
- 2 E2E tests for device_uuids scale-down + 1 full lifecycle E2E test (create -> scale up -> scale down with device_uuids -> verify)
- mypy: 0 new errors (20 pre-existing `BaseRequest has type Any` errors unchanged)
- basedpyright: 8 noise errors matching pre-existing pattern
- ruff: all checks passed
- Changed-line coverage: 97.4% on service (3 uncovered lines are dead defensive raises), 100% on publish service / router / protocols / models
- All 8704 unit tests pass (`not integration and not e2e and not baseline`)
- Pre-push gate passed (lint-only mode; heavier gates will run on CI)

What I could not run: the unified singlebox coverage and BCS E2E (not applicable — change is BaaS-only). CI will run those gates where relevant.

## Compatibility and risk

- **Backward compatible**. `device_uuids` is optional; existing callers that pass only `target_count` see no behavior change.
- **No schema migration**, no new publish type. Reuses `PublishConfig.target_device_uuids` already used by `UPDATE_DEVICE`.
- **Type contract**: `target_count` stays required `int` — no widening, no narrowing branch needed.
- **Rollback**: revert the PR. No persisted state, no migration. The `target_device_uuids` field on `PublishConfig` predates this change and remains used by `UPDATE_DEVICE`, so reverting only the SCALE_DOWN consumption is safe.

## Spec

OpenSpec change: `openspec/changes/scale-down-with-device-list/` — proposal, design (D-02 reversed), specs (`bot-scaling` delta), tasks (48/48 done).

## Related issues

- #2034 — records the problem, the solution rationale, and why `target_count` stays required.