### PR TITLE
fix(backend): carry release MCP, schema and deployment fixes into dev

### DIFF
--- a/src/baas/src/secbaas/community/core/service/bot_run/_baas_service.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_baas_service.py
@@ -310,7 +310,7 @@ class BaasBotService(BotService):
             ) from e
 
         # Step 2: Get or create adapter session
-        session_client = self._create_session_client(conn_info, engine_type)
+        session_client = self._create_session_client(conn_info, engine_type, metadata=metadata)
 
         # 评测流量：eval_id 存在且调用方未传 session_id 时，
         # 用 consistency_key（结构化格式，含 evalId）作为 session_id 传给 adapter，
@@ -952,12 +952,19 @@ class BaasBotService(BotService):
         return f"{scheme}://{base}"
 
     def _create_session_client(
-        self, conn_info: WsConnectionInfo, engine_type: str = "openclaw"
+        self,
+        conn_info: WsConnectionInfo,
+        engine_type: str = "openclaw",
+        metadata: dict[str, Any] | None = None,
     ) -> AsyncSessionClient:
         """Create an AsyncSessionClient from resolved WS connection info.
 
         Args:
             conn_info: WsConnectionInfo with ws_url, token, target.
+            engine_type: Engine type for URL resolution.
+            metadata: 请求 metadata，从中提取 eval_id / default_tag 注入
+                      X-Eval-Id / X-Agentclaw-Default-Tag Header 供引擎
+                      propagation 传播。为 None 或字段缺失时不注入。
 
         base_url 计算：新引擎（aicoding 等）用 adapter.ws_path() 作 strip 后缀，
         openclaw/teclaw 走原 _build_base_url。
@@ -967,7 +974,14 @@ class BaasBotService(BotService):
             base_url = self._strip_ws_url_to_base(conn_info.ws_url, _adapter.ws_path())
         else:
             base_url = self._build_base_url(conn_info, engine_type)
-        headers = {"x-proxypass-token": conn_info.token}
+        headers: dict[str, str] = {"x-proxypass-token": conn_info.token}
+        if metadata:
+            eval_id = metadata.get("eval_id")
+            if eval_id:
+                headers["X-Eval-Id"] = str(eval_id)
+            default_tag = metadata.get("default_tag")
+            if default_tag:
+                headers["X-Agentclaw-Default-Tag"] = str(default_tag)
         return AsyncSessionClient(
             base_url=base_url,
             headers=headers,

--- a/src/baas/src/secbaas/community/core/service/bot_run/_bot_websocket_client.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_bot_websocket_client.py
@@ -26,6 +26,7 @@ from websockets.asyncio.client import ClientConnection
 from secbaas.community.api.bot_interaction import InteractionResolution
 from secbaas.community.core.utils.env_utils import is_dev
 from secbaas.community.logger import get_logger
+from secbaas.community.tracer import get_tracer_plugin
 
 from ._interaction_protocol import (
     EngineInteractionResolveExchange,
@@ -269,6 +270,7 @@ class BotWebSocketClient:
                 for a in attachments
             ]
         params["x-iam-token"] = auth_token or "OPEN_API:NOT_PROVIDED"
+        params["traceId"] = get_tracer_plugin().get_trace_id()
 
         result = await self._send_request(
             "chat.send",
@@ -311,6 +313,7 @@ class BotWebSocketClient:
                 for a in attachments
             ]
         params["x-iam-token"] = auth_token or "OPEN_API:NOT_PROVIDED"
+        params["traceId"] = get_tracer_plugin().get_trace_id()
 
         result = await self._send_request(
             "chat.inject",
@@ -341,6 +344,7 @@ class BotWebSocketClient:
             interaction_id=interaction_id,
             resolution=resolution,
         )
+        request["params"]["traceId"] = get_tracer_plugin().get_trace_id()
         response = await self._send_request_frame(request, timeout=30.0)
         return EngineInteractionResolveExchange.from_frames(
             request=request,
@@ -356,6 +360,7 @@ class BotWebSocketClient:
         params: dict[str, Any] = {"sessionKey": session_key}
         if run_id:
             params["runId"] = run_id
+        params["traceId"] = get_tracer_plugin().get_trace_id()
 
         return await self._send_request("chat.abort", params)
 

--- a/src/baas/src/secbaas/community/core/service/bot_run/_executor.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_executor.py
@@ -455,67 +455,64 @@ class BotRunRequestExecutor:
         200ms 批量窗口合并 delta / agent chunks，并由 ``stream_flush_max_content_bytes``
         字节阈值提前 flush，避免单条 chunk content 在 ZDAS tracer 等非参数化内联
         SQL 路径下过大触发 1064：
-        - delta chunks 先缓冲，200ms / 字节阈值 / 非 delta/agent 事件触发 flush
-        - agent chunks 先缓冲到独立 buffer，200ms / 字节阈值 / 非 delta/agent 事件触发 flush（JSON array 合并）
-        - 非 delta/agent（final/error）先 flush 两个缓冲，再立即写入
+        - delta / agent chunks 统一进入一个有序 buffer，200ms / 字节阈值 / 非 delta/agent 事件触发 flush
+        - flush 时按到达顺序写出，相邻同类型事件合并（delta 拼接文本，agent 合并为 JSON array）
+        - 非 delta/agent（final/error）先 flush 缓冲，再立即写入
         - ZCache watermark: cache.set(f"run:{run_id}:seq", f"{seq}:{chunk_type}", ttl=120)
         """
 
         seq = 0
-        delta_buffer: list[str] = []
-        delta_engine_type: str | None = None
-        delta_buffer_bytes: int = 0
-        agent_buffer: list[dict[str, Any]] = []
-        agent_engine_type: str | None = None
-        agent_buffer_bytes: int = 0
+        # 统一有序 buffer，元素为 (chunk_type, payload, engine_type)
+        # payload: delta → str; agent → dict
+        pending: list[tuple[str, Any, str | None]] = []
+        pending_bytes: int = 0
         cache_key = f"run:{run.run_id}:seq"
 
-        def _flush_delta() -> None:
-            """将缓冲的 delta 合并为一条 chunk 写入。"""
-            nonlocal seq, delta_buffer, delta_engine_type, delta_buffer_bytes
-            if not delta_buffer:
-                return
-            merged = "".join(delta_buffer)
-            delta_buffer.clear()
-            delta_buffer_bytes = 0
-            metadata_json = None
-            if delta_engine_type:
-                metadata_json = json.dumps({"engine_type": delta_engine_type})
-            seq += 1
-            self._chunk_repository.insert_chunk(
-                run_id=run.run_id,
-                seq=seq,
-                chunk_type="delta",
-                content=merged,
-                metadata=metadata_json,
-            )
-            self._cache_plugin.set(cache_key, f"{seq}:delta", ttl_seconds=120)
-
-        def _flush_agent() -> None:
-            """将缓冲的 agent 事件合并为一条 chunk（JSON array）写入。"""
-            nonlocal seq, agent_buffer, agent_engine_type, agent_buffer_bytes
-            if not agent_buffer:
-                return
-            merged = json.dumps(agent_buffer, ensure_ascii=False)
-            agent_buffer.clear()
-            agent_buffer_bytes = 0
-            metadata_json = None
-            if agent_engine_type:
-                metadata_json = json.dumps({"engine_type": agent_engine_type})
-            seq += 1
-            self._chunk_repository.insert_chunk(
-                run_id=run.run_id,
-                seq=seq,
-                chunk_type="agent",
-                content=merged,
-                metadata=metadata_json,
-            )
-            self._cache_plugin.set(cache_key, f"{seq}:agent", ttl_seconds=120)
-
         def _flush_buffers() -> None:
-            """flush delta 和 agent 两个缓冲。"""
-            _flush_delta()
-            _flush_agent()
+            """按到达顺序 flush 缓冲，相邻同类型事件合并写入。"""
+            nonlocal seq, pending, pending_bytes
+            if not pending:
+                return
+            # 当前正在累积的同类型段
+            cur_type: str = pending[0][0]
+            cur_payloads: list[Any] = []
+            cur_engine_type: str | None = None
+
+            def _emit() -> None:
+                nonlocal seq, cur_payloads, cur_engine_type
+                metadata_json = (
+                    json.dumps({"engine_type": cur_engine_type})
+                    if cur_engine_type
+                    else None
+                )
+                if cur_type == "delta":
+                    content = "".join(cur_payloads)
+                else:  # agent
+                    content = json.dumps(cur_payloads, ensure_ascii=False)
+                seq += 1
+                self._chunk_repository.insert_chunk(
+                    run_id=run.run_id,
+                    seq=seq,
+                    chunk_type=cur_type,
+                    content=content,
+                    metadata=metadata_json,
+                )
+                self._cache_plugin.set(
+                    cache_key, f"{seq}:{cur_type}", ttl_seconds=120
+                )
+                cur_payloads = []
+                cur_engine_type = None
+
+            for chunk_type, payload, engine_type in pending:
+                if chunk_type != cur_type:
+                    _emit()
+                    cur_type = chunk_type
+                cur_payloads.append(payload)
+                if engine_type:
+                    cur_engine_type = engine_type
+            _emit()
+            pending = []
+            pending_bytes = 0
 
         def _write_chunk(stream_chunk: StreamChunk) -> None:
             """写入非 delta/agent chunk（先 flush 缓冲）。"""
@@ -550,26 +547,23 @@ class BotRunRequestExecutor:
                 attachments=attachments,
             ):
                 if chunk.type == "delta":
-                    delta_buffer.append(chunk.content)
-                    delta_buffer_bytes += len(chunk.content or "")
-                    if chunk.engine_type:
-                        delta_engine_type = chunk.engine_type
+                    pending.append(("delta", chunk.content, chunk.engine_type))
+                    pending_bytes += len(chunk.content or "")
                     if (
                         time.monotonic() - last_flush_ts >= self._stream_flush_interval
-                        or delta_buffer_bytes >= self._stream_flush_max_content_bytes
+                        or pending_bytes >= self._stream_flush_max_content_bytes
                     ):
                         _flush_buffers()
                         last_flush_ts = time.monotonic()
                 elif chunk.type == "agent":
-                    agent_buffer.append(chunk.metadata or {})
-                    agent_buffer_bytes += len(
-                        json.dumps(chunk.metadata or {}, ensure_ascii=False)
+                    agent_payload = chunk.metadata or {}
+                    pending.append(("agent", agent_payload, chunk.engine_type))
+                    pending_bytes += len(
+                        json.dumps(agent_payload, ensure_ascii=False)
                     )
-                    if chunk.engine_type:
-                        agent_engine_type = chunk.engine_type
                     if (
                         time.monotonic() - last_flush_ts >= self._stream_flush_interval
-                        or agent_buffer_bytes >= self._stream_flush_max_content_bytes
+                        or pending_bytes >= self._stream_flush_max_content_bytes
                     ):
                         _flush_buffers()
                         last_flush_ts = time.monotonic()

--- a/src/baas/tests/unit/core/service/bot_run/test_baas_service.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_baas_service.py
@@ -3356,3 +3356,61 @@ class TestSendMessageStreamEvalConsistencyCheck:
                 chat_metadata={"eval_id": "eval-789"},
             ):
                 chunks.append(chunk)
+
+
+class TestCreateSessionClientEvalIdHeader:
+    """_create_session_client 中 metadata 注入评测 Header 的测试。"""
+
+    def test_eval_id_injects_x_eval_id_header(self, service):
+        """metadata 中 eval_id 非空时，headers 包含 X-Eval-Id。"""
+        conn_info = _make_conn_info()
+        client = service._create_session_client(
+            conn_info, engine_type="teclaw", metadata={"eval_id": "eval-abc123"}
+        )
+        assert client.headers["X-Eval-Id"] == "eval-abc123"
+        assert client.headers["x-proxypass-token"] == conn_info.token
+
+    def test_default_tag_injects_header(self, service):
+        """metadata 中 default_tag 非空时，headers 包含 X-Agentclaw-Default-Tag。"""
+        conn_info = _make_conn_info()
+        client = service._create_session_client(
+            conn_info, engine_type="teclaw", metadata={"default_tag": "eval"}
+        )
+        assert client.headers["X-Agentclaw-Default-Tag"] == "eval"
+        assert "X-Eval-Id" not in client.headers
+
+    def test_eval_id_and_default_tag_both_inject(self, service):
+        """metadata 中 eval_id 和 default_tag 同时存在时，两个 Header 都注入。"""
+        conn_info = _make_conn_info()
+        client = service._create_session_client(
+            conn_info,
+            engine_type="teclaw",
+            metadata={"eval_id": "eval-abc", "default_tag": "eval"},
+        )
+        assert client.headers["X-Eval-Id"] == "eval-abc"
+        assert client.headers["X-Agentclaw-Default-Tag"] == "eval"
+
+    def test_no_metadata_no_eval_headers(self, service):
+        """metadata 为 None 时，headers 不含评测 Header。"""
+        conn_info = _make_conn_info()
+        client = service._create_session_client(
+            conn_info, engine_type="teclaw", metadata=None
+        )
+        assert "X-Eval-Id" not in client.headers
+        assert "X-Agentclaw-Default-Tag" not in client.headers
+        assert client.headers["x-proxypass-token"] == conn_info.token
+
+    def test_empty_metadata_no_eval_headers(self, service):
+        """metadata 为空 dict 时，headers 不含评测 Header。"""
+        conn_info = _make_conn_info()
+        client = service._create_session_client(
+            conn_info, engine_type="openclaw", metadata={}
+        )
+        assert "X-Eval-Id" not in client.headers
+        assert "X-Agentclaw-Default-Tag" not in client.headers
+
+    def test_default_metadata_no_eval_headers(self, service):
+        """未传 metadata 参数（默认 None），headers 不含评测 Header。"""
+        conn_info = _make_conn_info()
+        client = service._create_session_client(conn_info, engine_type="openclaw")
+        assert "X-Eval-Id" not in client.headers

--- a/src/baas/tests/unit/core/service/bot_run/test_bot_run_executor.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_bot_run_executor.py
@@ -465,10 +465,9 @@ async def test_executor_stream_agent_merge():
     assert len(final_calls) == 1
     assert final_calls[0][1]["content"] == "hello world"
 
-    # seq 递增：delta(1) → agent(2) → final(3)
-    # _flush_buffers() 先 flush delta 再 flush agent
-    assert delta_calls[0][1]["seq"] == 1
-    assert agent_calls[0][1]["seq"] == 2
+    # seq 递增：按到达顺序 agent(1) → delta(2) → final(3)
+    assert agent_calls[0][1]["seq"] == 1
+    assert delta_calls[0][1]["seq"] == 2
     assert final_calls[0][1]["seq"] == 3
 
     # update_result 写入 final content

--- a/src/baas/tests/unit/core/service/bot_run/test_bot_websocket_client.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_bot_websocket_client.py
@@ -163,10 +163,16 @@ async def test_interaction_resolve_sends_complete_normalized_frame(client) -> No
         selected_options=(("staging",),),
     )
 
-    exchange = await client.interaction_resolve(
-        interaction_id="int-1",
-        resolution=resolution,
-    )
+    tracer_plugin = MagicMock()
+    tracer_plugin.get_trace_id.return_value = "a" * 32
+    with patch(
+        "secbaas.community.core.service.bot_run._bot_websocket_client.get_tracer_plugin",
+        return_value=tracer_plugin,
+    ):
+        exchange = await client.interaction_resolve(
+            interaction_id="int-1",
+            resolution=resolution,
+        )
 
     assert exchange.accepted is True
     client._send_request_frame.assert_awaited_once_with(
@@ -182,6 +188,7 @@ async def test_interaction_resolve_sends_complete_normalized_frame(client) -> No
                 "values": {"target": "staging"},
                 "answers": {"Where?": "staging"},
                 "selectedOptions": [["staging"]],
+                "traceId": "a" * 32,
             },
         },
         timeout=30.0,
@@ -1112,3 +1119,151 @@ class TestGetDefaultHeaders:
         headers = client._get_default_headers()
         assert headers["X-Custom"] == "value"
         assert headers["User-Agent"] == "custom-agent"
+
+
+# ==================== Tests: traceId injection on downstream RPC ====================
+
+
+class TestTraceIdInjection:
+    """Tests for `traceId` injection on the four downstream RPC methods.
+
+    Covers both the active-span path (`get_trace_id()` returns a 32-char hex
+    trace id) and the no-span path (`get_trace_id()` returns ``"-"``) per the
+    `BareTracerPlugin` contract.
+    """
+
+    _TRACER_PATH = (
+        "secbaas.community.core.service.bot_run._bot_websocket_client.get_tracer_plugin"
+    )
+
+    async def _setup_mock_ws(self, client):
+        """Helper: set up a mock ws that auto-responds with ok=True."""
+        mock_ws = AsyncMock()
+        client._ws = mock_ws
+        client._connected = True
+        sent_frames = []
+
+        async def mock_send(data):
+            sent = json.loads(data)
+            sent_frames.append(sent)
+            req_id = sent["id"]
+            entry = client._pending_requests.get(req_id)
+            if entry:
+                if not entry.done():
+                    entry.set_result(
+                        {
+                            "type": "res",
+                            "id": req_id,
+                            "ok": True,
+                            "payload": {},
+                        }
+                    )
+
+        mock_ws.send = mock_send
+        return sent_frames
+
+    def _tracer_mock(self, trace_id: str) -> MagicMock:
+        plugin = MagicMock()
+        plugin.get_trace_id.return_value = trace_id
+        return plugin
+
+    # ----- chat_send -----
+
+    @pytest.mark.asyncio
+    async def test_chat_send_injects_trace_id_with_active_span(self, client):
+        sent_frames = await self._setup_mock_ws(client)
+        with patch(self._TRACER_PATH, return_value=self._tracer_mock("a" * 32)):
+            await client.chat_send(session_key="sk-1", message="hi")
+
+        params = sent_frames[0]["params"]
+        assert params["traceId"] == "a" * 32
+        assert params["sessionKey"] == "sk-1"
+
+    @pytest.mark.asyncio
+    async def test_chat_send_injects_trace_id_without_active_span(self, client):
+        sent_frames = await self._setup_mock_ws(client)
+        with patch(self._TRACER_PATH, return_value=self._tracer_mock("-")):
+            await client.chat_send(session_key="sk-1", message="hi")
+
+        assert sent_frames[0]["params"]["traceId"] == "-"
+
+    # ----- chat_inject -----
+
+    @pytest.mark.asyncio
+    async def test_chat_inject_injects_trace_id_with_active_span(self, client):
+        sent_frames = await self._setup_mock_ws(client)
+        with patch(self._TRACER_PATH, return_value=self._tracer_mock("b" * 32)):
+            await client.chat_inject(session_key="sk-2", message="inject")
+
+        assert sent_frames[0]["params"]["traceId"] == "b" * 32
+        assert sent_frames[0]["method"] == "chat.inject"
+
+    @pytest.mark.asyncio
+    async def test_chat_inject_injects_trace_id_without_active_span(self, client):
+        sent_frames = await self._setup_mock_ws(client)
+        with patch(self._TRACER_PATH, return_value=self._tracer_mock("-")):
+            await client.chat_inject(session_key="sk-2", message="inject")
+
+        assert sent_frames[0]["params"]["traceId"] == "-"
+
+    # ----- chat_abort -----
+
+    @pytest.mark.asyncio
+    async def test_chat_abort_injects_trace_id_with_run_id(self, client):
+        sent_frames = await self._setup_mock_ws(client)
+        with patch(self._TRACER_PATH, return_value=self._tracer_mock("c" * 32)):
+            await client.chat_abort(session_key="sk-3", run_id="run-1")
+
+        params = sent_frames[0]["params"]
+        assert params["traceId"] == "c" * 32
+        assert params["runId"] == "run-1"
+
+    @pytest.mark.asyncio
+    async def test_chat_abort_injects_trace_id_without_run_id(self, client):
+        sent_frames = await self._setup_mock_ws(client)
+        with patch(self._TRACER_PATH, return_value=self._tracer_mock("-")):
+            await client.chat_abort(session_key="sk-3")
+
+        params = sent_frames[0]["params"]
+        assert params["traceId"] == "-"
+        assert "runId" not in params
+
+    # ----- interaction_resolve -----
+
+    @pytest.mark.asyncio
+    async def test_interaction_resolve_injects_trace_id_with_active_span(self, client):
+        client._send_request_frame = AsyncMock(
+            return_value={"type": "res", "id": "1", "ok": True}
+        )
+        resolution = InteractionResolution(
+            kind="ask_user",
+            decision="submit",
+            answer="yes",
+            message="yes",
+        )
+        with patch(self._TRACER_PATH, return_value=self._tracer_mock("d" * 32)):
+            await client.interaction_resolve(
+                interaction_id="int-2", resolution=resolution
+            )
+
+        sent_request = client._send_request_frame.await_args.args[0]
+        assert sent_request["params"]["traceId"] == "d" * 32
+        assert sent_request["params"]["interactionId"] == "int-2"
+
+    @pytest.mark.asyncio
+    async def test_interaction_resolve_injects_trace_id_without_active_span(self, client):
+        client._send_request_frame = AsyncMock(
+            return_value={"type": "res", "id": "1", "ok": True}
+        )
+        resolution = InteractionResolution(
+            kind="ask_user",
+            decision="submit",
+            answer="yes",
+            message="yes",
+        )
+        with patch(self._TRACER_PATH, return_value=self._tracer_mock("-")):
+            await client.interaction_resolve(
+                interaction_id="int-2", resolution=resolution
+            )
+
+        assert client._send_request_frame.await_args.args[0]["params"]["traceId"] == "-"

--- a/src/backend/specs/2026-08-20-skill-capability-upgrade/spec.md
+++ b/src/backend/specs/2026-08-20-skill-capability-upgrade/spec.md
@@ -503,7 +503,7 @@ Canonical 前缀：`/openapi/v1/bots/{bot_id}/skill-sets`。
 | POST | `/skill-sets/{set_id}/activate` | 原子激活全部 Skill/MCP，一次 reconcile |
 | POST | `/skill-sets/{set_id}/deactivate` | 原子停用全部 Skill/MCP，一次 reconcile |
 | GET | `/skill-sets/resources` | 所有 Set 的 MCP/Default CLI 聚合 |
-| GET | `/skill-sets/{set_id}/mcps` | MCP Membership |
+| GET | `/skill-sets/{set_id}/mcps` | MCP Membership；Default Set 同时投影 Engine/Template 默认 MCP，并扣除当前 Bot 排除项 |
 | PUT | `/skill-sets/{set_id}/mcps/{server_code}` | 权限校验后添加 MCP |
 | DELETE | `/skill-sets/{set_id}/mcps/{server_code}` | 移除 MCP |
 | GET | `/skill-sets/{set_id}/mcp-permissions` | 聚合显式 MCP 与 Skill 依赖的权限状态 |

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/create_with_manifest.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/create_with_manifest.py
@@ -37,6 +37,7 @@ from agentclaw.community.adapters.http.openapi_v1.contracts import (
     Envelope,
 )
 from agentclaw.community.adapters.http.openapi_v1.principal import (
+    OwnerNameDep,
     UserIdDep,
     refuse_app_only_caller,
 )
@@ -143,6 +144,7 @@ async def create_bot_with_manifest(
     body: BotCreateWithManifest,
     request: Request,
     owner_id: UserIdDep,
+    owner_name: OwnerNameDep,
     bot_service: BotServiceProtocol = Injected(BotServiceProtocol),
     bot_repo: BotRepository = Injected(BotRepository),
     passport_plugin: PassportPlugin = Injected(PassportPlugin),
@@ -197,6 +199,7 @@ async def create_bot_with_manifest(
 
     submitted = submit_bot_creation_with_manifest(
         user_id=owner_id,
+        nick_name=owner_name,
         bot_id=bot_id,
         document=body.config_manifest,
         modifier=owner_id,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py
@@ -45,6 +45,7 @@ from agentclaw.community.adapters.http.openapi_v1.dependencies import (
 from agentclaw.community.adapters.http.openapi_v1.log_safe import for_log
 from agentclaw.community.adapters.http.openapi_v1.admission import ActingCaller
 from agentclaw.community.adapters.http.openapi_v1.principal import (
+    OwnerNameDep,
     ActingCallerDep,
     UserIdDep,
     refuse_app_only_caller,
@@ -529,6 +530,7 @@ async def create_bot(
     body: BotCreate,
     request: Request,
     owner_id: UserIdDep,
+    owner_name: OwnerNameDep,
     bot_service: BotServiceProtocol = Injected(BotServiceProtocol),
     bot_repo: BotRepository = Injected(BotRepository),
     passport_plugin: PassportPlugin = Injected(PassportPlugin),
@@ -576,7 +578,7 @@ async def create_bot(
     bot_id = generate_bot_id(owner_id, bot_repo)
     outcome = create_bot_with_authorization(
         user_id=owner_id,
-        nick_name=owner_id,
+        nick_name=owner_name,
         bot_id=bot_id,
         spec=BotCreateSpec(
             entity_id=owner_id,
@@ -1160,6 +1162,7 @@ def _complete_auth_status(
     bot_id: str,
     request: Request,
     owner_id: str,
+    owner_name: str,
     engine: str | None,
     cluster_name: ClusterName | None,
     bot_name: str | None,
@@ -1208,7 +1211,7 @@ def _complete_auth_status(
     try:
         result = complete_bot_authorization(
             user_id=owner_id,
-            nick_name=owner_id,
+            nick_name=owner_name,
             bot_id=bot_id,
             spec=BotCreateSpec(
                 entity_id=owner_id,
@@ -1272,6 +1275,7 @@ async def poll_bot_auth_status(
     body: BotAuthStatusPoll,
     request: Request,
     owner_id: UserIdDep,
+    owner_name: OwnerNameDep,
     bot_service: BotServiceProtocol = Injected(BotServiceProtocol),
     passport_plugin: PassportPlugin = Injected(PassportPlugin),
     auth_rel_plugin: AuthRelationshipPlugin = Injected(AuthRelationshipPlugin),
@@ -1306,6 +1310,7 @@ async def poll_bot_auth_status(
         bot_id=bot_id,
         request=request,
         owner_id=owner_id,
+        owner_name=owner_name,
         engine=body.engine,
         cluster_name=body.cluster_name,
         bot_name=body.bot_name,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/deprecated/auth_status.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/deprecated/auth_status.py
@@ -39,7 +39,7 @@ from agentclaw.community.adapters.http.openapi_v1.contracts import (
     BotIdPath,
     Envelope,
 )
-from agentclaw.community.adapters.http.openapi_v1.principal import UserIdDep
+from agentclaw.community.adapters.http.openapi_v1.principal import OwnerNameDep, UserIdDep
 from agentclaw.community.adapters.http.openapi_v1.responses import envelope_errors
 from agentclaw.community.api.bot_service import BotServiceProtocol
 from agentclaw.community.core.bot_inventory.protocols import (
@@ -60,6 +60,7 @@ async def get_bot_auth_status(
     bot_id: BotIdPath,
     request: Request,
     owner_id: UserIdDep,
+    owner_name: OwnerNameDep,
     engine: Annotated[
         str | None,
         Query(
@@ -131,6 +132,7 @@ async def get_bot_auth_status(
         bot_id=bot_id,
         request=request,
         owner_id=owner_id,
+        owner_name=owner_name,
         engine=engine,
         cluster_name=cluster_name,
         bot_name=bot_name,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/principal.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/principal.py
@@ -277,6 +277,21 @@ async def require_user_id(
 UserIdDep = Annotated[str, Depends(require_user_id)]
 
 
+async def require_owner_name(
+    user_id: UserIdDep,
+    principal: Annotated[Principal, Depends(require_principal)],
+) -> str:
+    """Use the verified owner's display name, retaining the ID fallback."""
+    user = getattr(principal, "user", None)
+    # COSEC: delegated callers must not lend their identity to another owner.
+    if user is not None and user.id == user_id and user.display_name:
+        return user.display_name.strip() or user_id
+    return user_id
+
+
+OwnerNameDep = Annotated[str, Depends(require_owner_name)]
+
+
 async def require_acting_caller(
     request: Request,
     principal: Annotated[Principal, Depends(require_principal)],

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/repository/apply_models.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/repository/apply_models.py
@@ -119,8 +119,15 @@ class BotConfigManifestApplyModel(Base):
     # The vocabulary is ``apply/triggers.py``: ``explicit`` (W4), W13's two
     # ``create:*`` phases, and ``put`` (W8). Restart and republish were deferred
     # (W8 spec D-1). None of them needed a migration; every value fits.
+    #
+    # The COLUMN is ``apply_trigger``: TRIGGER is a SQL keyword, and the DDL
+    # review standard that gates provisioning refuses keyword column names. The
+    # attribute, the record field and the API field all stay ``trigger``.
     trigger = Column(
-        String(32), nullable=False, comment="What started it: explicit/put/create:pre_container/create:on_container"
+        "apply_trigger",
+        String(32),
+        nullable=False,
+        comment="What started it: explicit/put/create:pre_container/create:on_container",
     )
     # RUNNING on insert, terminal on completion — the two-write lifecycle apply's
     # async shape requires. Denormalised out of ``report`` so "show me failed
@@ -141,6 +148,9 @@ class BotConfigManifestApplyModel(Base):
     # narrower width without anything being malformed.
     actor = Column(String(1024), nullable=False, comment="Audit: who started it")
 
+    # TIMESTAMP on OceanBase (the DDL standard refuses DATETIME); ``DateTime``
+    # here as for gmt_* below. Filled from ``datetime.now()`` and read back
+    # through the same session, so the value written is the value read.
     started_at = Column(DateTime, nullable=False, comment="When the apply began")
     # Null exactly while ``status`` is RUNNING. The two move together.
     finished_at = Column(DateTime, nullable=True, comment="When it ended; null while RUNNING")

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/sql/2026_08_31_bot_config_manifest_apply.sql
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/sql/2026_08_31_bot_config_manifest_apply.sql
@@ -47,23 +47,34 @@
 --     it prevents surfaces as duplicate rows, silently, never as an error.
 --     SQLAlchemy cannot render the modifier, so this file is the only place it
 --     can live.
---   * ``TIMESTAMP`` FOR THE DB-CLOCK COLUMNS, ``DATETIME`` FOR THE REST, and
---     which one a column gets is decided by who fills it, not by taste.
+--   * ``TIMESTAMP`` FOR EVERY TIME COLUMN, because the DDL review standard
+--     (研发规范) that gates provisioning refuses DATETIME outright -- along
+--     with BIT, FLOAT, DOUBLE, ENUM and SET -- and refuses any column whose
+--     name is a SQL keyword. The first draft of this table declared
+--     started_at/finished_at as DATETIME and a column named `trigger`, and
+--     was rejected on exactly those three findings; that is why the record
+--     table never existed in production while the lock table did.
+--
 --     gmt_create and gmt_modified are written by the database itself
 --     (``DEFAULT CURRENT_TIMESTAMP``, and ``func.now()`` from the ORM), so
 --     TIMESTAMP's session-time-zone conversion is a no-op round trip and they
---     match ac_bots and every table added since --
---     skill_center/sql/2026_09_03_align_space_skill_timestamps_with_gmt.sql is
---     the repair that convention exists to avoid repeating.
+--     match ac_bots and every table added since.
 --
---     A column the APPLICATION fills stays DATETIME. TIMESTAMP reads the naive
---     value being bound as session-local wall time and converts it to UTC for
---     storage, so a Python-supplied instant is stored shifted by the session
---     offset -- eight hours under the Asia/Shanghai session assumed here. This
---     was got wrong in the first draft of this change and caught in review; started_at and
---     finished_at are the columns in question here, per their comment below.
+--     started_at and finished_at are filled by the APPLICATION from
+--     datetime.now() (naive). TIMESTAMP binds that as session-local wall time,
+--     stores UTC, and converts back on read through the same session -- so the
+--     value the application wrote is the value it reads back, exactly as with
+--     DATETIME. The one difference is what an out-of-band reader sees when the
+--     process time zone and the session time zone differ (a UTC container
+--     against an Asia/Shanghai session): the stored instant is offset by that
+--     difference. That mismatch existed under DATETIME too, as a wall-clock
+--     disagreement with gmt_create; TIMESTAMP merely makes it visible.
 --
---     The ORM keeps ``DateTime`` for both kinds -- ac_skill_version's
+--     Every TIMESTAMP column carries an explicit DEFAULT (or an explicit NULL)
+--     so the server can never attach an implicit ON UPDATE CURRENT_TIMESTAMP;
+--     test_manifest_ddl_contract.py holds that line.
+--
+--     The ORM keeps ``DateTime`` for all of them -- ac_skill_version's
 --     published_at is the precedent for ``DateTime`` over a TIMESTAMP column.
 --   * NO ``ENGINE`` CLAUSE, and no BLOCK_SIZE / REPLICA_NUM / COMPRESSION /
 --     TABLET_SIZE / PCTFREE / ROW_FORMAT. OceanBase applies its own defaults
@@ -94,7 +105,11 @@ CREATE TABLE `ac_bot_config_manifest_apply` (
   -- 'explicit' is the only value this wave writes: W4's single entry point is
   -- the explicit POST. W8 adds 'republish'/'restart' and W13 adds 'create',
   -- neither of which needs a migration.
-  `trigger`        varchar(32)   NOT NULL COMMENT 'What started it: explicit/create/republish/restart',
+  --
+  -- apply_trigger, not `trigger`: TRIGGER is a SQL keyword and the DDL review
+  -- standard refuses keyword column names (see the header). The ORM attribute
+  -- and the API field are still ``trigger``; only the column is prefixed.
+  `apply_trigger`  varchar(32)   NOT NULL COMMENT 'What started it: explicit/create/republish/restart',
   -- RUNNING on insert, terminal on completion — the two-write lifecycle apply's
   -- async shape requires, since the route answers 202 and the work continues on
   -- a background thread.
@@ -111,16 +126,15 @@ CREATE TABLE `ac_bot_config_manifest_apply` (
   -- ("app:7:on-behalf-of:<...>"), so the composed value can legitimately be
   -- long without anything being malformed.
   `actor`          varchar(1024) NOT NULL COMMENT 'Audit: who started it',
-  -- DATETIME, not TIMESTAMP, for both of these: they are filled by the
-  -- application from datetime.now() (process-local, naive), never by the
-  -- database. TIMESTAMP binds a naive value as session-local, so these would
-  -- be stored correctly only where the process time zone happens to equal the
-  -- database session's -- and a container on UTC against an Asia/Shanghai
-  -- session is exactly where that stops being true. gmt_* below are a
-  -- different case: the database fills those itself.
-  `started_at`     datetime      NOT NULL COMMENT 'When the apply began',
+  -- TIMESTAMP because the DDL review standard refuses DATETIME (header note).
+  -- Both are filled by the application from datetime.now(); the round trip
+  -- through one session is the identity, so the application reads back what
+  -- it wrote. The explicit DEFAULT on started_at is what stops the server
+  -- attaching an implicit ON UPDATE CURRENT_TIMESTAMP to it -- the application
+  -- always supplies a value, so the default itself is never used.
+  `started_at`     timestamp     NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'When the apply began',
   -- NULL exactly while status is RUNNING. The two move together.
-  `finished_at`    datetime      NULL     COMMENT 'When it ended; NULL while RUNNING',
+  `finished_at`    timestamp     NULL     DEFAULT NULL COMMENT 'When it ended; NULL while RUNNING',
   `avernet_tenant` varchar(64)   NOT NULL DEFAULT 'teamclaw' COMMENT 'Tenant, for data isolation',
   `gmt_create`     timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'Row created',
   `gmt_modified`   timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Row last modified',

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/sql/2026_09_07_repair_misprovisioned_bot_config_manifest_apply.sql
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/sql/2026_09_07_repair_misprovisioned_bot_config_manifest_apply.sql
@@ -1,0 +1,113 @@
+-- Repair for a mis-provisioned ac_bot_config_manifest_apply.
+--
+-- WHAT WENT WRONG. 2026_08_31_bot_config_manifest_apply.sql declares two
+-- tables: the apply RECORD (ac_bot_config_manifest_apply: apply_id, trigger,
+-- status, report, actor, started_at, finished_at) and the apply LOCK
+-- (ac_bot_config_manifest_apply_lock: holder_user_id, lock_token, and the
+-- UNIQUE KEY that *is* the lock). At least one environment was provisioned with
+-- the LOCK's body under the RECORD's name -- SHOW CREATE TABLE
+-- ac_bot_config_manifest_apply came back with holder_user_id / lock_token /
+-- uk_manifest_apply_lock and the lock's COMMENT, and no apply_id at all.
+-- Every read of the record then fails the way GET .../config-manifest/last-apply
+-- did: ``1054 Unknown column 'ac_bot_config_manifest_apply.apply_id'``.
+--
+-- WHAT THIS DOES. Idempotent, and a no-op wherever the schema is already right:
+--
+--   1. Detect the mis-shape: ac_bot_config_manifest_apply exists but has no
+--      apply_id column. Nothing below touches a correctly shaped table.
+--   2. Move the mis-shaped table out of the way. It has exactly the lock's
+--      shape, so when the lock table is missing it is RENAMED INTO PLACE as
+--      ac_bot_config_manifest_apply_lock -- the same DDL, only under the right
+--      name now. When the lock table already exists it is renamed ASIDE to
+--      ac_bot_config_manifest_apply_misprovisioned_20260907 instead. Nothing is
+--      dropped: whatever rows it holds are at most stale lock rows, and the
+--      operator decides when to DROP the quarantined copy.
+--   3. Create ac_bot_config_manifest_apply with the canonical DDL, verbatim
+--      from 2026_08_31_bot_config_manifest_apply.sql (see that file for why
+--      every index is GLOBAL, why AUTO_INCREMENT_MODE is pinned to ORDER, why
+--      the column is apply_trigger and not `trigger`, and why
+--      started_at/finished_at are TIMESTAMP -- the DDL review standard that
+--      most likely caused the mis-provisioning refuses keyword column names
+--      and DATETIME).
+--   4. Verify. Save the results with the deployment record.
+--
+-- Conditional DDL goes through PREPARE/EXECUTE, the pattern
+-- skill_center/sql/2026_08_30_finalize_space_skill_group3_publication.sql set,
+-- because MySQL/OceanBase have no IF around a bare statement.
+
+-- 1. Is the record table the mis-shaped one? (1 = yes, 0 = no / absent.)
+SET @apply_is_misshaped = (
+  SELECT COUNT(*) FROM information_schema.TABLES t
+   WHERE t.TABLE_SCHEMA = DATABASE()
+     AND t.TABLE_NAME = 'ac_bot_config_manifest_apply'
+     AND NOT EXISTS (
+       SELECT 1 FROM information_schema.COLUMNS c
+        WHERE c.TABLE_SCHEMA = t.TABLE_SCHEMA
+          AND c.TABLE_NAME = t.TABLE_NAME
+          AND c.COLUMN_NAME = 'apply_id'
+     )
+);
+
+SET @lock_exists = (
+  SELECT COUNT(*) FROM information_schema.TABLES
+   WHERE TABLE_SCHEMA = DATABASE()
+     AND TABLE_NAME = 'ac_bot_config_manifest_apply_lock'
+);
+
+-- 2. Move the mis-shaped table out of the way: into place as the lock when the
+--    lock is missing, aside under a quarantine name when it is not.
+SET @move_misshaped_apply = IF(
+  @apply_is_misshaped = 1,
+  IF(
+    @lock_exists = 0,
+    'RENAME TABLE `ac_bot_config_manifest_apply` TO `ac_bot_config_manifest_apply_lock`',
+    'RENAME TABLE `ac_bot_config_manifest_apply` TO `ac_bot_config_manifest_apply_misprovisioned_20260907`'
+  ),
+  'SELECT 1'
+);
+PREPARE move_misshaped_apply_stmt FROM @move_misshaped_apply;
+EXECUTE move_misshaped_apply_stmt;
+DEALLOCATE PREPARE move_misshaped_apply_stmt;
+
+-- 3. The apply RECORD, as 2026_08_31_bot_config_manifest_apply.sql declares it.
+--    IF NOT EXISTS keeps this a no-op on an environment that was provisioned
+--    correctly in the first place.
+CREATE TABLE IF NOT EXISTS `ac_bot_config_manifest_apply` (
+  `id`             bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT 'Primary key',
+  `apply_id`       varchar(64)   NOT NULL COMMENT 'Public handle for this apply',
+  `env`            varchar(20)   NOT NULL COMMENT 'Environment: prod/pre/dev',
+  `entity_id`      varchar(256)  NOT NULL COMMENT 'Entity id: the bot entity_id',
+  `bot_id`         varchar(256)  NOT NULL COMMENT 'Bot ID',
+  `apply_trigger`  varchar(32)   NOT NULL COMMENT 'What started it: explicit/create/republish/restart',
+  `status`         varchar(16)   NOT NULL COMMENT 'RUNNING, or SUCCEEDED/PARTIAL/FAILED',
+  `report`         mediumtext    NOT NULL COMMENT 'The per-entry report (JSON)',
+  `actor`          varchar(1024) NOT NULL COMMENT 'Audit: who started it',
+  `started_at`     timestamp     NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'When the apply began',
+  `finished_at`    timestamp     NULL     DEFAULT NULL COMMENT 'When it ended; NULL while RUNNING',
+  `avernet_tenant` varchar(64)   NOT NULL DEFAULT 'teamclaw' COMMENT 'Tenant, for data isolation',
+  `gmt_create`     timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'Row created',
+  `gmt_modified`   timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Row last modified',
+  PRIMARY KEY (`id`),
+  KEY `idx_manifest_apply_latest`
+    (`avernet_tenant`, `env`, `entity_id`, `bot_id`, `id`) GLOBAL,
+  KEY `idx_manifest_apply_by_id`
+    (`avernet_tenant`, `env`, `entity_id`, `bot_id`, `apply_id`) GLOBAL
+) AUTO_INCREMENT_MODE = 'ORDER' DEFAULT CHARSET = utf8mb4
+  COMMENT = 'Bot config manifest apply record';
+
+-- 4. POST: both tables present, each with its own distinguishing column, and
+--    no quarantined copy unless step 2 had to leave one. Expected:
+--      ac_bot_config_manifest_apply       has_apply_id=1  has_lock_token=0
+--      ac_bot_config_manifest_apply_lock  has_apply_id=0  has_lock_token=1
+SELECT t.TABLE_NAME,
+       SUM(c.COLUMN_NAME = 'apply_id')   AS has_apply_id,
+       SUM(c.COLUMN_NAME = 'lock_token') AS has_lock_token
+  FROM information_schema.TABLES t
+  JOIN information_schema.COLUMNS c
+    ON c.TABLE_SCHEMA = t.TABLE_SCHEMA AND c.TABLE_NAME = t.TABLE_NAME
+ WHERE t.TABLE_SCHEMA = DATABASE()
+   AND t.TABLE_NAME IN ('ac_bot_config_manifest_apply',
+                        'ac_bot_config_manifest_apply_lock',
+                        'ac_bot_config_manifest_apply_misprovisioned_20260907')
+ GROUP BY t.TABLE_NAME
+ ORDER BY t.TABLE_NAME;

--- a/src/backend/src/agentclaw/community/core/bot_management/README.md
+++ b/src/backend/src/agentclaw/community/core/bot_management/README.md
@@ -87,3 +87,16 @@ internal_dependencies:
 ### Change impact
 
 Highest-fanout domain — 12+ other core domains import it. BotService signature changes ripple widely. Repository protocol changes break the corresponding plugin_impl repos.
+
+## Owner display name on OpenAPI creation
+
+OpenAPI creation supplies the matching verified gateway user's nonblank
+`display_name` as `nick_name`, stripping surrounding whitespace. When no matching
+user display name is available, the owner ID remains the fallback. The existing
+`ac_bots.owner_name` column persists this value; catalog search projects it
+without substituting the entity ID.
+
+Create-with-manifest freezes `nick_name` in the durable job's `spec` at submission,
+so background completion does not depend on request identity context. Jobs queued
+before this field was introduced remain readable and fall back to their `user_id`.
+This requires no database migration and does not backfill historical Bot rows.

--- a/src/backend/src/agentclaw/community/core/bot_management/create_flow.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/create_flow.py
@@ -574,6 +574,7 @@ class ManifestCreationSubmitted:
 def submit_bot_creation_with_manifest(
     *,
     user_id: str,
+    nick_name: str,
     bot_id: str,
     document: str,
     modifier: str,
@@ -653,6 +654,7 @@ def submit_bot_creation_with_manifest(
     # can.
     try:
         return _apply_and_hand_off(
+            nick_name=nick_name,
             manifest_seam=manifest_seam,
             passport_plugin=passport_plugin,
             skill_set_factory=skill_set_factory,
@@ -676,6 +678,7 @@ def _apply_and_hand_off(
     passport_plugin: PassportPlugin,
     skill_set_factory: SkillSetServiceFactory,
     user_id: str,
+    nick_name: str,
     bot_id: str,
     entity_id: str,
     bot_name: str | None,
@@ -740,7 +743,7 @@ def _apply_and_hand_off(
         entity_id=entity_id,
         user_id=user_id,
         document_owner=user_id,
-        spec=creation_spec_to_payload(spec, context),
+        spec={**creation_spec_to_payload(spec, context), "nick_name": nick_name},
         iframe_url=iframe_url,
         redirect_url=redirect_url,
     )
@@ -827,7 +830,8 @@ def complete_manifest_creation(
     user_id = str(job_payload["user_id"])
     return complete_bot_authorization(
         user_id=user_id,
-        nick_name=user_id,
+        # Tasks submitted before owner-name propagation contain no nickname.
+        nick_name=job_payload["spec"].get("nick_name", user_id),
         bot_id=str(job_payload["bot_id"]),
         spec=spec,
         context=context,

--- a/src/backend/src/agentclaw/community/core/bot_startup_script/repository/models.py
+++ b/src/backend/src/agentclaw/community/core/bot_startup_script/repository/models.py
@@ -97,10 +97,35 @@ class BotStartupScriptModel(Base):
     #: Written by the repository, never by a caller. Hex sha256 is 64 ASCII
     #: characters, and the tenant is carried alongside rather than hashed in, so
     #: the isolation boundary stays visible in the key itself.
+    #:
+    #: Declared 256 to match the deployed column, which is ``varchar(256)`` --
+    #: wider than the 64 characters that can ever be written here. The width is
+    #: mirrored rather than tightened because this declaration's job is to say
+    #: what the table *is*; the value's real width is stated above, and the
+    #: repository is what holds it to 64 by only ever writing a hex digest.
     script_key = Column(
-        String(64), nullable=False, comment="唯一键代理：sha256(env|entity_id|bot_id)"
+        String(256), nullable=False, comment="唯一键代理：sha256(env|entity_id|bot_id)"
     )
 
+    # ``DateTime`` here, ``timestamp`` in the DDL. Deliberate, and the same
+    # split apply_models.py states for the same reason.
+    #
+    # It cannot disagree with the deployed column, because it never describes
+    # it: the OceanBase schema is operator-provisioned (``create_schema:
+    # false``), so the .sql file creates these and the ORM emits no DDL there.
+    # For reads and writes the declaration makes no difference either --
+    # SQLAlchemy's ``TIMESTAMP`` is a subclass of ``DateTime``, both bind and
+    # return ``datetime``, and the driver hands back a ``datetime`` for a
+    # TIMESTAMP column whichever is declared.
+    #
+    # Where it is NOT a no-op, and this is the part worth knowing: a community
+    # deployment on MySQL with ``create_schema: true`` bootstraps through
+    # ``create_all(mysql=True)``, which emits DATETIME from this declaration.
+    # That gap is repo-wide rather than this table's -- every model here is
+    # declared this way -- and switching this one column would only half-close
+    # it, since ``default=``/``onupdate=`` are client-side constructs: the
+    # bootstrap emits neither DEFAULT CURRENT_TIMESTAMP nor ON UPDATE
+    # CURRENT_TIMESTAMP for any table here, whatever the type says.
     gmt_create = Column(
         DateTime, default=func.now(), nullable=False, comment="创建时间"
     )
@@ -112,11 +137,19 @@ class BotStartupScriptModel(Base):
         comment="修改时间",
     )
 
+    # ``_v2`` because the plain name is occupied in the deployed environments
+    # by a key on (avernet_tenant, env, entity_id, bot_id) -- this key's name
+    # carrying the pre-surrogate design's columns -- which cannot be dropped
+    # there, so the surrogate key is added alongside it. The suffix is not a
+    # second constraint: the two enforce the same logical uniqueness, because
+    # script_key is injective over the three columns it hashes. Declared here
+    # under the name the deployed key actually has, so create_all, the .sql
+    # file and every environment agree on one name.
     __table_args__ = (
         UniqueConstraint(
             "avernet_tenant",
             "script_key",
-            name="uk_tenant_script_key",
+            name="uk_tenant_script_key_v2",
         ),
     )
 

--- a/src/backend/src/agentclaw/community/core/bot_startup_script/sql/2026_08_10_bot_startup_script.sql
+++ b/src/backend/src/agentclaw/community/core/bot_startup_script/sql/2026_08_10_bot_startup_script.sql
@@ -6,7 +6,10 @@
 -- "no script" are the same state.
 --
 -- Key is (avernet_tenant, script_key), where script_key is a sha256 of the
--- logical key (env, entity_id, bot_id). The tenant is in the key because
+-- logical key (env, entity_id, bot_id). The table also carries an older unique
+-- key over those three columns directly -- both are declared below, both are
+-- really in the deployed table, and they are equivalent; only the surrogate is
+-- indexed the way the repository reads. The tenant is in the key because
 -- ac_bots is itself tenant-scoped, so a bot_id is unique only within a tenant —
 -- legacy "default" bots carry documented residual cross-tenant collision on
 -- that identifier. Without the tenant here, two such bots would share one
@@ -58,12 +61,52 @@ CREATE TABLE `ac_bot_startup_script` (
   -- constraint is carried on a fixed-width sha256 hex digest instead. Written
   -- by the repository; the tenant is carried alongside rather than hashed in,
   -- so the isolation boundary stays visible in the key.
-  `script_key`    char(64)      NOT NULL COMMENT '唯一键代理：sha256(env|entity_id|bot_id)',
-  `gmt_create`    datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
-  `gmt_modified`  datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '修改时间',
+  -- varchar(256) rather than char(64), matching the deployed table. The value
+  -- is always exactly 64 lowercase hex characters -- the column is wider than
+  -- anything that can be stored in it, and deliberately so: this file has to
+  -- read back identically to ``SHOW CREATE TABLE``, or the next transcription
+  -- error hides in the diff between them the way the mediumint/mediumtext one
+  -- did. CHAR's blank-padding is not relied on anywhere: the repository writes
+  -- a hex digest and compares it for equality.
+  `script_key`    varchar(256)  NOT NULL COMMENT '唯一键代理：sha256(env|entity_id|bot_id)',
+  -- TIMESTAMP, not DATETIME, and the split is the module rule the manifest
+  -- DDL states: a column the *database* fills round-trips through TIMESTAMP's
+  -- session-offset conversion unchanged, while one the *application* binds
+  -- would be stored shifted. Both of these are database-filled -- the ORM
+  -- maps them to ``func.now()``, which renders server-side as ``now()``, and
+  -- the upsert re-stamps gmt_modified the same way -- so TIMESTAMP is the
+  -- correct half of that rule and matches ac_bots.
+  `gmt_create`    timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `gmt_modified`  timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '修改时间',
   PRIMARY KEY (`id`),
-  -- The only index, and every read uses it: the repository filters on
-  -- script_key rather than on the three columns it hashes, so there is no
-  -- second lookup key here to drift out of step with the ORM model.
-  UNIQUE KEY `uk_tenant_script_key` (`avernet_tenant`, `script_key`)
+  -- TWO UNIQUE KEYS, AND BOTH ARE REALLY THERE. They enforce the same logical
+  -- uniqueness -- script_key is injective over (env, entity_id, bot_id), so a
+  -- row accepted by one is accepted by the other, and either may be the one
+  -- that raises the IntegrityError the repository's upsert retries on. Nothing
+  -- depends on which.
+  --
+  -- The first is the ORIGINAL key under the name the second one wants. It was
+  -- provisioned with this key's name and the pre-surrogate design's columns,
+  -- and dropping an index is not available in the deployed environments, so it
+  -- stays. It is declared here rather than quietly omitted because this file's
+  -- whole contract is that it reads back identically to ``SHOW CREATE TABLE``:
+  -- an index that exists in the database and not in this file is the same
+  -- invisible drift as a column type that does, and it is how the mediumint /
+  -- mediumtext transcription error stayed hidden.
+  --
+  -- ITS KEY IS 5456 utf8mb4 BYTES (64+20+1024+256 chars), past InnoDB's
+  -- 3072-byte cap. OceanBase accepts it; stock MySQL/InnoDB would refuse this
+  -- CREATE TABLE outright. That makes this file OceanBase-targeted, which it
+  -- already was in practice -- and it is exactly the constraint that made the
+  -- surrogate necessary in the first place. A fresh environment on InnoDB must
+  -- omit this first key; it loses nothing by doing so, because the second one
+  -- enforces the same rule within the cap.
+  UNIQUE KEY `uk_tenant_script_key` (`avernet_tenant`, `env`, `entity_id`, `bot_id`),
+  -- The second is the key EVERY READ USES: ``get``, ``upsert`` and ``delete``
+  -- all filter on script_key alone, so without this one each of them is a full
+  -- scan -- on a table ``_build_create_bot_payload`` reads on every payload it
+  -- composes. The ``_v2`` suffix is not a version of anything: it is simply the
+  -- name left over once the key above took the obvious one, and it is the name
+  -- the ORM model declares too, so one name is correct everywhere.
+  UNIQUE KEY `uk_tenant_script_key_v2` (`avernet_tenant`, `script_key`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='Bot 启动脚本';

--- a/src/backend/src/agentclaw/community/core/mcp/mcp_sync_service_protocol.py
+++ b/src/backend/src/agentclaw/community/core/mcp/mcp_sync_service_protocol.py
@@ -8,7 +8,13 @@ from typing import Any, Protocol, runtime_checkable
 
 @runtime_checkable
 class MCPSyncServiceProtocol(Protocol):
-    """Service API for syncing MCP details to bot devices."""
+    """Service API for syncing MCP details to bot devices.
+
+    ``sync_mcp_details_for_bot`` and ``remove_mcp_detail`` accept an optional
+    ``device_sync``: a caller-resolved DeviceSync for the same Bot and current
+    projection only. When supplied, do not re-resolve the target. Omission
+    retains standalone resolution. Never cache it across requests/retries.
+    """
 
     async def sync_mcp_details(self, *args: Any, **kwargs: Any) -> Any: ...
 

--- a/src/backend/src/agentclaw/community/core/mcp/services/sync_service.py
+++ b/src/backend/src/agentclaw/community/core/mcp/services/sync_service.py
@@ -286,6 +286,7 @@ class MCPSyncService(MCPSyncServiceProtocol):
         bot_id: str,
         entity_id: Optional[str] = None,
         engine_type: Optional[str] = None,
+        device_sync: DeviceSync | None = None,
     ) -> dict[str, Any]:
         """把一批已备齐的 MCP 详情推送到**同一个** bot 的设备。
 
@@ -300,6 +301,8 @@ class MCPSyncService(MCPSyncServiceProtocol):
             user_id: 用户 ID。仅用于 ``build_mcp_sync_payload`` 取该用户的 MCP
                 配置(api_key 等),是 per-user 维度。
             mcp_entries: 待推送的 MCP 详情列表;caller 已备齐,本方法不再回查。
+            device_sync: 本次投影已解析的目标；提供时不再解析或切换设备。
+                省略时保持独立调用的原行为。禁止跨请求复用。
             bot_id: 目标 bot ID——列表内所有 MCP 共用。
             entity_id: bot 所属实体 ID,缺省回退到 ``user_id``。
             engine_type: 引擎类型,默认 ``openclaw``。
@@ -313,19 +316,19 @@ class MCPSyncService(MCPSyncServiceProtocol):
             # 无 MCP 可投递:不必解析设备。allow-list 的声明是 caller 的事。
             return {"success": True}
 
-        try:
-            # resolve_for_bot 同步且内含阻塞 ws-info HTTP + DB 查询,放线程池,
-            # 否则会占住 event loop。
-            ctx = await asyncio.to_thread(
-                self._resolver_provider().resolve_for_bot,
-                bot_id,
-                entity_id or user_id,
-            )
-        except (DeviceNotBoundError, UnknownProviderError):
-            error = f"bot={_bot} 缺少设备连接信息，无法推送 MCP 配置"
-            logger.error("[MCPSyncService] %s", error)
-            return {"success": False, "error": error}
-        plugin = self._device_sync_dispatcher_provider().dispatch(ctx)
+        if device_sync is None:
+            try:
+                ctx = await asyncio.to_thread(
+                    self._resolver_provider().resolve_for_bot,
+                    bot_id,
+                    entity_id or user_id,
+                )
+            except (DeviceNotBoundError, UnknownProviderError):
+                error = f"bot={_bot} 缺少设备连接信息，无法推送 MCP 配置"
+                logger.error("[MCPSyncService] %s", error)
+                return {"success": False, "error": error}
+            device_sync = self._device_sync_dispatcher_provider().dispatch(ctx)
+        plugin = device_sync
 
         _successes, failures = await fan_out_mcp_details(
             mcps=mcp_entries,
@@ -357,6 +360,7 @@ class MCPSyncService(MCPSyncServiceProtocol):
         server_code: str,
         bot_id: str,
         user_id: str,
+        device_sync: DeviceSync | None = None,
     ) -> dict[str, Any]:
         """从指定 bot 的设备上移除单个 MCP。
 
@@ -368,17 +372,21 @@ class MCPSyncService(MCPSyncServiceProtocol):
             bot_id: 目标 bot ID。
             user_id: 用户 ID。
 
+            device_sync: 本次投影的已解析目标；省略时自行解析，不跨请求缓存。
+
         Returns:
             ``{"success": bool, "error": str|None}`` 格式的结果字典。
         """
         _bot = bot_id or "unknown"
-        try:
-            ctx = self._resolver_provider().resolve_for_bot(bot_id, user_id)
-        except (DeviceNotBoundError, UnknownProviderError):
-            error = f"bot={_bot} 缺少设备连接信息，无法移除 MCP {server_code}"
-            logger.error("[MCPSyncService] %s", error)
-            return {"success": False, "error": error}
-        plugin = self._device_sync_dispatcher_provider().dispatch(ctx)
+        if device_sync is None:
+            try:
+                ctx = self._resolver_provider().resolve_for_bot(bot_id, user_id)
+            except (DeviceNotBoundError, UnknownProviderError):
+                error = f"bot={_bot} 缺少设备连接信息，无法移除 MCP {server_code}"
+                logger.error("[MCPSyncService] %s", error)
+                return {"success": False, "error": error}
+            device_sync = self._device_sync_dispatcher_provider().dispatch(ctx)
+        plugin = device_sync
 
         # teclaw 在 sync_remove_mcp 内部重组并投递整产物（compose 反映删除后的状态），
         # arca/baas 走单条移除请求——由插件按容器类型决定。

--- a/src/backend/src/agentclaw/community/core/repository/implementations/publishing/bot_publish.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/publishing/bot_publish.py
@@ -356,6 +356,25 @@ class BotPublishRepository(
             record = row.to_record() if row else None
         return self._resolve_record(record)
 
+    def get_latest_built_by_source_bot_id(
+        self,
+        source_bot_id: str,
+        env: str,
+    ) -> Optional[BotPublishRecord]:
+        with self._db.orm_session() as db:
+            row = (
+                db.query(self.Model)
+                .filter(
+                    self.Model.source_bot_id == source_bot_id,
+                    self.Model.status == PublishStatus.BUILT.value,
+                    self.Model.env == env,
+                )
+                .order_by(self.Model.id.desc())
+                .first()
+            )
+            record = row.to_record() if row else None
+        return self._resolve_record(record)
+
     def get_by_last_pub_id(
         self,
         last_pub_id: int,

--- a/src/backend/src/agentclaw/community/core/repository/protocols/publishing.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/publishing.py
@@ -246,6 +246,27 @@ class BotPublishRepositoryProtocol(Protocol):
         ...
 
     @abstractmethod
+    def get_latest_built_by_source_bot_id(
+        self,
+        source_bot_id: str,
+        env: str,
+    ) -> Optional[BotPublishRecord]:
+        """Get the latest status=built publish record by source_bot_id (owner-agnostic).
+
+        Used by the Eval environment to anchor the latest draft (built) version
+        rather than the latest online (success) version. Deliberately NOT filtered
+        by owner_id for the same reason as get_latest_success_by_source_bot_id.
+
+        Args:
+            source_bot_id: source bot_id
+            env: environment
+
+        Returns:
+            The latest built publish record, or None if not found.
+        """
+        ...
+
+    @abstractmethod
     def get_by_last_pub_id(
         self,
         last_pub_id: int,

--- a/src/backend/src/agentclaw/community/core/service_bot/README.md
+++ b/src/backend/src/agentclaw/community/core/service_bot/README.md
@@ -62,6 +62,7 @@ internal_dependencies:
   - agentclaw.community.plugin_api.approval_workflow           # antprocess approval workflow for publish approval
   - agentclaw.community.core.devices.services.device_filesystem    # teclaw build-time file promotion (TeclawFilePromotion)
   - agentclaw.community.plugin_api.engine_ext_client
+  - agentclaw.community.plugin_api.eval_env             # DYNAMIC_ENV_TAG_KEY injected into eval container extra_envs
   - agentclaw.community.plugin_api.http_client
   - agentclaw.community.plugin_api.models
   - agentclaw.community.plugin_api.object_storage           # teclaw promotion stages files to OSS

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/eval_publish_mixin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/eval_publish_mixin.py
@@ -14,6 +14,7 @@ from agentclaw.community.core.service_bot.services.deploy.service_publish_env im
     service_publish_extra_envs,
     service_publish_template_config,
 )
+from agentclaw.community.plugin_api.eval_env import DYNAMIC_ENV_TAG_KEY
 from agentclaw.community.core.service_bot.services.publish_flow.errors import (
     PublishFlowServiceError,
 )
@@ -110,6 +111,11 @@ class EvalPublishMixin:
         )
 
         async def _issue():
+            # 注入评测环境容器环境变量，使容器内进程可通过 os.environ 感知区标识
+            eval_envs = dict(service_publish_extra_envs(publish_record.ext, bot))
+            if default_tag:
+                eval_envs[DYNAMIC_ENV_TAG_KEY] = default_tag
+
             release_kwargs: dict[str, Any] = dict(
                 bot=bot,
                 user_id=owner_id,
@@ -119,7 +125,7 @@ class EvalPublishMixin:
                 version=str(publish_record.version or 1),
                 delivery=delivery,
                 ext_info=ext_info,
-                extra_envs=service_publish_extra_envs(publish_record.ext, bot),
+                extra_envs=eval_envs,
                 docker_image=image_pin.docker_image,
                 template_config=service_publish_template_config(bot),
             )

--- a/src/backend/src/agentclaw/community/core/skill_center/AGENTS.md
+++ b/src/backend/src/agentclaw/community/core/skill_center/AGENTS.md
@@ -70,7 +70,7 @@ Bot 定位必须携带 `owner_id + bot_id`，并保持 Repository 的 tenant/env
 - `CapabilityDesiredStateRepository` 是 Set state、membership、Default exclusion 与 Skill/MCP Installation 的事务写入入口；表级 SQL owner 使用同一个事务 Session。
 - 普通 Set 新建默认 `is_active=True`。active Set 增删成员同步维护 Installation；inactive Set 编辑不要求 Runtime 投影。
 - `services/bot_capability_state_reader.py` 在读有效态前同步 Installation，然后只从 Installation 读取有效身份。Center 资产在返回前由 `SkillVersionResolver` 解析到精确 PUBLISHED Version。
-- Reader 的 `InstallationReadConfig` 由 `ConfigModule` 从 YAML `user_config.skill_installation.default_sync_only` 按规范化环境选择，`pre`、`prod` 缺省均为 `false`；旧 `SC_INSTALLATION_DEFAULT_SYNC_ONLY` 环境变量不再生效。验收某个环境的完整 backfill 后，才可单独将该环境置为 `true` 并重新部署 Backend。该模式仍同步 Default/exclusion，不等于完全取消 DB 补齐。运维 backfill 和新 Bot 的 `initialize_installations` 始终完整执行，不受此读侧配置影响。
+- Reader 的 `InstallationReadConfig` 从 `ac_common_config` 按规范化环境读取 `business_code=skill_installation`、`param_code=default_sync_only`。每个环境有独立记录，缺失、禁用、读取失败或非布尔值均 fail-safe 为 `false`（完整同步）；该值在每次 Effective Read 动态读取，因此验收某环境完整 backfill 后可将其单独设为 `true`，也可仅通过 DB 立即回退。旧 YAML 和 `SC_INSTALLATION_DEFAULT_SYNC_ONLY` 环境变量均不生效。该模式仍同步 Default/exclusion，不等于完全取消 DB 补齐。运维 backfill 和新 Bot 的 `initialize_installations` 始终完整执行，不受此读侧配置影响。
 - 普通 Asset、Draft、Version 查询不应为方便而触发 Bot flush。需要回答“Bot 当前应有哪些有效能力”时才使用 Reader。
 - `policies/capability_ownership.py` 统一判定：Set 成员（含 inactive Set 和 excluded Default member）由 Set 控制；Direct-active 能力加入 Set 前先停用；同一 Bot 下只能属于一个 reaching Set（含 Default）。`RESOURCE_DIRECT_ACTIVE` 优先于另一个 Set 冲突。
 - Default member 被 exclusion 后仍属于 Default；重新启用走 un-exclude。Default 选择统一使用 `policies/default_skill_set_selection.py`，保留全局 Default 与 engine/template 兼容规则。

--- a/src/backend/src/agentclaw/community/core/skill_center/AGENTS.md
+++ b/src/backend/src/agentclaw/community/core/skill_center/AGENTS.md
@@ -70,7 +70,7 @@ Bot 定位必须携带 `owner_id + bot_id`，并保持 Repository 的 tenant/env
 - `CapabilityDesiredStateRepository` 是 Set state、membership、Default exclusion 与 Skill/MCP Installation 的事务写入入口；表级 SQL owner 使用同一个事务 Session。
 - 普通 Set 新建默认 `is_active=True`。active Set 增删成员同步维护 Installation；inactive Set 编辑不要求 Runtime 投影。
 - `services/bot_capability_state_reader.py` 在读有效态前同步 Installation，然后只从 Installation 读取有效身份。Center 资产在返回前由 `SkillVersionResolver` 解析到精确 PUBLISHED Version。
-- `SC_INSTALLATION_DEFAULT_SYNC_ONLY=false` 时执行完整 `flush_installations`；验收历史 backfill 后可启用 Default-only 同步模式。该模式仍同步 Default/exclusion，不等于完全取消 DB 补齐。新 Bot 的 `initialize_installations` 始终完整初始化。
+- Reader 的 `InstallationReadConfig` 由 `ConfigModule` 从 YAML `user_config.skill_installation.default_sync_only` 按规范化环境选择，`pre`、`prod` 缺省均为 `false`；旧 `SC_INSTALLATION_DEFAULT_SYNC_ONLY` 环境变量不再生效。验收某个环境的完整 backfill 后，才可单独将该环境置为 `true` 并重新部署 Backend。该模式仍同步 Default/exclusion，不等于完全取消 DB 补齐。运维 backfill 和新 Bot 的 `initialize_installations` 始终完整执行，不受此读侧配置影响。
 - 普通 Asset、Draft、Version 查询不应为方便而触发 Bot flush。需要回答“Bot 当前应有哪些有效能力”时才使用 Reader。
 - `policies/capability_ownership.py` 统一判定：Set 成员（含 inactive Set 和 excluded Default member）由 Set 控制；Direct-active 能力加入 Set 前先停用；同一 Bot 下只能属于一个 reaching Set（含 Default）。`RESOURCE_DIRECT_ACTIVE` 优先于另一个 Set 冲突。
 - Default member 被 exclusion 后仍属于 Default；重新启用走 un-exclude。Default 选择统一使用 `policies/default_skill_set_selection.py`，保留全局 Default 与 engine/template 兼容规则。

--- a/src/backend/src/agentclaw/community/core/skill_center/AGENTS.md
+++ b/src/backend/src/agentclaw/community/core/skill_center/AGENTS.md
@@ -80,6 +80,8 @@ Bot 定位必须携带 `owner_id + bot_id`，并保持 Repository 的 tenant/env
 
 命令通过 `ProjectionScope` 表达变化范围；Skill claim/release 携带 MCP dependency candidates，由投影端结合完整有效集合过滤。不要把每次操作都扩大为 `everything()`。启动恢复等确实需要完整重投影的入口可使用它。
 
+一次 MCP 投影通过 Reader `active_capabilities` 同步一次 Installation，返回精确 Skill 与 installed MCP 的 `BotCapabilitySnapshot`，供 Skill Plan 和唯一 Effective MCP collector 共用。快照不包括 Policy MCP、不保证跨表事务快照隔离，不能跨变更、重试或请求缓存；Skill-only 仍使用独立 Skill 读取。Default/exclusion 与完整回刷模式均保留。MCP 配置、移除和完整白名单下发在同一次 `project_mcps` 内复用一个解析后的 `DeviceSync`；不改变下发顺序、失败处理、POST-conflict-update 或 Passport 语义。
+
 ## 4. Local、Repo、Center 的内容身份
 
 - `local://...`：Bot-owned 可变内容，由 Local upload/delete 服务及文件适配器管理；上传协议保留 raw ZIP，同时提供 multipart `files + file_paths` 文件夹上传。GET Bot Skills 的 `source=LOCAL` 仅列出该 Bot 上传资产，`active` 再筛选 Desired State；省略 source 保留完整可达资产列表。

--- a/src/backend/src/agentclaw/community/core/skill_center/README.md
+++ b/src/backend/src/agentclaw/community/core/skill_center/README.md
@@ -142,6 +142,7 @@ internal_dependencies:
   - agentclaw.community.core.access
   - agentclaw.community.core.base
   - agentclaw.community.core.bot_collaborator
+  - agentclaw.community.core.common_config
   - agentclaw.community.core.bot_management
   - agentclaw.community.core.config
   - agentclaw.community.core.config_compose

--- a/src/backend/src/agentclaw/community/core/skill_center/capability_state_contract.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/capability_state_contract.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
@@ -10,6 +11,20 @@ if TYPE_CHECKING:
     # package __init__ is still executing, so a module-level import of
     # skills_pool.models here would close an import cycle.
     from agentclaw.community.core.skills_pool.models import RegisteredSkillAsset
+
+
+@dataclass(frozen=True)
+class BotCapabilitySnapshot:
+    """One reader-backed projection input, never cached across mutations.
+
+    This groups reads after one synchronization, not a database isolation
+    guarantee. Policy defaults remain the effective-MCP collector's concern.
+    """
+
+    bot_id: str
+    owner_id: str
+    skills: tuple[RegisteredSkillAsset, ...]
+    installed_mcp_server_codes: frozenset[str]
 
 
 @runtime_checkable
@@ -60,6 +75,20 @@ class BotCapabilityStateReaderProtocol(Protocol):
         """Flush, then return Runtime-ready assets with exact Center Versions."""
         ...
 
+    def active_capabilities(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+        bot: Mapping[str, Any] | None = None,
+    ) -> BotCapabilitySnapshot:
+        """Synchronize once, then read exact Skills and installed MCP codes.
+
+        Consume only within the current projection; after a write or retry,
+        obtain a new snapshot. This does not include engine Policy MCPs.
+        """
+        ...
+
     def active_mcp_server_codes(
         self,
         *,
@@ -71,4 +100,4 @@ class BotCapabilityStateReaderProtocol(Protocol):
         ...
 
 
-__all__ = ["BotCapabilityStateReaderProtocol"]
+__all__ = ["BotCapabilitySnapshot", "BotCapabilityStateReaderProtocol"]

--- a/src/backend/src/agentclaw/community/core/skill_center/feature_flags.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/feature_flags.py
@@ -15,9 +15,6 @@ class SkillCenterFlags:
     symlink_verify_auto_fix: bool
     write_skill_uuid: bool  # 双写控制，不关
     space_skill_enabled: bool = False
-    # Migration gate for Installation backfill.  It remains false until the
-    # operator has completed and accepted the environment backfill.
-    installation_default_sync_only: bool = False
 
     @classmethod
     def from_env(cls) -> "SkillCenterFlags":
@@ -29,10 +26,6 @@ class SkillCenterFlags:
             symlink_verify_auto_fix=os.environ.get("SC_SYMLINK_AUTO_FIX", "false").lower() == "true",
             write_skill_uuid=os.environ.get("SC_WRITE_SKILL_UUID", "true").lower() == "true",
             space_skill_enabled=os.environ.get("SC_SPACE_SKILL_ENABLED", "false").lower() == "true",
-            installation_default_sync_only=(
-                os.environ.get("SC_INSTALLATION_DEFAULT_SYNC_ONLY", "false").lower()
-                == "true"
-            ),
         )
 
     def any_blocking_enabled(self) -> bool:

--- a/src/backend/src/agentclaw/community/core/skill_center/installation_read_config.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/installation_read_config.py
@@ -1,10 +1,73 @@
-"""Resolved Installation read mode; deployment parsing belongs to DI."""
+"""Runtime-configurable Installation Reader migration gate."""
 
-from dataclasses import dataclass
+from __future__ import annotations
+
+from typing import Any
+
+from agentclaw.community.core.common_config.common_config_service_protocol import (
+    CommonConfigServiceProtocol,
+)
+from agentclaw.community.log import get_logger
 
 
-@dataclass(frozen=True)
+logger = get_logger()
+
+INSTALLATION_READ_BUSINESS_CODE = "skill_installation"
+INSTALLATION_READ_PARAM_CODE = "default_sync_only"
+
+
 class InstallationReadConfig:
-    """False retains full repair until this environment's backfill is accepted."""
+    """Resolve the migration mode from ``ac_common_config`` for one environment.
 
-    default_sync_only: bool = False
+    A missing, disabled, unreadable, or malformed record deliberately keeps the
+    complete repair path enabled. The value is read on each effective-capability
+    access so an operator can roll an accepted environment back through DB
+    configuration without waiting for a process restart or release.
+
+    ``default_sync_only`` constructor argument exists only for direct unit-test wiring. The
+    production DI binding always supplies ``common_config_service`` and ``env``.
+    """
+
+    def __init__(
+        self,
+        default_sync_only: bool = False,
+        *,
+        common_config_service: CommonConfigServiceProtocol | None = None,
+        env: str | None = None,
+    ) -> None:
+        self._static_default_sync_only = default_sync_only
+        self._common_config_service = common_config_service
+        self._env = env
+
+    @property
+    def default_sync_only(self) -> bool:
+        """Return the current environment's DB-owned migration switch."""
+        if self._common_config_service is None or self._env is None:
+            return self._static_default_sync_only
+        try:
+            value: Any = self._common_config_service.get_value(
+                business_code=INSTALLATION_READ_BUSINESS_CODE,
+                param_code=INSTALLATION_READ_PARAM_CODE,
+                env=self._env,
+                default=False,
+                only_enabled=True,
+            )
+        except Exception:
+            logger.exception(
+                "[installation_read_config] common config read failed env=%s; "
+                "retaining complete installation repair",
+                self._env,
+            )
+            return False
+        if type(value) is bool:
+            return value
+        if value is not False:
+            logger.warning(
+                "[installation_read_config] invalid common config value env=%s "
+                "business_code=%s param_code=%s value=%r; retaining complete repair",
+                self._env,
+                INSTALLATION_READ_BUSINESS_CODE,
+                INSTALLATION_READ_PARAM_CODE,
+                value,
+            )
+        return False

--- a/src/backend/src/agentclaw/community/core/skill_center/installation_read_config.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/installation_read_config.py
@@ -1,0 +1,10 @@
+"""Resolved Installation read mode; deployment parsing belongs to DI."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class InstallationReadConfig:
+    """False retains full repair until this environment's backfill is accepted."""
+
+    default_sync_only: bool = False

--- a/src/backend/src/agentclaw/community/core/skill_center/legacy_skill_set_compatibility.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/legacy_skill_set_compatibility.py
@@ -3,7 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from collections.abc import Mapping
 from typing import Any, Protocol, runtime_checkable
+
+from agentclaw.community.core.repository.protocols.capability_desired_state import (
+    CapabilityDesiredStateRepositoryProtocol,
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -70,3 +75,37 @@ class LegacySkillSetCompatibilityFactoryProtocol(Protocol):
     def create(
         self, *args: Any, **kwargs: Any
     ) -> LegacySkillSetCompatibilityProtocol: ...
+
+
+def list_skill_set_mcp_projection(
+    *,
+    repository: CapabilityDesiredStateRepositoryProtocol,
+    legacy_factory: LegacySkillSetCompatibilityFactoryProtocol,
+    bot: Mapping[str, Any],
+    target: Mapping[str, Any],
+    bot_id: str,
+    owner_id: str,
+    engine_type: str,
+    default_engine_types: tuple[str, ...],
+) -> list[dict[str, Any]]:
+    """Project Default policy MCPs; read ordinary Set membership directly."""
+    if target["is_default"]:
+        legacy = legacy_factory.create(
+            entity_id=str(bot.get("entity_id") or owner_id),
+            bot_id=bot_id,
+            engine_type=engine_type,
+            entity_type=bot.get("entity_type") or "staff",
+        )
+        return legacy.get_set_mcp_servers(
+            str(target["id"]),
+            user_id=owner_id,
+            bot_id=bot_id,
+            engine_type=engine_type,
+        )
+    return repository.list_mcps(
+        bot_id=bot_id,
+        owner_id=owner_id,
+        set_id=str(target["id"]),
+        engine_type=engine_type,
+        default_engine_types=default_engine_types,
+    )

--- a/src/backend/src/agentclaw/community/core/skill_center/services/bot_capability_state_reader.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/bot_capability_state_reader.py
@@ -31,6 +31,7 @@ from agentclaw.community.core.skill_center.version_resolution_contract import (
 )
 from agentclaw.community.core.skills_pool.models import RegisteredSkillAsset
 from agentclaw.community.core.skill_center.bot_capability_state_reader_protocol import BotCapabilityStateReaderProtocol
+from agentclaw.community.core.skill_center.capability_state_contract import BotCapabilitySnapshot
 
 
 logger = get_logger()
@@ -118,6 +119,11 @@ class BotCapabilityStateReader(BotCapabilityStateReaderProtocol):
         self.synchronize_installations(
             bot_id=bot_id, owner_id=owner_id, bot=bot
         )
+        return self._read_skill_assets(bot_id=bot_id, owner_id=owner_id, bot=bot)
+
+    def _read_skill_assets(
+        self, *, bot_id: str, owner_id: str, bot: Mapping[str, Any]
+    ) -> tuple[RegisteredSkillAsset, ...]:
         assets = tuple(
             self._pool_skills.list_bot_installed_assets(
                 env=str(bot["env"]),
@@ -127,6 +133,24 @@ class BotCapabilityStateReader(BotCapabilityStateReaderProtocol):
         )
         return self._version_resolver.resolve_latest_runtime_assets(
             env=str(bot["env"]), assets=assets
+        )
+
+    def active_capabilities(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+        bot: Mapping[str, Any] | None = None,
+    ) -> BotCapabilitySnapshot:
+        bot = self._bot(bot_id=bot_id, owner_id=owner_id, bot=bot)
+        self.synchronize_installations(bot_id=bot_id, owner_id=owner_id, bot=bot)
+        return BotCapabilitySnapshot(
+            bot_id=bot_id,
+            owner_id=owner_id,
+            skills=self._read_skill_assets(bot_id=bot_id, owner_id=owner_id, bot=bot),
+            installed_mcp_server_codes=frozenset(
+                self._repository.list_installed_mcps(bot_id=bot_id, owner_id=owner_id)
+            ),
         )
 
     def active_mcp_server_codes(

--- a/src/backend/src/agentclaw/community/core/skill_center/services/bot_capability_state_reader.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/bot_capability_state_reader.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from time import perf_counter
 from typing import Any
 
 from injector import inject
+
+from agentclaw.community.log import get_logger
 
 from agentclaw.community.core.repository.capability_desired_state_types import (
     InstallationFlushPlan,
@@ -28,6 +31,9 @@ from agentclaw.community.core.skill_center.version_resolution_contract import (
 )
 from agentclaw.community.core.skills_pool.models import RegisteredSkillAsset
 from agentclaw.community.core.skill_center.bot_capability_state_reader_protocol import BotCapabilityStateReaderProtocol
+
+
+logger = get_logger()
 
 
 class BotCapabilityStateReader(BotCapabilityStateReaderProtocol):
@@ -152,15 +158,33 @@ class BotCapabilityStateReader(BotCapabilityStateReaderProtocol):
     def _flush(
         self, *, bot: Mapping[str, Any], bot_id: str, owner_id: str
     ) -> InstallationFlushPlan:
+        started = perf_counter()
+        default_sync_only = self._read_config.default_sync_only
+        sync_mode = "DEFAULT_ONLY" if default_sync_only else "FULL_FLUSH"
         sync = (
             self._repository.sync_default_installations
-            if self._read_config.default_sync_only
+            if default_sync_only
             else self._repository.flush_installations
         )
-        return sync(
-            bot_id=bot_id,
-            owner_id=owner_id,
-            env=str(bot["env"]),
-            engine_type=bot_engine_type(bot),
-            default_engine_types=bot_default_engine_types(bot),
-        )
+        status = "FAILED"
+        try:
+            plan = sync(
+                bot_id=bot_id,
+                owner_id=owner_id,
+                env=str(bot["env"]),
+                engine_type=bot_engine_type(bot),
+                default_engine_types=bot_default_engine_types(bot),
+            )
+            status = "SUCCEEDED"
+            return plan
+        finally:
+            logger.info(
+                "[BotCapabilityStateReader] installation_sync env=%s owner_id=%s "
+                "bot_id=%s sync_mode=%s status=%s duration_ms=%d",
+                str(bot["env"]),
+                owner_id,
+                bot_id,
+                sync_mode,
+                status,
+                int((perf_counter() - started) * 1000),
+            )

--- a/src/backend/src/agentclaw/community/core/skill_center/services/bot_capability_state_reader.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/bot_capability_state_reader.py
@@ -21,7 +21,7 @@ from agentclaw.community.core.skill_center.bot_engine_scope import (
     bot_default_engine_types,
     bot_engine_type,
 )
-from agentclaw.community.core.skill_center.feature_flags import get_skill_center_flags
+from agentclaw.community.core.skill_center.installation_read_config import InstallationReadConfig
 from agentclaw.community.core.skill_center.errors import LocalSkillNotFoundError
 from agentclaw.community.core.skill_center.version_resolution_contract import (
     SkillVersionResolverProtocol,
@@ -47,11 +47,13 @@ class BotCapabilityStateReader(BotCapabilityStateReaderProtocol):
         bot_repo: BotRepository,
         pool_skills: SkillsPoolSkillRepositoryProtocol,
         version_resolver: SkillVersionResolverProtocol,
+        read_config: InstallationReadConfig = InstallationReadConfig(),
     ) -> None:
         self._repository = repository
         self._bot_repo = bot_repo
         self._pool_skills = pool_skills
         self._version_resolver = version_resolver
+        self._read_config = read_config
 
     def member_skill_ids(self, *, bot: Mapping[str, Any]) -> frozenset[int]:
         return self._repository.list_member_skill_ids(
@@ -152,7 +154,7 @@ class BotCapabilityStateReader(BotCapabilityStateReaderProtocol):
     ) -> InstallationFlushPlan:
         sync = (
             self._repository.sync_default_installations
-            if get_skill_center_flags().installation_default_sync_only
+            if self._read_config.default_sync_only
             else self._repository.flush_installations
         )
         return sync(

--- a/src/backend/src/agentclaw/community/core/skill_center/services/bot_runtime_projector.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/bot_runtime_projector.py
@@ -16,6 +16,7 @@ from agentclaw.community.core.mcp.services.cli_passport_scope import (
     build_passport_resource_scope,
 )
 from agentclaw.community.core.skill_center.capability_state_contract import (
+    BotCapabilitySnapshot,
     BotCapabilityStateReaderProtocol,
 )
 from agentclaw.community.core.repository.protocols.bot import BotRepository
@@ -271,11 +272,16 @@ class BotRuntimeProjector(BotRuntimeProjectorProtocol):
             raise LocalSkillNotFoundError()
         skill_plan_started_at = time.perf_counter()
         try:
+            snapshot = (
+                self._reader.active_capabilities(bot_id=bot_id, owner_id=owner_id, bot=bot)
+                if scope.mcp else None
+            )
             skill_plan = self._build_skill_plan(
                 bot=bot,
                 bot_id=bot_id,
                 owner_id=owner_id,
                 retired_mappings=retired_mappings,
+                snapshot=snapshot,
             )
         except Exception:
             self._log_plan_timing(
@@ -304,7 +310,8 @@ class BotRuntimeProjector(BotRuntimeProjectorProtocol):
             return skill_plan
         capability_plan_started_at = time.perf_counter()
         try:
-            capability_plan = self._build_capability_plan(skill_plan)
+            assert snapshot is not None
+            capability_plan = self._build_capability_plan(skill_plan, snapshot)
         except Exception:
             self._log_plan_timing(
                 stage="build_mcp_plan",
@@ -382,13 +389,15 @@ class BotRuntimeProjector(BotRuntimeProjectorProtocol):
         bot_id: str,
         owner_id: str,
         retired_mappings: Sequence[PoolSkillMapping] = (),
+        snapshot: BotCapabilitySnapshot | None = None,
     ) -> ResolvedSkillPlan:
         engine = str(bot.get("active_engine") or "openclaw")
         # The reader flushes before answering, so the plan is always built
         # over Installation that agrees with Set configuration — the lazy
         # flush every read runs, not a projector-only repair.
         skill_assets = tuple(
-            self._reader.active_skill_assets(bot_id=bot_id, owner_id=owner_id, bot=bot)
+            snapshot.skills if snapshot is not None
+            else self._reader.active_skill_assets(bot_id=bot_id, owner_id=owner_id, bot=bot)
         )
         # Reject before querying or writing any external MCP, Passport, or
         # runtime boundary. What an engine's runtime cannot carry is the
@@ -406,7 +415,7 @@ class BotRuntimeProjector(BotRuntimeProjectorProtocol):
         )
 
     def _build_capability_plan(
-        self, skill_plan: ResolvedSkillPlan
+        self, skill_plan: ResolvedSkillPlan, snapshot: BotCapabilitySnapshot
     ) -> ResolvedCapabilityPlan:
         bot = skill_plan.bot
         bot_id = skill_plan.bot_id
@@ -456,6 +465,7 @@ class BotRuntimeProjector(BotRuntimeProjectorProtocol):
                 entity_type=bot.get("entity_type") or "staff",
                 engine_type=engine,
                 strict_policy_context=True,
+                capability_snapshot=snapshot,
             )
         except Exception as exc:
             self._log_plan_timing(
@@ -486,30 +496,7 @@ class BotRuntimeProjector(BotRuntimeProjectorProtocol):
             stage="query_passport_clis", bot_id=bot_id, engine=engine,
             started_at=started_at, outcome="success", cli_count=len(effective_cli_items),
         )
-        started_at = time.perf_counter()
-        try:
-            installed_mcp_codes = frozenset(
-                self._repository.list_installed_mcps(
-                    bot_id=bot_id, owner_id=owner_id
-                )
-            )
-        except Exception:
-            self._log_plan_timing(
-                stage="read_installed_mcps",
-                bot_id=bot_id,
-                engine=engine,
-                started_at=started_at,
-                outcome="error",
-            )
-            raise
-        self._log_plan_timing(
-            stage="read_installed_mcps",
-            bot_id=bot_id,
-            engine=engine,
-            started_at=started_at,
-            outcome="success",
-            mcp_count=len(installed_mcp_codes),
-        )
+        installed_mcp_codes = snapshot.installed_mcp_server_codes
         started_at = time.perf_counter()
         try:
             projection = RuntimeProjectionResolver().resolve(

--- a/src/backend/src/agentclaw/community/core/skill_center/services/bot_runtime_projector.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/bot_runtime_projector.py
@@ -415,8 +415,27 @@ class BotRuntimeProjector(BotRuntimeProjectorProtocol):
         # Resolved here, with the other pre-flight checks, because it can fail:
         # doing it at the Passport call would abort after the device allow-list
         # was already written, and compensation would hit the same failure.
-        identity_modes = self._resolve_mcp_identity_modes(
-            bot=bot, bot_id=bot_id, engine=engine
+        started_at = time.perf_counter()
+        try:
+            identity_modes = self._resolve_mcp_identity_modes(
+                bot=bot, bot_id=bot_id, engine=engine
+            )
+        except Exception:
+            self._log_plan_timing(
+                stage="resolve_mcp_identity_modes",
+                bot_id=bot_id,
+                engine=engine,
+                started_at=started_at,
+                outcome="error",
+            )
+            raise
+        self._log_plan_timing(
+            stage="resolve_mcp_identity_modes",
+            bot_id=bot_id,
+            engine=engine,
+            started_at=started_at,
+            outcome="success",
+            mcp_count=len(identity_modes),
         )
         service = self._factory.create(
             user_id=owner_id,
@@ -429,6 +448,7 @@ class BotRuntimeProjector(BotRuntimeProjectorProtocol):
         # System Defaults during Phase 1. It resolves template presets and
         # applies ac_default_skillset_mcp_exclusion.
         try:
+            started_at = time.perf_counter()
             effective_mcp_entries = service.collect_bot_active_mcps(
                 entity_id=str(bot.get("entity_id") or owner_id),
                 bot_id=bot_id,
@@ -438,32 +458,88 @@ class BotRuntimeProjector(BotRuntimeProjectorProtocol):
                 strict_policy_context=True,
             )
         except Exception as exc:
+            self._log_plan_timing(
+                stage="collect_effective_mcps", bot_id=bot_id, engine=engine,
+                started_at=started_at, outcome="error",
+            )
             raise SkillSetRuntimeReconcileError() from exc
+        self._log_plan_timing(
+            stage="collect_effective_mcps", bot_id=bot_id, engine=engine,
+            started_at=started_at, outcome="success", mcp_count=len(effective_mcp_entries),
+        )
         effective_default_mcp_codes = frozenset(
             str(item.get("server_code") or item.get("serverCode") or "").strip()
             for item in effective_mcp_entries
             if item.get("server_code") or item.get("serverCode")
         )
         try:
+            started_at = time.perf_counter()
             # Passport is the authority for the effective Default CLI scope.
             effective_cli_items = self._passport.query_passport_clis(bot_id, owner_id)
         except Exception as exc:
-            raise SkillSetRuntimeReconcileError() from exc
-        projection = RuntimeProjectionResolver().resolve(
-            RuntimeDesiredState(
-                skills=skill_plan.projection.skill_assets,
-                installed_mcp_server_codes=frozenset(
-                    self._repository.list_installed_mcps(
-                        bot_id=bot_id, owner_id=owner_id
-                    )
-                ),
-                system_default_mcp_server_codes=effective_default_mcp_codes,
-                system_default_cli_commands=tuple(
-                    str(item["cli_code"])
-                    for item in effective_cli_items
-                    if item.get("cli_code")
-                ),
+            self._log_plan_timing(
+                stage="query_passport_clis", bot_id=bot_id, engine=engine,
+                started_at=started_at, outcome="error",
             )
+            raise SkillSetRuntimeReconcileError() from exc
+        self._log_plan_timing(
+            stage="query_passport_clis", bot_id=bot_id, engine=engine,
+            started_at=started_at, outcome="success", cli_count=len(effective_cli_items),
+        )
+        started_at = time.perf_counter()
+        try:
+            installed_mcp_codes = frozenset(
+                self._repository.list_installed_mcps(
+                    bot_id=bot_id, owner_id=owner_id
+                )
+            )
+        except Exception:
+            self._log_plan_timing(
+                stage="read_installed_mcps",
+                bot_id=bot_id,
+                engine=engine,
+                started_at=started_at,
+                outcome="error",
+            )
+            raise
+        self._log_plan_timing(
+            stage="read_installed_mcps",
+            bot_id=bot_id,
+            engine=engine,
+            started_at=started_at,
+            outcome="success",
+            mcp_count=len(installed_mcp_codes),
+        )
+        started_at = time.perf_counter()
+        try:
+            projection = RuntimeProjectionResolver().resolve(
+                RuntimeDesiredState(
+                    skills=skill_plan.projection.skill_assets,
+                    installed_mcp_server_codes=installed_mcp_codes,
+                    system_default_mcp_server_codes=effective_default_mcp_codes,
+                    system_default_cli_commands=tuple(
+                        str(item["cli_code"])
+                        for item in effective_cli_items
+                        if item.get("cli_code")
+                    ),
+                )
+            )
+        except Exception:
+            self._log_plan_timing(
+                stage="resolve_effective_capabilities",
+                bot_id=bot_id,
+                engine=engine,
+                started_at=started_at,
+                outcome="error",
+            )
+            raise
+        self._log_plan_timing(
+            stage="resolve_effective_capabilities",
+            bot_id=bot_id,
+            engine=engine,
+            started_at=started_at,
+            outcome="success",
+            mcp_count=len(projection.mcp_server_codes),
         )
 
         return ResolvedCapabilityPlan(

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_management_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_management_service.py
@@ -32,6 +32,7 @@ from agentclaw.community.plugin_api.mcp_center import MCPCenterPlugin
 from agentclaw.community.core.skill_center.legacy_skill_set_compatibility import (
     LegacySkillSetCompatibilityFactoryProtocol,
     LegacySkillSetScope,
+    list_skill_set_mcp_projection,
 )
 from agentclaw.community.core.skill_center.runtime_projection_contract import (
     BotRuntimeProjectorProtocol,
@@ -541,10 +542,14 @@ class SkillSetManagementService(SkillSetManagementServiceProtocol):
         self, *, bot_id: str, owner_id: str, user_id: str, set_id: str
     ) -> list[dict]:
         bot = self._bot(bot_id=bot_id, owner_id=owner_id, user_id=user_id)
-        return self._repository.list_mcps(
+        target = self._target_set(bot=bot, bot_id=bot_id, set_id=set_id)
+        return list_skill_set_mcp_projection(
+            repository=self._repository,
+            legacy_factory=self._legacy_factory,
+            bot=bot,
             bot_id=bot_id,
             owner_id=str(bot["owner_id"]),
-            set_id=set_id,
+            target=target,
             engine_type=self._engine(bot),
             default_engine_types=self._default_engine_types(bot),
         )
@@ -552,7 +557,7 @@ class SkillSetManagementService(SkillSetManagementServiceProtocol):
     def list_mcp_permissions(
         self, *, bot_id: str, owner_id: str, user_id: str, set_id: str
     ) -> list[dict]:
-        mcps = self.list_mcps(
+        mcps = self._list_mcp_memberships(
             bot_id=bot_id,
             owner_id=owner_id,
             user_id=user_id,
@@ -577,7 +582,7 @@ class SkillSetManagementService(SkillSetManagementServiceProtocol):
         set_id: str,
         reason: str,
     ) -> list[dict]:
-        mcps = self.list_mcps(
+        mcps = self._list_mcp_memberships(
             bot_id=bot_id,
             owner_id=owner_id,
             user_id=user_id,
@@ -596,6 +601,20 @@ class SkillSetManagementService(SkillSetManagementServiceProtocol):
             }
             for item in mcps
         ]
+
+    def _list_mcp_memberships(
+        self, *, bot_id: str, owner_id: str, user_id: str, set_id: str
+    ) -> list[dict]:
+        """Read persisted MCP members without expanding Default policy."""
+        bot = self._bot(bot_id=bot_id, owner_id=owner_id, user_id=user_id)
+        target = self._target_set(bot=bot, bot_id=bot_id, set_id=set_id)
+        return self._repository.list_mcps(
+            bot_id=bot_id,
+            owner_id=str(bot["owner_id"]),
+            set_id=str(target["id"]),
+            engine_type=self._engine(bot),
+            default_engine_types=self._default_engine_types(bot),
+        )
 
     async def add_mcp(
         self,
@@ -798,38 +817,18 @@ class SkillSetManagementService(SkillSetManagementServiceProtocol):
             engine_type=self._engine(bot),
             default_engine_types=self._default_engine_types(bot),
         )
-        # Default MCPs are not stored as ordinary ac_skill_set_mcp rows.  The
-        # legacy service combines engine/template defaults, explicit rows, and
-        # ac_default_skillset_mcp_exclusion.  Keep that proven projection for
-        # the published BFF resource response; ordinary Sets stay canonical.
-        legacy = (
-            self._legacy_factory.create(
-                entity_id=str(bot.get("entity_id") or owner_id),
-                bot_id=bot_id,
-                engine_type=self._engine(bot),
-                entity_type=bot.get("entity_type") or "staff",
-            )
-            if any(item["is_default"] for item in items)
-            else None
-        )
         resources: list[dict] = []
         for item in items:
-            if item["is_default"]:
-                assert legacy is not None
-                mcps = legacy.get_set_mcp_servers(
-                    str(item["id"]),
-                    user_id=owner_id,
-                    bot_id=bot_id,
-                    engine_type=self._engine(bot),
-                )
-            else:
-                mcps = self._repository.list_mcps(
-                    bot_id=bot_id,
-                    owner_id=owner_id,
-                    set_id=item["id"],
-                    engine_type=self._engine(bot),
-                    default_engine_types=self._default_engine_types(bot),
-                )
+            mcps = list_skill_set_mcp_projection(
+                repository=self._repository,
+                legacy_factory=self._legacy_factory,
+                bot=bot,
+                bot_id=bot_id,
+                owner_id=owner_id,
+                target=item,
+                engine_type=self._engine(bot),
+                default_engine_types=self._default_engine_types(bot),
+            )
             resources.append(
                 {
                     **item,

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any, Callable, List, Mapping, Optional, TypeVa
 
 from agentclaw.community.core.devices.models import SynlinkMappingInfo
 from agentclaw.community.core.devices.services.device_accessor import DeviceAccessor
+from agentclaw.community.core.devices.services.device_sync import DeviceSync
 
 if TYPE_CHECKING:
     from agentclaw.community.core.repository.protocols.bot import BotRepository
@@ -28,6 +29,7 @@ from agentclaw.community.core.mcp.services.config_service import MCPConfigServic
 from agentclaw.community.core.repository.protocols.skill_center import SkillSetRepository
 from agentclaw.community.core.repository.protocols.skill_center import SkillRepository
 from agentclaw.community.core.skill_center.capability_state_contract import (
+    BotCapabilitySnapshot,
     BotCapabilityStateReaderProtocol,
 )
 from agentclaw.community.core.skill_center.errors import (
@@ -633,12 +635,36 @@ class SkillSetService:
         has to declare the larger one — the declaration is a full replacement,
         so skipping it would leave the device's view of the set behind.
         """
-        if not await self.sync_mcp_delivery(claimed=claimed, released=released):
+        started = time.perf_counter()
+        try:
+            ctx = await asyncio.to_thread(
+                self._resolver.resolve_for_bot,
+                self.bot_id,
+                self.entity_id or self.user_id or "",
+            )
+            device_sync = self._device_sync_dispatcher.dispatch(ctx)
+        except Exception:
+            logger.warning(
+                "[project_mcps] device resolution failed bot_id=%s",
+                self.bot_id, exc_info=True,
+            )
             return False
-        return await self.sync_mcp_desired_state(server_codes=declared)
+        finally:
+            logger.info(
+                "[project_mcps] timing stage=resolve_device bot_id=%s duration_ms=%.3f",
+                self.bot_id, (time.perf_counter() - started) * 1000,
+            )
+        if not await self.sync_mcp_delivery(
+            claimed=claimed, released=released, device_sync=device_sync
+        ):
+            return False
+        return await self.sync_mcp_desired_state(
+            server_codes=declared, device_sync=device_sync
+        )
 
     async def sync_mcp_delivery(
-        self, *, claimed: frozenset[str], released: frozenset[str]
+        self, *, claimed: frozenset[str], released: frozenset[str],
+        device_sync: DeviceSync | None = None,
     ) -> bool:
         """Deliver configuration for newly claimed MCPs, withdraw it for released ones.
 
@@ -683,6 +709,7 @@ class SkillSetService:
                     bot_id=self.bot_id,
                     entity_id=self.entity_id,
                     engine_type=self.engine_type,
+                    **({"device_sync": device_sync} if device_sync is not None else {}),
                 )
                 if not delivery.get("success"):
                     logger.error(
@@ -704,6 +731,7 @@ class SkillSetService:
                     server_code=server_code,
                     bot_id=self.bot_id,
                     user_id=self.entity_id or self.user_id or "",
+                    **({"device_sync": device_sync} if device_sync is not None else {}),
                 )
                 if not removal.get("success"):
                     logger.error(
@@ -721,7 +749,9 @@ class SkillSetService:
             )
             return False
 
-    async def sync_mcp_desired_state(self, *, server_codes: set[str]) -> bool:
+    async def sync_mcp_desired_state(
+        self, *, server_codes: set[str], device_sync: DeviceSync | None = None
+    ) -> bool:
         """Declare the complete MCP allow-list to the Bot runtime.
 
         Declaration is total on purpose: ``sync_all_mcp_servers`` is the
@@ -737,18 +767,20 @@ class SkillSetService:
         try:
             # resolve_for_bot 与 sync_all_mcp_servers 都是同步阻塞调用(前者含
             # ws-info HTTP,后者是设备侧 HTTP),留在协程里会占住 event loop。
-            ctx = await asyncio.to_thread(
-                self._resolver.resolve_for_bot,
-                self.bot_id,
-                self.entity_id or self.user_id or "",
-            )
+            if device_sync is None:
+                ctx = await asyncio.to_thread(
+                    self._resolver.resolve_for_bot,
+                    self.bot_id,
+                    self.entity_id or self.user_id or "",
+                )
+                device_sync = self._device_sync_dispatcher.dispatch(ctx)
             logger.info(
                 "[sync_mcp_desired_state] declaring MCP allow-list: bot_id=%s, mcps=%s",
                 self.bot_id, len(server_codes),
             )
             return bool(
                 await asyncio.to_thread(
-                    self._device_sync_dispatcher.dispatch(ctx).sync_all_mcp_servers,
+                    device_sync.sync_all_mcp_servers,
                     # ``filter_servers`` reads server_code/serverCode off each
                     # entry, so bare strings would silently declare nothing.
                     [{"server_code": code} for code in sorted(server_codes)],
@@ -1686,6 +1718,7 @@ class SkillSetService:
         engine_type: Optional[str] = None,
         *,
         strict_policy_context: bool = False,
+        capability_snapshot: BotCapabilitySnapshot | None = None,
     ) -> List[dict]:
         """Effective MCPs = default policy ∪ installed ∪ Skill dependencies.
 
@@ -1699,6 +1732,10 @@ class SkillSetService:
 
         Args:
             engine_type: Engine type for scoping. Defaults to self.engine_type.
+            capability_snapshot: Reader output for this same Bot and projection.
+                When supplied, reuse its Skills and Installation codes while
+                retaining the canonical Default/exclusion/metadata logic below.
+                Omit for standalone reads; never retain across commands.
         """
         if self._reader is None:
             raise RuntimeError(
@@ -1706,6 +1743,10 @@ class SkillSetService:
                 "capability state reader; construct through "
                 "SkillSetServiceFactory"
             )
+        if capability_snapshot is not None and (
+            capability_snapshot.bot_id != bot_id or capability_snapshot.owner_id != user_id
+        ):
+            raise ValueError("Capability snapshot belongs to a different Bot")
         effective_engine = engine_type if engine_type is not None else self.engine_type
         effective_ext_info = self._run_effective_mcp_stage(
             stage="default_ext_info",
@@ -1794,8 +1835,11 @@ class SkillSetService:
             stage="active_skill_assets",
             bot_id=bot_id,
             engine_type=effective_engine,
-            operation=lambda: self._active_skill_assets(
-                entity_id=entity_id, bot_id=bot_id, user_id=user_id
+            operation=lambda: (
+                capability_snapshot.skills if capability_snapshot is not None
+                else self._active_skill_assets(
+                    entity_id=entity_id, bot_id=bot_id, user_id=user_id
+                )
             ),
             item_count=len,
         )
@@ -1803,8 +1847,11 @@ class SkillSetService:
             stage="installed_mcp_codes",
             bot_id=bot_id,
             engine_type=effective_engine,
-            operation=lambda: self._installed_mcp_codes(
-                entity_id=entity_id, bot_id=bot_id, user_id=user_id
+            operation=lambda: (
+                capability_snapshot.installed_mcp_server_codes if capability_snapshot is not None
+                else self._installed_mcp_codes(
+                    entity_id=entity_id, bot_id=bot_id, user_id=user_id
+                )
             ),
             item_count=len,
         )

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
@@ -3,10 +3,11 @@
 Migrated from: services/openclawserver/server/services/skill_set_service.py
 """
 import asyncio
+import time
 import zlib
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, List, Mapping, Optional
+from typing import TYPE_CHECKING, Any, Callable, List, Mapping, Optional, TypeVar
 
 from agentclaw.community.core.devices.models import SynlinkMappingInfo
 from agentclaw.community.core.devices.services.device_accessor import DeviceAccessor
@@ -60,6 +61,8 @@ SKILLS_REPO_DIR = SKILLS_DIR / "skills-repo"
 SKILLS_LOCAL_DIR = SKILLS_DIR / "skills-local"
 
 logger = get_logger()
+
+_T = TypeVar("_T")
 
 
 def _get_bot_paths(
@@ -1704,34 +1707,63 @@ class SkillSetService:
                 "SkillSetServiceFactory"
             )
         effective_engine = engine_type if engine_type is not None else self.engine_type
-        effective_ext_info = self._get_default_capabilities_ext_info(
-            effective_engine,
-            bot_id,
-            strict=strict_policy_context,
-        )
-        effective_template_type = self._get_default_capabilities_template_type(
-            bot_id,
-            strict=strict_policy_context,
-        )
-        active_skill_sets = self._get_all_active_skill_sets_with_default_fallback(
-            user_id=entity_id,
-            bolt_id=bot_id,
+        effective_ext_info = self._run_effective_mcp_stage(
+            stage="default_ext_info",
+            bot_id=bot_id,
             engine_type=effective_engine,
+            operation=lambda: self._get_default_capabilities_ext_info(
+                effective_engine,
+                bot_id,
+                strict=strict_policy_context,
+            ),
+            report_has_value=True,
+        )
+        effective_template_type = self._run_effective_mcp_stage(
+            stage="default_template_type",
+            bot_id=bot_id,
+            engine_type=effective_engine,
+            operation=lambda: self._get_default_capabilities_template_type(
+                bot_id,
+                strict=strict_policy_context,
+            ),
+            report_has_value=True,
+        )
+        active_skill_sets = self._run_effective_mcp_stage(
+            stage="active_skill_sets",
+            bot_id=bot_id,
+            engine_type=effective_engine,
+            operation=lambda: self._get_all_active_skill_sets_with_default_fallback(
+                user_id=entity_id,
+                bolt_id=bot_id,
+                engine_type=effective_engine,
+            ),
+            item_count=len,
         )
 
         # This Bot's exclusions silence a Default member entirely — the row
         # half too: ``get_set_mcp_servers`` filters only the static default
         # codes, and the flush already treats an exclusion as the Default
         # Set's per-Bot deactivation.
-        excluded_codes = set(self.skill_set_repo.get_all_excluded_mcps(user_id, bot_id))
+        excluded_codes = self._run_effective_mcp_stage(
+            stage="default_mcp_exclusions",
+            bot_id=bot_id,
+            engine_type=effective_engine,
+            operation=lambda: set(
+                self.skill_set_repo.get_all_excluded_mcps(user_id, bot_id)
+            ),
+            item_count=len,
+        )
 
         # Each phase appends entries and marks their codes in
         # ``seen_server_codes``, so a later phase never duplicates an earlier
         # one; ordering is the union's precedence (rows, policy, installed).
         active_mcps: List[dict] = []
         seen_server_codes: set = set()
-        active_mcps.extend(
-            self._default_set_mcp_rows(
+        default_set_rows = self._run_effective_mcp_stage(
+            stage="default_set_mcp_rows",
+            bot_id=bot_id,
+            engine_type=effective_engine,
+            operation=lambda: self._default_set_mcp_rows(
                 active_skill_sets,
                 user_id=user_id,
                 bot_id=bot_id,
@@ -1740,40 +1772,128 @@ class SkillSetService:
                 ext_info=effective_ext_info,
                 excluded_codes=excluded_codes,
                 seen_server_codes=seen_server_codes,
-            )
+            ),
+            item_count=len,
         )
-        active_mcps.extend(
-            self._default_policy_mcp_entries(
+        active_mcps.extend(default_set_rows)
+        default_policy_entries = self._run_effective_mcp_stage(
+            stage="default_policy_mcp_entries",
+            bot_id=bot_id,
+            engine_type=effective_engine,
+            operation=lambda: self._default_policy_mcp_entries(
                 engine_type=effective_engine,
                 template_type=effective_template_type,
                 ext_info=effective_ext_info,
                 excluded_codes=excluded_codes,
                 seen_server_codes=seen_server_codes,
-            )
+            ),
+            item_count=len,
         )
-        effective_non_default_codes = resolve_effective_mcp_server_codes(
-            RuntimeDesiredState(
-                skills=self._active_skill_assets(
-                    entity_id=entity_id, bot_id=bot_id, user_id=user_id
-                ),
-                installed_mcp_server_codes=self._installed_mcp_codes(
-                    entity_id=entity_id, bot_id=bot_id, user_id=user_id
-                ),
-            )
+        active_mcps.extend(default_policy_entries)
+        active_skill_assets = self._run_effective_mcp_stage(
+            stage="active_skill_assets",
+            bot_id=bot_id,
+            engine_type=effective_engine,
+            operation=lambda: self._active_skill_assets(
+                entity_id=entity_id, bot_id=bot_id, user_id=user_id
+            ),
+            item_count=len,
         )
-        active_mcps.extend(
-            self._non_default_effective_mcp_entries(
+        installed_mcp_codes = self._run_effective_mcp_stage(
+            stage="installed_mcp_codes",
+            bot_id=bot_id,
+            engine_type=effective_engine,
+            operation=lambda: self._installed_mcp_codes(
+                entity_id=entity_id, bot_id=bot_id, user_id=user_id
+            ),
+            item_count=len,
+        )
+        effective_non_default_codes = self._run_effective_mcp_stage(
+            stage="resolve_non_default_codes",
+            bot_id=bot_id,
+            engine_type=effective_engine,
+            operation=lambda: resolve_effective_mcp_server_codes(
+                RuntimeDesiredState(
+                    skills=active_skill_assets,
+                    installed_mcp_server_codes=installed_mcp_codes,
+                )
+            ),
+            item_count=len,
+        )
+        non_default_entries = self._run_effective_mcp_stage(
+            stage="non_default_mcp_entries",
+            bot_id=bot_id,
+            engine_type=effective_engine,
+            operation=lambda: self._non_default_effective_mcp_entries(
                 effective_codes=effective_non_default_codes,
                 active_skill_sets=active_skill_sets,
                 seen_server_codes=seen_server_codes,
-            )
+            ),
+            item_count=len,
         )
+        active_mcps.extend(non_default_entries)
 
         logger.info(
             f"[collect_bot_active_mcps] bot_id={bot_id}, engine_type={effective_engine}, "
             f"total_mcps={len(active_mcps)}, codes={[m.get('server_code') for m in active_mcps]}"
         )
         return active_mcps
+
+    def _run_effective_mcp_stage(
+        self,
+        *,
+        stage: str,
+        bot_id: str,
+        engine_type: str | None,
+        operation: Callable[[], _T],
+        item_count: Callable[[_T], int] | None = None,
+        report_has_value: bool = False,
+    ) -> _T:
+        started_at = time.perf_counter()
+        try:
+            result = operation()
+        except Exception:
+            self._log_effective_mcp_timing(
+                stage=stage,
+                bot_id=bot_id,
+                engine_type=engine_type,
+                started_at=started_at,
+                outcome="error",
+            )
+            raise
+        self._log_effective_mcp_timing(
+            stage=stage,
+            bot_id=bot_id,
+            engine_type=engine_type,
+            started_at=started_at,
+            outcome="success",
+            item_count=item_count(result) if item_count is not None else None,
+            has_value=result is not None if report_has_value else None,
+        )
+        return result
+
+    @staticmethod
+    def _log_effective_mcp_timing(
+        *,
+        stage: str,
+        bot_id: str,
+        engine_type: str | None,
+        started_at: float,
+        outcome: str,
+        item_count: int | None = None,
+        has_value: bool | None = None,
+    ) -> None:
+        logger.info(
+            "[collect_bot_active_mcps] timing stage=%s bot_id=%s engine_type=%s "
+            "duration_ms=%s outcome=%s item_count=%s has_value=%s",
+            stage,
+            bot_id,
+            engine_type,
+            round((time.perf_counter() - started_at) * 1000),
+            outcome,
+            item_count,
+            has_value,
+        )
 
     def _default_set_mcp_rows(
         self,

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
@@ -1621,6 +1621,11 @@ class SkillSetService:
                     self.skill_set_repo.get_excluded_mcps(user_id, effective_bot_id, int(skill_set_id))
                 )
 
+            associations = [
+                association
+                for association in associations
+                if association.get("server_code") not in excluded_codes
+            ]
             db_codes = {a.get("server_code") for a in associations}
             logger.info(
                 f"[get_set_mcp_servers] skill_set_id={skill_set_id}, is_default=True, "

--- a/src/backend/src/agentclaw/community/di/container.py
+++ b/src/backend/src/agentclaw/community/di/container.py
@@ -49,6 +49,9 @@ from agentclaw.community.di.modules.grt_chat_module import GrtChatModule
 from agentclaw.community.di.modules.harness_module import HarnessModule
 from agentclaw.community.di.modules.http_client_module import HttpClientModule
 from agentclaw.community.di.modules.identity_module import IdentityModule
+from agentclaw.community.di.modules.installation_read_config_module import (
+    InstallationReadConfigModule,
+)
 from agentclaw.community.di.modules.mcp_module import McpModule
 from agentclaw.community.di.modules.quality_module import QualityModule
 from agentclaw.community.di.modules.resources_module import ResourcesModule
@@ -110,6 +113,7 @@ def build_injector(
     """
     modules: list[Module] = [
         ConfigModule(),
+        InstallationReadConfigModule(),
         SkillCenterModule(),
         SkillCenterGroup4Module(),
         SkillVersionModule(),

--- a/src/backend/src/agentclaw/community/di/modules/installation_read_config_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/installation_read_config_module.py
@@ -1,40 +1,24 @@
-"""InstallationReadConfig binding for the completed-backfill migration gate."""
+"""Installation Reader binding for the DB-owned completed-backfill gate."""
 
 from __future__ import annotations
 
 from injector import Module, provider, singleton
 
-from agentclaw.community.core.skill_center.installation_read_config import (
-    InstallationReadConfig,
-)
-from agentclaw.community.di.modules import config_module
-from agentclaw.community.log import get_logger
+from agentclaw.community.api.common_config_service import CommonConfigServiceProtocol
+from agentclaw.community.core.skill_center.installation_read_config import InstallationReadConfig
 from agentclaw.community.utils.env_utils import get_current_env
 
 
-logger = get_logger()
-
-
 class InstallationReadConfigModule(Module):
-    """Bind the environment-specific Installation Reader mode."""
+    """Bind a runtime DB-configured Installation Reader mode."""
 
     @singleton
     @provider
-    def installation_read(self) -> InstallationReadConfig:
-        """Choose Default-only sync only for an explicitly accepted environment."""
-        block = config_module.read_user_config().get("skill_installation", {})
-        if not isinstance(block, dict) or set(block) - {"default_sync_only"}:
-            raise ValueError("skill_installation must contain only default_sync_only")
-        modes = block.get("default_sync_only", {})
-        if not isinstance(modes, dict) or set(modes) - {"pre", "prod"}:
-            raise ValueError("skill_installation.default_sync_only must map pre/prod")
-        if any(type(value) is not bool for value in modes.values()):
-            raise ValueError("skill_installation.default_sync_only values must be booleans")
-        env = get_current_env()
-        config = InstallationReadConfig(default_sync_only=modes.get(env, False))
-        logger.info(
-            "[installation_read_config] env=%s default_sync_only=%s",
-            env,
-            config.default_sync_only,
+    def installation_read(
+        self, common_config_service: CommonConfigServiceProtocol
+    ) -> InstallationReadConfig:
+        """Use the normalized deployment environment's ``ac_common_config`` row."""
+        return InstallationReadConfig(
+            common_config_service=common_config_service,
+            env=get_current_env(),
         )
-        return config

--- a/src/backend/src/agentclaw/community/di/modules/installation_read_config_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/installation_read_config_module.py
@@ -1,0 +1,40 @@
+"""InstallationReadConfig binding for the completed-backfill migration gate."""
+
+from __future__ import annotations
+
+from injector import Module, provider, singleton
+
+from agentclaw.community.core.skill_center.installation_read_config import (
+    InstallationReadConfig,
+)
+from agentclaw.community.di.modules import config_module
+from agentclaw.community.log import get_logger
+from agentclaw.community.utils.env_utils import get_current_env
+
+
+logger = get_logger()
+
+
+class InstallationReadConfigModule(Module):
+    """Bind the environment-specific Installation Reader mode."""
+
+    @singleton
+    @provider
+    def installation_read(self) -> InstallationReadConfig:
+        """Choose Default-only sync only for an explicitly accepted environment."""
+        block = config_module.read_user_config().get("skill_installation", {})
+        if not isinstance(block, dict) or set(block) - {"default_sync_only"}:
+            raise ValueError("skill_installation must contain only default_sync_only")
+        modes = block.get("default_sync_only", {})
+        if not isinstance(modes, dict) or set(modes) - {"pre", "prod"}:
+            raise ValueError("skill_installation.default_sync_only must map pre/prod")
+        if any(type(value) is not bool for value in modes.values()):
+            raise ValueError("skill_installation.default_sync_only values must be booleans")
+        env = get_current_env()
+        config = InstallationReadConfig(default_sync_only=modes.get(env, False))
+        logger.info(
+            "[installation_read_config] env=%s default_sync_only=%s",
+            env,
+            config.default_sync_only,
+        )
+        return config

--- a/src/backend/tests/community/architecture/test_module_boundaries.py
+++ b/src/backend/tests/community/architecture/test_module_boundaries.py
@@ -120,7 +120,10 @@ _ACTIVE_SIGNIFICANT_MODULES: frozenset[str] = frozenset(
 # are not yet reflected in module README metadata. This keeps the unit test
 # focused on newly introduced undeclared dependencies.
 _TEST_ONLY_DECLARED_DEPS: dict[str, list[str]] = {
-    "agentclaw.community.core.service_bot": ["agentclaw.community.api.channel_service"],
+    "agentclaw.community.core.service_bot": [
+        "agentclaw.community.api.channel_service",
+        "agentclaw.community.plugin_api.eval_env",
+    ],
 }
 
 

--- a/src/backend/tests/community/core/bot_config_manifest/test_manifest_ddl_contract.py
+++ b/src/backend/tests/community/core/bot_config_manifest/test_manifest_ddl_contract.py
@@ -30,12 +30,26 @@ _SQL_DIR = (
 
 #: Columns filled by the application, which must stay DATETIME. TIMESTAMP reads
 #: the bound naive value as session-local and converts it, so an instant the
-#: application already normalised to UTC (``fetched_at``) or took from
-#: ``datetime.now()`` (the apply times) is stored shifted by the session offset.
+#: application already normalised to UTC (``fetched_at``) is stored shifted by
+#: the session offset.
+#:
+#: The apply table's started_at/finished_at used to be listed here and are
+#: not any more: the DDL review standard refused them as DATETIME (see
+#: ``_DDL_STANDARD_FORBIDDEN_TYPES``), and their round trip through one
+#: session is the identity, so TIMESTAMP loses nothing the application reads.
 _APPLICATION_SUPPLIED = {
-    "2026_08_31_bot_config_manifest_apply.sql": ("started_at", "finished_at"),
     "2026_08_31_manifest_content.sql": ("fetched_at",),
 }
+
+#: The DDL review standard (研发规范) that gates provisioning on OceanBase.
+#: ac_bot_config_manifest_apply was refused on exactly these two rules -- a
+#: column named `trigger`, and DATETIME started_at/finished_at -- which is why
+#: the record table never existed in production while its lock table did.
+_DDL_STANDARD_FORBIDDEN_TYPES = {"bit", "float", "double", "datetime", "enum", "set"}
+_DDL_STANDARD_FILES = (
+    "2026_08_31_bot_config_manifest_apply.sql",
+    "2026_09_07_repair_misprovisioned_bot_config_manifest_apply.sql",
+)
 
 #: Filled by the database itself, so TIMESTAMP's conversion is a no-op round
 #: trip and matches ac_bots. Every table here has both.
@@ -66,7 +80,7 @@ def _tables(path: Path) -> dict[str, dict[str, str]]:
     starts = [
         (match.group(1), match.start(), match.group(0).startswith("ALTER"))
         for match in re.finditer(
-            r"(?:CREATE|ALTER) TABLE\s+`(\w+)`", body
+            r"(?:CREATE TABLE\s+(?:IF NOT EXISTS\s+)?|ALTER TABLE\s+)`(\w+)`", body
         )
     ]
     assert starts, f"{path.name}: no CREATE TABLE or ALTER TABLE found"
@@ -74,7 +88,7 @@ def _tables(path: Path) -> dict[str, dict[str, str]]:
     bounds = [start for _, start, _ in starts] + [len(body)]
     tables: dict[str, dict[str, str]] = {}
     for index, (name, _, is_alter) in enumerate(starts):
-        segment = body[bounds[index] : bounds[index + 1]]
+        segment = body[bounds[index]:bounds[index + 1]]
         # An ALTER's columns are introduced by ADD COLUMN; a CREATE's are the
         # bare backticked declarations. Both are checked, and that is the
         # point of handling ALTER at all: a migration adding a gmt_ column
@@ -106,7 +120,7 @@ def _created_tables(path: Path) -> set[str]:
     body = path.read_text(encoding="utf-8")
     return {
         match.group(1)
-        for match in re.finditer(r"CREATE TABLE\s+`(\w+)`", body)
+        for match in re.finditer(r"CREATE TABLE\s+(?:IF NOT EXISTS\s+)?`(\w+)`", body)
     }
 
 
@@ -193,6 +207,31 @@ def test_every_table_in_every_file_is_parsed() -> None:
     }
 
 
+def test_apply_tables_pass_the_ddl_review_standard() -> None:
+    """The two findings the standard raised, held so they cannot come back.
+
+    Scoped to the apply file: ac_manifest_content.fetched_at is still DATETIME
+    and is a separate change with its own UTC-normalisation reasoning.
+    """
+    for filename in _DDL_STANDARD_FILES:
+        tables = _tables(_SQL_DIR / filename)
+        assert tables, f"{filename}: nothing parsed"
+        for table, declarations in tables.items():
+            assert "trigger" not in declarations, (
+                f"{table}: `trigger` is a SQL keyword; the column is apply_trigger"
+            )
+            for column, rest in declarations.items():
+                declared_type = rest.split()[0].lower().split("(")[0]
+                assert declared_type not in _DDL_STANDARD_FORBIDDEN_TYPES, (
+                    f"{table}.{column} is declared {declared_type}, which the DDL "
+                    "review standard refuses"
+                )
+        apply_columns = tables["ac_bot_config_manifest_apply"]
+        assert "apply_trigger" in apply_columns
+        for column in ("started_at", "finished_at"):
+            assert apply_columns[column].split()[0].lower() == "timestamp"
+
+
 def test_no_bare_timestamp_column_can_attach_an_implicit_on_update() -> None:
     """Guards the blocking finding from round 1 of review.
 
@@ -215,3 +254,20 @@ def test_no_bare_timestamp_column_can_attach_an_implicit_on_update() -> None:
                 f"{path.name}: {column} is a bare TIMESTAMP NOT NULL with no "
                 "DEFAULT; the server may attach ON UPDATE CURRENT_TIMESTAMP to it"
             )
+
+
+def test_parser_preserves_create_if_not_exists_and_alter_columns(tmp_path: Path) -> None:
+    path = tmp_path / "mixed.sql"
+    path.write_text(
+        "CREATE TABLE IF NOT EXISTS `created` (\n"
+        "  `gmt_create` TIMESTAMP DEFAULT CURRENT_TIMESTAMP\n"
+        ");\n"
+        "ALTER TABLE `created` ADD COLUMN `extra` TEXT;\n"
+        "ALTER TABLE `existing` ADD COLUMN `gmt_modified` DATETIME;\n",
+        encoding="utf-8",
+    )
+    tables = _tables(path)
+    assert set(tables) == {"created", "existing"}, f"parsed tables: {tables}"
+    assert set(tables["created"]) == {"gmt_create", "extra"}, tables
+    assert tables["existing"]["gmt_modified"].startswith("DATETIME"), tables
+    assert _created_tables(path) == {"created"}, "CREATE IF NOT EXISTS must count as creation"

--- a/src/backend/tests/community/core/bot_config_manifest/test_manifest_ddl_contract.py
+++ b/src/backend/tests/community/core/bot_config_manifest/test_manifest_ddl_contract.py
@@ -12,21 +12,30 @@ OceanBase modifiers these files carry. The distinction being guarded therefore
 cannot be observed by creating the tables — only by reading what is declared.
 The sibling ``core/task_queue/test_task_queue_schema_contract.py`` guards its
 file the same way and for the same reason.
+
+WHY ``bot_startup_script/sql`` IS IN SCOPE HERE. The rule these tests state is
+about a column-type choice under OceanBase, not about one module, and
+``ac_bot_startup_script`` is materialised by this module's ``script`` category
+-- it is the manifest's own storage for that construct, kept in its own package
+only because #926 shipped it first. It sat outside this directory and therefore
+outside this rule, and that is exactly where the drift turned up: the deployed
+table carries TIMESTAMP audit columns while the file declared DATETIME, found by
+reading a ``SHOW CREATE TABLE`` rather than by anything in CI. Scoping by rule
+instead of by directory is what closes that.
 """
 
 from pathlib import Path
 import re
 
 
-_SQL_DIR = (
-    Path(__file__).parents[4]
-    / "src"
-    / "agentclaw"
-    / "community"
-    / "core"
-    / "bot_config_manifest"
-    / "sql"
-)
+_CORE = Path(__file__).parents[4] / "src" / "agentclaw" / "community" / "core"
+
+_SQL_DIR = _CORE / "bot_config_manifest" / "sql"
+
+#: Every directory whose DDL this rule governs. ``_SQL_DIR`` stays a single
+#: directory because ``_APPLICATION_SUPPLIED`` addresses files inside it by
+#: name.
+_SQL_DIRS = (_SQL_DIR, _CORE / "bot_startup_script" / "sql")
 
 #: Columns filled by the application, which must stay DATETIME. TIMESTAMP reads
 #: the bound naive value as session-local and converts it, so an instant the
@@ -138,8 +147,15 @@ def _declarations(path: Path) -> dict[str, str]:
 
 
 def _sql_files() -> list[Path]:
-    files = sorted(_SQL_DIR.glob("*.sql"))
-    assert files, f"no DDL found under {_SQL_DIR}"
+    files = sorted(path for directory in _SQL_DIRS for path in directory.glob("*.sql"))
+    assert files, f"no DDL found under {[str(d) for d in _SQL_DIRS]}"
+    # Asserted per directory as well as overall: a mistyped path would other-
+    # wise leave one directory silently contributing nothing, which is the
+    # shape of the shadowing bug ``_tables`` already documents.
+    for directory in _SQL_DIRS:
+        assert any(
+            path.parent == directory for path in files
+        ), f"no DDL found under {directory}"
     return files
 
 
@@ -204,6 +220,7 @@ def test_every_table_in_every_file_is_parsed() -> None:
         "ac_manifest_content",
         "ac_source_credential",
         "ac_bot_cli_tool",
+        "ac_bot_startup_script",
     }
 
 

--- a/src/backend/tests/community/core/bot_management/test_create_flow_with_manifest.py
+++ b/src/backend/tests/community/core/bot_management/test_create_flow_with_manifest.py
@@ -82,6 +82,7 @@ def _submit(seam, apply_result=None, passport=None):
     skill_set_factory = MagicMock()
     skill_set_factory.create.return_value.get_bot_mcp_codes.return_value = []
     outcome = submit_bot_creation_with_manifest(
+        nick_name="Test Owner",
         user_id="u1",
         bot_id="b_1",
         document=_DOCUMENT,

--- a/src/backend/tests/community/core/mcp/services/test_sync_service.py
+++ b/src/backend/tests/community/core/mcp/services/test_sync_service.py
@@ -1092,6 +1092,24 @@ class TestSyncMcpDetailsForBot:
         return [{"server_code": f"mcp.s{i}"} for i in range(n)]
 
     @pytest.mark.asyncio
+    async def test_supplied_device_is_used_for_details_and_removal(self):
+        resolver, dispatcher, plugin = _make_resolver_and_dispatcher()
+        svc = _make_sync_service(resolver=resolver, dispatcher=dispatcher)
+        result = await svc.sync_mcp_details_for_bot(
+            user_id="u1", mcp_entries=self._entries(1), bot_id="bot1", device_sync=plugin
+        )
+        assert result["success"] is True
+        plugin.sync_remove_mcp.return_value = True
+        result = await svc.remove_mcp_detail(
+            user_id="u1", bot_id="bot1", server_code="mcp.old", device_sync=plugin
+        )
+        assert result["success"] is True
+        resolver.resolve_for_bot.assert_not_called()
+        dispatcher.dispatch.assert_not_called()
+        plugin.sync_single_mcp.assert_called_once()
+        plugin.sync_remove_mcp.assert_called_once_with("mcp.old")
+
+    @pytest.mark.asyncio
     async def test_device_is_resolved_once_for_the_whole_batch(self):
         resolver, dispatcher, plugin = _make_resolver_and_dispatcher()
         svc = _make_sync_service(resolver=resolver, dispatcher=dispatcher)

--- a/src/backend/tests/community/core/service_bot/services/test_publish_flow_service.py
+++ b/src/backend/tests/community/core/service_bot/services/test_publish_flow_service.py
@@ -3407,6 +3407,9 @@ async def test_eval_publish_success():
     assert build_service.release_async.await_args.kwargs["bot"] == bot_service.get_bot.return_value
     assert build_service.release_async.await_args.kwargs["ext_info"] == {"biz_id": "biz-001"}
     assert bot_service.get_bot.return_value["ext"] == {}
+    # 未传 default_tag 时 AGENTCLAW_DEFAULT_TAG 不应注入 extra_envs
+    extra_envs = build_service.release_async.await_args.kwargs["extra_envs"]
+    assert "AGENTCLAW_DEFAULT_TAG" not in extra_envs
     # #197 all-auto: eval CREATE is auto-approved server-side — no client approve.
     baas_service.approve_publish.assert_not_called()
     # #197: a TTL teardown safety-net task is enqueued for the eval bot.
@@ -3488,6 +3491,9 @@ async def test_eval_publish_with_default_tag():
     ext_info = build_service.release_async.await_args.kwargs["ext_info"]
     assert ext_info["biz_id"] == "eval_chat:bot-1:eval"
     assert ext_info["default_tag"] == "eval"
+    # default_tag 应注入 extra_envs[DYNAMIC_ENV_TAG_KEY]，使容器内进程可感知评测环境
+    extra_envs = build_service.release_async.await_args.kwargs["extra_envs"]
+    assert extra_envs.get("AGENTCLAW_DEFAULT_TAG") == "eval"
 
 
 def test_eval_teardown_with_default_tag():

--- a/src/backend/tests/community/core/skill_center/services/test_skill_set_service.py
+++ b/src/backend/tests/community/core/skill_center/services/test_skill_set_service.py
@@ -1,4 +1,5 @@
 """Tests for agentclaw.community.core.services.skill_set_service.SkillSetService."""
+import logging
 from unittest.mock import patch, MagicMock, AsyncMock
 
 import pytest
@@ -293,7 +294,7 @@ class TestGetSetMcpServers:
 class TestCollectBotActiveMcps:
     """collect_bot_active_mcps filters out user-excluded default MCPs."""
 
-    def test_collect_excludes_user_excluded_default_mcps(self):
+    def test_collect_excludes_user_excluded_default_mcps(self, caplog):
         from agentclaw.community.core.skill_center.services.skill_set_service import SkillSetService
         mock_repo = MagicMock()
         mock_repo.get_all_active_skill_sets.return_value = [
@@ -321,12 +322,118 @@ class TestCollectBotActiveMcps:
         svc.skill_set_repo = mock_repo
         svc.bot_id = "default"
 
+        caplog.set_level(logging.INFO)
         with patch.object(svc, "get_set_mcp_servers") as mock_get_mcps:
             mock_get_mcps.return_value = []
             result = svc.collect_bot_active_mcps("entity1", "default", "user1", "staff")
 
         codes = {r["server_code"] for r in result}
         assert "mcp.ant.antprocessai.anttaskmcp" not in codes
+        messages = [record.getMessage() for record in caplog.records]
+        for stage in (
+            "default_ext_info",
+            "active_skill_sets",
+            "default_mcp_exclusions",
+            "active_skill_assets",
+            "installed_mcp_codes",
+            "resolve_non_default_codes",
+        ):
+            assert any(
+                "[collect_bot_active_mcps] timing" in message
+                and f"stage={stage}" in message
+                and "duration_ms=" in message
+                and "outcome=success" in message
+                for message in messages
+            )
+
+    def test_collect_logs_stage_error_before_reraising(self, caplog):
+        from agentclaw.community.core.skill_center.services.skill_set_service import (
+            SkillSetService,
+        )
+
+        mock_repo = MagicMock()
+        mock_repo.get_all_active_skill_sets.return_value = []
+        mock_repo.get_all_excluded_mcps.return_value = []
+        svc = SkillSetService(
+            skill_repo=MagicMock(),
+            skill_set_repo=mock_repo,
+            mcp_center=MagicMock(),
+            mcp_config_service=MagicMock(),
+            skill_service=MagicMock(),
+            bot_repo=MagicMock(),
+            path_factory=MagicMock(),
+            reader=MagicMock(),
+        )
+        failure = RuntimeError("active skill read failed")
+
+        caplog.set_level(logging.INFO)
+        with (
+            patch.object(svc, "_active_skill_assets", side_effect=failure),
+            pytest.raises(RuntimeError, match="active skill read failed"),
+        ):
+            svc.collect_bot_active_mcps("entity1", "bot-1", "user1", "staff")
+
+        messages = [record.getMessage() for record in caplog.records]
+        assert any(
+            "[collect_bot_active_mcps] timing" in message
+            and "stage=active_skill_assets" in message
+            and "outcome=error" in message
+            for message in messages
+        )
+
+    def test_collect_logs_each_enrichment_cardinality(self, caplog):
+        from agentclaw.community.core.skill_center.services.skill_set_service import (
+            SkillSetService,
+        )
+
+        svc = SkillSetService(
+            skill_repo=MagicMock(),
+            skill_set_repo=MagicMock(),
+            mcp_center=MagicMock(),
+            mcp_config_service=MagicMock(),
+            skill_service=MagicMock(),
+            bot_repo=MagicMock(),
+            path_factory=MagicMock(),
+            reader=MagicMock(),
+        )
+        caplog.set_level(logging.INFO)
+        with (
+            patch.object(
+                svc,
+                "_get_all_active_skill_sets_with_default_fallback",
+                return_value=[],
+            ),
+            patch.object(svc.skill_set_repo, "get_all_excluded_mcps", return_value=[]),
+            patch.object(
+                svc,
+                "_default_set_mcp_rows",
+                return_value=[{"server_code": "default-row"}],
+            ),
+            patch.object(
+                svc,
+                "_default_policy_mcp_entries",
+                return_value=[{"server_code": "default-policy"}],
+            ),
+            patch.object(svc, "_active_skill_assets", return_value=[]),
+            patch.object(svc, "_installed_mcp_codes", return_value={"direct"}),
+            patch.object(
+                svc,
+                "_non_default_effective_mcp_entries",
+                return_value=[{"server_code": "direct"}],
+            ),
+        ):
+            svc.collect_bot_active_mcps("entity1", "bot-1", "user1", "staff")
+
+        messages = [record.getMessage() for record in caplog.records]
+        for stage in (
+            "default_set_mcp_rows",
+            "default_policy_mcp_entries",
+            "non_default_mcp_entries",
+        ):
+            assert any(
+                f"stage={stage}" in message and "item_count=1" in message
+                for message in messages
+            )
 
     def test_get_bot_mcp_codes_for_env_uses_only_explicit_env_repository_reads(self):
         from agentclaw.community.core.skill_center.services.skill_set_service import (

--- a/src/backend/tests/community/core/skill_center/services/test_skill_set_service.py
+++ b/src/backend/tests/community/core/skill_center/services/test_skill_set_service.py
@@ -294,7 +294,10 @@ class TestGetSetMcpServers:
 class TestCollectBotActiveMcps:
     """collect_bot_active_mcps filters out user-excluded default MCPs."""
 
-    def test_collect_excludes_user_excluded_default_mcps(self, caplog):
+    @pytest.mark.parametrize("reuse_snapshot", [False, True])
+    def test_collect_excludes_user_excluded_default_mcps(self, caplog, reuse_snapshot):
+        from agentclaw.community.core.skill_center.capability_state_contract import BotCapabilitySnapshot
+        from agentclaw.community.core.skills_pool.models import RegisteredSkillAsset
         from agentclaw.community.core.skill_center.services.skill_set_service import SkillSetService
         mock_repo = MagicMock()
         mock_repo.get_all_active_skill_sets.return_value = [
@@ -325,9 +328,25 @@ class TestCollectBotActiveMcps:
         caplog.set_level(logging.INFO)
         with patch.object(svc, "get_set_mcp_servers") as mock_get_mcps:
             mock_get_mcps.return_value = []
-            result = svc.collect_bot_active_mcps("entity1", "default", "user1", "staff")
+            snapshot = BotCapabilitySnapshot(
+                "default", "user1",
+                (RegisteredSkillAsset(
+                    skill_id=1, name="center", git_path="center://public-code",
+                    skill_uuid="00000000-0000-4000-8000-000000000001",
+                    sc_version_number="2.0.0", mcp_dependencies=("mcp.dependency",),
+                ),),
+                frozenset({"mcp.installed"}),
+            ) if reuse_snapshot else None
+            result = svc.collect_bot_active_mcps(
+                "entity1", "default", "user1", "staff", capability_snapshot=snapshot
+            )
+        if reuse_snapshot:
+            svc._reader.active_skill_assets.assert_not_called()
+            svc._reader.active_mcp_server_codes.assert_not_called()
 
         codes = {r["server_code"] for r in result}
+        if reuse_snapshot:
+            assert {"mcp.installed", "mcp.dependency"} <= codes
         assert "mcp.ant.antprocessai.anttaskmcp" not in codes
         messages = [record.getMessage() for record in caplog.records]
         for stage in (
@@ -813,6 +832,46 @@ class TestSyncMcpDesiredState:
         plugin.sync_all_mcp_servers.assert_called_once_with(
             [{"server_code": code} for code in sorted(codes)]
         )
+
+    @pytest.mark.asyncio
+    async def test_projection_reuses_device_for_details_and_declaration(self):
+        svc, plugin = self._make_svc()
+        events = []
+
+        async def deliver(**kwargs):
+            assert kwargs["device_sync"] is plugin
+            events.append("details")
+            return {"success": True}
+
+        svc._mcp_sync_service.sync_mcp_details_for_bot.side_effect = deliver
+        plugin.sync_all_mcp_servers.side_effect = lambda _codes: events.append("declare") or True
+        assert await svc.project_mcps(
+            claimed=frozenset({"mcp.new"}), released=frozenset(), declared={"mcp.new"}
+        )
+        assert events == ["details", "declare"]
+        svc._resolver.resolve_for_bot.assert_called_once_with("bot1", "staff_user1")
+        svc._device_sync_dispatcher.dispatch.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_projection_failure_does_not_declare_and_next_call_resolves_again(self):
+        svc, plugin = self._make_svc(delivery={"success": False})
+        for _ in range(2):
+            assert not await svc.project_mcps(
+                claimed=frozenset({"mcp.new"}), released=frozenset(), declared={"mcp.new"}
+            )
+        assert svc._resolver.resolve_for_bot.call_count == 2
+        plugin.sync_all_mcp_servers.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_release_only_reuses_device_and_still_declares_empty_scope(self):
+        svc, plugin = self._make_svc()
+        svc._mcp_sync_service.remove_mcp_detail = AsyncMock(return_value={"success": True})
+        assert await svc.project_mcps(
+            claimed=frozenset(), released=frozenset({"mcp.old"}), declared=set()
+        )
+        assert svc._mcp_sync_service.remove_mcp_detail.await_args.kwargs["device_sync"] is plugin
+        svc._resolver.resolve_for_bot.assert_called_once()
+        plugin.sync_all_mcp_servers.assert_called_once_with([])
 
     @pytest.mark.asyncio
     async def test_declaration_pushes_no_configuration(self):

--- a/src/backend/tests/community/core/skill_center/services/test_skill_set_service.py
+++ b/src/backend/tests/community/core/skill_center/services/test_skill_set_service.py
@@ -227,6 +227,40 @@ class TestGetSetMcpServers:
         codes = {r["server_code"] for r in result}
         assert "mcp.ant.antprocessai.anttaskmcp" not in codes
 
+    def test_default_skillset_excludes_persisted_mcp_membership(self):
+        from agentclaw.community.core.skill_center.services.skill_set_service import SkillSetService
+        mock_repo = MagicMock()
+        mock_repo.get_by_id.return_value = {"id": "1", "is_default": True}
+        mock_repo.get_mcp_servers_in_set.return_value = [
+            {
+                "id": 10,
+                "server_code": "mcp.persisted.default",
+                "name": "persisted",
+                "description": "desc",
+                "icon": None,
+            }
+        ]
+        mock_repo.get_excluded_mcps.return_value = ["mcp.persisted.default"]
+
+        with patch("agentclaw.community.core.skill_center.services.skill_set_service.WorkspacePathFactory"):
+            svc = SkillSetService(
+                skill_repo=MagicMock(),
+                skill_set_repo=MagicMock(),
+                mcp_center=MagicMock(),
+                mcp_config_service=MagicMock(),
+                skill_service=MagicMock(),
+                bot_repo=MagicMock(),
+                path_factory=MagicMock(),
+            )
+        svc.skill_set_repo = mock_repo
+        svc.bot_id = "default"
+
+        result = svc.get_set_mcp_servers("1", user_id="user1")
+
+        assert "mcp.persisted.default" not in {
+            item["server_code"] for item in result
+        }
+
     def test_normal_skillset_returns_db_mcps_only(self):
         from agentclaw.community.core.skill_center.services.skill_set_service import SkillSetService
         mock_repo = MagicMock()

--- a/src/backend/tests/community/core/skill_center/test_bot_capability_state_reader.py
+++ b/src/backend/tests/community/core/skill_center/test_bot_capability_state_reader.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import pytest
-from types import SimpleNamespace
+from agentclaw.community.core.skill_center.installation_read_config import InstallationReadConfig
 
 from agentclaw.community.api.bot_capability_state_reader import (
     BotCapabilityStateReaderProtocol,
@@ -70,7 +70,7 @@ class _Repository:
 
     def list_installed_mcps(self, **kwargs) -> set[str]:
         # A read that beats the flush would answer from unflushed rows.
-        assert self.flush_calls, "read reached Installation before the flush"
+        assert self.flush_calls or self.default_sync_calls, "read reached Installation before the flush"
         self.mcp_reads.append(kwargs)
         return {"mcp.weather"}
 
@@ -113,7 +113,7 @@ class _Versions:
 
 
 def _reader(
-    *, bots: _Bots | None = None
+    *, bots: _Bots | None = None, default_sync_only: bool = False
 ) -> tuple[BotCapabilityStateReader, _Repository, _PoolSkills, _Bots, _Versions]:
     repository = _Repository()
     pool_skills = _PoolSkills().bind(repository)
@@ -125,6 +125,7 @@ def _reader(
             bot_repo=bots,
             pool_skills=pool_skills,
             version_resolver=versions,
+            read_config=InstallationReadConfig(default_sync_only=default_sync_only),
         ),
         repository,
         pool_skills,
@@ -215,14 +216,8 @@ def test_member_skill_ids_reads_the_set_membership_without_materializing():
     assert ids == frozenset({1})
 
 
-def test_reader_uses_default_only_sync_after_the_explicit_migration_switch(
-    monkeypatch: pytest.MonkeyPatch,
-):
-    reader, repository, pool_skills, _bots, _versions = _reader()
-    monkeypatch.setattr(
-        "agentclaw.community.core.skill_center.services.bot_capability_state_reader.get_skill_center_flags",
-        lambda: SimpleNamespace(installation_default_sync_only=True),
-    )
+def test_reader_uses_default_only_sync_after_the_explicit_migration_switch():
+    reader, repository, pool_skills, _bots, _versions = _reader(default_sync_only=True)
 
     reader.active_skill_assets(bot_id="bot-1", owner_id="owner")
 
@@ -231,17 +226,18 @@ def test_reader_uses_default_only_sync_after_the_explicit_migration_switch(
     assert pool_skills.reads
 
 
-def test_new_bot_initialization_always_uses_the_complete_resolver(
-    monkeypatch: pytest.MonkeyPatch,
-):
-    reader, repository, _pool, _bots, _versions = _reader()
-    monkeypatch.setattr(
-        "agentclaw.community.core.skill_center.services.bot_capability_state_reader.get_skill_center_flags",
-        lambda: SimpleNamespace(installation_default_sync_only=True),
-    )
+def test_new_bot_initialization_always_uses_the_complete_resolver():
+    reader, repository, _pool, _bots, _versions = _reader(default_sync_only=True)
 
     reader.initialize_installations(bot_id="bot-1", owner_id="owner")
 
     assert repository.initialization_calls == [_EXPECTED_FLUSH]
     assert repository.flush_calls == []
     assert repository.default_sync_calls == []
+
+
+def test_default_only_mode_also_synchronizes_before_mcp_read():
+    reader, repository, _pool, _bots, _versions = _reader(default_sync_only=True)
+    assert reader.active_mcp_server_codes(bot_id="bot-1", owner_id="owner") == frozenset({"mcp.weather"})
+    assert repository.default_sync_calls == [_EXPECTED_FLUSH]
+    assert repository.flush_calls == []

--- a/src/backend/tests/community/core/skill_center/test_bot_capability_state_reader.py
+++ b/src/backend/tests/community/core/skill_center/test_bot_capability_state_reader.py
@@ -148,6 +148,19 @@ def test_the_implementation_satisfies_the_public_protocol():
     assert isinstance(reader, BotCapabilityStateReaderProtocol)
 
 
+@pytest.mark.parametrize("default_sync_only", [False, True])
+def test_projection_snapshot_synchronizes_once_and_is_not_cached(default_sync_only):
+    reader, repository, pool, bots, versions = _reader(default_sync_only=default_sync_only)
+    first = reader.active_capabilities(bot_id="bot-1", owner_id="owner")
+    assert first.skills[0].skill_id == 1
+    assert first.installed_mcp_server_codes == frozenset({"mcp.weather"})
+    assert len(repository.flush_calls) + len(repository.default_sync_calls) == 1
+    assert len(pool.reads) == len(versions.calls) == len(repository.mcp_reads) == 1
+    second = reader.active_capabilities(bot_id="bot-1", owner_id="owner")
+    assert second == first and second is not first
+    assert len(repository.flush_calls) + len(repository.default_sync_calls) == 2
+
+
 def test_skill_read_flushes_then_answers_from_the_installation_join():
     reader, repository, pool_skills, bots, versions = _reader()
 

--- a/src/backend/tests/community/core/skill_center/test_bot_runtime_projector_timing.py
+++ b/src/backend/tests/community/core/skill_center/test_bot_runtime_projector_timing.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 
 import pytest
+from agentclaw.community.core.skill_center.capability_state_contract import BotCapabilitySnapshot
 
 from agentclaw.community.core.skill_center.runtime_projection_contract import (
     ProjectionScope,
@@ -34,10 +35,18 @@ class _Factory:
 
 class _SkillSetService:
     def collect_bot_active_mcps(self, **_kwargs) -> list[dict]:
+        assert isinstance(_kwargs["capability_snapshot"], BotCapabilitySnapshot)
         return []
 
 
 class _Reader:
+    def __init__(self):
+        self.snapshot_reads = 0
+
+    def active_capabilities(self, **kwargs):
+        self.snapshot_reads += 1
+        return BotCapabilitySnapshot(kwargs["bot_id"], kwargs["owner_id"], (), frozenset())
+
     def active_skill_assets(self, **_kwargs) -> list:
         return []
 
@@ -91,6 +100,7 @@ def test_runtime_projector_logs_skill_and_mcp_plan_timing(caplog) -> None:
     )
 
     assert isinstance(plan, ResolvedCapabilityPlan)
+    assert projector._reader.snapshot_reads == 1
     messages = [record.getMessage() for record in caplog.records]
     for stage in (
         "build_skill_plan",
@@ -98,7 +108,6 @@ def test_runtime_projector_logs_skill_and_mcp_plan_timing(caplog) -> None:
         "resolve_mcp_identity_modes",
         "collect_effective_mcps",
         "query_passport_clis",
-        "read_installed_mcps",
         "resolve_effective_capabilities",
     ):
         assert any(
@@ -115,7 +124,7 @@ def test_runtime_projector_logs_skill_and_mcp_plan_timing(caplog) -> None:
     "stage",
     (
         "resolve_mcp_identity_modes",
-        "read_installed_mcps",
+        "build_skill_plan",
         "resolve_effective_capabilities",
     ),
 )
@@ -130,8 +139,8 @@ def test_runtime_projector_logs_substage_errors(
 
     if stage == "resolve_mcp_identity_modes":
         monkeypatch.setattr(projector, "_resolve_mcp_identity_modes", fail)
-    elif stage == "read_installed_mcps":
-        monkeypatch.setattr(projector._repository, "list_installed_mcps", fail)
+    elif stage == "build_skill_plan":
+        monkeypatch.setattr(projector._reader, "active_capabilities", fail)
     else:
         monkeypatch.setattr(RuntimeProjectionResolver, "resolve", fail)
 

--- a/src/backend/tests/community/core/skill_center/test_bot_runtime_projector_timing.py
+++ b/src/backend/tests/community/core/skill_center/test_bot_runtime_projector_timing.py
@@ -2,9 +2,14 @@ from __future__ import annotations
 
 import logging
 
+import pytest
+
 from agentclaw.community.core.skill_center.runtime_projection_contract import (
     ProjectionScope,
     ResolvedCapabilityPlan,
+)
+from agentclaw.community.core.skill_center.runtime_resolver import (
+    RuntimeProjectionResolver,
 )
 from agentclaw.community.core.skill_center.services.bot_runtime_projector import (
     BotRuntimeProjector,
@@ -63,8 +68,8 @@ class _IdentityRepository:
         return {}
 
 
-def test_runtime_projector_logs_skill_and_mcp_plan_timing(caplog) -> None:
-    projector = BotRuntimeProjector(
+def _projector() -> BotRuntimeProjector:
+    return BotRuntimeProjector(
         factory=_Factory(),
         bot_repo=_Bots(),
         repository=_Repository(),
@@ -73,6 +78,10 @@ def test_runtime_projector_logs_skill_and_mcp_plan_timing(caplog) -> None:
         passport=_Passport(),
         caller_identity_repo=_IdentityRepository(),
     )
+
+
+def test_runtime_projector_logs_skill_and_mcp_plan_timing(caplog) -> None:
+    projector = _projector()
     caplog.set_level(logging.INFO)
 
     plan = projector._resolve_plan(
@@ -83,11 +92,61 @@ def test_runtime_projector_logs_skill_and_mcp_plan_timing(caplog) -> None:
 
     assert isinstance(plan, ResolvedCapabilityPlan)
     messages = [record.getMessage() for record in caplog.records]
-    for stage in ("build_skill_plan", "build_mcp_plan"):
+    for stage in (
+        "build_skill_plan",
+        "build_mcp_plan",
+        "resolve_mcp_identity_modes",
+        "collect_effective_mcps",
+        "query_passport_clis",
+        "read_installed_mcps",
+        "resolve_effective_capabilities",
+    ):
         assert any(
             "[BotRuntimeProjector] timing" in message
             and f"stage={stage}" in message
             and "bot_id=bot-1" in message
             and "duration_ms=" in message
+            and "outcome=success" in message
             for message in messages
         )
+
+
+@pytest.mark.parametrize(
+    "stage",
+    (
+        "resolve_mcp_identity_modes",
+        "read_installed_mcps",
+        "resolve_effective_capabilities",
+    ),
+)
+def test_runtime_projector_logs_substage_errors(
+    caplog, monkeypatch, stage: str
+) -> None:
+    projector = _projector()
+    failure = RuntimeError(stage)
+
+    def fail(*_args, **_kwargs):
+        raise failure
+
+    if stage == "resolve_mcp_identity_modes":
+        monkeypatch.setattr(projector, "_resolve_mcp_identity_modes", fail)
+    elif stage == "read_installed_mcps":
+        monkeypatch.setattr(projector._repository, "list_installed_mcps", fail)
+    else:
+        monkeypatch.setattr(RuntimeProjectionResolver, "resolve", fail)
+
+    caplog.set_level(logging.INFO)
+    with pytest.raises(RuntimeError, match=stage):
+        projector._resolve_plan(
+            bot_id="bot-1",
+            owner_id="owner-1",
+            scope=ProjectionScope(skills=True, mcp=True),
+        )
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert any(
+        "[BotRuntimeProjector] timing" in message
+        and f"stage={stage}" in message
+        and "outcome=error" in message
+        for message in messages
+    )

--- a/src/backend/tests/community/core/skill_center/test_feature_flags.py
+++ b/src/backend/tests/community/core/skill_center/test_feature_flags.py
@@ -19,18 +19,15 @@ class TestSkillCenterFlags:
     def test_from_env_reads_env_vars(self):
         os.environ["SC_NAS_SYNC_ENABLED"] = "true"
         os.environ["SC_PROPAGATION_ENABLED"] = "true"
-        os.environ["SC_INSTALLATION_DEFAULT_SYNC_ONLY"] = "true"
         try:
             flags = SkillCenterFlags.from_env()
             assert flags.nas_sync_enabled is True
             assert flags.propagation_enabled is True
             assert flags.center_uri_enabled is False
             assert flags.space_skill_enabled is False
-            assert flags.installation_default_sync_only is True
         finally:
             del os.environ["SC_NAS_SYNC_ENABLED"]
             del os.environ["SC_PROPAGATION_ENABLED"]
-            del os.environ["SC_INSTALLATION_DEFAULT_SYNC_ONLY"]
 
     def test_any_blocking_enabled_true_when_any_flag_on(self):
         flags = SkillCenterFlags(

--- a/src/backend/tests/community/core/skill_center/test_skill_set_management_service.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_set_management_service.py
@@ -437,6 +437,13 @@ class _DefaultResourceRepository(_ResourceRepository):
         self.list_set_calls.append(kwargs)
         return [{"id": "global-default", "is_default": True}]
 
+    def get_set(self, **kwargs):
+        return {
+            "id": kwargs["set_id"],
+            "is_default": kwargs["set_id"] == "global-default",
+            "is_active": True,
+        }
+
     def list_mcps(self, **kwargs):
         self.list_mcp_calls.append(kwargs)
         return [{"server_code": "visible-default-mcp"}]
@@ -469,6 +476,7 @@ class _McpAuth:
     def __init__(self, allowed: bool) -> None:
         self.allowed = allowed
         self.calls: list[tuple[str, str]] = []
+        self.apply_calls: list[dict] = []
 
     def check_mcp_permission_detail(self, actor_id: str, server_code: str) -> dict:
         self.calls.append((actor_id, server_code))
@@ -478,6 +486,7 @@ class _McpAuth:
         }
 
     def apply_permission(self, **_kwargs) -> dict:
+        self.apply_calls.append(_kwargs)
         return {"success": True, "process_url": None, "error": None}
 
 
@@ -1694,6 +1703,157 @@ def test_resources_reads_global_default_mcp_projection_for_collaborator_owner_sc
             "engine_type": "openclaw",
         }
     ]
+
+
+def test_list_mcps_reads_global_default_projection_for_collaborator_owner_scope():
+    repository = _DefaultResourceRepository()
+    legacy = _ResourceLegacyFactory()
+    service = SkillSetManagementService(
+        repository=repository,
+        bot_repo=_Bots(),
+        runtime=_SuccessfulRuntime(),
+        legacy_factory=legacy,
+        passport=object(),
+        authorization=_Authorization(),
+        audit_log_repo=_Audit(),
+        mcp_center=_McpCenter(allowed=True),
+        mcp_auth=_McpAuth(allowed=True),
+        ext_info_provider=lambda _bot_id: None,
+    )
+
+    result = service.list_mcps(
+        bot_id="bot-1",
+        owner_id="true-owner",
+        user_id="collaborator",
+        set_id="global-default",
+    )
+
+    assert result == [{"server_code": "legacy-default-mcp"}]
+    assert repository.list_mcp_calls == []
+    assert legacy.service.default_mcp_calls == [
+        {
+            "skill_set_id": "global-default",
+            "user_id": "true-owner",
+            "bot_id": "bot-1",
+            "engine_type": "openclaw",
+        }
+    ]
+
+
+def test_list_mcps_keeps_ordinary_membership_on_canonical_repository_path():
+    repository = _MixedResourceRepository()
+    legacy = _ResourceLegacyFactory()
+    service = SkillSetManagementService(
+        repository=repository,
+        bot_repo=_Bots(),
+        runtime=_SuccessfulRuntime(),
+        legacy_factory=legacy,
+        passport=object(),
+        authorization=_Authorization(),
+        audit_log_repo=_Audit(),
+        mcp_center=_McpCenter(allowed=True),
+        mcp_auth=_McpAuth(allowed=True),
+        ext_info_provider=lambda _bot_id: None,
+    )
+
+    result = service.list_mcps(
+        bot_id="bot-1",
+        owner_id="true-owner",
+        user_id="true-owner",
+        set_id="ordinary-set",
+    )
+
+    assert result == [{"server_code": "ordinary-set-mcp"}]
+    assert legacy.calls == []
+    assert repository.list_mcp_calls == [
+        {
+            "bot_id": "bot-1",
+            "owner_id": "true-owner",
+            "set_id": "ordinary-set",
+            "engine_type": "openclaw",
+            "default_engine_types": ("openclaw",),
+        }
+    ]
+
+
+def test_default_mcp_permissions_remain_scoped_to_persisted_membership():
+    repository = _DefaultResourceRepository()
+    legacy = _ResourceLegacyFactory()
+    mcp_center = _McpCenter(allowed=True)
+    service = SkillSetManagementService(
+        repository=repository,
+        bot_repo=_Bots(),
+        runtime=_SuccessfulRuntime(),
+        legacy_factory=legacy,
+        passport=object(),
+        authorization=_Authorization(),
+        audit_log_repo=_Audit(),
+        mcp_center=mcp_center,
+        mcp_auth=_McpAuth(allowed=True),
+        ext_info_provider=lambda _bot_id: None,
+    )
+
+    result = service.list_mcp_permissions(
+        bot_id="bot-1",
+        owner_id="true-owner",
+        user_id="collaborator",
+        set_id="global-default",
+    )
+
+    assert result == [
+        {
+            "server_code": "visible-default-mcp",
+            "has_permission": True,
+            "access_level": "LOCAL",
+        }
+    ]
+    assert mcp_center.calls == [("collaborator", "visible-default-mcp")]
+    assert legacy.calls == []
+
+
+def test_default_mcp_permission_request_does_not_expand_platform_defaults():
+    repository = _DefaultResourceRepository()
+    legacy = _ResourceLegacyFactory()
+    mcp_auth = _McpAuth(allowed=True)
+    service = SkillSetManagementService(
+        repository=repository,
+        bot_repo=_Bots(),
+        runtime=_SuccessfulRuntime(),
+        legacy_factory=legacy,
+        passport=object(),
+        authorization=_Authorization(),
+        audit_log_repo=_Audit(),
+        mcp_center=_McpCenter(allowed=True),
+        mcp_auth=mcp_auth,
+        ext_info_provider=lambda _bot_id: None,
+    )
+
+    result = service.request_mcp_permissions(
+        bot_id="bot-1",
+        owner_id="true-owner",
+        user_id="collaborator",
+        set_id="global-default",
+        reason="needed",
+    )
+
+    assert result == [
+        {
+            "server_code": "visible-default-mcp",
+            "success": True,
+            "process_url": None,
+            "error": None,
+        }
+    ]
+    assert mcp_auth.apply_calls == [
+        {
+            "staff_no": "collaborator",
+            "service_code": "visible-default-mcp",
+            "tool_list": [],
+            "is_public": True,
+            "reason": "needed",
+        }
+    ]
+    assert legacy.calls == []
 
 
 def test_resources_keeps_ordinary_mcp_membership_on_canonical_repository_path():

--- a/src/backend/tests/community/core/skill_center/test_skill_set_management_service.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_set_management_service.py
@@ -2255,6 +2255,7 @@ async def test_runtime_projection_mcp_inputs_agree_when_the_union_overlaps():
 
 @pytest.mark.asyncio
 async def test_runtime_reconcile_projects_full_mcp_desired_state():
+    from agentclaw.community.core.skill_center.capability_state_contract import BotCapabilitySnapshot
     factory = _RuntimeFactory()
     passport = _RuntimePassport()
     runtime = BotRuntimeProjector(
@@ -2293,6 +2294,9 @@ async def test_runtime_reconcile_projects_full_mcp_desired_state():
             "entity_type": "staff",
             "engine_type": "openclaw",
             "strict_policy_context": True,
+            "capability_snapshot": BotCapabilitySnapshot(
+                "bot-1", "true-owner", (), frozenset({"mcp.weather"})
+            ),
         }
     ]
     assert passport.calls == [

--- a/src/backend/tests/community/di/modules/test_installation_read_config.py
+++ b/src/backend/tests/community/di/modules/test_installation_read_config.py
@@ -1,0 +1,65 @@
+"""Installation migration mode is YAML-owned and environment-isolated."""
+
+from unittest.mock import Mock
+
+import pytest
+from injector import Injector, InstanceProvider
+
+from agentclaw.community.core.repository.protocols.bot import BotRepository
+from agentclaw.community.core.repository.protocols.capability_desired_state import CapabilityDesiredStateRepositoryProtocol
+from agentclaw.community.core.repository.protocols.skills_pool import SkillsPoolSkillRepositoryProtocol
+from agentclaw.community.core.skill_center.installation_read_config import InstallationReadConfig
+from agentclaw.community.core.skill_center.services.bot_capability_state_reader import BotCapabilityStateReader
+from agentclaw.community.core.skill_center.version_resolution_contract import SkillVersionResolverProtocol
+from agentclaw.community.di.modules import config_module
+from agentclaw.community.di.modules.installation_read_config_module import (
+    InstallationReadConfigModule,
+)
+
+
+@pytest.mark.parametrize("environment,expected", [("pre", True), ("prepub", True), ("prod", False), ("gray", False), ("dev", False)])
+def test_environment_selection_and_reader_injection(monkeypatch, environment, expected):
+    monkeypatch.setenv("SERVER_ENV", environment)
+    monkeypatch.setenv("SC_INSTALLATION_DEFAULT_SYNC_ONLY", "true")
+    monkeypatch.setattr(config_module, "read_user_config", lambda: {
+        "skill_installation": {"default_sync_only": {"pre": True, "prod": False}}
+    })
+    injector = Injector([config_module.ConfigModule(), InstallationReadConfigModule()])
+    repository = Mock()
+    for protocol, value in [(CapabilityDesiredStateRepositoryProtocol, repository),
+                            (BotRepository, Mock()), (SkillsPoolSkillRepositoryProtocol, Mock()),
+                            (SkillVersionResolverProtocol, Mock())]:
+        injector.binder.bind(protocol, to=InstanceProvider(value))
+    reader = injector.get(BotCapabilityStateReader)
+    reader.synchronize_installations(bot_id="default", owner_id="owner", bot={
+        "bot_id": "default", "owner_id": "owner", "env": "pre" if expected else "prod",
+        "active_engine": "openclaw",
+    })
+    assert repository.sync_default_installations.called is expected
+    assert repository.flush_installations.called is not expected
+    assert injector.get(InstallationReadConfig).default_sync_only is expected
+
+
+@pytest.mark.parametrize("user_config", [{}, {"skill_installation": {}}, {"skill_installation": {"default_sync_only": {}}}])
+def test_missing_settings_are_disabled(monkeypatch, user_config):
+    monkeypatch.setenv("SC_INSTALLATION_DEFAULT_SYNC_ONLY", "true")
+    monkeypatch.setattr(config_module, "read_user_config", lambda: user_config)
+    assert InstallationReadConfigModule().installation_read() == InstallationReadConfig()
+
+
+@pytest.mark.parametrize("environment,expected", [("pre", False), ("prod", True)])
+def test_production_switch_does_not_enable_pre(monkeypatch, environment, expected):
+    monkeypatch.setenv("SERVER_ENV", environment)
+    monkeypatch.setattr(config_module, "read_user_config", lambda: {
+        "skill_installation": {"default_sync_only": {"prod": True}}
+    })
+    assert InstallationReadConfigModule().installation_read().default_sync_only is expected
+
+
+@pytest.mark.parametrize("block", [None, True, {"typo": True}, {"default_sync_only": None},
+    {"default_sync_only": True}, {"default_sync_only": {"pre": "false"}},
+    {"default_sync_only": {"prod": 1}}, {"default_sync_only": {"prd": True}}])
+def test_invalid_settings_fail_explicitly(monkeypatch, block):
+    monkeypatch.setattr(config_module, "read_user_config", lambda: {"skill_installation": block})
+    with pytest.raises(ValueError, match="skill_installation"):
+        InstallationReadConfigModule().installation_read()

--- a/src/backend/tests/community/di/modules/test_installation_read_config.py
+++ b/src/backend/tests/community/di/modules/test_installation_read_config.py
@@ -1,65 +1,125 @@
-"""Installation migration mode is YAML-owned and environment-isolated."""
+"""Installation migration mode is DB-owned and environment-isolated."""
 
 from unittest.mock import Mock
 
 import pytest
 from injector import Injector, InstanceProvider
 
+from agentclaw.community.api.common_config_service import CommonConfigServiceProtocol
 from agentclaw.community.core.repository.protocols.bot import BotRepository
-from agentclaw.community.core.repository.protocols.capability_desired_state import CapabilityDesiredStateRepositoryProtocol
-from agentclaw.community.core.repository.protocols.skills_pool import SkillsPoolSkillRepositoryProtocol
-from agentclaw.community.core.skill_center.installation_read_config import InstallationReadConfig
-from agentclaw.community.core.skill_center.services.bot_capability_state_reader import BotCapabilityStateReader
-from agentclaw.community.core.skill_center.version_resolution_contract import SkillVersionResolverProtocol
-from agentclaw.community.di.modules import config_module
+from agentclaw.community.core.repository.protocols.capability_desired_state import (
+    CapabilityDesiredStateRepositoryProtocol,
+)
+from agentclaw.community.core.repository.protocols.skills_pool import (
+    SkillsPoolSkillRepositoryProtocol,
+)
+from agentclaw.community.core.skill_center.installation_read_config import (
+    INSTALLATION_READ_BUSINESS_CODE,
+    INSTALLATION_READ_PARAM_CODE,
+    InstallationReadConfig,
+)
+from agentclaw.community.core.skill_center.services.bot_capability_state_reader import (
+    BotCapabilityStateReader,
+)
+from agentclaw.community.core.skill_center.version_resolution_contract import (
+    SkillVersionResolverProtocol,
+)
 from agentclaw.community.di.modules.installation_read_config_module import (
     InstallationReadConfigModule,
 )
 
 
-@pytest.mark.parametrize("environment,expected", [("pre", True), ("prepub", True), ("prod", False), ("gray", False), ("dev", False)])
-def test_environment_selection_and_reader_injection(monkeypatch, environment, expected):
-    monkeypatch.setenv("SERVER_ENV", environment)
-    monkeypatch.setenv("SC_INSTALLATION_DEFAULT_SYNC_ONLY", "true")
-    monkeypatch.setattr(config_module, "read_user_config", lambda: {
-        "skill_installation": {"default_sync_only": {"pre": True, "prod": False}}
-    })
-    injector = Injector([config_module.ConfigModule(), InstallationReadConfigModule()])
+def _injector(*, common_config: Mock) -> Injector:
+    injector = Injector([InstallationReadConfigModule()])
     repository = Mock()
-    for protocol, value in [(CapabilityDesiredStateRepositoryProtocol, repository),
-                            (BotRepository, Mock()), (SkillsPoolSkillRepositoryProtocol, Mock()),
-                            (SkillVersionResolverProtocol, Mock())]:
+    for protocol, value in [
+        (CommonConfigServiceProtocol, common_config),
+        (CapabilityDesiredStateRepositoryProtocol, repository),
+        (BotRepository, Mock()),
+        (SkillsPoolSkillRepositoryProtocol, Mock()),
+        (SkillVersionResolverProtocol, Mock()),
+    ]:
         injector.binder.bind(protocol, to=InstanceProvider(value))
+    return injector
+
+
+@pytest.mark.parametrize(
+    ("environment", "expected"),
+    [
+        ("pre", True),
+        ("prepub", True),
+        ("prod", False),
+        ("gray", False),
+        ("dev", False),
+    ],
+)
+def test_environment_scoped_common_config_drives_reader(monkeypatch, environment, expected):
+    monkeypatch.setenv("SERVER_ENV", environment)
+    common_config = Mock()
+    common_config.get_value.return_value = expected
+    injector = _injector(common_config=common_config)
+    repository = injector.get(CapabilityDesiredStateRepositoryProtocol)
+
     reader = injector.get(BotCapabilityStateReader)
-    reader.synchronize_installations(bot_id="default", owner_id="owner", bot={
-        "bot_id": "default", "owner_id": "owner", "env": "pre" if expected else "prod",
-        "active_engine": "openclaw",
-    })
+    reader.synchronize_installations(
+        bot_id="default",
+        owner_id="owner",
+        bot={
+            "bot_id": "default",
+            "owner_id": "owner",
+            "env": "pre" if expected else "prod",
+            "active_engine": "openclaw",
+        },
+    )
+
     assert repository.sync_default_installations.called is expected
     assert repository.flush_installations.called is not expected
-    assert injector.get(InstallationReadConfig).default_sync_only is expected
+    common_config.get_value.assert_called_with(
+        business_code=INSTALLATION_READ_BUSINESS_CODE,
+        param_code=INSTALLATION_READ_PARAM_CODE,
+        env={"prepub": "pre", "gray": "prod"}.get(environment, environment),
+        default=False,
+        only_enabled=True,
+    )
 
 
-@pytest.mark.parametrize("user_config", [{}, {"skill_installation": {}}, {"skill_installation": {"default_sync_only": {}}}])
-def test_missing_settings_are_disabled(monkeypatch, user_config):
-    monkeypatch.setenv("SC_INSTALLATION_DEFAULT_SYNC_ONLY", "true")
-    monkeypatch.setattr(config_module, "read_user_config", lambda: user_config)
-    assert InstallationReadConfigModule().installation_read() == InstallationReadConfig()
+@pytest.mark.parametrize("value", [None, "true", 1, {}, []])
+def test_missing_disabled_or_invalid_config_retains_complete_repair(value):
+    common_config = Mock()
+    common_config.get_value.return_value = value
+    config = InstallationReadConfig(common_config_service=common_config, env="pre")
+
+    assert config.default_sync_only is False
 
 
-@pytest.mark.parametrize("environment,expected", [("pre", False), ("prod", True)])
-def test_production_switch_does_not_enable_pre(monkeypatch, environment, expected):
-    monkeypatch.setenv("SERVER_ENV", environment)
-    monkeypatch.setattr(config_module, "read_user_config", lambda: {
-        "skill_installation": {"default_sync_only": {"prod": True}}
-    })
-    assert InstallationReadConfigModule().installation_read().default_sync_only is expected
+def test_common_config_read_error_retains_complete_repair():
+    common_config = Mock()
+    common_config.get_value.side_effect = RuntimeError("database unavailable")
+    config = InstallationReadConfig(common_config_service=common_config, env="prod")
+
+    assert config.default_sync_only is False
 
 
-@pytest.mark.parametrize("block", [None, True, {"typo": True}, {"default_sync_only": None},
-    {"default_sync_only": True}, {"default_sync_only": {"pre": "false"}},
-    {"default_sync_only": {"prod": 1}}, {"default_sync_only": {"prd": True}}])
-def test_invalid_settings_fail_explicitly(monkeypatch, block):
-    monkeypatch.setattr(config_module, "read_user_config", lambda: {"skill_installation": block})
-    with pytest.raises(ValueError, match="skill_installation"):
-        InstallationReadConfigModule().installation_read()
+def test_db_value_is_read_dynamically_for_emergency_rollback():
+    common_config = Mock()
+    common_config.get_value.side_effect = [True, False]
+    config = InstallationReadConfig(common_config_service=common_config, env="pre")
+
+    assert config.default_sync_only is True
+    assert config.default_sync_only is False
+    assert common_config.get_value.call_count == 2
+
+
+def test_pre_and_prod_read_independent_common_config_records():
+    common_config = Mock()
+    common_config.get_value.side_effect = lambda **kwargs: {
+        "pre": True,
+        "prod": False,
+    }[kwargs["env"]]
+
+    assert InstallationReadConfig(
+        common_config_service=common_config, env="pre"
+    ).default_sync_only is True
+    assert InstallationReadConfig(
+        common_config_service=common_config, env="prod"
+    ).default_sync_only is False

--- a/src/backend/tests/community/endpoints/test_openapi_bot_owner_name.py
+++ b/src/backend/tests/community/endpoints/test_openapi_bot_owner_name.py
@@ -1,0 +1,156 @@
+"""Trusted display names survive creation and durable manifest completion."""
+
+import jwt
+import pytest
+from fastapi.testclient import TestClient
+
+from agentclaw.community.adapters.http.openapi_v1.dependencies import PRINCIPAL_HEADER
+from agentclaw.community.core.bot_public.catalog_metadata import (
+    BotCatalogAddress,
+    BotCatalogMetadata,
+    BotCatalogMetadataPage,
+    BotCatalogMetadataServiceProtocol,
+)
+from agentclaw.community.core.repository.protocols.bot import BotRepository
+from tests.community.framework import bind_overrides
+from tests.community.endpoints.test_openapi_bot_auth_status import (
+    _KEY,
+    _OWNER,
+    _principal,
+    _seed_for_completion,
+)
+from tests.community.endpoints.test_openapi_create_with_manifest import _Worker
+
+
+@pytest.fixture
+def client(app_with_testing_modules):
+    return TestClient(app_with_testing_modules)
+
+
+@pytest.mark.parametrize("flow", ["create", "post-auth", "get-auth", "manifest"])
+@pytest.mark.parametrize(
+    ("display_name", "expected"),
+    [("  张三  ", "张三"), (None, _OWNER), ("", _OWNER), ("   ", _OWNER)],
+)
+def test_creation_persists_verified_owner_name(
+    client, world, flow, display_name, expected
+):
+    _seed_for_completion(world)
+    claims = jwt.decode(_principal(), _KEY, algorithms=["HS256"], audience="backend")
+    claims["principals"][0]["subject"]["display_name"] = display_name
+    headers = {PRINCIPAL_HEADER: jwt.encode(claims, _KEY, algorithm="HS256")}
+    params = {"user_id": _OWNER}
+    body = {
+        "engine": "openclaw",
+        "bot_name": "Owner Name Bot",
+        "bot_desc": "owner regression",
+        "cluster_name": "ACRA",
+        "bot_type": "personal",
+    }
+    bot_id = "owner-name-bot"
+    if flow == "create":
+        response = client.post(
+            "/openapi/v1/bots", params=params, headers=headers, json=body
+        )
+    elif flow == "manifest":
+        response = client.post(
+            "/openapi/v1/bots/with-manifest",
+            params=params,
+            headers=headers,
+            json={**body, "config_manifest": "schema_version: 1\n"},
+        )
+    elif flow == "post-auth":
+        response = client.post(
+            f"/openapi/v1/bots/{bot_id}/auth-status",
+            params=params,
+            headers=headers,
+            json=body,
+        )
+    else:
+        response = client.get(
+            f"/openapi/v1/bots/{bot_id}/auth-status",
+            params={**params, **body},
+            headers=headers,
+        )
+    assert response.status_code in (200, 201, 202), response.text
+    if flow in ("create", "manifest"):
+        bot_id = response.json()["data"]["bot_id"]
+    if flow == "manifest":
+        # Drive authorization until persistence, without waiting for a container.
+        worker = _Worker(world)
+        for _ in range(8):
+            worker.turn()
+            if world.get(BotRepository).get_by_id_and_entity(bot_id, _OWNER):
+                break
+    row = world.get(BotRepository).get_by_id_and_entity(bot_id, _OWNER)
+    assert row is not None, response.text
+    assert row["owner_name"] == expected
+    assert row["owner_id"] == _OWNER
+    assert row["entity_id"] == _OWNER
+
+    def catalog_metadata(_self, **_kwargs):
+        return BotCatalogMetadataPage(
+            total=1,
+            items=[BotCatalogMetadata(BotCatalogAddress(bot_id, _OWNER), kind="bot")],
+        )
+
+    bind_overrides(
+        world,
+        BotCatalogMetadataServiceProtocol,
+        {"search_public_bot_metadata": catalog_metadata},
+    )
+    catalog = client.get("/openapi/v1/bots/catalog/search", headers=headers)
+    assert catalog.status_code == 200, catalog.text
+    items = catalog.json()["data"]["items"]
+    assert len(items) == 1
+    assert items[0]["owner_name"] == expected
+    assert items[0]["entity_id"] == _OWNER
+
+
+def test_manifest_completion_accepts_pre_upgrade_job_without_nickname(world):
+    from agentclaw.community.core.bot_management.create_flow import (
+        complete_manifest_creation,
+    )
+    from agentclaw.community.core.bot_management.services.bot_service import BotService
+    from agentclaw.community.plugin_api.auth_relationship import AuthRelationshipPlugin
+    from agentclaw.community.plugin_api.passport import PassportPlugin
+
+    _seed_for_completion(world)
+    complete_manifest_creation(
+        {
+            "user_id": _OWNER,
+            "bot_id": "legacy-owner-name-bot",
+            "spec": {
+                "entity_id": _OWNER,
+                "engine_type": "openclaw",
+                "bot_type": "personal",
+                "bot_name": "Legacy Job Bot",
+                "template_validation_mode": "public",
+                "deployment_mode": "cloud",
+                "space_kind": "personal",
+            },
+        },
+        bot_service=world.get(BotService),
+        passport_plugin=world.get(PassportPlugin),
+        auth_rel_plugin=world.get(AuthRelationshipPlugin),
+        provision=False,
+    )
+    row = world.get(BotRepository).get_by_id_and_entity("legacy-owner-name-bot", _OWNER)
+    assert row["owner_name"] == _OWNER
+
+
+def test_create_rejects_owner_id_different_from_verified_user(client, world):
+    _seed_for_completion(world)
+    response = client.post(
+        "/openapi/v1/bots",
+        params={"user_id": "another-owner"},
+        headers={PRINCIPAL_HEADER: _principal()},
+        json={
+            "engine": "openclaw",
+            "bot_name": "Wrong Owner Bot",
+            "bot_desc": "identity boundary",
+            "cluster_name": "ACRA",
+            "bot_type": "personal",
+        },
+    )
+    assert response.status_code == 403, response.text

--- a/src/backend/tests/community/endpoints/test_openapi_skill_sets.py
+++ b/src/backend/tests/community/endpoints/test_openapi_skill_sets.py
@@ -939,6 +939,21 @@ def _seed_excluded_default_mcp(world) -> None:
         )
 
 
+def _seed_excluded_platform_default_mcp(world) -> None:
+    _seed_default_member(world)
+    server_code = "mcp.ant.antprocessai.anttaskmcp"
+    with avernet_tenant_scope(_TENANT):
+        world.get(CapabilityDesiredStateRepositoryProtocol).exclude_default_mcp(
+            bot_id=_BOT_ID,
+            owner_id=_OWNER,
+            set_id="2",
+            server_code=server_code,
+            engine_type="openclaw",
+            default_engine_types=("openclaw",),
+            platform_default_codes=frozenset({server_code}),
+        )
+
+
 def _excluded_skill_ids(world) -> set[int]:
     with avernet_tenant_scope(_TENANT):
         return world.get(
@@ -971,6 +986,63 @@ def _assert_mcp_excluded(_response, world) -> None:
 def _assert_mcp_unexcluded(_response, world) -> None:
     assert _excluded_mcp_codes(world) == set()
     _assert_reconciled(_response, world)
+
+
+def _assert_default_mcp_projection(response, _world) -> None:
+    codes = {item["server_code"] for item in response.json()["data"]}
+    assert "mcp.default" in codes
+    assert "mcp.ant.antprocessai.anttaskmcp" in codes
+
+
+def _assert_excluded_default_mcp_absent(response, _world) -> None:
+    codes = {item["server_code"] for item in response.json()["data"]}
+    assert "mcp.ant.antprocessai.anttaskmcp" not in codes
+    assert "mcp.ant.arkai.dimamcpserver" in codes
+
+
+def _assert_excluded_persisted_default_mcp_absent(response, _world) -> None:
+    codes = {item["server_code"] for item in response.json()["data"]}
+    assert "mcp.default" not in codes
+    assert "mcp.ant.antprocessai.anttaskmcp" in codes
+
+
+@_case(
+    "GET",
+    "/openapi/v1/bots/{bot_id}/skill-sets/{set_id}/mcps",
+    "lists_default_members_and_platform_defaults",
+    ExpectSuccess(status=200),
+    seed=_seed_default_member,
+    path_params=_DEFAULT_SET_PARAMS,
+    extra=(_assert_default_mcp_projection,),
+)
+def list_default_mcps_projects_platform_defaults():
+    """Default Set reads include code policy as well as persisted members."""
+
+
+@_case(
+    "GET",
+    "/openapi/v1/bots/{bot_id}/skill-sets/{set_id}/mcps",
+    "filters_excluded_default_mcp",
+    ExpectSuccess(status=200),
+    seed=_seed_excluded_platform_default_mcp,
+    path_params=_DEFAULT_SET_PARAMS,
+    extra=(_assert_excluded_default_mcp_absent,),
+)
+def list_default_mcps_filters_bot_exclusions():
+    """A Bot exclusion hides that Default Set MCP from the read projection."""
+
+
+@_case(
+    "GET",
+    "/openapi/v1/bots/{bot_id}/skill-sets/{set_id}/mcps",
+    "filters_excluded_persisted_default_mcp",
+    ExpectSuccess(status=200),
+    seed=_seed_excluded_default_mcp,
+    path_params=_DEFAULT_SET_PARAMS,
+    extra=(_assert_excluded_persisted_default_mcp_absent,),
+)
+def list_default_mcps_filters_persisted_membership_exclusions():
+    """Default exclusions apply to persisted members and code policy alike."""
 
 
 @_case(

--- a/src/backend/tests/community/repository/publishing/test_bot_publish_unified.py
+++ b/src/backend/tests/community/repository/publishing/test_bot_publish_unified.py
@@ -405,6 +405,28 @@ def test_get_latest_success_by_source_bot_id_returns_none_when_no_success(repo):
     assert repo.get_latest_success_by_source_bot_id("src-missing", "dev") is None
 
 
+def test_get_latest_built_by_source_bot_id_owner_agnostic_returns_latest(repo):
+    """Eval 区版本锚定：latest built row, owner-agnostic."""
+    repo.insert(_data(source_bot_id="src-1", owner_id="emp001", status="built", env="dev"))
+    latest = repo.insert(
+        _data(source_bot_id="src-1", owner_id="other-owner", status="built", env="dev", version=2)
+    )
+    repo.insert(_data(source_bot_id="src-1", owner_id="emp001", status="success", env="dev", version=3))
+    repo.insert(_data(source_bot_id="src-1", owner_id="emp001", status="built", env="pre", version=4))
+
+    got = repo.get_latest_built_by_source_bot_id("src-1", "dev")
+
+    assert got is not None
+    assert got.id == latest.id
+
+
+def test_get_latest_built_by_source_bot_id_returns_none_when_no_built(repo):
+    repo.insert(_data(source_bot_id="src-1", owner_id="emp001", status="success", env="dev"))
+
+    assert repo.get_latest_built_by_source_bot_id("src-1", "dev") is None
+    assert repo.get_latest_built_by_source_bot_id("src-missing", "dev") is None
+
+
 # ── config_artifact OSS offload ─────────────────────────────────────
 #
 # When ``ext['config_artifact']`` serializes past the inline TEXT-column


### PR DESCRIPTION
## Problem

The release branch contains Backend and BaaS fixes that are missing from dev: default MCP listing and installation reads can be inconsistent or repeated, deployment metadata can be incomplete, manifest/startup DDL can disagree with deployed tables, and streamed output can lose arrival ordering.

## Solution

Replay 13 release commits onto dev, retaining dev's existing behavior:

- Project default MCPs in SkillSet listings, configure installation reads through typed YAML and database settings, and add projection/read timing diagnostics while avoiding repeated reads and device resolution.
- Persist verified bot owner names and pass evaluation tags through deployment and HTTP session creation; propagate trace IDs on bot WebSocket RPC frames.
- Align manifest apply and startup-script schemas and provide the repair migration for mis-provisioned manifest tables.
- Preserve stream chunk arrival order when flushing.
- Resolve the DDL contract parser overlap by preserving both ALTER TABLE and CREATE TABLE IF NOT EXISTS support, with a mixed-DDL regression test.

The release commit removing browser relay from ARCA access was already patch-equivalent to dev and was not replayed.

## Validation

- SQL DDL contract suite: 6 passed; existing dependency deprecation warnings only.
- git diff --check: passed.
- dev ancestry and range-diff review: passed; 13 commits above dev at 54a944c45.
- All Backend test files changed by this PR: 485 passed locally (20 existing warnings).
- Changed BaaS test files: 243 passed locally.
- Remote checks for 73052f077: all 11 checks passed, including Backend, BaaS and Singlebox coverage.
- Backend CI: 18,063 passed, 60 skipped; total line coverage 88.84%, changed-line coverage 98.43% (188/191).
- BaaS CI: 8,940 passed, 5 skipped, 1 xfailed, 8 xpassed; total line coverage 93.34%, changed-line coverage 100% (47/47).
- Singlebox gate and artifact verification passed: BCS runtime line/method coverage 42.59%/38.15%; endpoint and CLI coverage both 100%.

## Compatibility and risk

This combines existing release fixes across Backend and BaaS. Schema and ORM changes must be deployed together; the repair migration is intended for environments with the mis-provisioned manifest apply table. The remote unit and Singlebox gates passed; deployment of the SQL repair still requires the normal environment-specific migration process.
