### PR TITLE
fix(backend): tolerate concurrent BaaS resource uploads

### DIFF
--- a/src/backend/src/agentclaw/community/core/devices/services/baas_device_filesystem.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/baas_device_filesystem.py
@@ -18,7 +18,10 @@ import httpx
 
 from agentclaw.community.log import get_logger
 from agentclaw.community.core.devices.services.device_filesystem import DeviceFileSystem
-from agentclaw.community.core.devices.services.baas_invoke_transport import BaasTransport
+from agentclaw.community.core.devices.services.baas_invoke_transport import (
+    BaasTransport,
+    is_not_directory_error,
+)
 
 logger = get_logger()
 
@@ -243,9 +246,16 @@ class BaasDeviceFileSystem(DeviceFileSystem):
         try:
             files = await self.list_dir(path)
         except httpx.HTTPStatusError as e:
-            if e.response.status_code != 404:
-                raise
-            return False
+            if e.response.status_code == 404:
+                return False
+            if is_not_directory_error(e):
+                # A concurrent writer can create the file after the first read
+                # returned 404 but before this directory probe lands. Re-read once;
+                # only verified content turns the probe into True. Otherwise the
+                # original transport error remains observable.
+                if await self.read_file(path) is not None:
+                    return True
+            raise
         return files is not None
 
 

--- a/src/backend/src/agentclaw/community/core/devices/services/baas_invoke_transport.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/baas_invoke_transport.py
@@ -54,6 +54,19 @@ _HTTP_INFO_TTL_SECONDS = 30.0
 _STALE_TOKEN_STATUS = 401
 
 
+def is_not_directory_error(exc: Exception) -> bool:
+    """Classify Engine's ``list(file_path)`` transport verdict.
+
+    The Engine file API maps ``NotADirectoryError`` to HTTP 400. Keeping that
+    translation here lets filesystem behavior avoid inspecting status codes while
+    preserving the original exception for callers that need to propagate it.
+    """
+    return (
+        isinstance(exc, httpx.HTTPStatusError)
+        and exc.response.status_code == 400
+    )
+
+
 def build_desktop_client() -> httpx.Client:
     """Build the pooled client :class:`DesktopBaasInvokeTransport` sends through.
 

--- a/src/backend/tests/community/plugins/prod/test_baas_device_filesystem.py
+++ b/src/backend/tests/community/plugins/prod/test_baas_device_filesystem.py
@@ -3,7 +3,7 @@
 8 个 file 方法走 transport.post / transport.post_multipart。write_file 是
 multipart,其他都是 json POST。
 """
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 import httpx
 import pytest
@@ -282,6 +282,56 @@ async def test_exists_returns_false_on_404():
     transport = _make_transport(response=err_resp)
     fs = BaasDeviceFileSystem(transport=transport, conn_info=_conn_info(), path_mapper=lambda p: p)
     assert await fs.exists("/missing") is False
+
+
+@pytest.mark.asyncio
+async def test_exists_recovers_when_file_appears_before_directory_probe():
+    """A concurrent upload may win between read(file) and list(file)."""
+    from agentclaw.community.core.devices.services.baas_device_filesystem import BaasDeviceFileSystem
+    missing = httpx.Response(
+        status_code=404, content=b"not found",
+        request=httpx.Request("POST", "http://fake/api/file/read"),
+    )
+    not_a_directory = httpx.Response(
+        status_code=400, content=b"not a directory",
+        request=httpx.Request("POST", "http://fake/api/file/list"),
+    )
+    winner = _ok_response(content=b"concurrent upload")
+    transport = _make_transport()
+    transport.post.side_effect = [missing, not_a_directory, winner]
+    fs = BaasDeviceFileSystem(transport=transport, conn_info=_conn_info(), path_mapper=lambda p: p)
+
+    assert await fs.exists("/workspace/install_coship_tools.py") is True
+    assert transport.post.call_args_list == [
+        call("/api/file/read", json={"file_path": "/workspace/install_coship_tools.py"}),
+        call(
+            "/api/file/list",
+            json={"dir_path": "/workspace/install_coship_tools.py", "recursive": False},
+        ),
+        call("/api/file/read", json={"file_path": "/workspace/install_coship_tools.py"}),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_exists_preserves_400_when_second_read_still_finds_nothing():
+    """A real bad list request must not be weakened into absence."""
+    from agentclaw.community.core.devices.services.baas_device_filesystem import BaasDeviceFileSystem
+    missing = httpx.Response(
+        status_code=404, content=b"not found",
+        request=httpx.Request("POST", "http://fake/api/file/read"),
+    )
+    bad_request = httpx.Response(
+        status_code=400, content=b"bad request",
+        request=httpx.Request("POST", "http://fake/api/file/list"),
+    )
+    transport = _make_transport()
+    transport.post.side_effect = [missing, bad_request, missing]
+    fs = BaasDeviceFileSystem(transport=transport, conn_info=_conn_info(), path_mapper=lambda p: p)
+
+    with pytest.raises(httpx.HTTPStatusError) as error:
+        await fs.exists("/workspace/bad.txt")
+
+    assert error.value.response.status_code == 400
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem
Concurrent overwrite uploads to the same BaaS Bot path can interleave as follows: both reads observe 404, one request creates the file, and the other request then receives HTTP 400 from `list(file_path)`. `BaasDeviceFileSystem.exists()` propagated that expected race as a public upload 500, which caused the upstream orchestration to enter its cleanup flow.

## Solution
Classify the Engine not-directory verdict at the BaaS transport boundary. When `exists()` encounters that verdict, it re-reads the exact path once. It returns `True` only when the concurrent writer is verified; otherwise it re-raises the original error.

The existing upload behavior remains last-writer-wins. `list_dir()` behavior, 404 absence handling, and 401/5xx propagation are unchanged.

## Validation
- `ruff check` on the three changed files: passed
- 150 focused Backend unit, adapter, contract, and architecture tests: passed
- Standards review: passed, no remaining findings
- Spec review: passed, no remaining findings
- Full Backend suite: 18,008 passed, 60 skipped; one unrelated task-discovery test crossed local midnight (`2026-09-08` to `2026-09-09`) and failed its date assertion, then passed immediately in a fresh process
- GitHub CI: in progress

## Compatibility and risk
No HTTP API, schema, database, or public protocol contract changes. The behavior change is limited to the verified read-404/list-400/read-success race. A genuine 400 is still re-raised unchanged. This does not add distributed locking or change the separately documented database-record concurrency boundary.

OCB enterprise code has no override of this filesystem implementation. Enterprise rollout still requires a separate OCB `ocb-public` gitlink bump and deployment after this PR is merged.