### PR TITLE
fix(identity): coding bot runtime MD files use CLI home paths

### DIFF
--- a/src/backend/src/agentclaw/community/core/services/identity_addressing.py
+++ b/src/backend/src/agentclaw/community/core/services/identity_addressing.py
@@ -9,9 +9,9 @@ injected into the device-filesystem plugins by the dispatcher
 
 - **arca / baas** (container reached via the engine's ``/api/file/*`` API, which
   remaps the prefix in ``_convert_path``): compose the same address the router did
-  before consolidation — for ``claude_code`` the fixed in-container ``.claude`` dir,
-  for every other engine the per-bot OSS host path (``path_factory``). Byte-identical
-  to the legacy behavior; the engine does the final remap.
+  before consolidation — coding runtimes pin CLI-owned files to CLI homes, while
+  every other engine uses the per-bot OSS host path (``path_factory``). The engine
+  does the final remap.
 - **teclaw**: not built here — teclaw keeps its own ``to_engine_relative`` mapper
   (``identity/<file>`` → ``/identity/<file>``), wired in the dispatcher.
 
@@ -19,8 +19,10 @@ Lives in ``core`` (imports only ``core.workspace`` + ``core.config_compose``); t
 dispatcher in ``di`` calls it. ``IdentityService`` does not import this module, so
 the service carries no provider/engine path knowledge.
 """
+
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Callable
 
 from agentclaw.community.core.config_compose.teclaw_paths import IDENTITY_NS
@@ -28,6 +30,13 @@ from agentclaw.community.core.workspace.path_factory import get_bot_engine_dir
 
 # claude_code Arca 容器内 workspace 路径 (relocated from the identity router).
 _CLAUDE_CODE_ARCA_WORKSPACE_ROOT = "/home/admin/.claude_code/workspace/.claude"
+
+# Coding runtime files live in the CLI's own container-level home, not the
+# per-bot workspace. These paths are stable engine image contracts.
+_AICODING_RUNTIME_IDENTITY_PATHS: dict[str, Path] = {
+    "CLAUDE.md": Path("/home/admin/.claude/CLAUDE.md"),
+    "AGENTS.md": Path("/home/admin/.codex/AGENTS.md"),
+}
 
 
 def build_arca_identity_mapper(
@@ -39,10 +48,10 @@ def build_arca_identity_mapper(
     """Build the ``identity/<file>`` → engine-address mapper for arca / baas.
 
     The returned callable maps a logical ``identity/<file>`` path to the address the
-    container's ``/api/file/*`` API expects (claude_code container path, or the
-    per-bot OSS host path the engine then remaps). The identity flow always passes
-    a ``identity/<file>`` path, so a non-namespace input is a programming error and
-    fails loudly rather than silently passing through.
+    container's ``/api/file/*`` API expects (coding runtime CLI home, claude_code
+    container path, or the per-bot OSS host path the engine then remaps). The identity
+    flow always passes a ``identity/<file>`` path, so a non-namespace input is a
+    programming error and fails loudly rather than silently passing through.
     """
     prefix = f"{IDENTITY_NS}/"
 
@@ -51,7 +60,9 @@ def build_arca_identity_mapper(
             raise ValueError(
                 f"identity mapper expected a {prefix!r}-prefixed path, got {logical!r}"
             )
-        name = logical[len(prefix):]
+        name = logical[len(prefix) :]
+        if engine_type == "aicoding" and name in _AICODING_RUNTIME_IDENTITY_PATHS:
+            return str(_AICODING_RUNTIME_IDENTITY_PATHS[name])
         if engine_type == "claude_code":
             return f"{_CLAUDE_CODE_ARCA_WORKSPACE_ROOT}/{name}"
         base = get_bot_engine_dir(entity_id, bot_id, engine_type, entity_type)

--- a/src/backend/tests/community/core/services/test_identity_runtime_addressing.py
+++ b/src/backend/tests/community/core/services/test_identity_runtime_addressing.py
@@ -1,0 +1,31 @@
+"""Coding Bot runtime identity files resolve to their CLI homes."""
+
+from agentclaw.community.core.services.identity_addressing import (
+    build_arca_identity_mapper,
+)
+
+
+def test_aicoding_identity_mapper_pins_claude_and_codex_cli_homes() -> None:
+    mapper = build_arca_identity_mapper("staff", "382641", "20260702_bot", "aicoding")
+
+    assert mapper("identity/CLAUDE.md") == "/home/admin/.claude/CLAUDE.md"
+    assert mapper("identity/AGENTS.md") == "/home/admin/.codex/AGENTS.md"
+
+
+def test_claude_code_identity_mapper_keeps_the_legacy_address() -> None:
+    mapper = build_arca_identity_mapper("staff", "u_1", "bot_cc", "claude_code")
+
+    assert mapper("identity/CLAUDE.md") == (
+        "/home/admin/.claude_code/workspace/.claude/CLAUDE.md"
+    )
+
+
+def test_aicoding_identity_mapper_still_requires_the_identity_namespace() -> None:
+    mapper = build_arca_identity_mapper("staff", "u_1", "bot_1", "aicoding")
+
+    try:
+        mapper("workspace/PROMPT.md")
+    except ValueError as exc:
+        assert "identity/" in str(exc)
+    else:
+        raise AssertionError("expected a non-identity path to be refused")


### PR DESCRIPTION
## Problem

AICoding runtime 是 Coding Bot 的实际 runtime，但 identity mapper 里没有针对 CLI-owned MD 文件的映射。`CLAUDE.md` 和 `AGENTS.md` 会落到 per-bot aicoding 工作区路径，而不是用户期望的实际 CLI home 文件，因此已写入的配置读不到，前端表现为内容为空。

## Solution

在 identity namespace mapper 中为 AICoding runtime 增加两个受控地址映射：

- `CLAUDE.md` -> `/home/admin/.claude/CLAUDE.md`
- `AGENTS.md` -> `/home/admin/.codex/AGENTS.md`

未命中的 file type 继续使用原有 per-bot mapping。普通 `claude_code`、OpenClaw、TEClaw 和其他引擎路径保持不变。读取接口遇到文件缺失仍返回空内容；写入路径由 engine 负责创建父目录，不会在本层做 fallback 或双写。暂不修改 manifest swagger。

未选择为 manifest 单独放宽 `legal_identity_types`，因为当前最小修复只覆盖 identity 文件路径，manifest 能力变更可以后续独立评估。

## Validation

新增 `test_identity_runtime_addressing.py`，覆盖：

- AICoding runtime 下 `CLAUDE.md` 与 `AGENTS.md` 的 CLI home 路径；
- 普通 `claude_code` runtime 保持 legacy 容器地址；
- 非 `identity/` namespace 路径被拒绝。

已运行：

```bash
uv run pytest tests/community -q --dist loadfile -n auto
```

结果：17860 passed, 60 skipped。

## Compatibility and risk

未修改 API、schema、配置或数据库结构。行为变化限定为：AICoding runtime 下这两个 runtime-owned MD 文件不再读写 per-bot aicoding 工作区路径。存量 per-bot 内容不做迁移。回滚方式是 revert 本提交。

## Spec

Spec: Coding Bot runtime MD files by CC/Codex CLI home.

<!--
Title format: <type>(<scope>): <concise outcome>
  e.g. feat(backend): add whitelist observed state
Types: feat | fix | refactor | docs | test | ci | build | chore
Scope is required and should identify the module or area the change touches.
The title becomes the commit message on squash merge, so make it self-contained.
See "Pull Request Conventions" in AGENTS.md.
Delete the optional sections that do not apply.
-->
