### PR TITLE
fix(backend): Using built or validating version of service rather than online version to create eval bot

### DIFF
--- a/src/backend/src/agentclaw/community/core/repository/implementations/publishing/bot_publish.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/publishing/bot_publish.py
@@ -366,7 +366,10 @@ class BotPublishRepository(
                 db.query(self.Model)
                 .filter(
                     self.Model.source_bot_id == source_bot_id,
-                    self.Model.status == PublishStatus.BUILT.value,
+                    self.Model.status.in_([
+                        PublishStatus.BUILT.value,
+                        PublishStatus.VALIDATING.value,
+                    ]),
                     self.Model.env == env,
                 )
                 .order_by(self.Model.id.desc())

--- a/src/backend/src/agentclaw/community/core/repository/protocols/publishing.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/publishing.py
@@ -251,18 +251,23 @@ class BotPublishRepositoryProtocol(Protocol):
         source_bot_id: str,
         env: str,
     ) -> Optional[BotPublishRecord]:
-        """Get the latest status=built publish record by source_bot_id (owner-agnostic).
+        """Get the latest non-online publish record by source_bot_id (owner-agnostic).
 
-        Used by the Eval environment to anchor the latest draft (built) version
-        rather than the latest online (success) version. Deliberately NOT filtered
-        by owner_id for the same reason as get_latest_success_by_source_bot_id.
+        Queries status IN ('built', 'validating') — the two stages that
+        precede online deployment. Used by the Eval environment to anchor
+        the latest draft or verify-stage version rather than the latest
+        online (success) version. Returns the highest-id row among
+        matching statuses.
+
+        Deliberately NOT filtered by owner_id for the same reason as
+        get_latest_success_by_source_bot_id.
 
         Args:
             source_bot_id: source bot_id
             env: environment
 
         Returns:
-            The latest built publish record, or None if not found.
+            The latest non-online publish record, or None if not found.
         """
         ...
 

--- a/src/backend/tests/community/repository/publishing/test_bot_publish_unified.py
+++ b/src/backend/tests/community/repository/publishing/test_bot_publish_unified.py
@@ -406,7 +406,7 @@ def test_get_latest_success_by_source_bot_id_returns_none_when_no_success(repo):
 
 
 def test_get_latest_built_by_source_bot_id_owner_agnostic_returns_latest(repo):
-    """Eval 区版本锚定：latest built row, owner-agnostic."""
+    """Eval 区版本锚定：latest non-online (built/validating) row, owner-agnostic."""
     repo.insert(_data(source_bot_id="src-1", owner_id="emp001", status="built", env="dev"))
     latest = repo.insert(
         _data(source_bot_id="src-1", owner_id="other-owner", status="built", env="dev", version=2)
@@ -418,6 +418,34 @@ def test_get_latest_built_by_source_bot_id_owner_agnostic_returns_latest(repo):
 
     assert got is not None
     assert got.id == latest.id
+
+
+def test_get_latest_built_by_source_bot_id_includes_validating(repo):
+    """status=validating 也属于非上线版本，应被查到。"""
+    repo.insert(_data(source_bot_id="src-1", owner_id="emp001", status="success", env="dev", version=1))
+    validating = repo.insert(
+        _data(source_bot_id="src-1", owner_id="emp001", status="validating", env="dev", version=2)
+    )
+
+    got = repo.get_latest_built_by_source_bot_id("src-1", "dev")
+
+    assert got is not None
+    assert got.id == validating.id
+
+
+def test_get_latest_built_by_source_bot_id_prefers_higher_id_across_statuses(repo):
+    """built 和 validating 都存在时，返回 id 更大的那一条。"""
+    built = repo.insert(
+        _data(source_bot_id="src-1", owner_id="emp001", status="built", env="dev", version=1)
+    )
+    validating = repo.insert(
+        _data(source_bot_id="src-1", owner_id="emp001", status="validating", env="dev", version=2)
+    )
+
+    got = repo.get_latest_built_by_source_bot_id("src-1", "dev")
+
+    assert got is not None
+    assert got.id == validating.id  # id 更大
 
 
 def test_get_latest_built_by_source_bot_id_returns_none_when_no_built(repo):


### PR DESCRIPTION
## Problem

`get_latest_built_by_source_bot_id` only queries `status='built'`, but publish status transitions in-place (`DRAFT→BUILT→VALIDATING→SUCCESS`). Once a bot is published to the verify/prepub environment (`status=validating`), the `built` record no longer exists, causing eval creation to fail with "尚未完成构建" even though a perfectly valid non-online version is available.

## Solution

Expand `get_latest_built_by_source_bot_id` to query `status IN ('built', 'validating')` instead of only `status='built'`. This covers both draft and prepub stages — the two statuses that precede online deployment.

In OCB's `create_eval_env_bot`, **no success fallback** is applied. If neither built nor validating exists, an error is raised: "尚未完成构建或预发布，无法创建评测环境。请先完成 Bot 构建或预发布". Falling back to success would make Eval区 identical to Default区, defeating the purpose of a separate eval environment.

**Rejected alternative**: Add a separate `get_latest_validating_by_source_bot_id` method and implement a 3-level fallback chain (built→validating→success). This requires a new method per candidate status and a success fallback that erases the distinction between Eval and Default environments.

## Validation

- `test_get_latest_built_by_source_bot_id_owner_agnostic_returns_latest` — built records still returned
- `test_get_latest_built_includes_validating` — validating-only records are found
- `test_get_latest_built_prefers_higher_id_across_statuses` — built and validating both exist, higher-id wins
- `test_get_latest_built_by_source_bot_id_returns_none_when_no_built` — only success exists → None
- OCB: `test_validating_record_returned` — `_find_latest_built_publish` returns validating record
- OCB: `test_no_built_or_validating_publish_raises` — neither built nor validating → error

## Compatibility and risk

- **Backward compatible**: `status IN (built, validating)` is a strict superset of `status = built`; existing built-only scenarios are unaffected
- **No schema change**: Query change only, no migration needed
- **Index**: Existing `source_bot_id + status + env` index covers the `IN` query efficiently