### PR TITLE
fix(workflow): preserve run version metadata in internal API

### DIFF
--- a/src/evolverun/clawweb/public/modules/workflow/docs/internal-version-contract.md
+++ b/src/evolverun/clawweb/public/modules/workflow/docs/internal-version-contract.md
@@ -1,0 +1,29 @@
+# Internal workflow version contract
+
+These routes are mounted below `/api/internal` and use the host's internal API authentication. They are consumed by ClawMind; they do not introduce a separate publishing model.
+
+## Deployment snapshots
+
+`GET /deploy-history/:workflowId/active` and `GET /deploy-history/:workflowId/versions/:version/snapshot` return a flat camelCase object, not a nested `record`:
+
+```json
+{
+  "found": true,
+  "workflowId": "example",
+  "packId": "example-pack",
+  "version": 2,
+  "deployNumber": 5,
+  "tagName": "deploy/example/#5",
+  "action": "deploy",
+  "specJson": "{\"id\":\"example\"}",
+  "gmtCreate": 1700000000
+}
+```
+
+The example shows the response envelope only; `specJson` contains the complete workflow spec. `version` is the deployment version, independently of any version declared inside the spec. `packId` identifies the historical snapshot's pack and allows callers to check an explicit pack pin. Both routes return `{ "found": false }` for absent snapshots. Non-success HTTP responses represent request/service failures, not absence.
+
+## Run records
+
+`POST /runs` accepts optional `workflow_version` and `workflow_deploy_number` fields alongside the existing required `flow_id`, `workflow_id`, and `status`. The route preserves both values in `flow_runs` and its response. Values must be positive safe integers or null; invalid values return HTTP 400 before insertion. Omitted fields remain null for older clients and unversioned runs.
+
+These changes are additive and require no schema migration: the two run columns already exist. Deploy the Avernet backend before the matching ClawMind client so version metadata is retained and pack-pinned historical lookups receive pack identity.

--- a/src/evolverun/clawweb/public/modules/workflow/server/repositories/workflow-deploy-history-repository.ts
+++ b/src/evolverun/clawweb/public/modules/workflow/server/repositories/workflow-deploy-history-repository.ts
@@ -122,9 +122,9 @@ export class WorkflowDeployHistoryRepository {
   }
 
   /** Find by version, filtered to deploy/edit actions only (for rollback content lookup). */
-  async findByVersionDeployOrEdit(workflowId: string, version: number): Promise<Pick<WorkflowDeployHistoryRow, "deploy_number" | "version" | "tag_name" | "action" | "spec_json" | "note" | "from_deploy_number" | "gmt_create"> | null> {
-    const rows = await this.db.query<Pick<WorkflowDeployHistoryRow, "deploy_number" | "version" | "tag_name" | "action" | "spec_json" | "note" | "from_deploy_number" | "gmt_create">>(
-      `SELECT deploy_number, version, tag_name, action, spec_json, note, from_deploy_number, gmt_create
+  async findByVersionDeployOrEdit(workflowId: string, version: number): Promise<Pick<WorkflowDeployHistoryRow, "pack_id" | "deploy_number" | "version" | "tag_name" | "action" | "spec_json" | "note" | "from_deploy_number" | "gmt_create"> | null> {
+    const rows = await this.db.query<Pick<WorkflowDeployHistoryRow, "pack_id" | "deploy_number" | "version" | "tag_name" | "action" | "spec_json" | "note" | "from_deploy_number" | "gmt_create">>(
+      `SELECT pack_id, deploy_number, version, tag_name, action, spec_json, note, from_deploy_number, gmt_create
        FROM workflow_deploy_history WHERE workflow_id = ? AND version = ? AND action IN ('deploy', 'edit')
        ORDER BY deploy_number DESC LIMIT 1`,
       [workflowId, version],

--- a/src/evolverun/clawweb/public/modules/workflow/server/routes/internal/__tests__/version-contract.test.ts
+++ b/src/evolverun/clawweb/public/modules/workflow/server/routes/internal/__tests__/version-contract.test.ts
@@ -1,0 +1,82 @@
+// @vitest-environment node
+import { beforeAll, afterAll, describe, it, expect } from "vitest";
+import express from "express";
+import Database from "better-sqlite3";
+import type { Server } from "node:http";
+import type { IDatabase } from "@avernet/clawweb-shared/server/db";
+import { sqliteDialect } from "@avernet/clawweb-shared/server/db/dialect";
+import { FlowRunRepository } from "../../../repositories/flow-run-repository.js";
+import { WorkflowDeployHistoryRepository } from "../../../repositories/workflow-deploy-history-repository.js";
+import { createInternalRunsRouter } from "../runs.js";
+import { createInternalDeployHistoryRouter } from "../deploy-history.js";
+
+describe("ClawMind workflow version wire contract", () => {
+  const raw = new Database(":memory:");
+  const db: IDatabase = {
+    dbType: "sqlite", dialect: sqliteDialect,
+    query: async <T>(sql: string, params: unknown[] = []) => raw.prepare(sql).all(...params) as T[],
+    exec: async (sql, params = []) => { const result = raw.prepare(sql).run(...params); return { affectedRows: result.changes }; },
+    transaction: async fn => fn(db),
+    close: async () => raw.close(),
+  };
+  let server: Server;
+  let baseUrl: string;
+  beforeAll(async () => {
+    raw.exec(`CREATE TABLE flow_runs (
+      id INTEGER PRIMARY KEY, flow_id TEXT UNIQUE, workflow_id TEXT, workflow_title TEXT, status TEXT,
+      params_json TEXT, input_json TEXT, result_json TEXT, node_count INTEGER, succeeded_count INTEGER,
+      failed_count INTEGER, total_duration_ms INTEGER, total_token_usage INTEGER, triggered_by TEXT,
+      identity_key TEXT, current_phase TEXT, started_at INTEGER, completed_at INTEGER, credentials_json TEXT,
+      origin_session_key TEXT, origin_session_id TEXT, origin_bot_id TEXT, user_id TEXT, plugin_version TEXT,
+      engine TEXT, state_json TEXT, workflow_version INTEGER, workflow_deploy_number INTEGER,
+      gmt_create INTEGER, gmt_modified INTEGER, evolution_analysis_status TEXT
+    ); CREATE TABLE workflow_deploy_history (
+      id INTEGER PRIMARY KEY, pack_id TEXT, workflow_id TEXT, deploy_number INTEGER, version INTEGER,
+      tag_name TEXT, action TEXT, from_deploy_number INTEGER, spec_json TEXT, note TEXT, bot_id TEXT,
+      owner_id TEXT, is_active INTEGER, gmt_create INTEGER, gmt_modified INTEGER
+    );`);
+    const history = new WorkflowDeployHistoryRepository(db);
+    await history.insert({ packId: "pack", workflowId: "demo", deployNumber: 5, version: 2, action: "deploy", tagName: "deploy/demo/#5", specJson: '{"id":"demo"}', isActive: true });
+    const app = express();
+    app.use(express.json());
+    app.use("/runs", createInternalRunsRouter(new FlowRunRepository(db)));
+    app.use("/deploy-history", createInternalDeployHistoryRouter(history));
+    await new Promise<void>(resolve => { server = app.listen(0, "127.0.0.1", resolve); });
+    baseUrl = `http://127.0.0.1:${(server.address() as { port: number }).port}`;
+  });
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) => server.close(error => error ? reject(error) : resolve()));
+    raw.close();
+  });
+
+  it("persists both runtime version fields through the HTTP route", async () => {
+    const response = await fetch(`${baseUrl}/runs`, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ flow_id: "v2-run", workflow_id: "demo", status: "running", workflow_version: 2, workflow_deploy_number: 5 }) });
+    expect(response.status).toBe(201);
+    const row = raw.prepare("SELECT workflow_version, workflow_deploy_number FROM flow_runs WHERE flow_id = ?").get("v2-run");
+    expect(row).toEqual({ workflow_version: 2, workflow_deploy_number: 5 });
+  });
+
+  it("keeps legacy inserts without version metadata compatible", async () => {
+    const response = await fetch(`${baseUrl}/runs`, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ flow_id: "legacy", workflow_id: "demo", status: "running" }) });
+    expect(response.status).toBe(201);
+    expect(raw.prepare("SELECT workflow_version, workflow_deploy_number FROM flow_runs WHERE flow_id = 'legacy'").get()).toEqual({ workflow_version: null, workflow_deploy_number: null });
+  });
+
+  it.each([0, -1, 1.5, "2", 9007199254740992])("rejects invalid version metadata %s before persistence", async value => {
+    for (const field of ["workflow_version", "workflow_deploy_number"]) {
+      const response = await fetch(`${baseUrl}/runs`, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ flow_id: `invalid-${field}-${value}`, workflow_id: "demo", status: "running", [field]: value }) });
+      expect(response.status).toBe(400);
+    }
+  });
+
+  it.each(["active", "versions/2/snapshot"])("returns a flat %s snapshot including pack identity", async endpoint => {
+    const response = await fetch(`${baseUrl}/deploy-history/demo/${endpoint}`);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ found: true, workflowId: "demo", packId: "pack", version: 2, deployNumber: 5, specJson: '{"id":"demo"}' });
+  });
+
+  it("does not substitute another workflow's snapshot", async () => {
+    const response = await fetch(`${baseUrl}/deploy-history/other/versions/2/snapshot`);
+    expect(await response.json()).toEqual({ found: false });
+  });
+});

--- a/src/evolverun/clawweb/public/modules/workflow/server/routes/internal/deploy-history.ts
+++ b/src/evolverun/clawweb/public/modules/workflow/server/routes/internal/deploy-history.ts
@@ -115,6 +115,7 @@ export function createInternalDeployHistoryRouter(
       : row.gmt_modified;
     res.json({
       found: true,
+      workflowId,
       packId: row.pack_id,
       deployNumber: row.deploy_number,
       version: row.version,
@@ -184,6 +185,8 @@ export function createInternalDeployHistoryRouter(
       : row.gmt_create;
     res.json({
       found: true,
+      workflowId,
+      packId: row.pack_id,
       deployNumber: row.deploy_number,
       version: row.version,
       tagName: row.tag_name,

--- a/src/evolverun/clawweb/public/modules/workflow/server/routes/internal/runs.ts
+++ b/src/evolverun/clawweb/public/modules/workflow/server/routes/internal/runs.ts
@@ -40,7 +40,7 @@ export function createInternalRunsRouter(
       return;
     }
     try {
-      const { flow_id, workflow_id, workflow_title, status, triggered_by, params_json, input_json, node_count, identity_key, started_at, credentials_json, origin_session_key, origin_session_id, origin_bot_id, user_id, plugin_version, engine } = req.body as {
+      const { flow_id, workflow_id, workflow_title, status, triggered_by, params_json, input_json, node_count, identity_key, started_at, credentials_json, origin_session_key, origin_session_id, origin_bot_id, user_id, plugin_version, engine, workflow_version, workflow_deploy_number } = req.body as {
         flow_id?: string;
         workflow_id?: string;
         workflow_title?: string;
@@ -58,12 +58,21 @@ export function createInternalRunsRouter(
         user_id?: string;
         plugin_version?: string;
         engine?: string;
+        workflow_version?: number | null;
+        workflow_deploy_number?: number | null;
       };
 
       if (!flow_id || !workflow_id || !status) {
         apiLog("WRITE", "/runs", { httpStatus: 400, error: "Missing required fields", flow_id, workflow_id, runStatus: status });
         res.status(400).json({ success: false, error: "Bad Request", message: "Missing required fields: flow_id, workflow_id, status" });
         return;
+      }
+
+      for (const [field, value] of Object.entries({ workflow_version, workflow_deploy_number })) {
+        if (value != null && (!Number.isSafeInteger(value) || value < 1)) {
+          res.status(400).json({ success: false, error: "Bad Request", message: `${field} must be a positive integer or null` });
+          return;
+        }
       }
 
       const ok = await flowRunRepo.insert({
@@ -84,6 +93,8 @@ export function createInternalRunsRouter(
         userId: user_id ?? null,
         pluginVersion: plugin_version ?? null,
         engine: engine ?? null,
+        workflowVersion: workflow_version ?? null,
+        workflowDeployNumber: workflow_deploy_number ?? null,
       });
       if (!ok) {
         apiLog("WRITE", "/runs", { status: 500, error: "Failed to insert flow run", flow_id, workflow_id });


### PR DESCRIPTION
## Problem
Workflow runs started through the internal API lose their selected workflow version and deployment number before persistence. Historical snapshot responses also omit pack identity, preventing callers from checking an explicit pack pin.

## Solution
Preserve the optional workflow_version and workflow_deploy_number fields through the internal run-insert route, rejecting invalid values before insertion. Include workflowId in active snapshots and workflowId/packId in version snapshots while retaining the existing flat response format. Document the wire contract and add HTTP tests backed by an in-memory SQLite database.

## Validation
- @avernet/workflow: 170 tests passed across 32 files, including 10 version-contract tests.
- @avernet/workflow build and type check passed.
- Cross-repository smoke test using the actual workflow client, Avernet Express routes, and SQLite passed: explicit v1/v2 selection, default-version switching, pack identity, missing-version rejection, and persisted version metadata.
- git diff --check and repository pre-push gate passed.

## Compatibility and risk
No schema migration or deployment-history model change. Legacy clients that omit version fields continue to store null. Deploy the backend before the matching client so version metadata is retained and historical pack pins can be checked. No production deployment was performed.