### PR TITLE
ci(hooks): detect Alibaba Cloud credentials on push

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -72,7 +72,16 @@ run_for_ref() {
   echo "merge base: $base"
   echo "head: $local_sha"
 
-  "$repo_root/scripts/ci/pre_push.sh" --base "$base" --head "$local_sha"
+  # Scan only added lines in the exact push range before any other gate runs.
+  # A non-zero result blocks this ref from being pushed. Keep the explicit
+  # conditional because run_for_ref is itself invoked from an `||` status
+  # collector, which would otherwise disable errexit inside the function.
+  if ! "$repo_root/scripts/ci/check_secrets.py" --base "$base" --head "$local_sha"; then
+    return 1
+  fi
+  if ! "$repo_root/scripts/ci/pre_push.sh" --base "$base" --head "$local_sha"; then
+    return 1
+  fi
 }
 
 while IFS=' ' read -r local_ref local_sha remote_ref remote_sha; do

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,6 +162,16 @@ Install the repository hooks separately in every Git worktree:
 scripts/install_git_hooks.sh
 ```
 
+The pre-push hook first scans added lines in each pushed commit range for
+likely plaintext credentials. It blocks the push on private keys, recognizable
+provider tokens (including Alibaba Cloud AccessKey/STS credentials),
+bearer/JWT credentials, or high-entropy values assigned to credential-like
+fields. When a finding is reported, the hook prints the
+corresponding added line with the matched sensitive value partially masked,
+alongside its file, line, and rule, so authors can locate and remove it without
+leaking the complete credential into terminal or CI logs. This check is always
+enabled and is independent of the lint/test mode below.
+
 By default the pre-push hook runs in **lint-only** mode: for changed Python
 modules it runs the fast `python_sast_local.sh` SAST/lint gate, but skips the
 heavier unit tests, changed-line coverage, and Singlebox E2E. Set

--- a/scripts/ci/check_secrets.py
+++ b/scripts/ci/check_secrets.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""Fail when newly added Git content contains likely plaintext credentials.
+
+The scanner intentionally inspects only added lines in the requested Git range.
+When a finding is reported, its added line is printed with the matched sensitive
+value partially masked so the author can locate and fix the issue without
+echoing a complete credential into the terminal or CI log.
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Finding:
+    path: str
+    line: int
+    rule: str
+    content: str
+
+
+PRIVATE_KEY_RE = re.compile(r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----")
+KNOWN_SECRET_RES = (
+    ("Alibaba Cloud AccessKey ID", re.compile(r"\bLTAI[0-9A-Za-z]{12,30}\b")),
+    ("Alibaba Cloud STS AccessKey ID", re.compile(r"\bSTS\.[0-9A-Za-z]{8,64}\b")),
+    ("Alibaba Cloud security token", re.compile(r"\bCAIS[A-Za-z0-9_+=/-]{16,}\b")),
+    ("AWS access key", re.compile(r"\b(?:AKIA|ASIA)[0-9A-Z]{16}\b")),
+    ("GitHub token", re.compile(r"\b(?:gh[pousr]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,})\b")),
+    ("GitLab token", re.compile(r"\bglpat-[A-Za-z0-9_-]{20,}\b")),
+    ("Slack token", re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{10,}\b")),
+    ("Google API key", re.compile(r"\bAIza[0-9A-Za-z_-]{30,}\b")),
+    ("OpenAI-style key", re.compile(r"\bsk-[A-Za-z0-9]{20,}\b")),
+    ("npm token", re.compile(r"\bnpm_[A-Za-z0-9]{20,}\b")),
+    ("PyPI token", re.compile(r"\bpypi-[A-Za-z0-9_-]{20,}\b")),
+    ("JWT", re.compile(r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b")),
+    ("Bearer token", re.compile(r"\bBearer[ \t]+[A-Za-z0-9._~+/=-]{24,}\b", re.IGNORECASE)),
+)
+
+ALIYUN_ASSIGNMENT_RE = re.compile(
+    r"(?ix)"
+    # Cover Alibaba Cloud/aliyun/OSS names in snake_case, kebab-case, and
+    # common camelCase forms, including AK/SK aliases.
+    r"(?:^|[^a-z0-9])"
+    r"(?:alibaba(?:[._-]?cloud)?|aliyun|oss)[a-z0-9._-]*"
+    r"(?:access[._-]?key(?:[._-]?(?:id|secret))?|ak|sk)\b[\"']?"
+    r"\s*(?:[:=]|=>)\s*"
+    r"(?:[\"'](?P<quoted>[^\"'\r\n]+)[\"']|(?P<bare>[^\s,;\"']+))"
+)
+
+ASSIGNMENT_RE = re.compile(
+    r"(?ix)"
+    # Permit common prefixes such as SERVICE_API_KEY while still requiring a
+    # credential-like field name rather than matching arbitrary prose.
+    r"(?:^|[^a-z0-9])(?:[a-z0-9]+[._-])*"
+    r"(?:api[._-]?key|access[._-]?key|secret(?:[._-]?key)?|"
+    r"private[._-]?key|client[._-]?secret|auth[._-]?token|"
+    r"password|passwd|credential|token)\b[\"']?"
+    r"\s*(?:[:=]|=>)\s*"
+    r"(?:[\"'](?P<quoted>[^\"'\r\n]+)[\"']|(?P<bare>[^\s,;\"']+))"
+)
+
+PLACEHOLDER_RE = re.compile(
+    r"(?ix)^(?:"
+    r"\$\{[^}]+\}|\$[A-Z_][A-Z0-9_]*|"
+    r"<[^>]+>|\.{3,}|"
+    r"(?:changeme|change[-_ ]?me|dummy|example|fake|local(?:[-_ ]?only)?|"
+    r"mock|not[-_ ]?a[-_ ]?real(?:[-_ ]?token)?|placeholder|sample|test(?:[-_ ]?token)?|"
+    r"your[-_ ]?(?:token|secret|key|password)|"
+    r"(?:dev|provider|bcs|baas|bot|gateway|openclaw|anthropic|e2e)[-_ ]?(?:test|token|secret|key)"
+    r"))$")
+
+# Common variable indirections and explicit non-secret values must not be
+# treated as plaintext credentials by the key/value rule.
+NON_SECRET_VALUE_RE = re.compile(
+    r"(?ix)^(?:null|none|true|false|undefined|empty|unset|"
+    r"os\.getenv\([^)]*\)|process\.env\.[A-Z0-9_]+)$"
+)
+
+
+def _entropy(value: str) -> float:
+    counts: dict[str, int] = {}
+    for char in value:
+        counts[char] = counts.get(char, 0) + 1
+    length = len(value)
+    return -sum((count / length) * math.log2(count / length) for count in counts.values())
+
+
+def _looks_like_plaintext_value(value: str) -> bool:
+    value = value.strip()
+    # Whitespace is not expected in the compact credential forms this rule
+    # targets. Rejecting it also avoids treating string-concatenation source
+    # such as `"KEY=" + value` as a literal credential.
+    if any(char.isspace() for char in value):
+        return False
+    if len(value) < 12 or PLACEHOLDER_RE.fullmatch(value) or NON_SECRET_VALUE_RE.fullmatch(value):
+        return False
+    # A high-entropy value is a strong signal. Password/secret assignments are
+    # also suspicious at a lower threshold because human-generated secrets can
+    # have less entropy than generated API tokens.
+    return _entropy(value) >= 3.2 or len(value) >= 24
+
+
+# 以下为安全注释COSEC：掩码所有命中的敏感值后再显示源码行，避免诊断信息
+# 在终端或 CI 日志中泄露完整凭据。
+def _redact_value(value: str) -> str:
+    if len(value) <= 8:
+        return "***"
+    return f"{value[:2]}***{value[-3:]}"
+
+
+def _redact_content(content: str) -> str:
+    spans: list[tuple[int, int]] = []
+    for pattern in (PRIVATE_KEY_RE, *(pattern for _, pattern in KNOWN_SECRET_RES)):
+        spans.extend((match.start(), match.end()) for match in pattern.finditer(content))
+
+    for assignment_pattern in (ALIYUN_ASSIGNMENT_RE, ASSIGNMENT_RE):
+        for assignment in assignment_pattern.finditer(content):
+            value = assignment.group("quoted") or assignment.group("bare") or ""
+            if not _looks_like_plaintext_value(value):
+                continue
+            value_start = assignment.start("quoted")
+            value_end = assignment.end("quoted")
+            if value_start < 0 or value_end < 0:
+                value_start = assignment.start("bare")
+                value_end = assignment.end("bare")
+            if value_start >= 0 and value_end >= 0:
+                spans.append((value_start, value_end))
+
+    if not spans:
+        return content
+
+    merged: list[tuple[int, int]] = []
+    for start, end in sorted(spans):
+        if merged and start <= merged[-1][1]:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+        else:
+            merged.append((start, end))
+
+    redacted = content
+    for start, end in reversed(merged):
+        redacted = redacted[:start] + _redact_value(content[start:end]) + redacted[end:]
+    return redacted
+
+
+def _added_lines(diff: str) -> list[tuple[str, int, str]]:
+    path = ""
+    new_line = 0
+    added: list[tuple[str, int, str]] = []
+    for raw_line in diff.splitlines():
+        if raw_line.startswith("+++ b/"):
+            path = raw_line[6:]
+            continue
+        if raw_line.startswith("@@ "):
+            match = re.search(r"\+(\d+)(?:,(\d+))?", raw_line)
+            if match is None:
+                path = ""
+                continue
+            new_line = int(match.group(1))
+            continue
+        if not path or raw_line.startswith("--- ") or raw_line.startswith("\\ No newline"):
+            continue
+        if raw_line.startswith("+"):
+            added.append((path, new_line, raw_line[1:]))
+            new_line += 1
+        elif raw_line.startswith(" "):
+            new_line += 1
+    return added
+
+
+def _findings(diff: str) -> list[Finding]:
+    findings: list[Finding] = []
+    for path, line, content in _added_lines(diff):
+        for rule, pattern in (("private key", PRIVATE_KEY_RE), *KNOWN_SECRET_RES):
+            if pattern.search(content):
+                findings.append(Finding(path, line, rule, _redact_content(content)))
+                break
+        else:
+            assignment_rules = (
+                ("Alibaba Cloud credential-like assignment", ALIYUN_ASSIGNMENT_RE),
+                ("credential-like assignment", ASSIGNMENT_RE),
+            )
+            for rule, assignment_pattern in assignment_rules:
+                assignment = assignment_pattern.search(content)
+                if assignment is None:
+                    continue
+                value = assignment.group("quoted") or assignment.group("bare") or ""
+                if _looks_like_plaintext_value(value):
+                    findings.append(Finding(path, line, rule, _redact_content(content)))
+                    break
+    return findings
+
+
+def _git_diff(base: str, head: str) -> str:
+    # Use an argv list and shell=False so revision names cannot become shell
+    # syntax. Git validates the revisions and reports errors to the caller.
+    result = subprocess.run(
+        [
+            "git",
+            "diff",
+            "--no-ext-diff",
+            "--no-color",
+            "--unified=0",
+            "--diff-filter=ACMRTUXB",
+            base,
+            head,
+            "--",
+        ],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if result.returncode != 0:
+        message = result.stderr.strip() or "git diff failed"
+        raise RuntimeError(message)
+    return result.stdout
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", required=True, help="exclusive base revision")
+    parser.add_argument("--head", required=True, help="inclusive head revision")
+    args = parser.parse_args(argv)
+
+    try:
+        findings = _findings(_git_diff(args.base, args.head))
+    except RuntimeError as error:
+        print(f"error: plaintext secret scan could not inspect Git range: {error}", file=sys.stderr)
+        return 2
+
+    if not findings:
+        print("plaintext secret scan passed")
+        return 0
+
+    print("ERROR: plaintext secret-like content detected; push blocked.", file=sys.stderr)
+    print("Remove the credential, move it to a secure runtime secret source, and rotate it if it was real.", file=sys.stderr)
+    for finding in findings:
+        print(f"  - {finding.path}:{finding.line} ({finding.rule})", file=sys.stderr)
+        # Encode control characters so source content cannot alter terminal
+        # output while still showing the author the relevant added line.
+        safe_content = finding.content.encode("unicode_escape").decode("ascii")
+        print(f"    added line: {safe_content}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/tests/test_pre_push_hook.py
+++ b/scripts/ci/tests/test_pre_push_hook.py
@@ -77,6 +77,10 @@ def _install_test_hook(developer: Path) -> Path:
     hook.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(HOOK_PATH, hook)
     hook.chmod(0o755)
+    scanner = developer / "scripts/ci/check_secrets.py"
+    scanner.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(REPO_ROOT / "scripts/ci/check_secrets.py", scanner)
+    scanner.chmod(0o755)
     dispatcher = developer / "scripts/ci/pre_push.sh"
     dispatcher.parent.mkdir(parents=True, exist_ok=True)
     dispatcher.write_text(
@@ -193,6 +197,107 @@ class PrePushHookTest(unittest.TestCase):
                 self.fail(f"test hook installation must be idempotent: {error}")
 
             self.assertEqual(second_hook, first_hook)
+
+    def test_plaintext_secret_blocks_push_before_dispatch(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            remote, _, developer = _create_repositories(root)
+            _git(developer, "switch", "-c", "feature")
+            # Build the synthetic credential from fragments so this test source
+            # does not itself contain a contiguous credential-like value.
+            fake_value = "Q7x!m2#P9v@L4sN8qZ6r"
+            _write(
+                developer,
+                "config/local.env",
+                "SERVICE_API_KEY=" + fake_value + "\n",
+            )
+            _git(developer, "add", ".")
+            _git(developer, "commit", "-m", "add local credential")
+            feature_sha = _git(developer, "rev-parse", "HEAD")
+
+            hook = _install_test_hook(developer)
+            result = _invoke_hook(
+                developer,
+                remote,
+                hook,
+                feature_sha,
+                check=False,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("plaintext secret-like content detected", result.stderr)
+            self.assertIn("config/local.env:1", result.stderr)
+            self.assertIn("added line: SERVICE_API_KEY=Q7***Z6r", result.stderr)
+            self.assertNotIn("dispatch-base:", result.stdout)
+            self.assertNotIn(fake_value, result.stderr)
+
+    def test_alibaba_cloud_access_keys_block_push_with_masked_context(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            remote, _, developer = _create_repositories(root)
+            _git(developer, "switch", "-c", "feature")
+            # Build synthetic Alibaba Cloud credentials from fragments so this
+            # test source does not contain contiguous credential-like values.
+            fake_access_key_id = "LTAI" + "5x7Y9z2Q4w6E8r0T1u3I"
+            fake_access_key_secret_parts = (
+                "aB3dE5gH7jK9mN2pQ4sT6",
+                "vW8xY0z",
+            )
+            fake_access_key_secret = "".join(fake_access_key_secret_parts)
+            fake_sts_access_key_id = "STS." + "a1B2c3D4e5F6g7H8"
+            fake_security_token = "CAIS" + "aB3dE5gH7jK9mN2pQ4sT6"
+            _write(
+                developer,
+                "config/alibaba.env",
+                "ALIBABA_CLOUD_ACCESS_KEY_ID="
+                + fake_access_key_id
+                + "\nALIBABA_CLOUD_ACCESS_KEY_SECRET="
+                + fake_access_key_secret
+                + "\nALIBABA_CLOUD_STS_ACCESS_KEY_ID="
+                + fake_sts_access_key_id
+                + "\nALIBABA_CLOUD_SECURITY_TOKEN="
+                + fake_security_token
+                + "\n",
+            )
+            _git(developer, "add", ".")
+            _git(developer, "commit", "-m", "add Alibaba Cloud credentials")
+            feature_sha = _git(developer, "rev-parse", "HEAD")
+
+            hook = _install_test_hook(developer)
+            result = _invoke_hook(
+                developer,
+                remote,
+                hook,
+                feature_sha,
+                check=False,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("Alibaba Cloud AccessKey ID", result.stderr)
+            self.assertIn("Alibaba Cloud STS AccessKey ID", result.stderr)
+            self.assertIn("Alibaba Cloud security token", result.stderr)
+            self.assertIn("Alibaba Cloud credential-like assignment", result.stderr)
+            self.assertIn(
+                "added line: ALIBABA_CLOUD_ACCESS_KEY_ID=LT***u3I",
+                result.stderr,
+            )
+            self.assertIn(
+                "added line: ALIBABA_CLOUD_ACCESS_KEY_SECRET=aB***Y0z",
+                result.stderr,
+            )
+            self.assertIn(
+                "added line: ALIBABA_CLOUD_STS_ACCESS_KEY_ID=ST***7H8",
+                result.stderr,
+            )
+            self.assertIn(
+                "added line: ALIBABA_CLOUD_SECURITY_TOKEN=CA***sT6",
+                result.stderr,
+            )
+            self.assertNotIn(fake_access_key_id, result.stderr)
+            self.assertNotIn(fake_access_key_secret, result.stderr)
+            self.assertNotIn(fake_sts_access_key_id, result.stderr)
+            self.assertNotIn(fake_security_token, result.stderr)
+            self.assertNotIn("dispatch-base:", result.stdout)
 
     def test_refreshes_stale_default_target_before_selecting_modules(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:

--- a/scripts/install_git_hooks.sh
+++ b/scripts/install_git_hooks.sh
@@ -32,6 +32,7 @@ hooks_before="$(git config --worktree --get core.hooksPath 2>/dev/null || git co
 
 chmod +x .githooks/pre-push
 chmod +x scripts/ci/pre_push.sh
+chmod +x scripts/ci/check_secrets.py
 chmod +x scripts/ci/python_sast_local.sh
 chmod +x scripts/ci/singlebox_coverage.sh
 chmod +x scripts/ci/report_check.py


### PR DESCRIPTION
## Problem

The repository pre-push hook did not detect plaintext cloud credentials before code was pushed to a remote repository.

This could allow Alibaba Cloud AccessKey ID, AccessKey Secret, STS credentials, Security Tokens, or other credential-like values to enter Git history. When a credential was detected, developers also needed enough context to locate and remove the problematic line.

## Solution

- Added a plaintext secret scanner at `scripts/ci/check_secrets.py`.
- Integrated the scanner into `.githooks/pre-push`.
- Scan only added lines in the exact push commit range calculated from the merge base.
- Block pushes containing:
  - Alibaba Cloud AccessKey IDs beginning with `LTAI`
  - Alibaba Cloud STS AccessKey IDs
  - Alibaba Cloud Security Tokens
  - Alibaba Cloud credential variables such as:
    - `ALIBABA_CLOUD_ACCESS_KEY_ID`
    - `ALIBABA_CLOUD_ACCESS_KEY_SECRET`
    - `ALIBABA_CLOUD_SECURITY_TOKEN`
    - `ALIYUN_AK`
    - `ALIYUN_SK`
  - Private keys
  - Recognizable provider tokens
  - JWT and Bearer credentials
  - High-entropy values assigned to credential-like fields
- When a finding is detected, print:
  - File path
  - Line number
  - Detection rule
  - The corresponding added line with sensitive values partially masked
- Ensure the scanner is executable when installing repository hooks.
- Added regression coverage for Alibaba Cloud AK/SK, STS credentials, Security Tokens, push blocking, and masked diagnostics.
- Updated repository documentation.

## Validation

Passed:

- `bash -n .githooks/pre-push scripts/install_git_hooks.sh scripts/ci/pre_push.sh`
- `python3 -m py_compile scripts/ci/check_secrets.py scripts/ci/tests/test_pre_push_hook.py`
- `git diff --check`
- Alibaba Cloud credential detection and masked output test
- Plaintext credential push-blocking test
- Manual SSH push to `origin/xianmu_dev`; the pre-push secret scan and local gate both passed

The full pre-push test file ran 12 tests:

- 11 tests passed
- 1 existing test failed because `/Users/xianmu.yq/workspace/code/Avernet/CLAUDE.md` is missing; this failure is unrelated to the current change

## Compatibility and risk

- No API, database schema, or runtime contract changes.
- The hook must be installed separately in each Git worktree with:

  ```bash
  scripts/install_git_hooks.sh