### PR TITLE
fix(bcs): resolve coordination references without truncated tool output

### DIFF
--- a/src/bcs/Cargo.lock
+++ b/src/bcs/Cargo.lock
@@ -295,6 +295,7 @@ dependencies = [
  "bcs-collaboration-template",
  "bcs-config",
  "bcs-config-api",
+ "bcs-coordination-client",
  "bcs-db-api",
  "bcs-db-local",
  "bcs-db-mysql",
@@ -978,6 +979,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "bcs-coordination-client"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "axum",
+ "bcs-service-api",
+ "bcs-test-support",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "bcs-db-api"
 version = "0.1.0"
 dependencies = [
@@ -1446,6 +1461,7 @@ name = "bcs-message-flow"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "bcs-bot",
  "bcs-cache-api",
  "bcs-cache-local",
  "bcs-chat-run-store",

--- a/src/bcs/Cargo.toml
+++ b/src/bcs/Cargo.toml
@@ -98,6 +98,7 @@ members = [
     # external-clients
     "crates/external-clients/bcs-fuse-client",
     "crates/external-clients/bcs-webhook-client",
+    "crates/external-clients/bcs-coordination-client",
     # tools
     "crates/tools/bcs-admin",
     "crates/tools/bcs-cli",
@@ -267,6 +268,7 @@ bcs-routing    = { path = "crates/services/bcs-routing" }
 bcs-fusion      = { path = "crates/services/bcs-fusion" }
 bcs-leader-election = { path = "crates/services/bcs-leader-election" }
 bcs-fuse-client = { path = "crates/external-clients/bcs-fuse-client" }
+bcs-coordination-client = { path = "crates/external-clients/bcs-coordination-client" }
 bcs-webhook-client = { path = "crates/external-clients/bcs-webhook-client" }
 bcs-security-gateway-local = { path = "crates/plugins/bcs-security-gateway-local" }
 bcs-security-gateway-api = { path = "crates/plugin-api/bcs-security-gateway-api" }

--- a/src/bcs/crates/bootstrap/bcs/CONTEXT.md
+++ b/src/bcs/crates/bootstrap/bcs/CONTEXT.md
@@ -2,6 +2,7 @@
 
 ## Provides
 
+- Optional coordination resolver HTTP adapter composition and credential loading.
 - BCS process entrypoint and composition root.
 - Config loading, logging bootstrap, runtime assembly, and adapter registration.
 - Concrete selection of services, plugins, and external clients from validated config.

--- a/src/bcs/crates/bootstrap/bcs/Cargo.toml
+++ b/src/bcs/crates/bootstrap/bcs/Cargo.toml
@@ -168,6 +168,7 @@ bcs-message = { workspace = true }
 bcs-message-store = { workspace = true }
 bcs-event-store = { workspace = true }
 bcs-eventing = { workspace = true }
+bcs-coordination-client = { workspace = true }
 bcs-webhook-client = { workspace = true }
 bcs-callback = { workspace = true }
 bcs-collaboration-template = { workspace = true }

--- a/src/bcs/crates/bootstrap/bcs/src/config.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/config.rs
@@ -573,10 +573,20 @@ fn default_group_session_ws_signing_key_secret() -> String {
     "bcn-group-session-ws-jwt".to_string()
 }
 
+/// Optional resolver; the bearer secret is loaded only in the composition root.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CoordinationResolverConfig {
+    pub base_url: String,
+    pub token_env: String,
+}
+
 /// BCS configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct BcsConfig {
+    #[serde(default)]
+    pub coordination_resolver: Option<CoordinationResolverConfig>,
     /// Address to bind to.
     #[serde(default = "default_bind")]
     pub bind: String,
@@ -1135,6 +1145,7 @@ fn validate_http_base_url(value: &str, field_name: &str) -> Result<(), String> {
 impl Default for BcsConfig {
     fn default() -> Self {
         Self {
+            coordination_resolver: None,
             bind: default_bind(),
             port: default_port(),
             bots_base_dir: PathBuf::from("/bots"),
@@ -3245,5 +3256,26 @@ enabled = true
         .expect("config parses");
         assert_eq!(config.human_notify.provider.as_deref(), Some("dummy"));
         assert!(config.human_notify.enabled_provider("dummy"));
+    }
+}
+
+#[cfg(test)]
+mod coordination_resolver_tests {
+    use super::*;
+
+    #[test]
+    fn coordination_resolver_is_disabled_by_default() {
+        assert!(BcsConfig::default().coordination_resolver.is_none());
+    }
+
+    #[test]
+    fn coordination_resolver_requires_endpoint_and_secret_selector() {
+        assert!(serde_json::from_value::<CoordinationResolverConfig>(serde_json::json!({
+            "base_url": "http://127.0.0.1:8888"
+        })).is_err());
+        assert!(serde_json::from_value::<CoordinationResolverConfig>(serde_json::json!({
+            "base_url": "http://127.0.0.1:8888", "token_env": "BCS_COORDINATION_TOKEN",
+            "token": "must not embed credentials"
+        })).is_err());
     }
 }

--- a/src/bcs/crates/bootstrap/bcs/src/server.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/server.rs
@@ -2070,7 +2070,10 @@ impl Default for BcsServerState {
             ]));
         let state_machine_terminal_observer =
             Arc::new(DeferredStateMachineTerminalObserver::new(terminal_observer));
+        let coordination_intents = create_coordination_intents(&config)
+            .expect("invalid coordination resolver configuration");
         let message_flow_builder = create_message_flow_builder(
+            coordination_intents.clone(),
             bot_registry.clone(),
             sessions.clone(),
             router.clone(),
@@ -2337,6 +2340,7 @@ impl Default for BcsServerState {
                 bot_run_context.clone(),
                 message_flow.clone(),
             )
+            .with_coordination_intents(coordination_intents.clone())
             .with_collaboration_runtime(collaboration_runtime.clone()),
         );
         let provider_event_ingest: Arc<dyn bcs_service_api::ProviderEventIngestService> =
@@ -2911,7 +2915,16 @@ impl BotTerminalObserverPort for DeferredStateMachineTerminalObserver {
     }
 }
 
+fn create_coordination_intents(config: &BcsConfig) -> bcs_service_api::ServiceResult<Option<Arc<dyn bcs_service_api::port::CoordinationIntentPort>>> {
+    let Some(resolver) = &config.coordination_resolver else { return Ok(None); };
+    let token = std::env::var(&resolver.token_env).map_err(|_|
+        bcs_service_api::ServiceError::InternalError("coordination resolver credential is missing".into()))?;
+    let client = bcs_coordination_client::CoordinationHttpClient::new(&resolver.base_url, token)?;
+    Ok(Some(Arc::new(client)))
+}
+
 fn create_message_flow_builder(
+    coordination_intents: Option<Arc<dyn bcs_service_api::port::CoordinationIntentPort>>,
     registry: Arc<dyn BotRegistryCoreService>,
     group: Arc<dyn GroupCoreService>,
     routing: Arc<dyn RoutingCoreService>,
@@ -2936,6 +2949,7 @@ fn create_message_flow_builder(
         bot_delivery.clone(),
         frontend_delivery.clone(),
     )
+    .with_coordination_intents(coordination_intents)
     .with_bot_relay_turn_limit(bot_relay_turn_limit)
     .with_interceptors(interceptors)
     .with_session_management(session_management)
@@ -3646,7 +3660,10 @@ impl BcsServer {
                  use BcsServer::new_with_storage to enable human mention notifications"
             );
         }
+        let coordination_intents = create_coordination_intents(&config)
+            .expect("invalid coordination resolver configuration");
         let message_flow_builder = create_message_flow_builder(
+            coordination_intents.clone(),
             bot_registry.clone(),
             sessions.clone(),
             router.clone(),
@@ -3898,6 +3915,7 @@ impl BcsServer {
                 bot_run_context.clone(),
                 message_flow.clone(),
             )
+            .with_coordination_intents(coordination_intents.clone())
             .with_collaboration_runtime(collaboration_runtime.clone()),
         );
         let provider_event_ingest: Arc<dyn bcs_service_api::ProviderEventIngestService> =
@@ -4476,7 +4494,10 @@ impl BcsServer {
             ]));
         let state_machine_terminal_observer =
             Arc::new(DeferredStateMachineTerminalObserver::new(terminal_observer));
+        let coordination_intents = create_coordination_intents(&config)
+            .expect("invalid coordination resolver configuration");
         let message_flow_builder = create_message_flow_builder(
+            coordination_intents.clone(),
             bot_registry.clone(),
             sessions.clone(),
             router.clone(),
@@ -4771,6 +4792,7 @@ impl BcsServer {
                 bot_run_context.clone(),
                 message_flow.clone(),
             )
+            .with_coordination_intents(coordination_intents.clone())
             .with_collaboration_runtime(collaboration_runtime.clone()),
         );
         let provider_event_ingest: Arc<dyn bcs_service_api::ProviderEventIngestService> =

--- a/src/bcs/crates/contracts/bcs-protocol/docs/contract.json
+++ b/src/bcs/crates/contracts/bcs-protocol/docs/contract.json
@@ -2,8 +2,33 @@
   "magic_key": "__bcs_coordination__",
   "version": 1,
   "tools": {
-    "bcs_assign_task": ["target_bot", "message", "response_mode?"],
-    "bcs_send_task_message": ["message"],
-    "bcs_task_complete": ["summary"]
+    "bcs_assign_task": [
+      "target_bot",
+      "message",
+      "response_mode?"
+    ],
+    "bcs_send_task_message": [
+      "message"
+    ],
+    "bcs_task_complete": [
+      "summary"
+    ]
+  },
+  "echo_versions": [
+    1,
+    2
+  ],
+  "reference_v2": {
+    "required_fields": [
+      "__bcs_coordination__",
+      "v",
+      "tool",
+      "intent_id",
+      "status"
+    ],
+    "status": "stored",
+    "intent_id_pattern": "^bcs_intent_[0-9a-f]{32}$",
+    "arguments_in_echo": false,
+    "resolver_api_version": 1
   }
 }

--- a/src/bcs/crates/contracts/bcs-protocol/docs/coordination-reference-v2.md
+++ b/src/bcs/crates/contracts/bcs-protocol/docs/coordination-reference-v2.md
@@ -1,0 +1,86 @@
+# Coordination reference echo v2
+
+Large `message`/`summary` arguments must not travel in tool stdout: providers may
+truncate even successful Bash output. All three coordination tools may return:
+
+```json
+{"__bcs_coordination__":true,"v":2,"tool":"bcs_assign_task","intent_id":"bcs_intent_0123456789abcdef0123456789abcdef","status":"stored"}
+```
+
+This is an additive **echo** version. Native `coordination_intent` remains v1,
+with unchanged argument shapes. Inline echo v1 remains accepted. Provider v1
+callbacks retain their historical tool-name trimming and tolerance for unused
+status metadata; the added source-tool restriction applies only to v2. V1 ignores
+`intent_id` as an unknown extension field and never resolves it. The reference
+contains no arguments, task dispatch ID, consumer identity, or resolver URL.
+`intent_id` identifies a stored request; an actual `task_id` exists only after
+successful dispatch. A compact response fits within 512 bytes.
+
+## Resolver Service API v1
+
+Bootstrap injects `CoordinationIntentPort`. Public BCS has no cache vendor SDK.
+The HTTP adapter uses only its configured base URL and bearer token, disables
+redirects and idle connection reuse, bounds response size to 2 MiB, and never logs payloads or credentials.
+
+All paths begin `/internal/bcs-coordination/v1/intents/{intent_id}`:
+
+| Method / suffix | Request | Response |
+| --- | --- | --- |
+| GET | none | `{payload, claimed, result}` |
+| POST `/claim` | `{context}` | `{acquired, claim_token, result}` |
+| POST `/finish` | `{context, claim_token, result}` | immutable `result` |
+
+`payload` has `intent_id`, `v:2`, `tool`, `arguments`, `created_at_ms`,
+`expires_at_ms`. `context` has authenticated `bot_id`, `group_id`, nullable
+`session_id`, `run_id`, `tool_call_id`. It must be identical across both intake
+paths. `result` has `status: applied|failed|unknown`, nullable `task_id`, and a
+nullable bounded `error_code`. The token is returned only on the first successful
+claim, never via GET or duplicate claims. `acquired:false` with no result is an
+uncertain earlier execution and never grants execution permission.
+
+Missing/expired/evicted payloads are unavailable (404; known expired metadata
+410). Cache failures are 503, mismatched claims/receipts 409. Authentication and
+schema errors reject the request. Claim and result records outlive payloads;
+finish may complete after payload expiry, if the claim still exists.
+
+## Consumption
+
+Authenticate the source and exact native tool mapping, check the live run,
+resolve and validate payload identity, version, tool, arguments and expiry, then
+claim. Recheck the live run before execution. Existing task services still
+validate roles, targets, sessions and pending workers. Record actual dispatch
+`task_id` only on success. Execution errors can follow partial side effects and
+therefore receive `unknown`; a run terminated before execution receives `failed`.
+
+GET retries transient failures up to three attempts, each at most 3 seconds,
+with 200/500 ms backoff bounded by the remaining run deadline. Claim is a single
+attempt. An ambiguous acknowledgement causes a status read and an error, never
+execution or claim reclamation. Finish alone may retry three times; it never
+repeats dispatch. Applied duplicates succeed without execution, while missing,
+failed or unknown receipts surface an error. Stream intake also emits a visible
+notification when system messaging is configured.
+
+## Configuration and rollout
+
+Absent `coordination_resolver` disables reference consumption. Example BCS TOML
+(the credential is injected through the named environment variable):
+
+```toml
+[coordination_resolver]
+base_url = "http://127.0.0.1:8888"
+token_env = "BCS_COORDINATION_TOKEN"
+```
+
+Deploy the authenticated resolver API first, with tools still returning v1.
+Deploy BCS with the resolver configured, then enable producer v2. Rollback only
+the producer to v1 and retain BCS v2 resolution until existing references expire.
+The producer's distributed cache retains payloads for 24 hours and claim/result
+records for 48 hours. Reads do not refresh TTLs. Atomic NX creates prevent
+concurrent claims while records persist. Cache eviction/loss is not durable
+exactly-once delivery; a lost tool-end event does not trigger redispatch.
+
+## Validation
+
+Protocol parsing, HTTP retry/uncertainty tests, and dual-intake contract tests
+cover long Chinese text, pretty printing, native mapping, both arrival orders,
+failed reads, immutable receipts, and no re-execution after receipt loss.

--- a/src/bcs/crates/contracts/bcs-protocol/src/ws/coordination.rs
+++ b/src/bcs/crates/contracts/bcs-protocol/src/ws/coordination.rs
@@ -18,6 +18,8 @@ pub struct CoordinationCall {
     pub v: u64,
     pub tool: String,
     #[serde(default)]
+    pub intent_id: Option<String>,
+    #[serde(default)]
     pub arguments: Map<String, Value>,
     #[serde(default)]
     pub status: String,
@@ -25,12 +27,22 @@ pub struct CoordinationCall {
 
 impl CoordinationCall {
     pub fn from_stdout(stdout: &str) -> Option<Self> {
+        Self::parse_stdout(stdout, false)
+    }
+
+    /// Preserve the provider callback's historical v1 normalization. V2 uses
+    /// the same strict validation at both intake paths.
+    pub fn from_provider_stdout(stdout: &str) -> Option<Self> {
+        Self::parse_stdout(stdout, true)
+    }
+
+    fn parse_stdout(stdout: &str, legacy_provider: bool) -> Option<Self> {
         for line in stdout.lines() {
             let line = line.trim();
             if !line.contains(MAGIC_KEY) {
                 continue;
             }
-            if let Some(call) = Self::parse_candidate(line) {
+            if let Some(call) = serde_json::from_str::<Value>(line).ok().and_then(|v| Self::from_value(v, legacy_provider)) {
                 return Some(call);
             }
         }
@@ -41,9 +53,9 @@ impl CoordinationCall {
                 continue;
             }
             let mut stream = serde_json::Deserializer::from_str(candidate)
-                .into_iter::<CoordinationCall>();
+                .into_iter::<Value>();
             if let Some(Ok(call)) = stream.next() {
-                if let Some(call) = Self::validate(call) {
+                if let Some(call) = Self::from_value(call, legacy_provider) {
                     return Some(call);
                 }
             }
@@ -51,14 +63,36 @@ impl CoordinationCall {
         None
     }
 
-    fn parse_candidate(candidate: &str) -> Option<Self> {
-        serde_json::from_str::<CoordinationCall>(candidate)
-            .ok()
-            .and_then(Self::validate)
+    fn from_value(mut value: Value, legacy_provider: bool) -> Option<Self> {
+        let object = value.as_object_mut()?;
+        if object.get("v").and_then(Value::as_u64) == Some(1) {
+            // This was an unknown extension field before v2, so ignore it in v1.
+            object.remove("intent_id");
+            if legacy_provider {
+                let tool = object.get("tool")?.as_str()?.trim().to_string();
+                if tool.is_empty() { return None; }
+                object.insert("tool".into(), Value::String(tool));
+                object.remove("status");
+                if !object.get("arguments").is_some_and(Value::is_object) {
+                    object.insert("arguments".into(), Value::Object(Map::new()));
+                }
+            }
+        }
+        serde_json::from_value(value).ok().and_then(Self::validate)
     }
 
     fn validate(call: Self) -> Option<Self> {
-        (call.magic && call.v == CONTRACT_VERSION).then_some(call)
+        let valid = call.magic && match call.v {
+            1 => call.intent_id.is_none(),
+            2 => call.status == "stored" && call.arguments.is_empty()
+                && matches!(call.tool.as_str(), TOOL_ASSIGN_TASK | TOOL_SEND_TASK_MESSAGE | TOOL_TASK_COMPLETE)
+                && call.intent_id.as_deref().is_some_and(|id| {
+                    id.strip_prefix("bcs_intent_").is_some_and(|suffix|
+                        suffix.len() == 32 && suffix.bytes().all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b)))
+                }),
+            _ => false,
+        };
+        valid.then_some(call)
     }
 }
 
@@ -104,6 +138,36 @@ mod tests {
     #[test]
     fn ignores_non_coordination_stdout() {
         assert!(CoordinationCall::from_stdout("just regular output").is_none());
+    }
+
+    #[test]
+    fn v2_reference_survives_pretty_printing_and_output_cutoff() {
+        let mut value = serde_json::json!({"__bcs_coordination__": true, "v": 2,
+            "tool": "bcs_assign_task", "intent_id": "bcs_intent_0123456789abcdef0123456789abcdef",
+            "status": "stored"});
+        let stdout = format!("log\n{}\n{}", serde_json::to_string_pretty(&value).unwrap(), "x".repeat(8000));
+        let call = CoordinationCall::from_stdout(&stdout[..4000]).unwrap();
+        assert!(call.intent_id.is_some());
+        assert!(call.arguments.is_empty());
+        value["arguments"] = serde_json::json!({"message": "must not override stored arguments"});
+        assert!(CoordinationCall::from_stdout(&value.to_string()).is_none());
+        value.as_object_mut().unwrap().remove("arguments");
+        value["intent_id"] = serde_json::json!("../../other");
+        assert!(CoordinationCall::from_stdout(&value.to_string()).is_none());
+    }
+
+    #[test]
+    fn legacy_provider_v1_keeps_lenient_metadata_and_tool_normalization() {
+        let value = serde_json::json!({"__bcs_coordination__": true, "v": 1,
+            "tool": " bcs_task_complete ", "arguments": {"summary": "done"},
+            "status": {"legacy": true}, "intent_id": 123});
+        let call = CoordinationCall::from_provider_stdout(&value.to_string()).unwrap();
+        assert_eq!(call.tool, "bcs_task_complete");
+        assert_eq!(call.arguments["summary"], "done");
+        assert!(call.intent_id.is_none());
+        let stream = serde_json::json!({"__bcs_coordination__": true, "v": 1,
+            "tool": "bcs_task_complete", "arguments": {"summary": "done"}, "intent_id": 123});
+        assert!(CoordinationCall::from_stdout(&stream.to_string()).unwrap().intent_id.is_none());
     }
 
     #[test]

--- a/src/bcs/crates/contracts/bcs-protocol/tests/coordination_contract_alignment.rs
+++ b/src/bcs/crates/contracts/bcs-protocol/tests/coordination_contract_alignment.rs
@@ -55,3 +55,13 @@ fn contract_alignment_locks_tool_argument_shapes() {
         Some(&["summary".to_string()][..])
     );
 }
+
+#[test]
+fn reference_v2_is_additive_to_native_v1_contract() {
+    let body = include_str!("../docs/contract.json");
+    let value: serde_json::Value = serde_json::from_str(body).unwrap();
+    assert_eq!(value["version"], 1);
+    assert_eq!(value["echo_versions"], serde_json::json!([1, 2]));
+    assert_eq!(value["reference_v2"]["status"], "stored");
+    assert_eq!(value["reference_v2"]["arguments_in_echo"], false);
+}

--- a/src/bcs/crates/external-clients/bcs-coordination-client/CONTEXT.md
+++ b/src/bcs/crates/external-clients/bcs-coordination-client/CONTEXT.md
@@ -1,0 +1,32 @@
+# bcs-coordination-client Context
+
+## Provides
+
+`CoordinationIntentPort` over an authenticated, configured HTTP resolver API.
+Bounded reads, single claim attempts, immutable finish retries, and reference
+payload validation. Credentials and endpoints never come from tool output.
+
+## Consumes
+
+Coordination references and authenticated run context from `bcs-service-api`.
+Endpoint and bearer credential injected by bootstrap.
+
+## Allowed dependencies
+
+- `bcs-service-api`
+- HTTP, serialization and async runtime libraries
+
+## Forbidden dependencies
+
+Database/cache implementations, provider policy, task dispatch, bootstrap,
+direct environment reads and company SDKs.
+
+## Runtime ownership
+
+The remote store owns payload and claim retention. This adapter owns only HTTP
+exchanges. Task services own authorization, execution and its result. No claim
+reclamation or redispatch after an uncertain exchange.
+
+## Tests
+
+`cargo test -p bcs-coordination-client`

--- a/src/bcs/crates/external-clients/bcs-coordination-client/Cargo.toml
+++ b/src/bcs/crates/external-clients/bcs-coordination-client/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "bcs-coordination-client"
+description = "Authenticated HTTP adapter for coordination payload references"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+async-trait = { workspace = true }
+bcs-service-api = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+
+[dev-dependencies]
+bcs-test-support = { workspace = true }
+axum = { workspace = true }

--- a/src/bcs/crates/external-clients/bcs-coordination-client/src/lib.rs
+++ b/src/bcs/crates/external-clients/bcs-coordination-client/src/lib.rs
@@ -1,0 +1,166 @@
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use async_trait::async_trait;
+use bcs_service_api::port::{CoordinationClaim, CoordinationContext, CoordinationIntentPort,
+    CoordinationLease, CoordinationResult};
+use bcs_service_api::{ServiceError, ServiceResult};
+use reqwest::{Client, Method, StatusCode, Url};
+use serde::Deserialize;
+use serde_json::{Map, Value, json};
+
+pub struct CoordinationHttpClient {
+    client: Client,
+    base: Url,
+    token: String,
+}
+
+fn error(code: &str) -> ServiceError { ServiceError::InternalError(code.to_string()) }
+fn now_ms() -> u64 {
+    SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_millis() as u64
+}
+
+#[derive(Deserialize)]
+struct Payload {
+    intent_id: String,
+    v: u64,
+    tool: String,
+    arguments: Map<String, Value>,
+    created_at_ms: u64,
+    expires_at_ms: u64,
+}
+
+#[derive(Deserialize)]
+struct ReadResponse { payload: Payload }
+
+#[derive(Deserialize)]
+struct ClaimResponse {
+    acquired: bool,
+    claim_token: Option<String>,
+    result: Option<CoordinationResult>,
+}
+
+impl CoordinationHttpClient {
+    pub fn new(base_url: &str, token: String) -> ServiceResult<Self> {
+        let base = Url::parse(base_url).map_err(|_| error("invalid_coordination_endpoint"))?;
+        if !matches!(base.scheme(), "http" | "https") || base.host_str().is_none()
+            || !base.username().is_empty() || base.password().is_some()
+            || base.query().is_some() || base.fragment().is_some() || token.len() < 32
+        {
+            return Err(error("invalid_coordination_config"));
+        }
+        let client = Client::builder().redirect(reqwest::redirect::Policy::none())
+            // Isolate claim/status/finish exchanges from stale pooled connections
+            // after an ambiguous response; these are low-volume control calls.
+            .pool_max_idle_per_host(0)
+            .timeout(Duration::from_secs(3)).build()
+            .map_err(|_| error("coordination_client_initialization_failed"))?;
+        Ok(Self { client, base, token })
+    }
+
+    fn url(&self, id: &str, operation: &str) -> ServiceResult<Url> {
+        if !id.strip_prefix("bcs_intent_").is_some_and(|s| s.len() == 32
+            && s.bytes().all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))) {
+            return Err(error("invalid_coordination_reference"));
+        }
+        self.base.join(&format!("/internal/bcs-coordination/v1/intents/{id}{operation}"))
+            .map_err(|_| error("invalid_coordination_endpoint"))
+    }
+
+    async fn request(&self, method: Method, url: Url, body: Option<&Value>,
+        attempts: usize, deadline_ms: u64) -> ServiceResult<Value> {
+        for attempt in 0..attempts {
+            let remaining = deadline_ms.saturating_sub(now_ms()).min(3000);
+            if remaining == 0 { return Err(error("coordination_deadline_exceeded")); }
+            let mut request = self.client.request(method.clone(), url.clone())
+                .bearer_auth(&self.token).timeout(Duration::from_millis(remaining));
+            if let Some(body) = body { request = request.json(body); }
+            let result = async {
+                let mut response = request.send().await.map_err(|_| (true, "coordination_transport_error"))?;
+                let status = response.status();
+                let mut bytes = Vec::new();
+                while let Some(chunk) = response.chunk().await.map_err(|_| (true, "coordination_transport_error"))? {
+                    if bytes.len() + chunk.len() > 2 * 1024 * 1024 {
+                        return Err((false, "coordination_response_too_large"));
+                    }
+                    bytes.extend_from_slice(&chunk);
+                }
+                match status {
+                    StatusCode::NOT_FOUND | StatusCode::GONE => return Err((false, "intent_unavailable")),
+                    StatusCode::CONFLICT => return Err((false, "intent_conflict")),
+                    status if status.is_server_error() => return Err((true, "coordination_store_unavailable")),
+                    status if !status.is_success() => return Err((false, "coordination_resolver_rejected")),
+                    _ => {}
+                }
+                serde_json::from_slice(&bytes).map_err(|_| (false, "invalid_coordination_response"))
+            }.await;
+            match result {
+                Ok(value) => return Ok(value),
+                Err((retry, code)) => {
+                    if !retry || attempt + 1 == attempts { return Err(error(code)); }
+                }
+            }
+            let delay = if attempt == 0 { 200 } else { 500 };
+            if now_ms().saturating_add(delay) >= deadline_ms {
+                return Err(error("coordination_deadline_exceeded"));
+            }
+            tokio::time::sleep(Duration::from_millis(delay)).await;
+        }
+        Err(error("coordination_transport_error"))
+    }
+}
+
+#[async_trait]
+impl CoordinationIntentPort for CoordinationHttpClient {
+    async fn resolve_and_claim(&self, id: &str, tool: &str,
+        context: &CoordinationContext, deadline_ms: u64) -> ServiceResult<CoordinationClaim> {
+        let value = self.request(Method::GET, self.url(id, "")?, None, 3, deadline_ms).await?;
+        let read: ReadResponse = serde_json::from_value(value).map_err(|_| error("invalid_coordination_payload"))?;
+        let p = read.payload;
+        if p.intent_id != id || p.v != 2 || p.tool != tool || p.expires_at_ms <= now_ms()
+            || p.created_at_ms >= p.expires_at_ms {
+            return Err(error("coordination_payload_mismatch"));
+        }
+        let required: &[&str] = match tool {
+            "bcs_assign_task" => &["target_bot", "message"],
+            "bcs_send_task_message" => &["message"],
+            "bcs_task_complete" => &["summary"],
+            _ => return Err(error("unknown_coordination_tool")),
+        };
+        if required.iter().any(|key| !p.arguments.get(*key).and_then(Value::as_str)
+            .is_some_and(|v| !v.trim().is_empty()))
+            || p.arguments.keys().any(|key| !required.contains(&key.as_str())
+                && !(tool == "bcs_assign_task" && key == "response_mode"))
+            || p.arguments.get("response_mode").is_some_and(|v|
+                !matches!(v.as_str(), Some("full" | "after-last-tool-call"))) {
+            return Err(error("invalid_coordination_arguments"));
+        }
+        let body = json!({"context": context});
+        let claim = self.request(Method::POST, self.url(id, "/claim")?, Some(&body), 1, deadline_ms).await;
+        let value = match claim {
+            Ok(value) => value,
+            Err(e) => {
+                // A lost acknowledgement never grants execution permission.
+                let _ = self.request(Method::GET, self.url(id, "")?, None, 1, deadline_ms).await;
+                return Err(e);
+            }
+        };
+        let claim: ClaimResponse = serde_json::from_value(value).map_err(|_| error("invalid_coordination_claim"))?;
+        if claim.acquired {
+            let token = claim.claim_token.filter(|t| t.len() == 32)
+                .ok_or_else(|| error("invalid_coordination_claim"))?;
+            Ok(CoordinationClaim::Acquired(CoordinationLease { arguments: p.arguments, claim_token: token }))
+        } else {
+            Ok(CoordinationClaim::Duplicate(claim.result))
+        }
+    }
+
+    async fn finish(&self, id: &str, context: &CoordinationContext, token: &str,
+        result: &CoordinationResult) -> ServiceResult<()> {
+        let receipt = self.request(Method::POST, self.url(id, "/finish")?,
+            Some(&json!({"context": context, "claim_token": token, "result": result})),
+            3, now_ms() + 10000).await?;
+        let receipt: CoordinationResult = serde_json::from_value(receipt)
+            .map_err(|_| error("invalid_coordination_receipt"))?;
+        if &receipt != result { return Err(error("coordination_receipt_mismatch")); }
+        Ok(())
+    }
+}

--- a/src/bcs/crates/external-clients/bcs-coordination-client/tests/conformance_coordination_intent.rs
+++ b/src/bcs/crates/external-clients/bcs-coordination-client/tests/conformance_coordination_intent.rs
@@ -1,0 +1,80 @@
+use bcs_coordination_client::CoordinationHttpClient;
+use bcs_service_api::port::{CoordinationClaim, CoordinationContext, CoordinationIntentPort};
+use bcs_test_support::contract::port::coordination_intent::coordination_intent_port_contract_tests;
+use reqwest::StatusCode;
+use serde_json::{Value, json};
+use std::time::{SystemTime, UNIX_EPOCH};
+fn now_ms() -> u64 { SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis() as u64 }
+
+use axum::{Router, Json, routing::{get, post}, extract::State, http::HeaderMap};
+use std::sync::{Arc, atomic::{AtomicUsize, Ordering}};
+const ID: &str = "bcs_intent_0123456789abcdef0123456789abcdef";
+
+struct Store { reads: AtomicUsize, claims: AtomicUsize, finishes: AtomicUsize, lose_claim: bool, mismatch: bool, receipt: std::sync::Mutex<Option<Value>> }
+async fn read(State(s): State<Arc<Store>>, headers: HeaderMap) -> (StatusCode, Json<Value>) {
+    assert_eq!(headers["authorization"], format!("Bearer {}", "x".repeat(32)));
+    if s.reads.fetch_add(1, Ordering::SeqCst) == 0 {
+        return (StatusCode::SERVICE_UNAVAILABLE, Json(json!({})));
+    }
+    (StatusCode::OK, Json(json!({"payload": {"intent_id": ID, "v": 2,
+        "tool": if s.mismatch { "bcs_task_complete" } else { "bcs_assign_task" },
+        "arguments": {"target_bot": "worker", "message": "中".repeat(4198) + "\n\"🙂"},
+        "created_at_ms": now_ms(), "expires_at_ms": now_ms() + 86400000}})))
+}
+async fn claim(State(s): State<Arc<Store>>, Json(body): Json<Value>) -> (StatusCode, Json<Value>) {
+    assert_eq!(body["context"]["bot_id"], "manager");
+    let count = s.claims.fetch_add(1, Ordering::SeqCst);
+    if s.lose_claim { return (StatusCode::SERVICE_UNAVAILABLE, Json(json!({}))); }
+    (StatusCode::OK, Json(json!({"acquired": count == 0,
+        "claim_token": if count == 0 { Some("a".repeat(32)) } else { None }, "result": s.receipt.lock().unwrap().clone()})))
+}
+async fn finish(State(s): State<Arc<Store>>, Json(body): Json<Value>) -> (StatusCode, Json<Value>) {
+    assert_eq!(body["result"]["task_id"], "task-real");
+    if s.finishes.fetch_add(1, Ordering::SeqCst) == 0 {
+        return (StatusCode::SERVICE_UNAVAILABLE, Json(json!({})));
+    }
+    *s.receipt.lock().unwrap() = Some(body["result"].clone());
+    (StatusCode::OK, Json(body["result"].clone()))
+}
+async fn fixture(lose_claim: bool, mismatch: bool) -> (CoordinationHttpClient, Arc<Store>, tokio::task::JoinHandle<()>) {
+    let state = Arc::new(Store { reads: AtomicUsize::new(0), claims: AtomicUsize::new(0),
+        finishes: AtomicUsize::new(0), lose_claim, mismatch, receipt: std::sync::Mutex::new(None) });
+    let base = format!("/internal/bcs-coordination/v1/intents/{ID}");
+    let router = Router::new().route(&base, get(read)).route(&format!("{base}/claim"), post(claim))
+        .route(&format!("{base}/finish"), post(finish)).with_state(state.clone());
+    let socket = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let url = format!("http://{}", socket.local_addr().unwrap());
+    let handle = tokio::spawn(async move { axum::serve(socket, router).await.unwrap() });
+    (CoordinationHttpClient::new(&url, "x".repeat(32)).unwrap(), state, handle)
+}
+fn context() -> CoordinationContext {
+    CoordinationContext { bot_id: "manager".into(), group_id: "group".into(), session_id: None,
+        run_id: "run".into(), tool_call_id: "tool".into() }
+}
+#[tokio::test]
+async fn long_payload_read_retry_claim_once_and_finish_retry() {
+    let (client, state, server) = fixture(false, false).await;
+    coordination_intent_port_contract_tests(&client, ID, "bcs_assign_task", &context(), now_ms()+10000).await;
+    assert_eq!(state.reads.load(Ordering::SeqCst), 3);
+    assert_eq!(state.claims.load(Ordering::SeqCst), 2);
+    assert_eq!(state.finishes.load(Ordering::SeqCst), 2);
+    assert!(matches!(client.resolve_and_claim(ID, "bcs_assign_task", &context(), now_ms()+10000).await.unwrap(), CoordinationClaim::Duplicate(Some(_))));
+    server.abort();
+}
+#[tokio::test]
+async fn lost_claim_ack_is_never_retried_as_execution() {
+    let (client, state, server) = fixture(true, false).await;
+    assert!(client.resolve_and_claim(ID, "bcs_assign_task", &context(), now_ms()+10000).await.is_err());
+    assert_eq!(state.claims.load(Ordering::SeqCst), 1);
+    assert_eq!(state.reads.load(Ordering::SeqCst), 3);
+    server.abort();
+}
+#[tokio::test]
+async fn payload_tool_mismatch_and_expired_run_never_claim() {
+    let (client, state, server) = fixture(false, true).await;
+    assert!(client.resolve_and_claim(ID, "bcs_assign_task", &context(), now_ms()+10000).await.is_err());
+    assert_eq!(state.claims.load(Ordering::SeqCst), 0);
+    assert!(client.resolve_and_claim(ID, "bcs_assign_task", &context(), 1).await.is_err());
+    assert_eq!(state.reads.load(Ordering::SeqCst), 2);
+    server.abort();
+}

--- a/src/bcs/crates/service-api/bcs-service-api/CONTEXT.md
+++ b/src/bcs/crates/service-api/bcs-service-api/CONTEXT.md
@@ -2,6 +2,7 @@
 
 ## Provides
 
+- `CoordinationIntentPort` with authenticated consumer identity and immutable execution receipts.
 - Application, core, and port trait contracts for BCS.
 - Shared contract-level DTOs, error types, and service container types.
 - Default `Noop*` implementations used to keep contract boundaries explicit in tests and local wiring.

--- a/src/bcs/crates/service-api/bcs-service-api/src/port/coordination_intent.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/port/coordination_intent.rs
@@ -1,0 +1,53 @@
+//! Optional external coordination payload resolution. Identity is supplied by
+//! the authenticated run, never by the tool's arguments.
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+use crate::ServiceResult;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CoordinationContext {
+    pub bot_id: String,
+    pub group_id: String,
+    pub session_id: Option<String>,
+    pub run_id: String,
+    pub tool_call_id: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CoordinationStatus { Applied, Failed, Unknown }
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CoordinationResult {
+    pub status: CoordinationStatus,
+    pub task_id: Option<String>,
+    pub error_code: Option<String>,
+}
+
+pub struct CoordinationLease {
+    pub arguments: Map<String, Value>,
+    pub claim_token: String,
+}
+
+pub enum CoordinationClaim {
+    Acquired(CoordinationLease),
+    /// None means an earlier claimant may have executed, without a receipt.
+    Duplicate(Option<CoordinationResult>),
+}
+
+#[async_trait]
+pub trait CoordinationIntentPort: Send + Sync {
+    /// Only an explicitly acknowledged claim permits execution. A timeout must
+    /// not be retried as an execution grant. Reads are bounded by run deadline.
+    async fn resolve_and_claim(
+        &self, intent_id: &str, tool: &str, context: &CoordinationContext,
+        deadline_ms: u64,
+    ) -> ServiceResult<CoordinationClaim>;
+
+    /// Append an immutable receipt. Retries must only repeat this operation.
+    async fn finish(
+        &self, intent_id: &str, context: &CoordinationContext,
+        claim_token: &str, result: &CoordinationResult,
+    ) -> ServiceResult<()>;
+}

--- a/src/bcs/crates/service-api/bcs-service-api/src/port/mod.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/port/mod.rs
@@ -1,3 +1,5 @@
+pub mod coordination_intent;
+pub use coordination_intent::*;
 pub mod bot_connection;
 pub mod bot_terminal_observer;
 pub mod channel_binding_cleanup;

--- a/src/bcs/crates/services/bcs-bot/CONTEXT.md
+++ b/src/bcs/crates/services/bcs-bot/CONTEXT.md
@@ -2,6 +2,7 @@
 
 ## Provides
 
+- Authenticated provider coordination callbacks share reference claims with stream intake.
 - Bot service implementations for BCS, including the independent Bot
   control-plane Core.
 - Bot onboarding, discovery, status, connectivity, and binding metadata behavior.

--- a/src/bcs/crates/services/bcs-bot/src/application/provider_events.rs
+++ b/src/bcs/crates/services/bcs-bot/src/application/provider_events.rs
@@ -1,3 +1,4 @@
+use bcs_service_api::port::{CoordinationIntentPort, CoordinationContext, CoordinationClaim, CoordinationResult, CoordinationStatus};
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex as StdMutex};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -18,12 +19,12 @@ use bcs_service_api::{
 use bcs_protocol::stream::{
     ProviderTextEventState, ProviderTextResponseMode, apply_provider_event_text,
 };
-use serde_json::{Map, Value, json};
+use serde_json::{Value, json};
 use tokio::sync::Mutex;
 use tracing::{error, info, warn};
 use tracing::instrument::WithSubscriber;
 
-const COORDINATION_MAGIC_KEY: &str = "__bcs_coordination__";
+use bcs_protocol::CoordinationCall;
 const CONTRACT_VERSION: u64 = 1;
 const TOOL_ASSIGN_TASK: &str = "bcs_assign_task";
 const TOOL_SEND_TASK_MESSAGE: &str = "bcs_send_task_message";
@@ -61,76 +62,13 @@ impl Drop for StateMachineTerminalInflightGuard {
     }
 }
 
-#[derive(Debug, Clone)]
-struct CoordinationCall {
-    tool: String,
-    arguments: Map<String, Value>,
-}
-
-impl CoordinationCall {
-    fn from_stdout(stdout: &str) -> Option<Self> {
-        for line in stdout.lines() {
-            let line = line.trim();
-            if !line.contains(COORDINATION_MAGIC_KEY) {
-                continue;
-            }
-            if let Some(call) = Self::parse_candidate(line) {
-                return Some(call);
-            }
-        }
-
-        for (idx, _) in stdout.match_indices('{') {
-            let candidate = &stdout[idx..];
-            if !candidate.contains(COORDINATION_MAGIC_KEY) {
-                continue;
-            }
-            let mut stream = serde_json::Deserializer::from_str(candidate).into_iter::<Value>();
-            if let Some(Ok(value)) = stream.next() {
-                if let Some(call) = Self::from_value(value) {
-                    return Some(call);
-                }
-            }
-        }
-        None
-    }
-
-    fn parse_candidate(candidate: &str) -> Option<Self> {
-        serde_json::from_str::<Value>(candidate)
-            .ok()
-            .and_then(Self::from_value)
-    }
-
-    fn from_value(value: Value) -> Option<Self> {
-        let object = value.as_object()?;
-        let magic = object
-            .get(COORDINATION_MAGIC_KEY)
-            .and_then(Value::as_bool)
-            .unwrap_or(false);
-        let version = object.get("v").and_then(Value::as_u64).unwrap_or(0);
-        if !magic || version != CONTRACT_VERSION {
-            return None;
-        }
-        let tool = object
-            .get("tool")
-            .and_then(Value::as_str)
-            .map(str::trim)
-            .filter(|value| !value.is_empty())?
-            .to_string();
-        let arguments = object
-            .get("arguments")
-            .and_then(Value::as_object)
-            .cloned()
-            .unwrap_or_default();
-        Some(Self { tool, arguments })
-    }
-}
-
 #[derive(Clone)]
 pub struct ProviderBotEvents {
     provider_bot_core: Arc<dyn ProviderBotCoreService>,
     bot_run_context: Arc<dyn BotRunContextPort>,
     message_flow: Arc<dyn MessageFlowService>,
     collaboration_runtime: Option<Arc<dyn CollaborationRuntimeService>>,
+    pub(crate) coordination_intents: Option<Arc<dyn CoordinationIntentPort>>,
     coordination_seen: Arc<Mutex<HashMap<String, u64>>>,
     state_machine_terminals_inflight: Arc<StdMutex<HashSet<StateMachineTerminalKey>>>,
     state_machine_visible_text: Arc<Mutex<HashMap<String, StateMachineVisibleText>>>,
@@ -147,10 +85,16 @@ impl ProviderBotEvents {
             bot_run_context,
             message_flow,
             collaboration_runtime: None,
+            coordination_intents: None,
             coordination_seen: Arc::new(Mutex::new(HashMap::new())),
             state_machine_terminals_inflight: Arc::new(StdMutex::new(HashSet::new())),
             state_machine_visible_text: Arc::new(Mutex::new(HashMap::new())),
         }
+    }
+
+    pub fn with_coordination_intents(mut self, port: Option<Arc<dyn CoordinationIntentPort>>) -> Self {
+        self.coordination_intents = port;
+        self
     }
 
     pub fn with_collaboration_runtime(
@@ -213,7 +157,8 @@ impl ProviderBotEvents {
         caller_bot_id: &str,
         context: &BotRunContext,
         call: &CoordinationCall,
-    ) -> Result<(), ProviderBotEventError> {
+    ) -> Result<Option<String>, ProviderBotEventError> {
+        let mut task_id = None;
         match call.tool.as_str() {
             TOOL_ASSIGN_TASK => {
                 let target_bot_id =
@@ -236,7 +181,7 @@ impl ProviderBotEvents {
                 if let Some(session_id) = context.bcs_session_id.as_deref() {
                     payload["bcs_session_id"] = serde_json::Value::String(session_id.to_string());
                 }
-                self.message_flow
+                let outcome = self.message_flow
                     .handle_task_dispatch(TaskDispatchCommand {
                         driver_bot_id: caller_bot_id.to_string(),
                         group_id: context.group_id.clone(),
@@ -246,6 +191,7 @@ impl ProviderBotEvents {
                     })
                     .await
                     .map_err(map_service_error)?;
+                task_id = Some(outcome.task_id);
             }
             TOOL_SEND_TASK_MESSAGE => {
                 let session_id = context.bcs_session_id.as_deref().ok_or_else(|| {
@@ -308,7 +254,7 @@ impl ProviderBotEvents {
                 )));
             }
         }
-        Ok(())
+        Ok(task_id)
     }
 
     async fn ingest_event(
@@ -889,6 +835,43 @@ impl ProviderBotEventService for ProviderBotEvents {
             .map_err(map_service_error)?;
         let call = coordination_call_from_command(&coordination, &command)?;
 
+        if let Some(intent_id) = call.intent_id.as_deref() {
+            let port = self.coordination_intents.as_ref().ok_or_else(||
+                ProviderBotEventError::Internal("coordination_resolver_disabled".into()))?;
+            let consumer = CoordinationContext { bot_id: context.bot_id.clone(),
+                group_id: context.group_id.clone(), session_id: context.bcs_session_id.clone(),
+                run_id: context.run_id.clone(), tool_call_id: command.tool_call_id.trim().to_string() };
+            let lease = match port.resolve_and_claim(intent_id, &call.tool, &consumer, context.deadline_ms)
+                .await.map_err(map_service_error)? {
+                CoordinationClaim::Acquired(lease) => lease,
+                CoordinationClaim::Duplicate(Some(result)) if result.status == CoordinationStatus::Applied =>
+                    return Ok(ProviderBotCoordinationOutcome { processed: true, duplicate: true }),
+                CoordinationClaim::Duplicate(_) => return Err(ProviderBotEventError::Internal(
+                    "coordination_previous_outcome_unknown_or_failed".into())),
+            };
+            if !self.bot_run_context.get_context(&context.run_id).await.is_some_and(|run|
+                !run.terminal && run.deadline_ms > now_ms() && run.bot_id == consumer.bot_id
+                && run.group_id == consumer.group_id && run.bcs_session_id == consumer.session_id) {
+                port.finish(intent_id, &consumer, &lease.claim_token, &CoordinationResult {
+                    status: CoordinationStatus::Failed, task_id: None,
+                    error_code: Some("run_terminated_before_execution".into()),
+                }).await.map_err(map_service_error)?;
+                return Err(ProviderBotEventError::RunTerminated("run_terminated".into()));
+            }
+            let mut resolved = call.clone();
+            resolved.arguments = lease.arguments;
+            let dispatched = self.dispatch_coordination_call(&identity.bot_uuid, &context, &resolved).await;
+            let result = match &dispatched {
+                Ok(task_id) => CoordinationResult { status: CoordinationStatus::Applied,
+                    task_id: task_id.clone(), error_code: None },
+                Err(_) => CoordinationResult { status: CoordinationStatus::Unknown,
+                    task_id: None, error_code: Some("coordination_execution_not_confirmed".into()) },
+            };
+            port.finish(intent_id, &consumer, &lease.claim_token, &result).await.map_err(map_service_error)?;
+            dispatched?;
+            return Ok(ProviderBotCoordinationOutcome { processed: true, duplicate: false });
+        }
+
         let dedup_key = format!("{}:{}", command.run_id.trim(), command.tool_call_id.trim());
         {
             let mut seen = self.coordination_seen.lock().await;
@@ -1011,11 +994,16 @@ fn coordination_call_from_command(
                         "tool_result callback requires result_text".to_string(),
                     )
                 })?;
-            CoordinationCall::from_stdout(result_text).ok_or_else(|| {
+            let call = CoordinationCall::from_provider_stdout(result_text).ok_or_else(|| {
                 ProviderBotEventError::InvalidRequest(
                     "tool_result did not contain a BCS coordination echo".to_string(),
                 )
-            })
+            })?;
+            if call.v == 2 && command.tool_name.as_deref().is_some_and(|name| !name.trim().is_empty()
+                && !matches!(name.trim().to_ascii_lowercase().as_str(), "bash" | "exec" | "shell" | "mcporter")) {
+                return Err(ProviderBotEventError::Forbidden("unsupported coordination source tool".into()));
+            }
+            Ok(call)
         }
         CoordinationMode::NativeMcp => {
             let expected_server = coordination
@@ -1085,7 +1073,7 @@ fn coordination_call_from_command(
                                 "native_mcp tool_result requires result_text".to_string(),
                             )
                         })?;
-                    let call = CoordinationCall::from_stdout(result_text).ok_or_else(|| {
+                    let call = CoordinationCall::from_provider_stdout(result_text).ok_or_else(|| {
                         ProviderBotEventError::InvalidRequest(
                             "tool_result did not contain a BCS coordination echo".to_string(),
                         )
@@ -1147,6 +1135,7 @@ fn coordination_intent_to_call(
         ));
     }
     Ok(CoordinationCall {
+        magic: true, v: 1, status: "received".to_string(), intent_id: None,
         tool: intent.tool.trim().to_string(),
         arguments: intent.arguments.clone(),
     })
@@ -1238,5 +1227,30 @@ mod tests {
         );
         assert!(runs.is_empty());
         assert_eq!(cleanup_expired_visible_text_entries(&mut runs, u64::MAX), 0);
+    }
+}
+
+#[cfg(test)]
+mod coordination_legacy_compatibility_tests {
+    use super::*;
+
+    #[test]
+    fn callback_source_restriction_applies_only_to_v2() {
+        let coordination: ProviderCoordinationConfig = serde_json::from_value(json!({
+            "mode": "mcporter_mcp"
+        })).unwrap();
+        let mut command = ProviderBotCoordinationCommand {
+            provider_id: "provider".into(), credential: ProviderBotEventCredential::StaticBearer("test".into()),
+            run_id: "run".into(), tool_call_id: "tool".into(),
+            kind: ProviderCoordinationEventKind::ToolResult, tool_name: Some("legacy_wrapper".into()),
+            result_text: Some(json!({"__bcs_coordination__":true,"v":1,
+                "tool":" bcs_task_complete ","arguments":{"summary":"done"},"status":null}).to_string()),
+            mcp_server: None, intent: None,
+        };
+        assert_eq!(coordination_call_from_command(&coordination, &command).unwrap().tool, "bcs_task_complete");
+        command.result_text = Some(json!({"__bcs_coordination__":true,"v":2,
+            "tool":"bcs_task_complete","status":"stored",
+            "intent_id":"bcs_intent_0123456789abcdef0123456789abcdef"}).to_string());
+        assert!(matches!(coordination_call_from_command(&coordination, &command), Err(ProviderBotEventError::Forbidden(_))));
     }
 }

--- a/src/bcs/crates/services/bcs-message-flow/CONTEXT.md
+++ b/src/bcs/crates/services/bcs-message-flow/CONTEXT.md
@@ -2,6 +2,7 @@
 
 ## Provides
 
+- Inline v1 and reference v2 coordination consumption through an injected resolver port.
 - `MessageFlowService` implementation for Workbench/Web group send, bot event relay, chat abort, and master-slave task flow.
 - `A2aChatService` implementation for direct bot chat and async chat run APIs.
 

--- a/src/bcs/crates/services/bcs-message-flow/Cargo.toml
+++ b/src/bcs/crates/services/bcs-message-flow/Cargo.toml
@@ -29,6 +29,7 @@ bcs-protocol = { workspace = true }
 chrono = { workspace = true }
 
 [dev-dependencies]
+bcs-bot = { workspace = true }
 bcs-test-support = { workspace = true }
 bcs-cache-local = { workspace = true }
 tokio = { workspace = true }

--- a/src/bcs/crates/services/bcs-message-flow/src/bot_event.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/bot_event.rs
@@ -1,6 +1,7 @@
 use bcs_domain::{
     CoordinationMode, CoordinationSurface, MessageAudience, MessageVisibilityDomain, SenderType,
 };
+use bcs_service_api::port::{CoordinationContext, CoordinationClaim, CoordinationResult, CoordinationStatus};
 use bcs_protocol::{
     BcsFrame, CoordinationCall, DirectiveAction, EventFrame, GroupContext, RequestFrame,
     RequestSource, ResponseDirective, ResponseMode as WireResponseMode, TOOL_ASSIGN_TASK,
@@ -114,7 +115,26 @@ pub async fn handle_bot_event(
             "start" => cache_tool_start(flow, &cmd, data).await,
             "result" => {
                 persist_tool_result(flow, &cmd, data).await?;
-                if let Some(coordination) = maybe_handle_coordination_echo(flow, &cmd, data).await?
+                let coordination = maybe_handle_coordination_echo(flow, &cmd, data).await;
+                if let Err(error) = &coordination {
+                    warn!(bot_id = %cmd.bot_id, run_id = %cmd.run_id, error = %error,
+                        "Coordination event could not be confirmed");
+                    if let Some(system_message) = &flow.system_message {
+                        if let Some(group) = flow.group.get(&cmd.group_id).await {
+                            let event = SystemMessageEvent::GenericNotification {
+                                group_id: cmd.group_id.clone(),
+                                message: "协同操作未确认完成，请检查任务状态后再处理；系统不会自动重复分发。".into(),
+                                receivers: group.participants.iter()
+                                    .filter(|p| p.bot_uuid == cmd.bot_id).cloned().collect(),
+                            };
+                            if let Err(notice_error) = system_message.notify(&cmd.group_id, event,
+                                cmd.bcs_session_id.as_deref().unwrap_or(&cmd.group_id), &group.participants).await {
+                                warn!(error = %notice_error, "Coordination failure notice could not be delivered");
+                            }
+                        }
+                    }
+                }
+                if let Some(coordination) = coordination?
                 {
                     bot_deliveries.extend(coordination.bot_deliveries);
                     frontend_deliveries.extend(coordination.frontend_deliveries);
@@ -1604,6 +1624,7 @@ async fn persist_tool_result(
 }
 
 struct CoordinationEchoDispatch {
+    task_id: Option<String>,
     bot_deliveries: Vec<BotDeliveryResult>,
     frontend_deliveries: Vec<FrontendDeliveryResult>,
 }
@@ -1652,6 +1673,54 @@ async fn maybe_handle_coordination_echo(
         );
         return Ok(None);
     };
+    if let Some(intent_id) = call.intent_id.as_deref() {
+        let port = flow.coordination_intents.as_ref()
+            .ok_or_else(|| ServiceError::InternalError("coordination_resolver_disabled".into()))?;
+        let context = match &flow.bot_run_context {
+            Some(runs) => runs.get_context(&cmd.run_id).await,
+            None => None,
+        }.ok_or_else(|| ServiceError::Forbidden("coordination_run_not_found".into()))?;
+        if context.terminal || context.deadline_ms <= now_ms() || context.bot_id != cmd.bot_id
+            || context.group_id != cmd.group_id || context.bcs_session_id != cmd.bcs_session_id {
+            return Err(ServiceError::Forbidden("coordination_run_mismatch_or_terminated".into()));
+        }
+        let identity = CoordinationContext {
+            bot_id: context.bot_id, group_id: context.group_id, session_id: context.bcs_session_id,
+            run_id: context.run_id, tool_call_id: tool_call_id.to_string(),
+        };
+        let lease = match port.resolve_and_claim(intent_id, &call.tool, &identity, context.deadline_ms).await? {
+            CoordinationClaim::Acquired(lease) => lease,
+            CoordinationClaim::Duplicate(Some(result)) if result.status == CoordinationStatus::Applied => return Ok(None),
+            CoordinationClaim::Duplicate(_) => return Err(ServiceError::Conflict("coordination_previous_outcome_unknown_or_failed".into())),
+        };
+        let active = match &flow.bot_run_context {
+            Some(runs) => runs.get_context(&cmd.run_id).await,
+            None => None,
+        };
+        if !active.is_some_and(|run| !run.terminal && run.deadline_ms > now_ms()
+            && run.bot_id == identity.bot_id && run.group_id == identity.group_id
+            && run.bcs_session_id == identity.session_id) {
+            port.finish(intent_id, &identity, &lease.claim_token, &CoordinationResult {
+                status: CoordinationStatus::Failed, task_id: None,
+                error_code: Some("run_terminated_before_execution".into()),
+            }).await?;
+            return Err(ServiceError::Forbidden("coordination_run_terminated".into()));
+        }
+        let mut resolved = call.clone();
+        resolved.arguments = lease.arguments;
+        let dispatched = dispatch_coordination_call(flow, cmd, &resolved).await;
+        let result = match &dispatched {
+            Ok(Some(outcome)) => CoordinationResult { status: CoordinationStatus::Applied,
+                task_id: outcome.task_id.clone(), error_code: None },
+            _ => CoordinationResult { status: CoordinationStatus::Unknown,
+                task_id: None, error_code: Some("coordination_execution_not_confirmed".into()) },
+        };
+        port.finish(intent_id, &identity, &lease.claim_token, &result).await?;
+        return match dispatched {
+            Ok(None) => Err(ServiceError::InternalError("coordination_execution_not_confirmed".into())),
+            other => other,
+        };
+    }
     let dedup_key = format!("{}:{}", cmd.run_id, tool_call_id);
     if !flow
         .message_tracker
@@ -1717,6 +1786,7 @@ async fn dispatch_coordination_call(
             .await
             {
                 Ok(outcome) => Ok(Some(CoordinationEchoDispatch {
+                    task_id: Some(outcome.task_id),
                     bot_deliveries: outcome.bot_deliveries,
                     frontend_deliveries: outcome.frontend_deliveries,
                 })),
@@ -1728,7 +1798,7 @@ async fn dispatch_coordination_call(
                         error = %error,
                         "Failed to dispatch bcs_assign_task coordination echo"
                     );
-                    Ok(None)
+                    if call.v == 2 { Err(error) } else { Ok(None) }
                 }
             }
         }
@@ -1763,6 +1833,7 @@ async fn dispatch_coordination_call(
             .await
             {
                 Ok(outcome) => Ok(Some(CoordinationEchoDispatch {
+                    task_id: None,
                     bot_deliveries: outcome.bot_deliveries,
                     frontend_deliveries: outcome.frontend_deliveries,
                 })),
@@ -1774,7 +1845,7 @@ async fn dispatch_coordination_call(
                         error = %error,
                         "Failed to dispatch bcs_send_task_message coordination echo"
                     );
-                    Ok(None)
+                    if call.v == 2 { Err(error) } else { Ok(None) }
                 }
             }
         }
@@ -1818,6 +1889,7 @@ async fn dispatch_coordination_call(
                         return Ok(None);
                     }
                     Ok(Some(CoordinationEchoDispatch {
+                        task_id: None,
                         bot_deliveries: Vec::new(),
                         frontend_deliveries: outcome.frontend_deliveries,
                     }))
@@ -1830,7 +1902,7 @@ async fn dispatch_coordination_call(
                         error = %error,
                         "Failed to dispatch bcs_task_complete coordination echo"
                     );
-                    Ok(None)
+                    if call.v == 2 { Err(error) } else { Ok(None) }
                 }
             }
         }

--- a/src/bcs/crates/services/bcs-message-flow/src/group_flow.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/group_flow.rs
@@ -1,3 +1,4 @@
+use bcs_service_api::port::CoordinationIntentPort;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::{Arc, OnceLock};
 
@@ -56,6 +57,7 @@ pub struct BcsMessageFlow {
     pub bot_relay_turn_limit: i64,
     pub interceptors: Arc<InterceptorChain>,
     pub session_management: Option<Arc<dyn SessionManagementService>>,
+    pub(crate) coordination_intents: Option<Arc<dyn CoordinationIntentPort>>,
     pub bot_run_context: Option<Arc<dyn BotRunContextPort>>,
     pub provider_chat_run_timeout_ms: u64,
     pub system_message: Option<Arc<dyn SystemMessageService>>,
@@ -89,6 +91,7 @@ impl BcsMessageFlow {
             bot_relay_turn_limit: 0,
             interceptors: Arc::new(InterceptorChain::new()),
             session_management: None,
+            coordination_intents: None,
             bot_run_context: None,
             provider_chat_run_timeout_ms: DEFAULT_PROVIDER_CALLBACK_TIMEOUT_MS,
             system_message: None,
@@ -101,6 +104,11 @@ impl BcsMessageFlow {
             bot_terminal_observer: Arc::new(NoopBotTerminalObserver),
             human_mention_notify: None,
         }
+    }
+
+    pub fn with_coordination_intents(mut self, port: Option<Arc<dyn CoordinationIntentPort>>) -> Self {
+        self.coordination_intents = port;
+        self
     }
 
     pub fn channel_slot(&self) -> Arc<OnceLock<Arc<dyn ChannelService>>> {

--- a/src/bcs/crates/services/bcs-message-flow/tests/contract_bot_event.rs
+++ b/src/bcs/crates/services/bcs-message-flow/tests/contract_bot_event.rs
@@ -6684,3 +6684,164 @@ async fn bot_event_policy_blocked_message_does_not_notify() {
         "policy-blocked content must not reach humans via notifications"
     );
 }
+
+// Both authenticated intake paths share the same external claim namespace.
+mod reference_coordination {
+use super::*;
+use bcs_service_api::*;
+use bcs_service_api::port::*;
+use bcs_bot::ProviderBotEvents;
+
+struct ReferenceProvider(ProviderCoordinationConfig);
+#[async_trait::async_trait]
+impl ProviderBotCoreService for ReferenceProvider {
+    async fn register_provider_bot_with_bot_uuid(
+        &self,
+        _provider_id: &str,
+        _provider_admin_token: &str,
+        _params: RegisterProviderBotParams,
+    ) -> ServiceResult<(ProviderBotBinding, Option<String>)> {
+        Err(ServiceError::InternalError("unused test operation".into()))
+    }
+
+    async fn list_provider_bots(
+        &self,
+        _provider_id: &str,
+        _provider_admin_token: &str,
+    ) -> ServiceResult<Vec<ProviderBotBinding>> {
+        Ok(Vec::new())
+    }
+
+    async fn authenticate_static_bearer_event(&self, provider_id: &str, token: &str) -> ServiceResult<RuntimeBotIdentity> {
+        if token != "valid" { return Err(ServiceError::Unauthorized("invalid token".into())); }
+        Ok(RuntimeBotIdentity { bot_uuid: "bot-driver".into(), provider_id: provider_id.into() })
+    }
+
+    async fn authenticate_agentpass_event(
+        &self,
+        _provider_id: &str,
+        _agent_code: &str,
+    ) -> ServiceResult<RuntimeBotIdentity> {
+        Err(ServiceError::InternalError("unused test operation".into()))
+    }
+
+    async fn authenticate_provider_admin_event(
+        &self,
+        _provider_id: &str,
+        _provider_admin_token: &str,
+        _provider_bot_ref: &str,
+    ) -> ServiceResult<RuntimeBotIdentity> {
+        Err(ServiceError::InternalError("unused test operation".into()))
+    }
+
+    async fn get_provider_coordination_config(&self, _: &str) -> ServiceResult<ProviderCoordinationConfig> {
+        Ok(self.0.clone())
+    }
+
+    async fn set_provider_bot_disabled(
+        &self,
+        _provider_id: &str,
+        _bot_uuid: &str,
+        _provider_admin_token: &str,
+        _disabled: bool,
+    ) -> ServiceResult<ProviderBotBinding> {
+        Err(ServiceError::InternalError("unused test operation".into()))
+    }
+}
+
+#[derive(Default)]
+struct ReferenceStore {
+    claimed: Mutex<Option<CoordinationContext>>,
+    result: Mutex<Option<CoordinationResult>>,
+    fail_read: AtomicBool,
+}
+#[async_trait::async_trait]
+impl CoordinationIntentPort for ReferenceStore {
+    async fn resolve_and_claim(&self, _: &str, _: &str, context: &CoordinationContext, _: u64) -> ServiceResult<CoordinationClaim> {
+        if self.fail_read.swap(false, Ordering::SeqCst) {
+            return Err(ServiceError::InternalError("transient read failure".into()));
+        }
+        let mut claim = self.claimed.lock().await;
+        if let Some(previous) = &*claim {
+            if previous != context { return Err(ServiceError::Conflict("different context".into())); }
+            return Ok(CoordinationClaim::Duplicate(self.result.lock().await.clone()));
+        }
+        *claim = Some(context.clone());
+        Ok(CoordinationClaim::Acquired(CoordinationLease { claim_token: "a".repeat(32),
+            arguments: json!({"target_bot": "bot-observer", "message": "中".repeat(4198) + "\n🙂"}).as_object().unwrap().clone() }))
+    }
+    async fn finish(&self, _: &str, _: &CoordinationContext, _: &str, result: &CoordinationResult) -> ServiceResult<()> {
+        *self.result.lock().await = Some(result.clone());
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn v2_dual_intake_dispatches_once_in_both_orders_and_modes() {
+    for native in [false, true] {
+        for callback_first in [false, true] {
+            let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
+            let mut group = support.group.get("group-1").await.unwrap();
+            group.service_mode = Some("master_slave".into());
+            support.group.upsert(group).await.unwrap();
+            let mode = if native { CoordinationMode::NativeMcp } else { CoordinationMode::McporterMcp };
+            let mapping = BTreeMap::from([("native_assign".into(), "bcs_assign_task".into())]);
+            let config = ProviderCoordinationConfig { mode: mode.clone(), worker_send_task_message_enabled: true,
+                mcp_server: Some("bcs".into()), mcporter_command: None, tool_name_mapping: mapping.clone() };
+            support.registry.set_coordination_surface("bot-driver", CoordinationSurface {
+                mode, worker_send_task_message_enabled: true, mcp_server: Some("bcs".into()),
+                mcporter_command: None, tool_name_mapping: mapping,
+            }).await;
+            let runs = Arc::new(MemoryBotRunContextStore::new());
+            runs.put_context(BotRunContext { run_id: "run-reference".into(), bot_id: "bot-driver".into(),
+                group_id: "group-1".into(), bcs_session_id: Some("group-1:abcdef12".into()),
+                deadline_ms: u64::MAX, terminal: false }).await;
+            let store = Arc::new(ReferenceStore::default());
+            let flow = Arc::new(BcsMessageFlow::new(support.group.clone(), support.routing.clone(),
+                support.registry.clone(), support.bot_delivery.clone(), support.frontend_delivery.clone())
+                .with_bot_run_context(runs.clone()).with_coordination_intents(Some(store.clone())));
+            let provider = ProviderBotEvents::new(Arc::new(ReferenceProvider(config)), runs, flow.clone())
+                .with_coordination_intents(Some(store.clone()));
+            let echo = json!({"__bcs_coordination__": true, "v": 2, "tool": "bcs_assign_task",
+                "intent_id": "bcs_intent_0123456789abcdef0123456789abcdef", "status": "stored"}).to_string();
+            let name = if native { "native_assign" } else { "Bash" };
+            let event = BotEventCommand { bot_id: "bot-driver".into(), run_id: "run-reference".into(),
+                group_id: "group-1".into(), event_type: "agent".into(),
+                event_payload: agent_tool_result_payload(Some(name), "tool-reference", &echo, false),
+                state: ChatEventState::Delta, bcs_session_id: Some("group-1:abcdef12".into()) };
+            let command = ProviderBotCoordinationCommand { provider_id: "provider".into(),
+                credential: ProviderBotEventCredential::StaticBearer("valid".into()),
+                run_id: "run-reference".into(), tool_call_id: "tool-reference".into(),
+                kind: ProviderCoordinationEventKind::ToolResult, tool_name: Some(name.into()),
+                result_text: Some(echo), mcp_server: Some("bcs".into()), intent: None };
+            // A failed fetch does not mark the event seen.
+            store.fail_read.store(true, Ordering::SeqCst);
+            assert!(flow.handle_bot_event(event.clone()).await.is_err());
+            if callback_first {
+                assert!(!provider.submit_coordination(command.clone()).await.unwrap().duplicate);
+                flow.handle_bot_event(event.clone()).await.unwrap();
+            } else {
+                flow.handle_bot_event(event.clone()).await.unwrap();
+                assert!(provider.submit_coordination(command.clone()).await.unwrap().duplicate);
+            }
+            assert_eq!(support.bot_delivery.kinds().await, vec![BotDeliveryKind::TaskDispatch]);
+            let result = store.result.lock().await.clone().unwrap();
+            assert_eq!(result.status, CoordinationStatus::Applied);
+            assert!(result.task_id.is_some());
+            let frames = support.bot_delivery.frames().await;
+            let text = request_params(&frames[0])["message"]["content"][0]["text"].as_str().unwrap().to_string();
+            assert!(text.contains(&"中".repeat(4198)));
+            *store.result.lock().await = None; // execution happened, receipt lost
+            assert!(flow.handle_bot_event(event).await.is_err());
+            assert!(provider.submit_coordination(command.clone()).await.is_err());
+            assert_eq!(support.bot_delivery.kinds().await.len(), 1);
+            let mut unauthorized = command.clone();
+            unauthorized.credential = ProviderBotEventCredential::StaticBearer("invalid".into());
+            assert!(matches!(provider.submit_coordination(unauthorized).await, Err(ProviderBotEventError::Unauthorized(_))));
+            let mut replay = command;
+            replay.tool_call_id = "different-call".into();
+            assert!(provider.submit_coordination(replay).await.is_err());
+        }
+    }
+}
+}

--- a/src/bcs/crates/test-support/bcs-test-support/src/contract/port/coordination_intent.rs
+++ b/src/bcs/crates/test-support/bcs-test-support/src/contract/port/coordination_intent.rs
@@ -1,0 +1,17 @@
+//! Contract for a fixture containing a fresh bcs_assign_task reference.
+use bcs_service_api::port::{CoordinationClaim, CoordinationContext, CoordinationIntentPort,
+    CoordinationResult, CoordinationStatus};
+
+pub async fn coordination_intent_port_contract_tests(
+    port: &dyn CoordinationIntentPort, id: &str, tool: &str,
+    context: &CoordinationContext, deadline_ms: u64,
+) {
+    let CoordinationClaim::Acquired(lease) = port.resolve_and_claim(id, tool, context, deadline_ms)
+        .await.expect("fresh reference grants one lease") else { panic!("expected lease") };
+    assert!(lease.arguments["message"].as_str().expect("message").contains(&"中".repeat(4198)));
+    assert!(matches!(port.resolve_and_claim(id, tool, context, deadline_ms).await.expect("duplicate"),
+        CoordinationClaim::Duplicate(None)));
+    port.finish(id, context, &lease.claim_token, &CoordinationResult {
+        status: CoordinationStatus::Applied, task_id: Some("task-real".into()), error_code: None,
+    }).await.expect("immutable finish");
+}

--- a/src/bcs/crates/test-support/bcs-test-support/src/contract/port/mod.rs
+++ b/src/bcs/crates/test-support/bcs-test-support/src/contract/port/mod.rs
@@ -1,5 +1,6 @@
 //! Port contract harnesses.
 
+pub mod coordination_intent;
 pub mod bot_terminal_observer;
 pub mod human_notify;
 pub mod metrics;


### PR DESCRIPTION
## Problem

Coordination tools can echo task instructions or completion summaries longer than a provider's tool-output limit. A successful Bash call can therefore arrive with truncated JSON, preventing BCS from recognizing and applying the coordination action.

## Solution

Add an optional v2 reference echo and an authenticated HTTP resolver adapter. Stream events and provider coordination callbacks resolve the complete arguments, share an atomic remote claim, run the existing task services, and append an execution receipt containing the actual task ID when dispatch succeeds.

Resolver URLs and credentials come from bootstrap configuration. Reads and finish requests have bounded retries; an uncertain claim never permits execution or redispatch. The resolver is disabled by default. No cache vendor SDK or database changes are introduced in Avernet.

## Validation

- Passed, 519 tests: `cargo test -p bcs-protocol -p bcs-coordination-client -p bcs-bot -p bcs-message-flow --manifest-path src/bcs/Cargo.toml`
- Passed, 121 tests: `cargo test -p bcs --lib config --manifest-path src/bcs/Cargo.toml`
- Passed: `git diff origin/dev...HEAD --check`
- Coverage includes long Chinese payloads, pretty-printed output truncation, both intake orders, native MCP mappings, duplicate claims, uncertain acknowledgements, finish-only retries, and legacy v1 parsing.
- The earlier full architecture run did not pass: existing dependency-check shell failure at `check-deps.sh:36`, unrelated import/trait-naming findings, and missing legacy R25 conformance entries. The new port has a centralized contract harness and an HTTP conformance entry.
- Live distributed-cache/resolver deployment and Singlebox E2E were not run. The external MCP producer and its cache implementation are a separate ocb_2 change.
- Commit and push hooks were skipped with `--no-verify`; the explicit test commands above were run separately.

## Compatibility and risk

Inline v1 echoes retain their existing parsing and execution paths, including the provider callback's historical metadata tolerance and tool-name normalization. Native `coordination_intent` remains v1. The new source-tool restriction applies only to v2.

Deploy the resolver and BCS consumer before enabling producer v2. Roll back the producer to v1 while retaining resolution for outstanding references. Claim/receipt retention prevents duplicates only while records persist; cache loss is not durable exactly-once delivery. Failed or uncertain receipts surface an error rather than causing automatic re-execution.

## Spec

[Coordination reference echo v2](src/bcs/crates/contracts/bcs-protocol/docs/coordination-reference-v2.md)
