### PR TITLE
feat(backend): add pluggable outbound token exchange pipeline

### DIFF
--- a/src/backend/specs/generic-token-exchange-jit/001-spec-output.md
+++ b/src/backend/specs/generic-token-exchange-jit/001-spec-output.md
@@ -1,0 +1,130 @@
+---
+agent: tc-review
+status: completed
+created: 2026-09-06T00:00:00+08:00
+iteration: 1
+---
+
+# 通用 Token 换签与 BaaS 注入 Spec
+
+## 1. 需求与范围
+
+在不修改现有 Caller 业务实现和调用方 HTTP 契约的前提下，为 `/api/v1/token/iam` 增加可插拔 Token 插件编排。本期仅支持 `personal` Bot 的 JIT Token：命中上层传入且可信的用户名单与 Bot 类型后，准备 JIT 请求参数，调用 JIT HTTP 接口，再通过 BaaS append 注入 `x-jit-token`。
+
+现有 Caller 必须先执行；无论 Caller 成功、失败或返回错误 Outcome，插件流水线均继续执行。插件之间相互独立，任一插件失败不得改变 Caller 结果、异常语义或阻断后续插件。
+
+## 2. 既有链路
+
+`/api/v1/token/iam` → `CallerIamTokenServiceProtocol.get_iam_token()` → 现有 Caller 匹配/换签 → BaaS `outbound-rule` 注入 `x-caller-token` → 返回既有 `CallerIamTokenOutcome`。
+
+现有 `ac_entity_user_list`/`UserListServiceProtocol` 可提供环境隔离名单查询；现有 `RuntimeBindingResolutionService` 与 BaaS 服务提供 runtime binding、provider device 与 outbound append 能力；企业 Passport 插件通过 tcauthmng Facade 可查询 `agentCode`。
+
+## 3. 目标流程
+
+```text
+先执行既有 Caller
+  → 保存 Caller outcome 或 exception
+  → TokenPluginPipeline 按注册顺序执行每个插件
+      1. match
+      2. prepare_exchange_token_request
+      3. exchange_token
+      4. append_to_outbound
+  → 原样返回 Caller outcome 或重新抛出 Caller exception
+```
+
+单插件异常在插件边界捕获并转换为 `FAILED`，不向 Caller 传播。
+
+## 4. 中立协议与模型
+
+新增中立 `core/token_exchange`：
+
+- `TokenExchangeContext`：只承载上层提供的可信 bot/user/entity/stage/env/binding/request 参数。
+- `PreparedExchangeTokenRequest`：承载 endpoint key、HTTP method、headers、body、超时、响应 parser、BaaS target/header。
+- `ExchangedToken`：仅进程内传递 token value；附带 expiry/fingerprint/非敏感 metadata。
+- `TokenPluginResult`：plugin code、status、failed stage、稳定 error code，不携带 token。
+- `TokenExchangePlugin`：四个阶段方法。
+- `TokenPluginPipeline`：串行执行插件，隔离单插件失败。
+- `CallerTokenExchangeOrchestrator`：Caller first，再运行 pipeline；保持既有 Caller 协议和返回语义。
+
+本模块不得导入 corp plugins；具体 JIT 实现通过 DI 注入。
+
+## 5. JIT Plugin
+
+### match
+
+仅当以下条件同时满足时命中：
+
+- `context.bot_type == "personal"`；
+- `UserListServiceProtocol.is_in_user_list(entity_id=context.user_list_entity_id, user_list_type="token_exchange_jit", env=context.env)` 返回 true。
+
+用户/实体标识由上层传入，插件不重新解析 Cookie/Header，也不新增 YAML user id 名单。
+
+### prepare_exchange_token_request
+
+通过一个统一的 `prepare_exchange_token_request` 方法准备：
+
+- `source`：受管配置；
+- `acraId`：当前 personal Bot runtime 对应的裸 ARCA sandbox ID；
+- `agentCode`：tcauthmng `AgentPassportFacade.queryAgentPassport`；
+- `bizTraceId`：上层 request id；
+- BaaS `paas_device_id`；
+- outbound header `x-jit-token`、action `set`；
+- outbound domains 直接复用后端固定的 `CALLER_TOKEN_DOMAINS`，不维护第二份名单；
+- response parser。
+
+本期不获取 AgentToken，不调用 `queryToken`，不自行增加 Authorization。
+
+### exchange_token
+
+调用配置中的 JIT endpoint：
+
+`POST /api/tbac/token/issue_or_renew.json`。
+
+严格校验 HTTP 状态、`success == true`、成功 errorCode、非空 jwt、未来 expiredTime、`ISSUED|REUSED|RENEWED` tokenAction。Token 仅内存传递。
+
+### append_to_outbound
+
+调用既有 BaaS append：
+
+`PUT /api/v1/paas/devices/{paas_device_id}/outbound-rule?mode=append`
+
+请求规则：`header_name=x-jit-token`, `action=set`, `value=<jwt>`, `domains=CALLER_TOKEN_DOMAINS`。应用层不读取旧规则、不合并/去重、不回滚，依赖 BaaS 幂等。
+
+## 6. 允许与禁止修改边界
+
+允许：
+
+- OCB `src/backend/src/agentclaw/community/core/token_exchange/*`（中立协议/编排，如代码位于社区子模块则保持其独立修改边界）；
+- OCB `src/backend/src/agentclaw/corp/plugins/prod/token_exchange_jit/*`；
+- OCB corp DI 的最小绑定；
+- BaaS append 的通用内部抽象，但必须保持 `append_caller_outbound_rule` 兼容；
+- 对应 unit/integration/contract tests；
+- 本任务 spec、编码/Review/回归报告与根目录 `log.md`。
+
+禁止：
+
+- 修改现有 Caller 核心业务语义；
+- 修改现有 `/api/v1/token/iam` HTTP 响应契约；
+- 修改 Relay、OpenClaw、Engine runtime、前端；
+- 修改 tcauthmng Facade 契约；
+- 新增 AgentToken 获取链路；
+- 将名单、URL、Header 注入参数暴露给用户请求；
+- 记录 token、Authorization、Cookie 或完整 HTTP body。
+
+## 7. 日志与安全
+
+外部 JIT HTTP 和 BaaS append 必须分别记录 start/success/failure，字段包含系统、操作、method/path、request id、非敏感入参、状态码、耗时、结果码。Token 只记录 presence、fingerprint、expiry seconds/action；递归脱敏所有凭据字段。测试必须断言成功/失败日志与原始 token 不出现在日志中。
+
+## 8. 测试与验收
+
+- Caller first 的顺序测试；Caller success/failure/exception 与 JIT success/failure 组合测试；
+- 四阶段顺序和阶段失败短路测试；插件失败不影响其他插件；
+- personal 命中，service/其他类型跳过；名单按 entity/type/env 精确隔离；名单错误只影响插件；
+- JIT 请求字段、严格响应解析、超时/5xx/4xx/空 token/过期 token/未知 action；
+- BaaS append path/query/body/header/action；不覆盖 x-caller-token；
+- queryToken/AgentToken 未调用；
+- 日志脱敏；import/ruff/architecture checks；既有 Caller 定向回归。
+
+## 9. Ship/QA
+
+仅在 Review 与本地回归均通过且用户确认后部署。远端发布需验证真实运行路径、BaaS append 与 personal Bot 黑盒行为；JIT 外部服务不可用时应验证 Caller 仍保持原行为并产生独立 JIT failure evidence。

--- a/src/backend/specs/generic-token-exchange-jit/002-code-report.md
+++ b/src/backend/specs/generic-token-exchange-jit/002-code-report.md
@@ -1,0 +1,36 @@
+---
+agent: tc-code
+status: completed
+created: 2026-09-09T12:30:00+08:00
+iteration: 2
+source: migrated-to-avernet-worktree
+---
+
+# Avernet 编码报告
+
+## Worktree
+
+- 路径：`/Users/helloworld/Desktop/codes/teamclaw_worktrees/Avernet_worktrees/generic-token-exchange-jit`
+- 分支：`feat/generic-token-exchange-jit`
+- Base：GitHub `inclusionAI/Avernet` `dev` @ `20a02b43c`
+
+## 改动边界
+
+- 新增中立 Token Plugin 四阶段协议、Pipeline 和 Caller-first Orchestrator。
+- 既有 Router 仍注入 `CallerIamTokenServiceProtocol`，DI 将 corp 可扩展编排包装在原 Caller service 外层。
+- BaaS 新增通用 token header append；保留既有 Caller append 方法与响应契约。
+- 对 BaaS URL 中的 `paas_device_id` 复用严格校验，拒绝路径/控制字符。
+
+## 排查日志与脱敏
+
+- Pipeline：match 跳过、执行成功、失败阶段。
+- Orchestrator：Caller 异常、上下文构造异常、Pipeline 非预期异常。
+- BaaS：append 请求、成功、业务拒绝、HTTP 失败、非法输入。
+- token 仅进入 BaaS 请求体，不写日志；测试断言成功和非法输入日志均不包含原 token。
+
+## 本地验证
+
+- 相关 Caller、Router、DI、Pipeline、BaaS 定向回归：455 passed。
+- Pipeline/API 变更覆盖率定向检查：99%。
+- 相关 Ruff：passed。
+- `git diff --check`：passed。

--- a/src/backend/specs/generic-token-exchange-jit/003-review-report.md
+++ b/src/backend/specs/generic-token-exchange-jit/003-review-report.md
@@ -1,0 +1,20 @@
+---
+agent: tc-code-reviewer
+status: completed
+created: 2026-09-09T12:35:00+08:00
+iteration: 2
+conclusion: PASS
+---
+
+# Avernet 代码评审报告
+
+## 结论
+
+PASS（Avernet 源码边界）。
+
+- Caller 先执行，插件结果互相独立；Caller 返回值和异常语义保持不变。
+- Router 无需修改，DI 通过既有协议透明接入 Orchestrator。
+- community/singlebox profile 继续由 profile module 覆盖为既有无 Caller 实现。
+- BaaS 只执行 `mode=append`，不读取或合并旧规则。
+- `paas_device_id` 在进入相对 URL 前通过既有严格 allowlist 校验。
+- 日志未记录 token，测试覆盖成功、失败隔离、跳过、Caller 异常与非法路径。

--- a/src/backend/specs/generic-token-exchange-jit/003b-regression-report.md
+++ b/src/backend/specs/generic-token-exchange-jit/003b-regression-report.md
@@ -1,0 +1,19 @@
+---
+agent: tc-engine-regression
+status: completed
+created: 2026-09-09T12:40:00+08:00
+iteration: 2
+conclusion: PASS
+---
+
+# Avernet 本地回归报告
+
+| 验证 | 结果 |
+|---|---:|
+| Token Pipeline/Orchestrator + BaaS 定向 | 31 passed |
+| Caller core、IAM routers、API、DI 综合定向 | 455 passed |
+| Token Pipeline/API coverage | 99% |
+| Ruff changed files | passed |
+| git diff --check | passed |
+
+完整 `tests/community` 曾运行至约 8% 且当时无失败，因测试集规模较大主动停止；完整门禁交由 GitHub PR CI，不能把该次未完成运行记为 PASS。

--- a/src/backend/specs/generic-token-exchange-jit/009-pr-report.md
+++ b/src/backend/specs/generic-token-exchange-jit/009-pr-report.md
@@ -28,7 +28,8 @@
 
 | Job/指标 | 状态 | 证据 | 根因 | 修复/提交 | 验证 |
 |---|---|---|---|---|---|
-| GitHub checks | PENDING | PR #2055 | PR 刚创建 | - | 本地定向 455 passed |
+| Backend unit tests (round 1) | FAIL | [job 102338721499](https://github.com/inclusionAI/Avernet/actions/runs/34311412711/job/102338721499) | E3 要求新增 `core/token_exchange` 必须有 singlebox flow 或带原因的显式 exempt | 增加 corp-only/noop-singlebox 的精确 exempt 原因 | 本地运行 E3 architecture tests |
+| Other GitHub checks (round 1) | PASS | PR #2055 | - | - | BCS/BaaS/Engine/Gateway/Sandbox-proxy、Singlebox、title/design guard 均通过 |
 
 ## 人工意见
 
@@ -40,6 +41,6 @@
 
 - PR：OPEN
 - 自动意见：PENDING
-- ACI/CI：PENDING
+- ACI/CI：修复后待新一轮 checks
 - 人工意见：PENDING
-- 下一步：提交本报告后等待并收敛 GitHub PR checks/reviews。
+- 下一步：提交 E3 修复并等待新一轮 GitHub PR checks/reviews。

--- a/src/backend/specs/generic-token-exchange-jit/009-pr-report.md
+++ b/src/backend/specs/generic-token-exchange-jit/009-pr-report.md
@@ -1,0 +1,45 @@
+# PR 收敛报告：generic-token-exchange-jit（Avernet）
+
+## 范围
+
+- Worktree：`/Users/helloworld/Desktop/codes/teamclaw_worktrees/Avernet_worktrees/generic-token-exchange-jit`
+- Source repo：GitHub `inclusionAI/Avernet`
+- Head / base：`feat/generic-token-exchange-jit` / `dev`
+- PR：https://github.com/inclusionAI/Avernet/pull/2055
+- PR title：`feat(backend): add pluggable outbound token exchange pipeline`
+- PR description sections：Problem / Solution / Validation / Compatibility and risk / Spec
+- 人工意见模式：auto
+
+## PR 判定
+
+| 结果 | 证据 | 说明 |
+|---|---|---|
+| OPEN | PR #2055 | GitHub 源码 PR，非 OCB 内部镜像 |
+| Rebase PASS | base `20a02b43c`, head `d0bcf6e95` | `origin/dev` 是 HEAD 祖先 |
+| Local targeted PASS | 455 passed | Caller、Router、DI、Pipeline、BaaS 定向回归 |
+
+## 自动意见
+
+| 轮次 | 来源 | 链接 | 决定 | 理由 | 修改/提交 | 验证 |
+|---|---|---|---|---|---|---|
+| 1 | 尚无 | PR #2055 | PENDING | 等待 GitHub reviewers | - | - |
+
+## ACI/CI
+
+| Job/指标 | 状态 | 证据 | 根因 | 修复/提交 | 验证 |
+|---|---|---|---|---|---|
+| GitHub checks | PENDING | PR #2055 | PR 刚创建 | - | 本地定向 455 passed |
+
+## 人工意见
+
+| 轮次 | 作者 | 链接 | 决定 | 理由 | 修改/提交 | 验证 |
+|---|---|---|---|---|---|---|
+| 1 | 尚无 | PR #2055 | PENDING | 等待评审 | - | - |
+
+## 当前结论
+
+- PR：OPEN
+- 自动意见：PENDING
+- ACI/CI：PENDING
+- 人工意见：PENDING
+- 下一步：提交本报告后等待并收敛 GitHub PR checks/reviews。

--- a/src/backend/src/agentclaw/community/core/service_bot/services/baas_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/baas_service.py
@@ -66,6 +66,7 @@ from agentclaw.community.core.devices.services.sandbox_overrides import (
 )
 
 from agentclaw.community.kernel.device_dto import (
+    HeaderOperationRule,
     OutBoundOperationRule,
     ResourceSpecification,
 )
@@ -3000,6 +3001,120 @@ class BaasService:  # pragma: no cover
             raise BaasServiceError(
                 f"BaaS API error: {e.response.status_code} - {e.response.text}"
             )
+
+    def append_token_outbound_rule(
+        self,
+        *,
+        paas_device_id: str,
+        header_name: str,
+        action: str,
+        token: str,
+        plugin_code: str,
+        domains: tuple[str, ...] = (),
+    ) -> bool:
+        """Append one plugin-owned token header without replacing existing rules."""
+        # COSEC: paas_device_id is interpolated into a relative BaaS URL; reuse
+        # the strict Caller validator so database/plugin values cannot alter the path.
+        paas_device_id_valid = self._is_valid_paas_device_id(paas_device_id)
+        if not paas_device_id_valid or not token or action != "set" or not header_name:
+            logger.warning(
+                "token_outbound_append_rejected_invalid_input plugin_code=%s "
+                "paas_device_id_valid=%s header_name_present=%s action=%s token_present=%s",
+                plugin_code,
+                paas_device_id_valid,
+                bool(header_name),
+                action,
+                bool(token),
+            )
+            raise ValueError("invalid token outbound rule")
+        rule = OutBoundOperationRule(
+            header_operation_rules=(
+                HeaderOperationRule(
+                    domains=list(domains),
+                    action=action,
+                    header_name=header_name,
+                    value=token,
+                ),
+            )
+        )
+        logger.info(
+            "token_outbound_append_started plugin_code=%s paas_device_id=%s "
+            "header_name=%s rule_count=%s",
+            plugin_code,
+            paas_device_id,
+            header_name,
+            len(rule.header_operation_rules),
+        )
+        started = time.perf_counter()
+        try:
+            response = self._http.put(
+                f"/api/v1/paas/devices/{paas_device_id}/outbound-rule?mode=append",
+                json=self._outbound_rule_to_dict(rule),
+                timeout=30.0,
+            )
+            response.raise_for_status()
+            response_data = response.json()
+            if response_data.get("code") != 0:
+                logger.warning(
+                    "token_outbound_append_rejected plugin_code=%s status_code=%s "
+                    "result_code=%s elapsed_ms=%s",
+                    plugin_code,
+                    response.status_code,
+                    response_data.get("code"),
+                    int((time.perf_counter() - started) * 1000),
+                )
+                raise BaasServiceError("BaaS token outbound append rejected")
+        except httpx.HTTPStatusError as exc:
+            logger.warning(
+                "token_outbound_append_http_failed plugin_code=%s status_code=%s "
+                "elapsed_ms=%s",
+                plugin_code,
+                exc.response.status_code,
+                int((time.perf_counter() - started) * 1000),
+            )
+            raise BaasServiceError("BaaS token outbound append failed") from exc
+        except BaasServiceError:
+            raise
+        except Exception as exc:
+            logger.warning(
+                "token_outbound_append_failed plugin_code=%s status_code=%s "
+                "error_type=%s elapsed_ms=%s",
+                plugin_code,
+                None,
+                type(exc).__name__,
+                int((time.perf_counter() - started) * 1000),
+            )
+            raise BaasServiceError("BaaS token outbound append failed") from exc
+        logger.info(
+            "token_outbound_append_succeeded plugin_code=%s paas_device_id=%s "
+            "header_name=%s status_code=%s elapsed_ms=%s",
+            plugin_code,
+            paas_device_id,
+            header_name,
+            response.status_code,
+            int((time.perf_counter() - started) * 1000),
+        )
+        return True
+
+    def append_token(
+        self,
+        *,
+        paas_device_id: str,
+        header_name: str,
+        action: str,
+        token: str,
+        plugin_code: str,
+        domains: tuple[str, ...] = (),
+    ) -> bool:
+        """Implement the neutral TokenOutboundAppender contract."""
+        return self.append_token_outbound_rule(
+            paas_device_id=paas_device_id,
+            header_name=header_name,
+            action=action,
+            token=token,
+            plugin_code=plugin_code,
+            domains=domains,
+        )
 
     def append_caller_outbound_rule(
         self,

--- a/src/backend/src/agentclaw/community/core/token_exchange/__init__.py
+++ b/src/backend/src/agentclaw/community/core/token_exchange/__init__.py
@@ -1,0 +1,7 @@
+"""Independent outbound token plugin orchestration."""
+
+from .orchestrator import TokenExchangeOrchestrator
+from .pipeline import NoopTokenPluginPipeline, TokenPluginPipeline
+
+
+__all__ = ["NoopTokenPluginPipeline", "TokenExchangeOrchestrator", "TokenPluginPipeline"]

--- a/src/backend/src/agentclaw/community/core/token_exchange/orchestrator.py
+++ b/src/backend/src/agentclaw/community/core/token_exchange/orchestrator.py
@@ -1,0 +1,131 @@
+"""Caller-first orchestration for independent outbound token plugins."""
+from __future__ import annotations
+
+from agentclaw.community.core.caller_identity.caller_iam_token_service_protocol import CallerIamTokenServiceProtocol
+from agentclaw.community.core.caller_identity.contracts import (
+    CallerIamTokenOutcome,
+    CallerIdentityStage,
+)
+from agentclaw.community.core.repository.protocols.bot import BotRepository
+from agentclaw.community.core.token_exchange.pipeline import TokenPluginPipeline
+from agentclaw.community.core.token_exchange.protocols import TokenExchangeContext
+from agentclaw.community.log import get_logger
+from agentclaw.community.plugin_api.auth import AuthRequestContext
+
+
+logger = get_logger()
+
+
+class TokenExchangeOrchestrator:
+    """Run the existing Caller service first, then independent token plugins."""
+
+    def __init__(
+        self,
+        *,
+        caller_service: CallerIamTokenServiceProtocol,
+        token_pipeline: TokenPluginPipeline,
+        bot_repository: BotRepository,
+    ) -> None:
+        self._caller_service = caller_service
+        self._token_pipeline = token_pipeline
+        self._bot_repository = bot_repository
+
+    async def get_iam_token(
+        self,
+        *,
+        iam_token: str,
+        auth_request: AuthRequestContext,
+        bot_id: str | None,
+        stage: CallerIdentityStage,
+        publish_id: int | None,
+        entity_id: str | None,
+        is_test_exchange: bool,
+    ) -> CallerIamTokenOutcome:
+        caller_error: Exception | None = None
+        caller_outcome: CallerIamTokenOutcome | None = None
+        try:
+            caller_outcome = await self._caller_service.get_iam_token(
+                iam_token=iam_token,
+                auth_request=auth_request,
+                bot_id=bot_id,
+                stage=stage,
+                publish_id=publish_id,
+                entity_id=entity_id,
+                is_test_exchange=is_test_exchange,
+            )
+        except Exception as exc:
+            caller_error = exc
+            logger.warning(
+                "caller_first_execution_failed error_type=%s bot_id=%s",
+                type(exc).__name__,
+                bot_id,
+            )
+
+        try:
+            context = self._build_context(
+                bot_id=bot_id,
+                entity_id=entity_id,
+                stage=stage,
+                publish_id=publish_id,
+            )
+        except Exception as exc:
+            context = None
+            logger.warning(
+                "token_plugin_context_build_failed bot_id=%s error_type=%s",
+                bot_id,
+                type(exc).__name__,
+            )
+        if context is not None:
+            try:
+                await self._token_pipeline.run(context)
+            except Exception as exc:
+                # Pipeline and individual plugins are expected to isolate errors;
+                # this guard preserves the legacy Caller contract if they do not.
+                logger.warning(
+                    "token_plugin_pipeline_failed bot_id=%s error_type=%s",
+                    context.bot_id,
+                    type(exc).__name__,
+                )
+
+        if caller_error is not None:
+            raise caller_error
+        assert caller_outcome is not None
+        return caller_outcome
+
+    def _build_context(
+        self,
+        *,
+        bot_id: str | None,
+        entity_id: str | None,
+        stage: CallerIdentityStage,
+        publish_id: int | None,
+    ) -> TokenExchangeContext | None:
+        if not bot_id or not entity_id:
+            return None
+        bot = self._bot_repository.get_by_id_and_entity(bot_id, entity_id)
+        if not bot:
+            logger.info(
+                "token_plugin_context_unavailable bot_id=%s entity_id_present=%s",
+                bot_id,
+                True,
+            )
+            return None
+        owner_user_id = str(bot.get("owner_id") or "")
+        bot_type = str(bot.get("bot_type") or "")
+        if not owner_user_id or not bot_type:
+            return None
+        return TokenExchangeContext(
+            bot_id=bot_id,
+            bot_type=bot_type,
+            owner_user_id=owner_user_id,
+            user_list_entity_id=entity_id,
+            entity_id=entity_id,
+            stage=stage.value,
+            env=str(bot.get("env") or ""),
+            publish_id=publish_id,
+            binding_id=None,
+            request_id=None,
+        )
+
+
+__all__ = ["TokenExchangeOrchestrator"]

--- a/src/backend/src/agentclaw/community/core/token_exchange/pipeline.py
+++ b/src/backend/src/agentclaw/community/core/token_exchange/pipeline.py
@@ -1,0 +1,100 @@
+"""Four-phase, failure-isolated token plugin pipeline."""
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from agentclaw.community.core.token_exchange.protocols import (
+    OutboundTokenPlugin,
+    TokenExchangeContext,
+    TokenOutboundAppender,
+    TokenPluginResult,
+)
+from agentclaw.community.log import get_logger
+
+
+logger = get_logger()
+
+
+class TokenPluginPipeline:
+    """Run registered plugins serially without cross-plugin failure coupling."""
+
+    def __init__(
+        self,
+        *,
+        plugins: Iterable[OutboundTokenPlugin],
+        outbound_appender: TokenOutboundAppender,
+    ) -> None:
+        self._plugins = tuple(plugins)
+        self._outbound_appender = outbound_appender
+
+    async def run(self, context: TokenExchangeContext) -> list[TokenPluginResult]:
+        return [await self._run_plugin(plugin=plugin, context=context) for plugin in self._plugins]
+
+    async def _run_plugin(
+        self,
+        *,
+        plugin: OutboundTokenPlugin,
+        context: TokenExchangeContext,
+    ) -> TokenPluginResult:
+        stage = "match"
+        try:
+            if not plugin.match(context):
+                logger.info(
+                    "token_plugin_match_completed plugin_code=%s status=skipped bot_id=%s stage=%s",
+                    plugin.code,
+                    context.bot_id,
+                    context.stage,
+                )
+                return TokenPluginResult.skipped(plugin.code)
+
+            stage = "prepare_exchange_token_request"
+            prepared = plugin.prepare_exchange_token_request(context)
+            stage = "exchange_token"
+            token = await plugin.exchange_token(context=context, prepared=prepared)
+            stage = "append_to_outbound"
+            plugin.append_to_outbound(
+                context=context,
+                prepared=prepared,
+                token=token,
+                appender=self._outbound_appender,
+            )
+            logger.info(
+                "token_plugin_completed plugin_code=%s status=succeeded bot_id=%s stage=%s token_present=%s",
+                plugin.code,
+                context.bot_id,
+                context.stage,
+                True,
+            )
+            return TokenPluginResult.succeeded(plugin.code)
+        except Exception as exc:
+            logger.warning(
+                "token_plugin_failed plugin_code=%s failed_stage=%s bot_id=%s stage=%s error_type=%s",
+                plugin.code,
+                stage,
+                context.bot_id,
+                context.stage,
+                type(exc).__name__,
+            )
+            return TokenPluginResult.failed(
+                plugin.code,
+                failed_stage=stage,
+                error_code="TOKEN_PLUGIN_EXECUTION_FAILED",
+            )
+
+
+class NoopTokenOutboundAppender:
+    """No-op appender used by community and local profiles."""
+
+    def append_token(self, **kwargs: object) -> bool:
+        del kwargs
+        return True
+
+
+class NoopTokenPluginPipeline(TokenPluginPipeline):
+    """Empty pipeline preserving profiles without corporate token plugins."""
+
+    def __init__(self) -> None:
+        super().__init__(plugins=(), outbound_appender=NoopTokenOutboundAppender())
+
+
+__all__ = ["NoopTokenOutboundAppender", "NoopTokenPluginPipeline", "TokenPluginPipeline"]

--- a/src/backend/src/agentclaw/community/core/token_exchange/protocols.py
+++ b/src/backend/src/agentclaw/community/core/token_exchange/protocols.py
@@ -1,0 +1,25 @@
+"""Core-local aliases for the token plugin contracts."""
+from agentclaw.community.plugin_api.token_plugin import (
+    ExchangedToken,
+    OutboundTokenPlugin,
+    PreparedExchangeTokenRequest,
+    TokenExchangeContext,
+    TokenInjectionTarget,
+    TokenOutboundAppender,
+    TokenPluginResult,
+    TokenRuntimeTargetResolver,
+    TokenScopeMatcher,
+)
+
+
+__all__ = [
+    "TokenExchangeContext",
+    "TokenInjectionTarget",
+    "TokenRuntimeTargetResolver",
+    "TokenScopeMatcher",
+    "OutboundTokenPlugin",
+    "PreparedExchangeTokenRequest",
+    "ExchangedToken",
+    "TokenOutboundAppender",
+    "TokenPluginResult",
+]

--- a/src/backend/src/agentclaw/community/di/modules/caller_identity_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/caller_identity_module.py
@@ -33,6 +33,7 @@ from agentclaw.community.core.runtime_binding.service import RuntimeBindingResol
 from agentclaw.community.core.service_bot.services.baas_service import BaasService
 from agentclaw.community.core.mcp.services.repositories import BotMCPProvider
 from agentclaw.community.core.repository.implementations.identity.caller_identity import CallerIdentityRepository
+from agentclaw.community.core.token_exchange import NoopTokenPluginPipeline, TokenExchangeOrchestrator, TokenPluginPipeline
 from agentclaw.community.plugin_api.auth import AuthPlugin
 from agentclaw.community.plugin_api.passport import PassportPlugin
 
@@ -136,7 +137,7 @@ class CallerIdentityModule(Module):
         runtime_updater: CallerRuntimeUpdater,
         runtime_bindings: RuntimeBindingResolutionService,
         lock_repository: BotCollabLockRepositoryProtocol,
-    ) -> CallerIamTokenServiceProtocol:
+    ) -> CallerIamTokenService:
         return CallerIamTokenService(
             caller_identity=caller_identity,
             auth_plugin=auth_plugin,
@@ -144,4 +145,27 @@ class CallerIdentityModule(Module):
             runtime_updater=runtime_updater,
             runtime_bindings=runtime_bindings,
             lock_repository=lock_repository,
+        )
+
+    @singleton
+    @provider
+    @inject
+    def token_plugin_pipeline(self) -> TokenPluginPipeline:
+        """Community-safe empty pipeline; corp overrides this binding."""
+        return NoopTokenPluginPipeline()
+
+    @singleton
+    @provider
+    @inject
+    def caller_iam_token_service_protocol(
+        self,
+        caller_service: CallerIamTokenService,
+        token_pipeline: TokenPluginPipeline,
+        bot_repository: BotRepository,
+    ) -> CallerIamTokenServiceProtocol:
+        """Expose Caller through a Caller-first independent plugin wrapper."""
+        return TokenExchangeOrchestrator(
+            caller_service=caller_service,
+            token_pipeline=token_pipeline,
+            bot_repository=bot_repository,
         )

--- a/src/backend/src/agentclaw/community/plugin_api/token_plugin.py
+++ b/src/backend/src/agentclaw/community/plugin_api/token_plugin.py
@@ -1,0 +1,175 @@
+"""Contracts for independent outbound token exchange plugins."""
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+
+@dataclass(frozen=True, slots=True)
+class TokenExchangeContext:
+    """Trusted context assembled by the application boundary."""
+
+    bot_id: str
+    bot_type: str
+    owner_user_id: str
+    user_list_entity_id: str
+    entity_id: str | None
+    stage: str
+    env: str
+    publish_id: int | None
+    binding_id: int | None
+    request_id: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class TokenInjectionTarget:
+    """Resolved runtime target used by an outbound token plugin."""
+
+    arca_sandbox_id: str
+    paas_device_id: str
+
+
+@runtime_checkable
+class TokenScopeMatcher(Protocol):
+    """Check a configured user-list scope without exposing list entries."""
+
+    def is_allowed(
+        self,
+        *,
+        entity_id: str,
+        user_list_type: str,
+        env: str,
+    ) -> bool: ...
+
+
+@runtime_checkable
+class TokenRuntimeTargetResolver(Protocol):
+    """Resolve one existing runtime target for token injection."""
+
+    def resolve(self, context: TokenExchangeContext) -> TokenInjectionTarget: ...
+
+
+class TokenResponseParser(Protocol):
+    """Parse one upstream response into an opaque exchanged token."""
+
+    def parse(self, *, status_code: int, body: object) -> ExchangedToken: ...
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedExchangeTokenRequest:
+    """All data needed by one plugin's exchange and append phases."""
+
+    plugin_code: str
+    method: str
+    path: str
+    headers: Mapping[str, str]
+    body: Mapping[str, object]
+    timeout_seconds: float
+    response_parser: TokenResponseParser
+    paas_device_id: str
+    outbound_header_name: str
+    outbound_action: str = "set"
+    outbound_domains: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class ExchangedToken:
+    """An opaque token kept in memory only."""
+
+    value: str
+    expires_at_ms: int | None
+    fingerprint: str
+    metadata: Mapping[str, object]
+
+
+@dataclass(frozen=True, slots=True)
+class TokenPluginResult:
+    """A non-sensitive result for one plugin execution."""
+
+    plugin_code: str
+    status: str
+    failed_stage: str | None = None
+    error_code: str | None = None
+
+    @classmethod
+    def skipped(cls, plugin_code: str) -> TokenPluginResult:
+        return cls(plugin_code=plugin_code, status="skipped")
+
+    @classmethod
+    def succeeded(cls, plugin_code: str) -> TokenPluginResult:
+        return cls(plugin_code=plugin_code, status="succeeded")
+
+    @classmethod
+    def failed(
+        cls,
+        plugin_code: str,
+        *,
+        failed_stage: str,
+        error_code: str,
+    ) -> TokenPluginResult:
+        return cls(
+            plugin_code=plugin_code,
+            status="failed",
+            failed_stage=failed_stage,
+            error_code=error_code,
+        )
+
+
+@runtime_checkable
+class TokenOutboundAppender(Protocol):
+    """Append one token header through the BaaS outbound-rule boundary."""
+
+    def append_token(
+        self,
+        *,
+        paas_device_id: str,
+        header_name: str,
+        action: str,
+        token: str,
+        plugin_code: str,
+        domains: tuple[str, ...] = (),
+    ) -> bool: ...
+
+
+class OutboundTokenPlugin(Protocol):
+    """One independently executable four-phase token plugin."""
+
+    code: str
+
+    def match(self, context: TokenExchangeContext) -> bool: ...
+
+    def prepare_exchange_token_request(
+        self,
+        context: TokenExchangeContext,
+    ) -> PreparedExchangeTokenRequest: ...
+
+    async def exchange_token(
+        self,
+        *,
+        context: TokenExchangeContext,
+        prepared: PreparedExchangeTokenRequest,
+    ) -> ExchangedToken: ...
+
+    def append_to_outbound(
+        self,
+        *,
+        context: TokenExchangeContext,
+        prepared: PreparedExchangeTokenRequest,
+        token: ExchangedToken,
+        appender: TokenOutboundAppender,
+    ) -> None: ...
+
+
+__all__ = [
+    "ExchangedToken",
+    "PreparedExchangeTokenRequest",
+    "TokenExchangeContext",
+    "TokenInjectionTarget",
+    "TokenRuntimeTargetResolver",
+    "TokenScopeMatcher",
+    "OutboundTokenPlugin",
+    "TokenOutboundAppender",
+    "TokenPluginResult",
+    "TokenResponseParser",
+]

--- a/src/backend/tests/community/core/service_bot/services/test_baas_service_http_methods.py
+++ b/src/backend/tests/community/core/service_bot/services/test_baas_service_http_methods.py
@@ -16,6 +16,7 @@ import pytest
 from agentclaw.community.core.service_bot.services.deploy.managed_composer import (
     ManagedDeployConfigComposer,
 )
+from agentclaw.community.core.service_bot.services import baas_service as baas_service_module
 from agentclaw.community.core.service_bot.services.baas_service import BaasService
 from agentclaw.community.plugins.local.http_client import LocalHttpClient
 from agentclaw.community.plugins.local.outbound_rules import NoopOutboundRuleProvider
@@ -204,6 +205,58 @@ class TestBaasServiceHttpMethods:
         call = http.calls_to("put")[0]
         assert call.args[0] == "/api/v1/paas/devices/PAAS-1/outbound-rule"
         assert call.kwargs["json"] == {"header_operation_rules": []}
+
+    def test_append_token_uses_exact_append_path_and_jit_header(self, monkeypatch):
+        service, http = _make_service()
+        test_logger = MagicMock()
+        monkeypatch.setattr(baas_service_module, "logger", test_logger)
+        http.set_response("put", _resp({}))
+
+        assert service.append_token(
+            paas_device_id="dev-1@tpl-1",
+            header_name="x-jit-token",
+            action="set",
+            token="jit-secret",
+            plugin_code="jit_token",
+        ) is True
+
+        call = http.calls_to("put")[0]
+        assert call.args[0] == "/api/v1/paas/devices/dev-1@tpl-1/outbound-rule?mode=append"
+        assert call.kwargs["json"] == {
+            "header_operation_rules": [
+                {
+                    "domains": [],
+                    "action": "set",
+                    "header_name": "x-jit-token",
+                    "value": "jit-secret",
+                    "placeholder": None,
+                    "separator": None,
+                }
+            ]
+        }
+        assert "token_outbound_append_started" in repr(test_logger.info.call_args_list)
+        assert "token_outbound_append_succeeded" in repr(test_logger.info.call_args_list)
+        assert "jit-secret" not in repr(test_logger.method_calls)
+
+    def test_append_token_rejects_unsafe_paas_device_id_before_http(self, monkeypatch):
+        service, http = _make_service()
+        test_logger = MagicMock()
+        monkeypatch.setattr(baas_service_module, "logger", test_logger)
+
+        with pytest.raises(ValueError, match="invalid token outbound rule"):
+            service.append_token(
+                paas_device_id="dev-1@../../admin",
+                header_name="x-jit-token",
+                action="set",
+                token="jit-secret",
+                plugin_code="jit_token",
+            )
+
+        assert http.calls_to("put") == []
+        assert "token_outbound_append_rejected_invalid_input" in repr(
+            test_logger.warning.call_args_list
+        )
+        assert "jit-secret" not in repr(test_logger.method_calls)
 
     def test_append_caller_outbound_rule_uses_exact_append_path_and_body(self):
         service, http = _make_service()

--- a/src/backend/tests/community/core/token_exchange/test_pipeline.py
+++ b/src/backend/tests/community/core/token_exchange/test_pipeline.py
@@ -1,0 +1,318 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from agentclaw.community.core.caller_identity.contracts import (
+    CallerIdentityStage,
+    CallerIamTokenOutcome,
+)
+from agentclaw.community.core.token_exchange import (
+    NoopTokenPluginPipeline,
+    TokenExchangeOrchestrator,
+    TokenPluginPipeline,
+)
+from agentclaw.community.core.token_exchange.protocols import (
+    ExchangedToken,
+    PreparedExchangeTokenRequest,
+    TokenExchangeContext,
+)
+from agentclaw.community.plugin_api.auth import AuthRequestContext
+
+
+class _Appender:
+    def append_token(self, **kwargs: object) -> bool:
+        self.kwargs = kwargs
+        return True
+
+
+class _Plugin:
+    code = "test"
+
+    def __init__(
+        self,
+        events: list[str],
+        *,
+        fail: bool = False,
+        matches: bool = True,
+    ) -> None:
+        self.events = events
+        self.fail = fail
+        self.matches = matches
+
+    def match(self, context: TokenExchangeContext) -> bool:
+        del context
+        self.events.append("match")
+        return self.matches
+
+    def prepare_exchange_token_request(self, context: TokenExchangeContext):
+        del context
+        self.events.append("prepare")
+        if self.fail:
+            raise RuntimeError("prepare failed")
+        return PreparedExchangeTokenRequest(
+            plugin_code=self.code,
+            method="POST",
+            path="https://example.test/token",
+            headers={},
+            body={},
+            timeout_seconds=1,
+            response_parser=MagicMock(),
+            paas_device_id="device@template",
+            outbound_header_name="x-test-token",
+        )
+
+    async def exchange_token(self, *, context, prepared):
+        del context, prepared
+        self.events.append("exchange")
+        return ExchangedToken("token", None, "fingerprint", {})
+
+    def append_to_outbound(self, *, context, prepared, token, appender):
+        del context, prepared, token
+        self.events.append("append")
+        appender.append_token(
+            paas_device_id="device@template",
+            header_name="x-test-token",
+            action="set",
+            token="token",
+            plugin_code=self.code,
+        )
+
+
+def _context() -> TokenExchangeContext:
+    return TokenExchangeContext(
+        bot_id="bot-1",
+        bot_type="personal",
+        owner_user_id="owner-1",
+        user_list_entity_id="user-1",
+        entity_id="user-1",
+        stage="draft",
+        env="pre",
+        publish_id=None,
+        binding_id=None,
+        request_id="request-1",
+    )
+
+
+@pytest.mark.asyncio
+async def test_pipeline_runs_four_phases_in_order() -> None:
+    events: list[str] = []
+    appender = _Appender()
+    results = await TokenPluginPipeline(
+        plugins=(_Plugin(events),), outbound_appender=appender
+    ).run(_context())
+
+    assert events == ["match", "prepare", "exchange", "append"]
+    assert results[0].status == "succeeded"
+    assert appender.kwargs["header_name"] == "x-test-token"
+
+
+@pytest.mark.asyncio
+async def test_one_plugin_failure_isolated() -> None:
+    events: list[str] = []
+    results = await TokenPluginPipeline(
+        plugins=(_Plugin(events, fail=True), _Plugin(events)),
+        outbound_appender=_Appender(),
+    ).run(_context())
+
+    assert [result.status for result in results] == ["failed", "succeeded"]
+    assert events == ["match", "prepare", "match", "prepare", "exchange", "append"]
+
+
+@pytest.mark.asyncio
+async def test_pipeline_skips_plugin_when_match_is_false() -> None:
+    events: list[str] = []
+
+    results = await TokenPluginPipeline(
+        plugins=(_Plugin(events, matches=False),),
+        outbound_appender=_Appender(),
+    ).run(_context())
+
+    assert events == ["match"]
+    assert results[0].status == "skipped"
+
+
+@pytest.mark.asyncio
+async def test_noop_pipeline_has_no_results() -> None:
+    assert await NoopTokenPluginPipeline().run(_context()) == []
+
+
+@pytest.mark.asyncio
+async def test_caller_runs_before_plugins_and_keeps_result_on_plugin_failure() -> None:
+    events: list[str] = []
+    caller = MagicMock()
+    caller.get_iam_token = AsyncMock(
+        side_effect=lambda **kwargs: (
+            events.append("caller"),
+            CallerIamTokenOutcome(iam_token="original"),
+        )[1]
+    )
+    plugin = _Plugin(events, fail=True)
+    bot_repo = MagicMock()
+    bot_repo.get_by_id_and_entity.return_value = {
+        "owner_id": "owner-1",
+        "bot_type": "personal",
+        "env": "pre",
+    }
+    orchestrator = TokenExchangeOrchestrator(
+        caller_service=caller,
+        token_pipeline=TokenPluginPipeline(
+            plugins=(plugin,), outbound_appender=_Appender()
+        ),
+        bot_repository=bot_repo,
+    )
+
+    result = await orchestrator.get_iam_token(
+        iam_token="iam",
+        auth_request=AuthRequestContext(cookies={}, headers={}, query_params={}, base_url="http://test"),
+        bot_id="bot-1",
+        stage=CallerIdentityStage.DRAFT,
+        publish_id=None,
+        entity_id="user-1",
+        is_test_exchange=False,
+    )
+
+    assert result.iam_token == "original"
+    assert events[0] == "caller"
+
+
+@pytest.mark.asyncio
+async def test_context_build_failure_does_not_change_caller_result() -> None:
+    caller = MagicMock()
+    caller.get_iam_token = AsyncMock(
+        return_value=CallerIamTokenOutcome(iam_token="original")
+    )
+    bot_repo = MagicMock()
+    bot_repo.get_by_id_and_entity.side_effect = RuntimeError("db unavailable")
+    orchestrator = TokenExchangeOrchestrator(
+        caller_service=caller,
+        token_pipeline=TokenPluginPipeline(plugins=(), outbound_appender=_Appender()),
+        bot_repository=bot_repo,
+    )
+
+    result = await orchestrator.get_iam_token(
+        iam_token="iam",
+        auth_request=AuthRequestContext(cookies={}, headers={}, query_params={}, base_url="http://test"),
+        bot_id="bot-1",
+        stage=CallerIdentityStage.DRAFT,
+        publish_id=None,
+        entity_id="user-1",
+        is_test_exchange=False,
+    )
+
+    assert result.iam_token == "original"
+
+
+@pytest.mark.asyncio
+async def test_caller_exception_is_rethrown_after_independent_pipeline_run() -> None:
+    caller = MagicMock()
+    caller.get_iam_token = AsyncMock(side_effect=RuntimeError("caller failed"))
+    pipeline = MagicMock()
+    pipeline.run = AsyncMock(return_value=[])
+    bot_repo = MagicMock()
+    bot_repo.get_by_id_and_entity.return_value = {
+        "owner_id": "owner-1",
+        "bot_type": "personal",
+        "env": "pre",
+    }
+    orchestrator = TokenExchangeOrchestrator(
+        caller_service=caller,
+        token_pipeline=pipeline,
+        bot_repository=bot_repo,
+    )
+
+    with pytest.raises(RuntimeError, match="caller failed"):
+        await orchestrator.get_iam_token(
+            iam_token="iam",
+            auth_request=AuthRequestContext(
+                cookies={}, headers={}, query_params={}, base_url="http://test"
+            ),
+            bot_id="bot-1",
+            stage=CallerIdentityStage.DRAFT,
+            publish_id=None,
+            entity_id="user-1",
+            is_test_exchange=False,
+        )
+
+    pipeline.run.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_unexpected_pipeline_exception_keeps_caller_result() -> None:
+    caller = MagicMock()
+    caller.get_iam_token = AsyncMock(
+        return_value=CallerIamTokenOutcome(iam_token="original")
+    )
+    pipeline = MagicMock()
+    pipeline.run = AsyncMock(side_effect=RuntimeError("pipeline failed"))
+    bot_repo = MagicMock()
+    bot_repo.get_by_id_and_entity.return_value = {
+        "owner_id": "owner-1",
+        "bot_type": "personal",
+        "env": "pre",
+    }
+    orchestrator = TokenExchangeOrchestrator(
+        caller_service=caller,
+        token_pipeline=pipeline,
+        bot_repository=bot_repo,
+    )
+
+    result = await orchestrator.get_iam_token(
+        iam_token="iam",
+        auth_request=AuthRequestContext(
+            cookies={}, headers={}, query_params={}, base_url="http://test"
+        ),
+        bot_id="bot-1",
+        stage=CallerIdentityStage.DRAFT,
+        publish_id=None,
+        entity_id="user-1",
+        is_test_exchange=False,
+    )
+
+    assert result.iam_token == "original"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("bot_id", "entity_id", "bot_record"),
+    [
+        (None, "user-1", None),
+        ("bot-1", None, None),
+        ("bot-1", "user-1", None),
+        ("bot-1", "user-1", {"owner_id": "", "bot_type": "personal"}),
+    ],
+)
+async def test_unavailable_context_skips_pipeline(
+    bot_id: str | None,
+    entity_id: str | None,
+    bot_record: dict[str, str] | None,
+) -> None:
+    caller = MagicMock()
+    caller.get_iam_token = AsyncMock(
+        return_value=CallerIamTokenOutcome(iam_token="original")
+    )
+    pipeline = MagicMock()
+    pipeline.run = AsyncMock(return_value=[])
+    bot_repo = MagicMock()
+    bot_repo.get_by_id_and_entity.return_value = bot_record
+    orchestrator = TokenExchangeOrchestrator(
+        caller_service=caller,
+        token_pipeline=pipeline,
+        bot_repository=bot_repo,
+    )
+
+    result = await orchestrator.get_iam_token(
+        iam_token="iam",
+        auth_request=AuthRequestContext(
+            cookies={}, headers={}, query_params={}, base_url="http://test"
+        ),
+        bot_id=bot_id,
+        stage=CallerIdentityStage.DRAFT,
+        publish_id=None,
+        entity_id=entity_id,
+        is_test_exchange=False,
+    )
+
+    assert result.iam_token == "original"
+    pipeline.run.assert_not_awaited()

--- a/src/backend/tests/community/framework/flow_coverage.py
+++ b/src/backend/tests/community/framework/flow_coverage.py
@@ -107,6 +107,13 @@ _RUNTIME_BINDING_EXEMPT_REASON = (
     "in singlebox."
 )
 
+_TOKEN_EXCHANGE_EXEMPT_REASON = (
+    "The neutral token pipeline is intentionally empty in community/singlebox; "
+    "real exchange, Passport, and BaaS append behavior is installed only by the "
+    "corp profile. Covered by pipeline/orchestrator and BaaS HTTP seam tests. "
+    "Drain when singlebox has a real token exchange plugin and BaaS target."
+)
+
 _TASK_FRAMEWORK_EXEMPT_REASON = (
     "Task goal-driven execution framework skeleton (core/task). No HTTP/router or DI surface is wired yet (no adapters/http/openapi_v1/task/, no di/modules/task_module.py), so there is no endpoint for an e2e flow to drive. Covered by domain/unit tests on the graph, planner, dispatcher, runner, and harness as each lands. Drain this when a router + DI provider expose the TaskService facade over a real singlebox stack."
 )
@@ -241,6 +248,7 @@ SINGLEBOX_E2E_EXEMPT: dict[str, str] = {
         "Agent Principal and BaaS outbound-rule calls require remote credentials; "
         "covered by local API/core tests until a singlebox-compatible external seam exists."
     ),
+    "token_exchange": _TOKEN_EXCHANGE_EXEMPT_REASON,
     "common_config": _EXEMPT_REASON,
     "config": _EXEMPT_REASON,
     "config_compose": _EXEMPT_REASON,


### PR DESCRIPTION
## Problem

Caller IAM preparation currently has no reusable way to run additional, independently failing token exchanges without changing existing HTTP callers or coupling token-specific behavior to the Caller service.

## Solution

- Add a four-stage outbound token plugin contract: `match`, `prepare_exchange_token_request`, `exchange_token`, and `append_to_outbound`.
- Wrap the existing `CallerIamTokenService` behind the unchanged protocol so Caller runs first and plugin failures remain isolated.
- Add a generic BaaS `mode=append` token-header operation while preserving the existing Caller append API.
- Validate `paas_device_id` before interpolating it into the BaaS relative URL and emit token-safe diagnostic events.
- Keep community and singlebox behavior unchanged through their existing profile-specific protocol bindings.

## Validation

- `uv run pytest -q tests/community/core/token_exchange/test_pipeline.py tests/community/core/service_bot/services/test_baas_service_http_methods.py tests/community/core/caller_identity tests/community/endpoints/test_token_iam_router.py tests/community/endpoints/test_openapi_iam_token.py tests/community/adapters/http/openapi_v1/test_token_router.py tests/community/api/test_caller_iam_token.py tests/community/di` — 455 passed.
- Token pipeline/API focused coverage — 99%.
- Ruff checks for all changed Python files — passed.
- `git diff --check` — passed.

## Compatibility and risk

The HTTP contract and existing Caller service behavior are preserved. Token plugins run independently after Caller, including when Caller raises; the original Caller result or exception is returned after plugin execution. Corporate JIT-specific matching, exchange, and domain policy are delivered separately by the OCB PR.

## Spec

- `src/backend/specs/generic-token-exchange-jit/001-spec-output.md`
