### PR TITLE
fix(backend): reject platform default MCPs in ordinary skill sets

### DIFF
--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/mcp_skill_set_control_plane.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/mcp_skill_set_control_plane.py
@@ -19,6 +19,7 @@ from agentclaw.community.core.repository.capability_desired_state_types import (
 from agentclaw.community.core.skill_center.policies.capability_ownership import (
     require_direct_mcp_control_allowed,
     require_can_join_set,
+    require_non_platform_mcp,
 )
 from agentclaw.community.utils.avernet_tenant import get_current_avernet_tenant
 from agentclaw.community.utils.env_utils import get_current_env
@@ -66,6 +67,7 @@ class McpSkillSetControlPlaneCommands:
 
     def add_mcp(
         self, *, bot_id: str, owner_id: str, set_id: str, server_code: str,
+        platform_default_codes: frozenset[str],
         name: str, description: str | None, icon: str | None,
         engine_type: str | None = None,
         default_engine_types: tuple[str, ...] | None = None,
@@ -73,6 +75,9 @@ class McpSkillSetControlPlaneCommands:
         with self._db.transactional_orm_session() as session:
             row = self._set(session, bot_id=bot_id, owner_id=owner_id, set_id=set_id, engine_type=engine_type, default_engine_types=default_engine_types, locked=True)
             self._ordinary(row)
+            require_non_platform_mcp(
+                server_code=server_code, platform_default_codes=platform_default_codes
+            )
             old = self._snapshot(session, bot_id, owner_id, engine_type=engine_type)
             current = (
                 self._scope(session.query(SkillSetMCPServer), SkillSetMCPServer)

--- a/src/backend/src/agentclaw/community/core/repository/protocols/capability_desired_state.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/capability_desired_state.py
@@ -174,12 +174,20 @@ class CapabilityDesiredStateRepositoryProtocol(Protocol):
         owner_id: str,
         set_id: str,
         server_code: str,
+        platform_default_codes: frozenset[str],
         name: str,
         description: str | None,
         icon: str | None,
         engine_type: str | None = None,
         default_engine_types: tuple[str, ...] | None = None,
-    ) -> DesiredStateMutation: ...
+    ) -> DesiredStateMutation:
+        """Add an ordinary member; reject caller-resolved platform defaults.
+
+        Policy codes include excluded defaults. Resolve with the target Bot's
+        engine/template/ext-info before entering this UoW; lookup errors must
+        propagate rather than being replaced with an empty set.
+        """
+        ...
     @abstractmethod
     def remove_mcp(
         self,

--- a/src/backend/src/agentclaw/community/core/skill_center/AGENTS.md
+++ b/src/backend/src/agentclaw/community/core/skill_center/AGENTS.md
@@ -75,6 +75,7 @@ Bot 定位必须携带 `owner_id + bot_id`，并保持 Repository 的 tenant/env
 - `policies/capability_ownership.py` 统一判定：Set 成员（含 inactive Set 和 excluded Default member）由 Set 控制；Direct-active 能力加入 Set 前先停用；同一 Bot 下只能属于一个 reaching Set（含 Default）。`RESOURCE_DIRECT_ACTIVE` 优先于另一个 Set 冲突。
 - Default member 被 exclusion 后仍属于 Default；重新启用走 un-exclude。Default 选择统一使用 `policies/default_skill_set_selection.py`，保留全局 Default 与 engine/template 兼容规则。
 - Engine/template 的代码型 Default MCP 是显式例外：`policies/platform_default_mcp.py` 管理政策事实，不能将它误认为都存在于 `ac_skill_set_mcp`。有效 MCP 还需合并政策默认项（应用 exclusion）及 active Skill dependencies；沿用 `collect_bot_active_mcps` 的统一入口。Platform Default MCP 拒绝 Direct control。
+- 普通技能集添加 MCP 同样必须拒绝目标 Bot 的代码型 Default MCP（按 `server_code`、engine/template/ext-info 判断，不减 exclusion）。Service 严格解析默认 codes，UoW 在写入前重检；返回 `RESOURCE_MANAGED_BY_PLATFORM_POLICY`。此校验不物化 Policy、不清理历史数据；默认集 un-exclude 及普通集移除历史重复成员仍可用。
 
 `services/_mutation_flow.py::MutationProjectionFlow` 先提交 DB，再尽力投影；Runtime 不可达、PENDING、DEGRADED 不补偿回滚已提交的 Installation。DB/权限/领域校验失败仍返回失败。响应中的 `runtime_projection` 由 `runtime_projection_contract.py` 定义，不能把接口成功解释成全部设备文件已收敛。
 

--- a/src/backend/src/agentclaw/community/core/skill_center/policies/capability_ownership.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/policies/capability_ownership.py
@@ -140,4 +140,5 @@ __all__ = [
     "is_set_managed",
     "require_can_join_set",
     "require_direct_mcp_control_allowed",
+    "require_non_platform_mcp",
 ]

--- a/src/backend/src/agentclaw/community/core/skill_center/policies/capability_ownership.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/policies/capability_ownership.py
@@ -80,6 +80,17 @@ def require_direct_mcp_control_allowed(
     membership walk cannot see them. They remain policy-managed even after a
     Bot excludes them; exclusion/un-exclusion is their only control surface.
     """
+    require_non_platform_mcp(server_code=server_code, platform_default_codes=platform_default_codes)
+
+
+def require_non_platform_mcp(
+    *, server_code: str, platform_default_codes: frozenset[str]
+) -> None:
+    """Policy-owned MCPs cannot be Direct or ordinary-Set controlled.
+
+    Pass the complete applicable engine/template policy, before exclusions:
+    excluding a default changes activation, not ownership.
+    """
     if server_code in platform_default_codes:
         raise SkillSetControlPlaneConflictError(
             "RESOURCE_MANAGED_BY_PLATFORM_POLICY"

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_management_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_management_service.py
@@ -24,10 +24,12 @@ from agentclaw.community.core.skill_center.errors import (
     SkillSetControlPlaneNotFoundError,
     SkillSetAccessDeniedError,
 )
-from agentclaw.community.core.mcp.services._defaults import (
-    get_default_mcp_server_codes,
+from agentclaw.community.core.skill_center.policies.capability_ownership import (
+    require_non_platform_mcp,
 )
-from agentclaw.community.core.skill_center.policies.capability_ownership import require_non_platform_mcp
+from agentclaw.community.core.skill_center.policies.platform_default_mcp import (
+    PlatformDefaultMcpPolicy,
+)
 from agentclaw.community.plugin_api.mcp_auth import MCPAuthPlugin
 from agentclaw.community.plugin_api.mcp_center import MCPCenterPlugin
 from agentclaw.community.core.skill_center.legacy_skill_set_compatibility import (
@@ -86,7 +88,9 @@ class SkillSetManagementService(SkillSetManagementServiceProtocol):
         self._audit_log_repo = audit_log_repo
         self._mcp_center = mcp_center
         self._mcp_auth = mcp_auth
-        self._ext_info_provider = ext_info_provider
+        self._platform_default_mcp_policy = PlatformDefaultMcpPolicy(
+            ext_info_provider
+        )
 
     def _bot(self, *, bot_id: str, owner_id: str, user_id: str) -> dict:
         """Resolve the exact addressed Bot before applying caller policy."""
@@ -948,22 +952,8 @@ class SkillSetManagementService(SkillSetManagementServiceProtocol):
             )
 
     def _platform_default_mcp_codes(self, bot: dict, bot_id: str) -> frozenset[str]:
-        """The unmaterialized platform Default MCP policy (spec A.2).
-
-        Resolved at write time with the same context the read-side union
-        uses — engine, template, ext info. A provider failure propagates
-        rather than degrading to base defaults: for a template-preset-only
-        default MCP, a silently narrowed set would make the exclusion
-        command mis-read the genuine member as a stray and no-op the
-        removal as ``changed=False`` — a wrong persisted answer, where an
-        error is merely a retry.
-        """
-        return frozenset(
-            get_default_mcp_server_codes(
-                self._engine(bot),
-                bot.get("template_type"),
-                ext_info=self._ext_info_provider(bot_id),
-            )
+        return self._platform_default_mcp_policy.server_codes_for(
+            {**bot, "bot_id": bot_id}
         )
 
     @staticmethod

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_management_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_management_service.py
@@ -27,6 +27,7 @@ from agentclaw.community.core.skill_center.errors import (
 from agentclaw.community.core.mcp.services._defaults import (
     get_default_mcp_server_codes,
 )
+from agentclaw.community.core.skill_center.policies.capability_ownership import require_non_platform_mcp
 from agentclaw.community.plugin_api.mcp_auth import MCPAuthPlugin
 from agentclaw.community.plugin_api.mcp_center import MCPCenterPlugin
 from agentclaw.community.core.skill_center.legacy_skill_set_compatibility import (
@@ -653,6 +654,10 @@ class SkillSetManagementService(SkillSetManagementServiceProtocol):
                     default_engine_types=self._default_engine_types(bot),
                 ),
             )
+        platform_default_codes = self._platform_default_mcp_codes(bot, bot_id)
+        require_non_platform_mcp(
+            server_code=server_code, platform_default_codes=platform_default_codes
+        )
         catalog = self._mcp_catalog_entry(server_code)
         return await self._mutate(
             bot=bot,
@@ -667,6 +672,7 @@ class SkillSetManagementService(SkillSetManagementServiceProtocol):
                 set_id=set_id,
                 server_code=server_code,
                 name=catalog["name"],
+                platform_default_codes=platform_default_codes,
                 description=catalog["description"],
                 icon=catalog["icon"],
                 engine_type=self._engine(bot),

--- a/src/backend/tests/community/core/skill_center/test_skill_set_management_service.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_set_management_service.py
@@ -4329,6 +4329,40 @@ async def test_default_mcp_exclusion_passes_the_platform_default_policy():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("active", [False, True])
+async def test_ordinary_set_rejects_platform_default_before_mutation(active):
+    class Repository(_Repository):
+        def get_set(self, **kwargs):
+            return {"id": "set-1", "is_default": False, "is_active": active}
+
+    repository = Repository()
+    runtime = _ProjectionCountingRuntime()
+    service = _default_wire_service(repository, runtime)
+    with pytest.raises(SkillSetControlPlaneConflictError, match="RESOURCE_MANAGED_BY_PLATFORM_POLICY"):
+        await service.add_mcp(
+            bot_id="bot-1", owner_id="true-owner", user_id="true-owner",
+            set_id="set-1", server_code="mcp.ant.arkai.dimamcpserver",
+        )
+    assert repository.add_mcp_calls == []
+    assert runtime.projections == 0
+
+
+@pytest.mark.asyncio
+async def test_ordinary_set_policy_lookup_failure_does_not_write():
+    def unavailable(_bot_id):
+        raise RuntimeError("policy unavailable")
+
+    repository = _Repository()
+    service = _default_wire_service(repository, ext_info_provider=unavailable)
+    with pytest.raises(RuntimeError, match="policy unavailable"):
+        await service.add_mcp(
+            bot_id="bot-1", owner_id="true-owner", user_id="true-owner",
+            set_id="set-1", server_code="mcp.new",
+        )
+    assert repository.add_mcp_calls == []
+
+
+@pytest.mark.asyncio
 async def test_default_mcp_exclusion_propagates_a_template_context_failure():
     """A failed ext lookup is an error, never a silently narrower gate.
 

--- a/src/backend/tests/community/endpoints/test_openapi_skill_sets.py
+++ b/src/backend/tests/community/endpoints/test_openapi_skill_sets.py
@@ -697,6 +697,7 @@ def _seed_mcp_member(world) -> None:
     _seed(world)
     with avernet_tenant_scope(_TENANT):
         world.get(CapabilityDesiredStateRepositoryProtocol).add_mcp(
+            platform_default_codes=frozenset(),
             bot_id=_BOT_ID,
             owner_id=_OWNER,
             set_id="1",
@@ -771,6 +772,22 @@ def list_mcps_error():
     extra=(_assert_mcp_catalog_metadata_persisted,),
 )
 def add_mcp_happy():
+    pass
+
+
+@_case(
+    "PUT",
+    "/openapi/v1/bots/{bot_id}/skill-sets/{set_id}/mcps/{server_code}",
+    "rejects_code_policy_default_mcp",
+    ExpectError(status=409, json_contains={"code": 409210}),
+    seed=_seed_mcp_catalog,
+    path_params={
+        "bot_id": _BOT_ID, "set_id": "1",
+        "server_code": "mcp.ant.arkai.dimamcpserver",
+    },
+    extra=(_assert_no_mcp_membership,),
+)
+def add_platform_default_mcp_rejected():
     pass
 
 

--- a/src/backend/tests/community/repository/skill_center/test_capability_desired_state_uow.py
+++ b/src/backend/tests/community/repository/skill_center/test_capability_desired_state_uow.py
@@ -497,6 +497,7 @@ def test_mcp_membership_is_independent_for_two_owners_sharing_default_bot_id():
         )
 
     result = CapabilityDesiredStateRepository(db).add_mcp(
+        platform_default_codes=frozenset(),
         bot_id="default",
         owner_id="owner-a",
         set_id=str(owner_a.id),
@@ -674,6 +675,31 @@ def test_database_allows_system_default_and_one_ordinary_membership():
         )
 
 
+@pytest.mark.parametrize("excluded", [False, True])
+@pytest.mark.parametrize("active", [False, True])
+def test_code_policy_mcp_cannot_join_ordinary_set_without_default_membership(active, excluded):
+    db = _Database()
+    repository = CapabilityDesiredStateRepository(db)
+    with db.transactional_orm_session() as session:
+        ordinary = SkillSet(name="ordinary", user_id="owner", bolt_id="bot", is_active=active, env="dev", engine_type="openclaw")
+        default = SkillSet(name="default", is_default=True, engine_type="openclaw", env="dev")
+        session.add_all([ordinary, default])
+        session.flush()
+        if excluded:
+            session.add(DefaultSkillsetMcpExclusion(
+                user_id="owner", bot_id="bot", skill_set_id=default.id, server_code="mcp.policy"
+            ))
+    with pytest.raises(SkillSetControlPlaneConflictError, match="RESOURCE_MANAGED_BY_PLATFORM_POLICY"):
+        repository.add_mcp(
+            bot_id="bot", owner_id="owner", set_id=str(ordinary.id), server_code="mcp.policy",
+            name="Policy", description=None, icon=None,
+            platform_default_codes=frozenset({"mcp.policy"}), engine_type="openclaw",
+        )
+    with db.orm_session() as session:
+        assert session.query(SkillSetMCPServer).count() == 0
+        assert session.query(BotMCPInstallation).count() == 0
+
+
 def test_active_skill_set_mutates_mcp_membership_and_installation_atomically():
     db = _Database()
     repository = CapabilityDesiredStateRepository(db)
@@ -683,6 +709,7 @@ def test_active_skill_set_mutates_mcp_membership_and_installation_atomically():
         session.flush()
 
     added = repository.add_mcp(
+        platform_default_codes=frozenset(),
         bot_id="bot", owner_id="owner", set_id=str(skill_set.id), server_code="mcp.weather",
         name="Weather MCP", description="Weather tools",
         icon="https://example.test/weather.png",
@@ -690,6 +717,7 @@ def test_active_skill_set_mutates_mcp_membership_and_installation_atomically():
     assert added.changed is True
     assert added.mcp_codes == frozenset({"mcp.weather"})
     unchanged_add = repository.add_mcp(
+        platform_default_codes=frozenset(),
         bot_id="bot", owner_id="owner", set_id=str(skill_set.id),
         server_code="mcp.weather", name="Weather MCP",
         description="Weather tools", icon="https://example.test/weather.png",
@@ -737,6 +765,7 @@ def test_mcp_direct_and_skill_set_ownership_conflicts_are_enforced():
         SkillSetControlPlaneConflictError, match="RESOURCE_DIRECT_ACTIVE"
     ):
         repository.add_mcp(
+            platform_default_codes=frozenset(),
             bot_id="bot", owner_id="owner", set_id=str(skill_set.id), server_code="mcp.weather",
             name="Weather", description=None, icon=None,
         )
@@ -745,6 +774,7 @@ def test_mcp_direct_and_skill_set_ownership_conflicts_are_enforced():
         platform_default_codes=frozenset(),
     ).changed
     assert repository.add_mcp(
+        platform_default_codes=frozenset(),
         bot_id="bot", owner_id="owner", set_id=str(skill_set.id), server_code="mcp.weather",
         name="Weather", description=None, icon=None,
     ).changed
@@ -2333,6 +2363,7 @@ def test_a_default_set_mcp_member_cannot_join_an_ordinary_set():
 
     with pytest.raises(SkillSetControlPlaneConflictError) as error:
         CapabilityDesiredStateRepository(db).add_mcp(
+            platform_default_codes=frozenset(),
             bot_id="bot",
             owner_id="owner",
             set_id=str(ordinary.id),


### PR DESCRIPTION
## Problem

Engine/template Default MCPs are code policy rather than database SkillSet membership. Ordinary SkillSet add checked only persisted membership and Direct Installation, allowing policy-owned MCPs into another Set and potentially bypassing Default exclusion through that Set's Installation.

## Solution

- Resolve the target Bot's complete engine/template/ext-info Default MCP policy before ordinary MCP addition. Exclusion does not relinquish policy ownership.
- Enforce the shared policy at the service entry and transactional repository boundary. The repository requires the caller-resolved policy codes.
- Reuse the existing platform-policy conflict (OpenAPI HTTP 409 / business code 409210).
- Keep Default un-exclusion and ordinary removal available. Do not materialize policy, clean historical data, change runtime projection, or alter non-policy ownership rules.
- Reuse `PlatformDefaultMcpPolicy` for policy resolution so `SkillSetManagementService` remains below the architecture size cap.

## Validation

- Retargeted and replayed as exactly three feature commits on `REL20260910@20e5a536b`; no unrelated `dev` commits are included.
- Focused architecture, SkillSet service, Endpoint and transactional UoW tests on the release baseline: 206 passed.
- `skill_set_management_service.py`: 995 lines, below the 1000-line architecture limit.
- Ruff, whitespace checks and Backend changed-line SAST passed on the prior dev-based revision; the release-target CI has been retriggered.
- Standards/Spec reviews found no actionable issues.

## Compatibility and risk

No HTTP request schema, DDL, config, Engine or Installation-model change. Ordinary Set addition of a platform-default code is intentionally newly rejected. Existing historical duplicates are not removed automatically; removal remains available.

The internal repository `add_mcp` contract now requires `platform_default_codes`; its production caller and direct test callers are updated. Current OCB `REL20260910@6eda649135` was checked for additional Corp Backend callers: none found. Its `ocb-public` gitlink still points to the earlier release SHA and must be updated separately when integrating this Avernet change. No deployment or enterprise live validation has run.

## Spec

Target-Bot policy ownership check approved in this task; maintenance contract recorded in the Skill Center AGENTS.md.
