### PR TITLE
fix(workflow): keep run history independent of metric window

### DIFF
--- a/src/evolverun/clawweb/public/modules/workflow/web/components/workflow-workspace/OverviewTab.tsx
+++ b/src/evolverun/clawweb/public/modules/workflow/web/components/workflow-workspace/OverviewTab.tsx
@@ -171,6 +171,7 @@ export default function OverviewTab({ workflow }: OverviewTabProps) {
     : isMetricsError ? '运行指标加载失败' : '运行指标加载中'
   const totalPages = Math.max(1, Math.ceil(totalCount / pageSize))
   const currentPage = Math.min(page + 1, totalPages)
+  const isRefreshing = isFetching || isMetricsFetching
 
   const changeDays = (nextDays: 7 | 30) => {
     setDays(nextDays)
@@ -250,12 +251,13 @@ export default function OverviewTab({ workflow }: OverviewTabProps) {
             </button>
           </div>
           <button
-            onClick={() => void refetch()}
-            disabled={isFetching}
+            onClick={() => { void refetch(); void refetchMetrics() }}
+            disabled={isRefreshing}
+            aria-busy={isRefreshing}
             className="inline-flex items-center gap-1.5 rounded-md border border-gray-300 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 shadow-sm transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
           >
             <svg
-              className={`h-3.5 w-3.5 ${isFetching ? 'animate-spin' : ''}`}
+              className={`h-3.5 w-3.5 ${isRefreshing ? 'animate-spin' : ''}`}
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"

--- a/src/evolverun/clawweb/public/modules/workflow/web/components/workflow-workspace/OverviewTab.tsx
+++ b/src/evolverun/clawweb/public/modules/workflow/web/components/workflow-workspace/OverviewTab.tsx
@@ -119,6 +119,12 @@ export default function OverviewTab({ workflow }: OverviewTabProps) {
   } = useWorkflowHealth(workflowId, days)
   const pageSize = 20
   const windowStart = windowEnd - days * 86400
+  const { data: metricsData } = useFlowRuns({
+    workflowId,
+    limit: 1,
+    from: String(windowStart),
+    to: String(windowEnd),
+  })
   const {
     data,
     isLoading,
@@ -130,15 +136,13 @@ export default function OverviewTab({ workflow }: OverviewTabProps) {
     workflowId,
     limit: pageSize,
     offset: page * pageSize,
-    from: String(windowStart),
-    to: String(windowEnd),
   })
 
   const runs = useMemo(() => data?.runs ?? [], [data?.runs])
   const totalCount = data?.total ?? 0
 
   const stats = useMemo(() => {
-    const counts = data?.statusCounts ?? {}
+    const counts = metricsData?.statusCounts ?? {}
     const succeededRuns = counts.succeeded ?? 0
     const abnormalRuns = (counts.failed ?? 0) + (counts.aborted ?? 0) + (counts.cancelled ?? 0) + (counts.canceled ?? 0)
     const terminalRuns = succeededRuns + abnormalRuns
@@ -152,7 +156,7 @@ export default function OverviewTab({ workflow }: OverviewTabProps) {
       blockedRuns: counts.blocked ?? 0,
       queuedRuns: counts.queued ?? 0,
     }
-  }, [data?.statusCounts])
+  }, [metricsData?.statusCounts])
 
   const currentSuccessRate = stats.terminalRuns > 0 ? `${stats.successRate}%` : '—'
   const currentDetail = `${stats.succeededRuns} / ${stats.terminalRuns} 个终态运行`
@@ -161,7 +165,6 @@ export default function OverviewTab({ workflow }: OverviewTabProps) {
 
   const changeDays = (nextDays: 7 | 30) => {
     setDays(nextDays)
-    setPage(0)
   }
 
   return (

--- a/src/evolverun/clawweb/public/modules/workflow/web/components/workflow-workspace/OverviewTab.tsx
+++ b/src/evolverun/clawweb/public/modules/workflow/web/components/workflow-workspace/OverviewTab.tsx
@@ -119,7 +119,13 @@ export default function OverviewTab({ workflow }: OverviewTabProps) {
   } = useWorkflowHealth(workflowId, days)
   const pageSize = 20
   const windowStart = windowEnd - days * 86400
-  const { data: metricsData } = useFlowRuns({
+  const {
+    data: metricsData,
+    isPending: isMetricsPending,
+    isError: isMetricsError,
+    isFetching: isMetricsFetching,
+    refetch: refetchMetrics,
+  } = useFlowRuns({
     workflowId,
     limit: 1,
     from: String(windowStart),
@@ -158,8 +164,11 @@ export default function OverviewTab({ workflow }: OverviewTabProps) {
     }
   }, [metricsData?.statusCounts])
 
-  const currentSuccessRate = stats.terminalRuns > 0 ? `${stats.successRate}%` : '—'
-  const currentDetail = `${stats.succeededRuns} / ${stats.terminalRuns} 个终态运行`
+  const hasMetrics = !isMetricsPending && !isMetricsError && metricsData?.statusCounts != null
+  const currentSuccessRate = hasMetrics && stats.terminalRuns > 0 ? `${stats.successRate}%` : '—'
+  const currentDetail = hasMetrics
+    ? `${stats.succeededRuns} / ${stats.terminalRuns} 个终态运行`
+    : isMetricsError ? '运行指标加载失败' : '运行指标加载中'
   const totalPages = Math.max(1, Math.ceil(totalCount / pageSize))
   const currentPage = Math.min(page + 1, totalPages)
 
@@ -182,7 +191,7 @@ export default function OverviewTab({ workflow }: OverviewTabProps) {
       <section aria-label="工作流关键指标" className="grid grid-cols-2 divide-x divide-y divide-slate-100 overflow-hidden rounded-xl border border-slate-200 bg-white lg:grid-cols-4 lg:divide-y-0">
         <MetricCell label="健康度" value={health ? String(health.overallScore) : '—'} detail={health ? (health.overallScore >= 80 ? '运行稳定' : health.overallScore >= 60 ? '需要关注' : '建议优先处理') : '等待健康数据'} emphasis={health && health.overallScore < 60 ? 'danger' : 'default'} />
         <MetricCell label="运行成功率" value={currentSuccessRate} detail={`近 ${days} 天 · 成功 / 终态`} />
-        <MetricCell label="异常结束" value={String(stats.abnormalRuns)} detail="失败、终止或取消" emphasis={stats.abnormalRuns > 0 ? 'danger' : 'default'} />
+        <MetricCell label="异常结束" value={hasMetrics ? String(stats.abnormalRuns) : '—'} detail="失败、终止或取消" emphasis={hasMetrics && stats.abnormalRuns > 0 ? 'danger' : 'default'} />
         <MetricCell label="节点耗时 P95" value={health ? formatDuration(health.p95DurationMs) : '—'} detail="最慢节点 P95 口径" />
       </section>
 
@@ -194,10 +203,17 @@ export default function OverviewTab({ workflow }: OverviewTabProps) {
           ['排队中', stats.queuedRuns, 'bg-violet-50 text-violet-700'],
         ].map(([label, count, cls]) => (
           <div key={String(label)} className={`rounded-lg px-3 py-2 text-xs font-medium ${cls}`}>
-            {`${label} ${count}`}
+            {`${label} ${hasMetrics ? count : '—'}`}
           </div>
         ))}
       </section>
+
+      {isMetricsError ? (
+        <div role="alert" className="flex items-center justify-between rounded-lg border border-rose-100 bg-rose-50 px-4 py-2 text-xs text-rose-600">
+          <span>运行指标加载失败；运行列表仍可继续查看。</span>
+          <button type="button" onClick={() => void refetchMetrics()} disabled={isMetricsFetching} className="shrink-0 rounded px-2 py-1 font-medium hover:bg-rose-100 disabled:opacity-50">重试指标</button>
+        </div>
+      ) : isMetricsPending && <p role="status" className="px-4 text-xs text-slate-500">运行指标加载中…</p>}
 
       {isHealthError && <div className="rounded-lg border border-rose-100 bg-rose-50 px-4 py-2 text-xs text-rose-600">健康指标加载失败；运行列表仍可继续查看。</div>}
 

--- a/src/evolverun/clawweb/public/modules/workflow/web/components/workflow-workspace/__tests__/OverviewTabLayout.test.tsx
+++ b/src/evolverun/clawweb/public/modules/workflow/web/components/workflow-workspace/__tests__/OverviewTabLayout.test.tsx
@@ -14,7 +14,7 @@ vi.mock('../../../api/hooks', () => ({
   useFlowRuns: mocks.useFlowRuns,
   useAnalysisProgress: () => ({ data: null, isError: false }),
 }))
-vi.mock('../../SuccessTrendCard', () => ({ SuccessTrendCard: ({ days }: { days?: number }) => <div>成功率趋势 · {days}天</div> }))
+vi.mock('../../SuccessTrendCard', () => ({ SuccessTrendCard: ({ days, currentDetail }: { days?: number; currentDetail?: string }) => <div><span>成功率趋势 · {days}天</span><span>{currentDetail}</span></div> }))
 vi.mock('../../NodeAnalysisPanel', () => ({ default: () => <div>节点分析</div> }))
 
 import OverviewTab from '../OverviewTab'
@@ -56,6 +56,37 @@ const workflow = {
 }
 
 describe('task escort overview layout', () => {
+  it.each(['loading', 'error', 'refetchError', 'empty'] as const)('handles metric %s independently of successful history', async (state) => {
+    mockQueries()
+    const history = mocks.useFlowRuns()
+    let metrics = {
+      ...history,
+      data: state === 'refetchError' ? history.data : state === 'empty' ? { runs: [], total: 0, statusCounts: {} } : undefined,
+      isPending: state === 'loading',
+      isError: state === 'error' || state === 'refetchError',
+    }
+    const retry = vi.fn(() => { metrics = { ...history, isPending: false, isError: false } })
+    mocks.useFlowRuns.mockImplementation((params) => params.from ? { ...metrics, refetch: retry } : history)
+    const view = render(<MemoryRouter><OverviewTab workflow={workflow} /></MemoryRouter>)
+    const region = screen.getByRole('region', { name: '工作流关键指标' })
+    expect(within(region).getByText('异常结束').nextElementSibling).toHaveTextContent(state === 'empty' ? '0' : '—')
+    for (const label of ['运行中', '等待中', '阻塞', '排队中']) {
+      expect(screen.getByText(`${label} ${state === 'empty' ? '0' : '—'}`)).toBeInTheDocument()
+    }
+    expect(screen.getByRole('button', { name: '下一页' })).toBeEnabled()
+    if (state === 'loading') expect(screen.getByRole('status')).toHaveTextContent('运行指标加载中')
+    if (metrics.isError) {
+      expect(screen.getByRole('alert')).toHaveTextContent('运行指标加载失败')
+      expect(screen.queryByText('14 / 20 个终态运行')).not.toBeInTheDocument()
+      await userEvent.click(screen.getByRole('button', { name: '重试指标' }))
+      expect(retry).toHaveBeenCalledTimes(1)
+      expect(history.refetch).not.toHaveBeenCalled()
+      view.rerender(<MemoryRouter><OverviewTab workflow={workflow} /></MemoryRouter>)
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+      expect(within(region).getByText('70%')).toBeInTheDocument()
+    }
+  })
+
   it('uses a consistent window, terminal success rate, abnormal endings and live-state breakdown', () => {
     mockQueries()
     render(<MemoryRouter><OverviewTab workflow={workflow} /></MemoryRouter>)

--- a/src/evolverun/clawweb/public/modules/workflow/web/components/workflow-workspace/__tests__/OverviewTabLayout.test.tsx
+++ b/src/evolverun/clawweb/public/modules/workflow/web/components/workflow-workspace/__tests__/OverviewTabLayout.test.tsx
@@ -56,6 +56,32 @@ const workflow = {
 }
 
 describe('task escort overview layout', () => {
+  it.each(['history', 'metrics'])('refreshes both queries and stays busy while %s is fetching', async (pendingQuery) => {
+    mockQueries()
+    const history = mocks.useFlowRuns()
+    const metrics = { ...history, refetch: vi.fn() }
+    mocks.useFlowRuns.mockImplementation((params) => params.from ? metrics : history)
+    const view = render(<MemoryRouter><OverviewTab workflow={workflow} /></MemoryRouter>)
+    const refresh = screen.getByRole('button', { name: '刷新' })
+    await userEvent.click(refresh)
+    expect(history.refetch).toHaveBeenCalledTimes(1)
+    expect(metrics.refetch).toHaveBeenCalledTimes(1)
+
+    const pending = pendingQuery === 'history' ? history : metrics
+    pending.isFetching = true
+    view.rerender(<MemoryRouter><OverviewTab workflow={workflow} /></MemoryRouter>)
+    expect(refresh).toBeDisabled()
+    expect(refresh).toHaveAttribute('aria-busy', 'true')
+    await userEvent.click(refresh)
+    expect(history.refetch).toHaveBeenCalledTimes(1)
+    expect(metrics.refetch).toHaveBeenCalledTimes(1)
+
+    pending.isFetching = false
+    view.rerender(<MemoryRouter><OverviewTab workflow={workflow} /></MemoryRouter>)
+    expect(refresh).toBeEnabled()
+    expect(refresh).toHaveAttribute('aria-busy', 'false')
+  })
+
   it.each(['loading', 'error', 'refetchError', 'empty'] as const)('handles metric %s independently of successful history', async (state) => {
     mockQueries()
     const history = mocks.useFlowRuns()

--- a/src/evolverun/clawweb/public/modules/workflow/web/components/workflow-workspace/__tests__/OverviewTabLayout.test.tsx
+++ b/src/evolverun/clawweb/public/modules/workflow/web/components/workflow-workspace/__tests__/OverviewTabLayout.test.tsx
@@ -81,13 +81,11 @@ describe('task escort overview layout', () => {
     }))
   })
 
-  it('can switch the page window and paginate through all matching runs', async () => {
+  it('keeps history pagination independent of the metric window', async () => {
     mockQueries()
     render(<MemoryRouter><OverviewTab workflow={workflow} /></MemoryRouter>)
 
-    await userEvent.click(screen.getByRole('button', { name: '30天' }))
-    expect(mocks.useWorkflowHealth).toHaveBeenLastCalledWith('tech-research', 30)
-    expect(mocks.useFlowRuns).toHaveBeenLastCalledWith(expect.objectContaining({ workflowId: 'tech-research', limit: 20, offset: 0 }))
+    expect(mocks.useFlowRuns).toHaveBeenLastCalledWith({ workflowId: 'tech-research', limit: 20, offset: 0 })
 
     await userEvent.click(screen.getByRole('button', { name: '下一页' }))
     await waitFor(() => expect(mocks.useFlowRuns).toHaveBeenLastCalledWith(expect.objectContaining({
@@ -95,5 +93,10 @@ describe('task escort overview layout', () => {
       limit: 20,
       offset: 20,
     })))
+    await userEvent.click(screen.getByRole('button', { name: '30天' }))
+    expect(mocks.useWorkflowHealth).toHaveBeenLastCalledWith('tech-research', 30)
+    expect(mocks.useFlowRuns).toHaveBeenLastCalledWith({ workflowId: 'tech-research', limit: 20, offset: 20 })
+    const metricParams = mocks.useFlowRuns.mock.calls.at(-2)?.[0]
+    expect(Number(metricParams.to) - Number(metricParams.from)).toBe(30 * 86400)
   })
 })


### PR DESCRIPTION
## Problem
Run history inherited the default 7-day metric window, hiding older runs despite a nonzero lifetime count.

## Solution
Query paginated run history without date bounds. Keep the 7/30-day window for metrics only, without resetting the history page.

## Validation
ClawWeb workspace build, workflow TypeScript check, two focused regression tests, and git diff --check passed.