### PR TITLE
docs(skills): freeze desktop capability implementation baseline

### DIFF
--- a/docs/specs/2026-09-08-desktop-skill-capabilities/README.md
+++ b/docs/specs/2026-09-08-desktop-skill-capabilities/README.md
@@ -1,0 +1,25 @@
+# Desktop Skill 文档基线
+
+本目录固定Desktop Skill适配的设计与交付范围，不包含功能实现。后续实施Issue应引用合入后的固定提交及本目录，避免依赖个人工作树或历史聊天。
+
+## 阅读顺序
+
+| 需要做什么 | 阅读材料 |
+| --- | --- |
+| 理解目标、接口、兼容边界与验收 | [spec.md](spec.md)：唯一实现规范入口，含A01–A34验收与Q1–Q29追溯。 |
+| 理解一个决定的取舍和明确保留的限制 | [decisions.md](decisions.md)：定稿摘要，不包含被替代的历史候选。 |
+| 划分跨仓工作、依赖和共享文件owner | [plan.md](plan.md)：G1–G4交付计划。 |
+| 建立实施Issue、记录执行结果 | [tasks.md](tasks.md)：四组工作清单，当前均未开始。 |
+| 检查市场/工坊/Bot能力是否有遗漏 | [capability-coverage-matrix.md](capability-coverage-matrix.md)：能力到工程包的映射。 |
+| 查正式HTTP方法、路径和调用前置条件 | [openapi-capability-coverage-audit.md](openapi-capability-coverage-audit.md)：固定源码入口审计。 |
+| 查SC懒物化、Reference完成与Desktop恢复的衔接 | [market-coverage-audit.md](market-coverage-audit.md)：市场专线源码证据。 |
+
+## 基线与使用限制
+
+- 文档PR起点：Avernet `github/dev@678be7ef0980aa00a09c32c502a08c33ebf4444d`。
+- 创建文档PR时核对的OCB：`dev@384146cff15758dae2817e7069321b94bfdcee51`，实际`ocb-public` gitlink为`ca308268927f10df887ad3543d664244dbe6ce52`。
+- 两份审计仍引用各自声明的固定研究SHA；不是将所有旧研究重新标成最新dev，也不是部署证据。实施前须再次核对相关调用方、DI、配置和实际gitlink。
+- `spec.md`规定目标行为；审计描述当时已实现行为，不能将占位Adapter或未实现Handler当作已经交付。新用户决定需要同步规范和受影响测试。
+- 不发布个人研究目录、原始长对话、凭证或现场运行数据。本文档基线自包含，关联的正式ADR已在仓库中。
+
+文档PR合并只完成“规范可追溯”，不完成开发、CI验收、客户端/Engine升级或真实Desktop验证。四组工作按各自结果分别记录这些阶段。

--- a/docs/specs/2026-09-08-desktop-skill-capabilities/capability-coverage-matrix.md
+++ b/docs/specs/2026-09-08-desktop-skill-capabilities/capability-coverage-matrix.md
@@ -1,0 +1,111 @@
+# Desktop Skill：能力覆盖与四工程包归属核对
+
+日期：2026-09-09。状态：只读源码审计与设计范围收口；不是实现完成或验收通过记录。
+
+用户确认Q28原验收内容，并明确要求能力市场添加SkillCenter公共Skill、云端懒物化、加入Bot能力、Desktop最终生效全链路纳入。Q29的四组结构已获认可，但用户要求用完整能力清单核对遗漏；本文件用于回答该问题，不构成编码、创建任务、部署或推送授权。
+
+最终确认补记：用户已确认本轮覆盖分析，并于2026-09-09对“所有入口共用一套Bot级恢复任务”的进一步解释明确回复“定稿”。本矩阵与决策账本共同作为后续正式Spec/四工程包拆分的依据；这不代表实现或实机验收已经完成。
+
+## 1. 基线与证据范围
+
+- 本轮重新fetch Avernet `github/dev`：`ca308268927f10df887ad3543d664244dbe6ce52`。
+- 本轮重新fetch OCB `origin/dev`：`658abdf1cc88b047c73463463c695510866b4759`。
+- OCB实际`ocb-public` gitlink：`137219270c46a3508daeaf92d9e660e5ee38aeb9`，不等于上述公共dev。
+- 工作目录HEAD没有checkout到这些提交，源码审计使用`git show`/`git grep`固定SHA；不把工作目录旧文件的行号当最新实现。
+- 对比gitlink与Avernet当前dev，`src/engine`、`src/baas`及Skill Center直接核心实现无差异；Backend其它调用面存在差异，尤其Bot Config Manifest、Object Store与部分DI。不能宣称完整企业集成已一致；实现时需重验最终gitlink及装配。
+- 本轮没有执行真实SC、数据库、OSS或Desktop操作，也没有运行业务测试。前端产品的真实部署代码没有核验；用户此前确认的SC详情iframe属于产品已知事实，不因仓库内demo/旧consumer缺功能而推翻。
+
+正式实现规范见[spec.md](spec.md)，工程顺序见[plan.md](plan.md)，本地工作清单见[tasks.md](tasks.md)。[decisions.md](decisions.md)保存最终选择及关键取舍；旧研究中的候选不能覆盖Q13/Q25/Q26等最终KISS取舍，新增决定须同步正式规范。
+
+逐HTTP方法/路径附录：[OpenAPI能力审计](openapi-capability-coverage-audit.md)。市场专线证据：[市场/Reference/Sync审计](market-coverage-audit.md)。两份附件均已完成固定源码核查，覆盖动态注册的旧接口，不以静态搜索到的decorator数量代替完整入口表。
+
+## 2. 能力市场必须拆清两次内容准备
+
+```text
+SkillCenter市场搜索/详情（仍是外部skill_code）
+  → POST skill-center-references（多个skill_codes）
+  → 解析精确SC版本
+  → 幂等创建/复用TeamClaw Center资产与精确Version
+  → 云端Canonical Store物化成功、Version PUBLISHED
+  → 最终重新校验当前目标SkillSet、权限与成员规则
+  → SkillSetManagementService.add_skills
+      ├─ inactive Set：只写Membership；不因这次引用下载或激活
+      └─ active Set：写Membership与Installation、触发共同投影
+           → Backend准备/复用精确分发包、签名下载描述
+           → Engine按需下载、完整缓存、建立/切换软链
+           → PENDING由Skill专用恢复任务继续推动
+```
+
+云端懒物化把外部市场Skill变成可引用的TeamClaw资产，Desktop下载把已经存在的精确版本变成设备可用内容。二者不是同一个事务、同一个任务或同一个完成点。
+
+- **TeamClaw已有市场Skill、已发布Space工坊Skill**：按`skill_id`走已有成员添加，不要求前端再次走SC懒物化；如目标Desktop缺少Center缓存，仍复用后半段下载/投影。
+- **SC Public市场Skill**：按`skill_code`走专用批量Reference；云端已就绪资产/Version复用，不能拿display name与Local/Repo合并身份。
+- **Reference COMPLETED**：已完成正式添加，不等于Desktop Runtime CONVERGED。不为下载等待回退共享Version或Membership，不把Desktop下载塞回Reference任务。
+- 不新增Desktop专属市场、Membership写路径、SC同步器或第二套Installation SSOT。
+
+### 当前源码揭示的关键交接点
+
+以下路径均相对Avernet根目录，基线为上述`ca3082689`：
+
+1. `src/backend/src/agentclaw/community/core/skill_center/services/skill_center_reference_processor.py:240–274`：精确Version和云物化完成后，**先**调用`track_latest.version_published`，然后准备最终成员添加。首次目标Bot可能尚无该Installation，不能把这次提前扇出当最终添加的恢复保证。
+2. 同文件`:360–444`：重新get_set、调用正式add_skills，按`outcome.succeeded`置COMPLETED，不以Runtime已收敛为条件。
+3. `.../services/skill_set_management_service.py:523–538`：正式添加结果已经携带`runtime_projection`；Reference最终状态不保留该结果。现有Reference查询不能被文档写成“持续查询桌面下载状态”的接口。
+4. `.../services/_mutation_flow.py:137–157,233–251`：inactive跳过投影；Bot未就绪、snapshot不可得时可在调用Engine前返回PENDING。G4恢复覆盖必须包括这些入口，不仅在下载器返回PENDING后建任务。
+5. `.../services/bot_runtime_projector.py:125–186`及`.../services/runtime_projections/per_domain.py:83–105`：共同投影与SkillRuntimeDelivery适合集中复用，市场/SkillSet/Direct不应各自实现Desktop下载分支；任务执行仍遵守最新Reader和当前绑定。
+
+G4应在正式变更/共同恢复入口承担PENDING后续责任，覆盖直接`apply_plan`调用和提前返回，而非只挂在某个`project()`调用点。具体窄Interface在Spec定义，不因此引入TaskQueue事务基础设施或新状态表。失败入队窗口按Q9/Q20的低频扫漏兜底，不能将Reference COMPLETED误报为持久调度已保证。
+
+**用户进一步确认的统一性约束**：上面列出的市场、Set、Direct、启动和TrackLatest不是分别开发恢复能力。共同收尾/触发点只调用同一恢复Module，复用一个Desktop Skill task type；相同owner+bot在Queue作用域内共用一条live工作项。Handler读取最新Reader并经同一个Projector/apply观察Ready/PENDING和推动建链；不加独立下载进度probe或每入口专用Task。现有activation_sync文件只是未实现骨架，G4仍有真实开发工作。详细边界见决策账本末尾。
+
+## 3. 逐能力覆盖矩阵
+
+分类：**共享回归**=已有共同实现，不重复建设Desktop业务；**适配**=本期需要补齐或接线；**相邻兼容**=不开放新产品功能，但保护被共享代码影响的调用方。每一行既有主责组，又保留跨组联调责任。
+
+| 能力/产品操作 | 本期处理 | 归属与验收重点 |
+| --- | --- | --- |
+| Desktop创建/首次启动/重启 | 适配+回归 | G1补Hermes创建入口；G4启动、当前绑定和恢复触发；G3准备缺失Center。 |
+| TeamClaw市场搜索、列表、详情、收藏等已有入口 | 共享回归 | G1入口/字段/权限矩阵；不另建Desktop市场。SC iframe详情沿用产品现有方案。 |
+| Repo仓库目录、Skill详情、README、同步 | 共享回归 | G1目录与查询，G2字节通道回归，G3/G4确认原Repo交付/投影不被Center改造破坏；不重写Repo下载器。 |
+| SC市场搜索和外部详情 | 共享回归 | G1确认外部skill_code、版本/来源字段、前端调用约定；搜索不批量写ac_skill。 |
+| SC市场批量Reference创建、列表和单项查询 | 共享回归+交接适配 | G1明确现有端点与异步/幂等/错误合同；G3云就绪后设备交付；G4最终add后Skill恢复。 |
+| Public Reference批量部分失败、同key重放、现有自动重试 | 共享回归 | G1逐项结果，不把一个失败当全部回滚；G4已成功项仍有恢复责任；不虚构独立Reference retry路由。 |
+| Public云懒物化、并发/跨Bot复用 | 共享回归 | G3接在现有Materializer产物后，不重复创建资产/Version，不重复SC下载逻辑；精确身份与Local/Repo同名隔离。 |
+| 已物化Center被其它Desktop/云Bot引用 | 适配+回归 | G3复用共享Canonical和派生包，各Desktop只准备自己的缺失缓存；各Bot的Installation与运行结果独立。 |
+| 可消费Space Skill列表与已发布工坊引用 | 共享回归+适配 | G1可见性、授权与已发布过滤；G3/G4复用同一Center交付，不再强制Public懒加载。 |
+| Space文件夹/Git创建、草稿文件读写/Git刷新/删除、升级 | 共享回归 | G1列入API验收索引；这些是云端资产操作，不经过Desktop文件上传通道，不复制Draft Store；不凭历史Spec新增当前Router没有的整包Draft replacement接口。 |
+| Grants/Editor Request/Lease/Publication及Retry | 共享回归 | G1既有权限/状态机/并发令牌合同；G4只承接发布后的Track Latest，Desktop未下载完成不改变云发布成功判据。 |
+| 工坊下线、血缘/影响面、复制独立Skill | 共享回归 | G1必须列出既有入口；使用当前已合入业务语义，不从历史讨论恢复旧退役/自动Draft行为；Desktop引用遵守共同血缘模型。 |
+| Bot Skill列表/详情/active与LOCAL过滤 | 适配+回归 | G1完整Center Query及当前Bot记录投影、Reader读取；不能只实现Canonical文件读取而遗漏Router前置校验。 |
+| Bot Skill内容、共享README | 适配+回归 | G1明确Bot-scoped内容与botless README的访问合同；Center基于精确Published内容，非Engine缓存是否Ready；Local历史owner+default定位风险要收口。 |
+| Bot-local上传、替换、删除与文件读取 | 适配+回归 | G1沿用业务/权限/文件校验；G2双向字节保真；G3原Local映射兼容，失败不伪造文件成功。 |
+| SkillSet创建/编辑/删除、开关、成员列表及增删 | 共享回归+交付适配 | G1按现有普通/Default/exclusion/R1–R3规则；G3下载/映射；G4正式成员/开关变更后的恢复。active/inactive分别验收。 |
+| 单项Direct activate/deactivate（即使当前UI未开放） | 适配+回归 | G1 Center Query与Bot grant前置校验；G3/G4共同命令交付恢复，不新增Desktop私有Direct策略。Local DELETE不扩成删除Center共享资产。 |
+| 参数GET/PUT | 适配+回归 | G1仅已定存储/误吞错修复；G2请求响应兼容；不把Native参数消费列成已经保证。 |
+| Skill依赖MCP、显式MCP/CLI及Default Policy | 共享回归 | G1保持当前API与权限行为；G3不重复Scanner推导精确Version依赖；G4只隔离Skill等待，不每5秒重推MCP/Passport，不新增MCP任务。 |
+| SC周期性/手动同步，Space/Public更新后Track Latest | 共享回归+适配 | G1现有手动入口，G4共用同步完成→版本通知→候选→Reader→投影；G3按最新exact下载。无SC webhook、无Desktop第二同步器。 |
+| 老版本升级、断网/重连、重试过期及漏唤醒 | 适配 | G3旧合同保护与缓存状态；G4自动恢复，零依赖用户再次变更；仅Skill完成，不掩盖MCP其它域失败。 |
+| Deprecated Skill OpenAPI与Legacy BFF兼容 | 共享回归 | G1识别动态legacy_route及旧调用合同；G3共享投影变更保兼容，不让旧接口成为Desktop专属第二写路径。 |
+| 真实企业DI/任务注册/配置/客户端与镜像装配 | 必须核验 | 各组自己的协议/DI/测试负责，G4集成收口；OCB gitlink与最终Engine/客户端版本明确，不能只测Avernet Fake。 |
+| Bot Config Manifest/CLI工具平台、Service Artifact | 相邻兼容，非Desktop新功能 | 不开放整个配置平台或Desktop服务发布。保护共享LocalUpload/Direct/Reader/文件适配路径的现有云端行为。 |
+
+这份矩阵确认的是“每类能力有归属”，不是“上述全部已实现或实测成功”。逐HTTP方法/路径清单与市场源码细节见同目录审计附件。
+
+## 4. 四组职责应如何补写
+
+- **G1：Skill API/市场/工坊兼容与缺口补齐。** 原标题“既有API补齐”过窄，须包含完整入口清单、Center访问Adapter、Bot-facing记录与权限校验、共享README、参数、Hermes创建及前端接口说明。对已有市场/Space业务以回归为主，不重复开发。Center是共享资产，Bot-facing记录只在返回投影中带目标Bot身份，不能把持久资产改成该Bot所有；Direct activate前可尚无Installation，不能以“必须已经安装”替代消费权限校验。
+- **G2：Desktop文件字节通道。** 保持Q27最小范围，同时覆盖上传/替换/读取/参数文本/启动health等实际消费者，不只测试一个Rust函数。
+- **G3：Center从Canonical到设备的统一交付。** 消费者同时包括SC市场Reference、已物化市场、Space工坊和Direct/Set；不只实现“给定UUID下载一个ZIP”。补齐分发、权限/描述、Engine内容Adapter、结果与跨仓字段透传。
+- **G4：所有入口的自动恢复及整体联调。** 必须包括市场最终add、普通Set/Direct、启动/重连、Track Latest，以及调用Engine前的PENDING；不是只有“一个定时任务+测试”。当前mutate、listener、Task都复用正式Projector，不复制有效能力计算。
+
+G4验收不仅逐入口可用，还要证明跨入口共用：同一Bot由市场/Set/TrackLatest同时触发，至多一个live Desktop Skill任务，每轮处理最新期望，不复制下载/退避算法，不生成三个独立恢复循环。
+
+前端联调归属：G1交付按现有真实endpoint编写的调用/结果说明，G4协调真实产品前端验收（包含用户已确认的Desktop离线禁变更、SC详情iframe、Reference已添加与设备生效区别）。这是核验已有产品前提，不是本轮新授权前端改造。共享README没有目标Bot，不能照搬Bot content的Desired Version选择；其Center可见性与Published版本选择必须在G1正式合同中明确，不能从“content可用”推导README也已可用。SkillSet resources中的Default CLI展示也不等于具备CLI成员CRUD或独立二进制工具安装能力。
+
+因此目前未发现为了已定Skill产品范围而必须增加第五个架构模块的理由；但若只按原四行简略标题开发，存在漏验收、漏接线的实际风险。四组必须共同引用本矩阵，不能把跨组链路划成“别人负责”而无人验收。
+
+## 5. 尚不能宣称已证明的事项
+
+1. 实际前端是否正确区分Reference已添加和Runtime已生效，需要后续联调；当前Reference DTO不提供持续桌面下载进度。不是本轮自动新增Runtime进度API/表的授权。
+2. Bot Config Manifest明确拒绝Desktop（`.../core/bot_config_manifest/capabilities.py:325–326,363–364`），不会因为本次Skill接口适配就自动支持。它属于已定范围外的Bot配置平台能力；若用户另行要求，单独评估，不以“所有OpenAPI”悄悄扩大。
+3. 未对全量产品PRD逐页面做新的前端UI验收；本轮完整性以已定Skill相关OpenAPI与关键触发链为边界。
+4. 分发包、客户端/Engine升级、签名URL可达性、真实软链/hash和自动恢复效果需要实现后实机证据。当前只是基于固定源码的设计覆盖分析。

--- a/docs/specs/2026-09-08-desktop-skill-capabilities/decisions.md
+++ b/docs/specs/2026-09-08-desktop-skill-capabilities/decisions.md
@@ -1,0 +1,58 @@
+# Desktop Skill：最终决策摘要
+
+状态：Q1–Q29总体方案及统一恢复约束已定稿；业务待实现。本文件提取最终选择和理由，原始探索中的未采纳候选不作为实施指令。详细目标合同及验收以[spec.md](spec.md)为准。
+
+## 已定选择
+
+| 决策 | 最终选择与理由 | 规范落点 |
+| --- | --- | --- |
+| Q1 范围 | Skill相关OpenAPI/市场/工坊能力适配Desktop；OpenClaw/Hermes主验收，其它已有Engine保留受影响兼容。不扩成所有Bot平台API。 | Solution、D2 |
+| Q2 升级 | 新Desktop Center及bytes能力可要求客户端/Engine更新；原有能力兼容，不要求云端统一重启。 | D10 |
+| Q3 与#455关系 | 复用逻辑交付seam，但不等待#455全部模块；不以本次适配改DB locator或强制切Pool。 | D5/D10 |
+| Q4 内容来源 | Backend触发，Engine按需取得当前有效exact内容；不启动时全拉Center市场。 | D3/D6 |
+| Q5 成功边界 | Publication、Reference添加、缓存Ready、Runtime生效分别表达；Runtime降级不回滚合法Desired State，文件上传/参数写入另守实际成功合同。 | D1/D4 |
+| Q6 Hermes创建 | 修正式Local Bot Workflow的Hermes政策缺口，不据枚举存在就开放所有Engine。 | D4、A01 |
+| Q7 恢复方向 | Backend通用任务重读最新Reader并投影；Engine只准备缓存，不在下载完成回调激活旧目标。 | D8 |
+| Q8 部分结果 | Mixed Local/Repo/Center逐项best-effort；一个等待项不拦其它可执行项。旧DTO整批拒绝是明确兼容例外。 | D7/D10 |
+| Q9 唤醒 | 启动/变更/Track Latest主动触发、任务跟进和低频扫漏进入同一恢复机制；健康扫描状态更新不是已有投影保障。 | D8 |
+| Q10 频率 | 新due-now任务及时唤醒；正常内容等待5秒Reschedule；异常原退避；约10分钟扫漏。周期不是SLA。 | D8 |
+| Q11 完成判据 | 看逐项可恢复工作，DEGRADED不得掩盖PENDING；停止重试不代表CONVERGED。 | D8 |
+| Q12 新旧版本 | V2未Ready保留V1有效链接；切换使用新一轮最新期望，不保证旧MCP环境也保持。 | D9 |
+| Q13 退出KISS | 前端离线禁SkillSet变更，Backend不新增Desktop政策。沿用显式retired，不新增退出账本、链接回执或整目录接管；接受历史retired遗失限制。 | D9 |
+| Q14 派生包 | Canonical exact生成可复用ZIP，冷包重工作在后台；独立分发namespace，不复用Draft/staging字段，不新增业务Version。 | D6 |
+| Q15 下载描述 | Backend签发精确对象描述，Engine直连OSS；大包不经BaaS、不直连SC，不公开私有meta或长期凭证。 | D6/D7 |
+| Q16 深Module | 共用Reader/Resolver/Projector/apply；Engine通过Mounted/Downloaded Adapter准备内容；Backend新差异集中SkillRuntimeDelivery。 | D5 |
+| Q17 URL期限 | 一小时签名，过期后正式投影刷新；URL不是内容身份，过期不删除Ready缓存。 | D6 |
+| Q18 Ready | 首次完整校验与安全落盘后才可用；命中轻量检查。缓存元信息不是链接所有权回执，也不证明所有用户篡改都可检测。 | D6 |
+| Q19 缓存清理 | 只清理确认归属且已结束的临时工作；不做完整缓存TTL/LRU/keep-N或云端派生包GC，磁盘风险可见。 | D6 |
+| Q20 工作项生命周期 | 单Bot一个live工作项，30分钟单轮；重复enqueue不合并payload/加速/续期。保留既有Queue窗口，由扫漏兜底，不加outbox/generation/全局锁。 | D8 |
+| Q21 MCP过渡 | Skill与MCP继续独立best-effort，保留V1链接不承诺V1业务零中断；不临时授权旧MCP依赖。 | D9 |
+| Q22 apply合同 | 复用一次逻辑apply，可选下载描述与实际Adapter evidence；不新增日常probe/verify。Backend按可信bot_type、Engine按既有部署配置集中选择。 | D5/D7 |
+| Q23 旧端保护 | 只在明确合同拒绝时提示升级；未知结果不换写协议。旧DTO混合请求整批拒绝不拆批补发；合法DB期望保留。 | D10 |
+| Q24 Center查看 | 云端/Desktop共用Canonical精确内容读取，不看设备Ready、不触发下载；期望内容与实际运行内容区分。 | D4 |
+| Q25 参数最小修复 | 保留接口、name键JSON和历史地址；读失败零写、写失败失败。不新增参数API/DB/CAS锁/自动注入；原生消费另列未验证。 | D4 |
+| Q26 MCP保持现状 | 只新增Skill恢复，后续轮次零MCP/Passport重推；原MCP故障处理保留，不新增第二个MCP任务。 | D9 |
+| Q27 bytes | 修Desktop内部请求/响应bytes保真，保留BaaS base64和旧文本wire；不新增上传系统。 | D4 |
+| Q28 完整验收 | 包含市场SC批量Reference→云物化→正式Set/Installation→Desktop下载→实际软链，并覆盖工坊、Local/Repo及共享辅助入口。 | D3、A01–A34 |
+| Q29 分组与统一恢复 | 四组分工；所有Desktop Skill入口共用一个Bot级恢复Module/task type，不能每入口各建一套。 | D2/D8、Plan |
+
+## 统一恢复的具体边界
+
+1. `ac_task_queue`负责持久执行和调度，G4负责一套Desktop Skill业务Handler；旧activation_sync骨架不是现成实现。
+2. 所有触发源只通过共同Interface确保Bot恢复工作；按Queue作用域与owner+bot去重，不按Skill/Set/Reference/version分别排长期恢复任务。
+3. Worker准备缺包后重读当前Reader与绑定，再调用共同Projector；正常apply同时观察内容就绪状态并推动映射，不再单独查百分比进度。
+4. 市场物化后Track Latest可能发生在最终add之前，故正式add及共同变更收尾必须接入；Bot未就绪/snapshot失败的提前PENDING也不能漏接。
+5. inactive Set的SKIPPED、权限/DB失败不是自动下载或重放业务命令的理由。Reference COMPLETED不改定义为所有设备Ready。
+6. 跨入口合同测试必须证明：同Bot由市场、Set和Track Latest共同触发仍只有一个live恢复任务，读取最新目标；不能只提供三条独立入口成功测试。
+
+## 明确保留的限制
+
+| 限制 | 后续处理原则 |
+| --- | --- |
+| 遗失retired可能留下旧链接 | 不通过新扫漏推断全部链接归属；正常受支持取消场景必须通过窄测试，发现不足只评估最小共享修复。 |
+| 入队与最后检查窗口、有限任务期限 | 记录真实失败并低频重新ensure；不宣称强一致或固定恢复秒数。 |
+| 参数原生消费未证实 | 存储/回读与原生执行分别验收，未验证不宣传已完成。 |
+| 旧MCP过渡及原MCP重试覆盖 | 保持既有行为，不掩盖失败，不扩成本期MCP治理。 |
+| 完整缓存增长 | 记录容量/下载错误；不未经授权清理在用或用户内容。 |
+
+所有源码审计均为固定提交证据。文档定稿不表示实现、CI、评审、合并、部署或实机验证已经通过。

--- a/docs/specs/2026-09-08-desktop-skill-capabilities/market-coverage-audit.md
+++ b/docs/specs/2026-09-08-desktop-skill-capabilities/market-coverage-audit.md
@@ -1,0 +1,69 @@
+# Desktop 市场 / Reference / Sync 覆盖审计
+
+结论：G1–G4 可以覆盖该链路，但必须显式补上 **Reference 最终 `add_skills` → Desktop Skill 恢复** 的交接与测试。已有市场查询、Public 云端物化、Reference 持久任务和正式 SkillSet 写入均应复用；不能把 Reference `COMPLETED`、版本 `PUBLISHED` 或 Track Latest 已入队当成设备已生效。
+
+## 基线和证据边界
+
+- A：Avernet `ca308268927f10df887ad3543d664244dbe6ce52`，仓库 `<Avernet research checkout>`。下文 A 源码均用 `git show/git grep` 固定该 SHA，而非当前 checkout。
+- O：OCB `658abdf1cc88b047c73463463c695510866b4759`，仓库 `<OCB research checkout>`。`git ls-tree O ocb-public` 为 `137219270c46a3508daeaf92d9e660e5ee38aeb9`；与 A 是两种集成快照，不能当部署证据。
+- 研究依据包括两仓架构与模块约束。本审计只读固定代码；未执行测试或线上API，不代表企业部署已验证。
+- 真实 TeamClaw 前端未现场核验。**保留用户已确认“SC 详情以 iframe 实现”的事实**；仓库内 OCB 旧前端及 A `frontend-nextgen` 只能作为调用方样例，不是当前线上前端权威，不能据此判定产品详情未实现或追加市场 UI 重写。
+
+## 现有链路与工程包映射
+
+| 链路 | 当前事实 | Desktop 覆盖责任 |
+| --- | --- | --- |
+| TeamClaw Repo 市场查询、详情、添加 | POST `/openapi/v1/bots/market/skills` 只读 `git://` 资产；GET `/openapi/v1/bots/skills/repository`、`/repository/{skill_id}` 提供目录与详情；已有资产通过 PUT `/{bot_id}/skill-sets/{set_id}/skills/{skill_id}`，最终进正式 `add_skills`。Legacy 批量路由先解析历史名称/path 为 ID，再一次正式 add。[A1–A3] | 复用查询/权限与正式写入，不为 Desktop 重做 Repo 市场；G1 相关回归，G3 原有 Repo/Local 映射兼容，G4 正式变更恢复入口覆盖。 |
+| SC Public 搜索、详情 | POST `/openapi/v1/bots/market/skill-center/skills`、GET `/market/skill-center/tags` 已有。Backend `get_public_skill` 是 Gateway 方法；O Corp 实现读取 SC 精确 code 详情，SC 凭证留在服务器。现有 market OpenAPI router **没有新 Public-detail HTTP route**；不需要为了 Desktop 发明一个，前端 iframe 详情保持现状。[A4,O1] | 共享资产链路仅回归；G1 检验既有内容入口，不能把查看市场列表变成下载全部内容。 |
+| Public Reference 创建、列表、详情 | POST `/{bot_id}/skill-sets/{set_id}/skill-center-references` 要求 `Idempotency-Key`、`skill_codes`，返回 202、`request_id/reference_ids`；GET collection 可按 request/status 分页，GET `/{reference_id}` 查逐项。owner+bot+set+tenant/env 冻结/过滤。[A5,A6] | 既有 API 与鉴权复用，G1/G4 按真实合同联调；202 只表示接收。 |
+| 重复请求与“重试” | 去重保序，去重后 1–20 code；同 key+同命令重放原 batch 并 ensure task，同 key 不同请求报冲突。Gateway/物化暂态失败内部至多 3 次；**没有独立 Reference retry HTTP route**。终态 item 不再处理，因此重发同 key 不是重置 FAILED；换新 key 是新 Reference 命令。[A5–A7] | 必测重复接收、ensure-task 窗口、部分成功/失败；不新增 retry 路由、进度表，也不把下载等待塞回 Reference 任务。 |
+| 云端懒物化、Ready 共享复用 | 每项查 Public detail/latest exact version，按 tenant/env/code 派生 Public 身份，复用同 locator/同 exact Version；不按同名复用 Local/Repo/Space。Materializer 已有 `PUBLISHED` 分支先 verify Canonical 后直接复用；新版本核对 exact code/version、下载 SHA、包结构、Canonical 写入/验证，最后置 `PUBLISHED`。MCP 元数据来自 exact response。[A7–A9] | 不复制 SC 状态机/鉴权；G3 在已物化 Canonical 上补精确派生 ZIP/限时签名描述及 Desktop 下载缓存，而不是再次让 Desktop 访问 SC。 |
+| Ready → 正式 SkillSet/Installation | 所有可成功项经过 barrier 后一次 `add_skills`，重新验证 Bot/Set/权限/Offline；部分 item 失败不阻断成功项。active Set 写 Membership 与 Installation 后一次最终投影；inactive Set 仅 Membership，返回 `SKIPPED/RUNTIME_NOT_REQUIRED`，不因引用成功要求 Desktop 下载。已有 Membership 返回 changed=false，可跳过投影。[A7,A10,A11] | G4 从正式共同变更入口接恢复，覆盖 Reference 而不是旁写 Installation。active/inactive、同 Set 重复、跨 Set/Direct 冲突、物化后权限/Offline 变化均必测。 |
+| 后续周期/手动 Sync | POST `/openapi/v1/bots/market/skill-center/sync` 与启动/周期执行同一 `SkillCenterSyncService.sync`。仅枚举有 PUBLISHED Version 的 Public Center 且无 Space binding；不导入全市场。代码默认周期 30 分钟，固定锁 TTL 30 分钟；现场生效值未核验。每次 exact materialize 后即使已 PUBLISHED 也重新 ensure Track Latest。[A4,A8,A12] | 复用服务与协调；G3 验证 exact 更新内容，G4 验证 Sync→Track Latest→Desktop 新版本切换；不把资产 Sync 计数当设备生效结果。 |
+| Track Latest → Desktop | fanout 按当前候选事实排逐 Bot/Skill 任务；Bot handler 重新 Reader，已不 active 则完成；PENDING 返回 Retry，DEGRADED 记录后继续，现有 scope 含 Skill+MCP，任务 deadline 30 分钟。[A13] | G4 明确接 Desktop Skill-only 后续恢复，保留现有首次 MCP best-effort；新恢复重试不得每轮重跑 MCP/Passport，也不得用旧 exact ref/URL 代替最新 Reader。 |
+
+## 必须补齐的交接：不是新市场系统
+
+1. **`COMPLETED` 不等于 Runtime Ready，且当前没有可持续查询的 Runtime 结果。** `SkillSetSkillOutcome.succeeded` 仅检查 error；正式 service 把 `runtime_projection` 附到成功 outcome，但 Reference processor 只读 succeeded 然后置 `COMPLETED`，没有读取该 projection。Reference DB model、domain DTO、HTTP DTO 均无 `runtime_projection` 字段。[A5,A7,A10,A14] 保留 `COMPLETED=已加入能力集`；文档/实机验收不得报成“设备已生效”。新增 Runtime 轮询 API/表是另一公开合同，本期未批准。
+2. **物化完成的 Track Latest 可能在最终 add 前抢跑。** processor 在 materialize 后立即 `version_published`，随后才置 ADDING 并最终 add；fanout 当时可能没有该 Bot 的 Membership/Installation，因此产生零候选后完成。[A7,A13] 它修的是物化后的 enqueue 窗口，不是首次 Reference 的“加 Set 后确保恢复”。G4 必须从正式 add/共同变更结果交接 Skill 恢复，不依赖再次发布、周期 Sync 或用户第二次点击。
+3. **恢复接线不能只放在 Engine 返回下载 PENDING 后。** `_mutation_flow.apply` 的 Bot 未 Ready 提前分支先写 DB 后返回 PENDING；snapshot/resolve 异常也可不进入 apply 就返回 PENDING。[A11] G4 应覆盖这些入口及队列 ensure 失败/进程中断窗口，并用已批准的扫漏策略收口；inactive SKIPPED 不是要补下载的 PENDING。
+4. **共享版本复用与重复 Membership 也必须可收口。** 物化 PUBLISHED 复用、同 Set 重复 changed=false 均合法；后者可能 `DESIRED_STATE_UNCHANGED` 跳过本次投影。[A8–A11] 验收要覆盖旧 Reference 已 COMPLETED、设备仍缺缓存/新绑定的恢复，不把重新创建共享资产、重发历史 add 或重新发布当补救条件。
+5. **状态映射要逐层证明。** 最少区分 Reference item FAILED、Reference COMPLETED+inactive（无 Runtime 要求）、Reference COMPLETED+active+Desktop PENDING、最终 Runtime 对当前 exact version 生效。保留部分成功和共享资产，不把权限/DB 失败伪装成 PENDING；最终 Ready 必须有 Engine 缓存/目标软链/可读 `SKILL.md` 的真实证据。[A7,A9–A11,A14]
+
+G2 对市场元数据/Reference JSON 没有新的物化职责；其 bytes 保真主要保护本期 Local 文件通道。G1/G3/G4 自带相应窄测试与跨仓 DI/合同门禁，不能把所有正确性测试推迟至 G4。G3 单轮下载+映射通过仍不等于整个市场添加 Desktop 链路可上线。
+
+## 最小验收增量（接入 G1/G3/G4，非已执行结果）
+
+- 保留现有测试的 dedupe/20 项/同 key 冲突、单次 batch add、缺失项部分成功、Offline 竞争保留共享资产、已 PUBLISHED ensure fanout；已有对应测试入口见 [T1–T3]，本次未运行。
+- 新增交接用例：先执行 fanout 得零候选，再完成最终 active add 且 Runtime PENDING，证明独立 Skill 恢复任务仍被 ensure；覆盖 Bot 未 Ready、snapshot 不可达及 Engine 正常下载 PENDING 三种分支。
+- 同一批成功/失败混合：成功 Membership/Installation 保留、失败项错误可查；Reference 的终态不作为 Runtime 收敛条件，后台补齐无需用户第二次操作。
+- inactive Reference 完成后零下载；后续 activate 才按最新 Reader 下载。移除/停用/改绑定后，迟到下载不得复活旧期望态。
+- 两个 Bot 引用相同 Public code/exact version 复用云端资产与完整 canonical；Desktop 缓存只复用经过当前规则验证的 exact 内容。后续手动/周期 Sync 发布 V2，Track Latest 单轮 MCP 语义不变，后续 Skill-only retry 零 MCP/Passport 调用。
+- OCB 真实装配、BaaS、客户端/Engine 版本及 OpenClaw/Hermes 实机分别给证据；线上前端确认仍使用正式 Reference 路由（不能走 Legacy 占位 install），展示“已添加”与“设备生效”的边界一致。用户已确认的 iframe 详情不改造。[A15,O1,O2]
+
+## 固定源码索引
+
+下列 `A/O:path:行号` 都指上方固定 SHA；可用 `git show <SHA>:<path> | nl -ba` 复核。
+
+- A1 `src/backend/src/agentclaw/community/adapters/http/openapi_v1/market/router.py:120-140`；`src/backend/src/agentclaw/community/core/skill_center/services/skill_market_service.py:17-78`。
+- A2 `src/backend/src/agentclaw/community/adapters/http/openapi_v1/repository_catalog.py:32-100`。
+- A3 `src/backend/src/agentclaw/community/adapters/http/openapi_v1/skill_sets/router.py:250-286`；`src/backend/src/agentclaw/community/adapters/http/skill_center/skillsets.py:754-869`；`src/backend/src/agentclaw/community/core/skill_center/services/skill_set_management_service.py:306-350`。
+- A4 `src/backend/src/agentclaw/community/adapters/http/openapi_v1/market/router.py:192-285`。
+- A5 `src/backend/src/agentclaw/community/adapters/http/openapi_v1/skill_sets/skill_center_references.py:25-106,131-231`。
+- A6 `src/backend/src/agentclaw/community/core/skill_center/services/skill_center_reference_service.py:57-123,169-217`；`src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill_center_reference.py:381-445`。
+- A7 `src/backend/src/agentclaw/community/core/skill_center/services/skill_center_reference_processor.py:100-185,199-280,305-357,360-478`。
+- A8 `src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill_center_reference.py:233-379,447-484`。
+- A9 `src/backend/src/agentclaw/community/core/skill_center/services/skill_version_materializer.py:159-277`。
+- A10 `src/backend/src/agentclaw/community/core/skill_center/services/skill_set_management_service.py:306-350,447-539`；`src/backend/src/agentclaw/community/core/repository/implementations/skill_center/capability_desired_state.py:301-439`。
+- A11 `src/backend/src/agentclaw/community/core/skill_center/services/_mutation_flow.py:137-157,161-220,233-282`。
+- A12 `src/backend/src/agentclaw/community/core/skill_center/services/skill_center_sync_service.py:58-110,111-154,156-193,195-251`；`src/backend/src/agentclaw/community/di/modules/skill_center_group4_module.py:174-199`。
+- A13 `src/backend/src/agentclaw/community/core/skill_center/services/track_latest.py:39-59,78-106,145-200`；`src/backend/src/agentclaw/community/core/skill_center/track_latest_contract.py:25-72`。
+- A14 `src/backend/src/agentclaw/community/core/skill_center/skill_set_batch.py:9-25`；`src/backend/src/agentclaw/community/core/skill_center/reference_contract.py:45-57`；`src/backend/src/agentclaw/community/core/models/skill_center_reference.py:106-125`。
+- A15 `src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py:2932-2981`（Legacy Public 搜索/标签与仍然占位的 install；不是正式 Reference 替代）。
+- O1 `src/backend/src/agentclaw/corp/plugins/prod/skill_center_gateway.py:111-168,348-430`；`src/backend/src/agentclaw/corp/di/modules/infrastructure/corp/skill_center.py:53-68`（公开 Gateway 由 Corp 凭证/HTTP 实现装配）。
+- O2 `src/frontend/src/services/backend-api/SkillController.ts:135-152,516-546`；`src/frontend/src/services/backend-api/SkillsetController.ts:115-139`（旧 frontend consumer 样例，非线上权威）。
+- T1 A `src/backend/tests/community/core/skill_center/test_skill_center_reference_processor.py:202-352`。
+- T2 A `src/backend/tests/community/core/skill_center/test_skill_center_reference_service.py:115-159`；`src/backend/tests/community/repository/skill_center/test_skill_center_reference_repository.py:60,185,284`。
+- T3 A `src/backend/tests/community/core/skill_center/test_track_latest.py:180-321`；`src/backend/tests/community/integration/skill_center/test_reference_offline_cross_seam.py:189`。
+
+仓库内非权威 consumer 例子：A `src/frontend-nextgen/src/services/backendApi/bots/botEditorController.ts:205-253` 使用 Repo catalog、SC search、Reference POST/collection；`src/frontend-nextgen/src/services/botWorkshop/botEditorService.ts:255-271` 用有限轮询判断 Reference 终态。它只能说明 API 的一种消费方式，不能证明当前 TeamClaw 页面行为或 Desktop 上线状态；本审计不据此追加 UI 修复范围。

--- a/docs/specs/2026-09-08-desktop-skill-capabilities/openapi-capability-coverage-audit.md
+++ b/docs/specs/2026-09-08-desktop-skill-capabilities/openapi-capability-coverage-audit.md
@@ -1,0 +1,308 @@
+# Desktop Skill OpenAPI 能力覆盖审计
+
+日期：2026-09-09。性质：只读源码研究与方案覆盖审计；不是实施、测试通过或上线记录。
+
+## 结论
+
+G1–G4 可以继续作为工程分组，当前没有证据要求新增第五个工程包；但四个名字本身不能证明 Skill 产品能力完整。正式 Spec 至少要补齐以下承接关系：
+
+1. **G1 的 Center Query 必须承接 Bot-facing 身份解析、详情、内容、参数和 Direct 入口前置校验，不只是增加一个 Canonical `SKILL.md` 读取函数。** 当前这些 Router 都先经过 `query_service.get_skill()`；Center 在这一步就会进入占位 Adapter 并失败。共享资产需形成面向目标 Bot 的只读返回视图，不能篡改共享资产持久归属。[A: H/skills/router.py:338–470, 584–666；C/services/skill_query_service.py:142, 207–226, 409–422, 589–605]
+2. **共享 README 是独立入口，不是 Bot content 的别名。** 当前它只支持 Local/Repo，Center 返回 not-found；Local 分支仍用 `get_unique_by_id(bot_id)`，没有按资产记录的 owner+bot 定位。G1 应明确维护其现有范围及 shared-default 修复；若要让无 Bot 上下文的 README 新支持 Center，需要写清可见性和版本选择，不能机械复用“目标 Bot Desired Version”。[A: H/skills/router.py:168–186；C/services/skill_query_service.py:311–360]
+3. **Repo catalog/tree/detail/sync、市场 tags/sync、Space consumable/favorites、Draft/Version 文件、Grant/Lease/Publication/Offline/Copy 要在验收索引中逐项出现。** 它们大多已有共享云端业务，不应新建 Desktop 分叉。需要的是共享合同回归，以及从已发布/已引用资产进入 Desktop 的桥接验收，不是把所有云端模块重做一遍。[附录 A–E]
+4. **SkillSet resources 的 CLI、Skill 依赖 MCP、直接 MCP API 是三种不同调用面。** 保持现状并验证不回归；G4 的 Skill 下载恢复不能轮询这些 Passport/MCP 入口。不要把 `clis` 展示字段解释成已经具备 SkillSet CLI 成员 CRUD，也不要把含 MCP 的旧投影改称新 MCP 持久恢复。[A: H/skill_sets/router.py:124–150；C/services/skill_set_management_service.py:803–839]
+5. **配置清单是必须识别但明确不开放的相邻调用面。** 最新 `config_manifest` 的所有 Desktop construct/source cell 都拒绝；其云端 Skill materialiser 复用 LocalUpload、DirectActivation 和 Reader，属于受影响回归，不是本期 Desktop 主验收，更不能据此打开整套配置平台。独立 `cli-tools` 也是另一种二进制工具产品，不等于 SkillSet Default CLI。[A: core/bot_config_manifest/capabilities.py:325–326, 363–364；core/bot_config_manifest/apply/materialisers/skills.py:393–434；H/bots/cli_tools.py:83–185]
+
+因此应补的是“能力 → 当前事实 → 改造/复用/排除 → 工程包 → 验收证据”的映射；不能写成“四包都做完，所以所有名字带 Skill 的功能都自动可用”。
+
+## 基线、范围和源码坐标
+
+- **A**：Avernet `github/dev@ca308268927f10df887ad3543d664244dbe6ce52`，本地对象库 `<Avernet research checkout>`。
+- **O**：OCB `origin/dev@658abdf1cc88b047c73463463c695510866b4759`，本地对象库 `<OCB research checkout>`。
+- **I**：上述 OCB 提交实际 gitlink 为 `ocb-public@137219270c46a3508daeaf92d9e660e5ee38aeb9`，由 `git ls-tree O ocb-public` 核实。A 与 I 不同，不把 A 的当前能力直接称作 OCB 已集成能力。
+- 两个 checkout 的 HEAD 均不是本审计基线；源码以 `git show <sha>:<path>` / `git grep <sha>` 读取，行号属于该固定 SHA，不应按工作树当前文件跳转核对。
+- **H** 展开为 `src/backend/src/agentclaw/community/adapters/http/openapi_v1`。
+- **C** 展开为 `src/backend/src/agentclaw/community/core/skill_center`。
+- `core/...` 展开为 `src/backend/src/agentclaw/community/core/...`。
+- 附录路径统一省略公共前缀 **P = `/openapi/v1/bots`**；每个表格的源码文件均属于 A。`L` 指该文件中对应 route decorator 的起始行。
+- 设计范围以本目录 `decisions.md` 的最终确认段为准，特别是 Q24/Q25/Q26/Q27 和 Q28/Q29最终决定。决策摘要与本审计是文档基线，不是代码实现证据。
+
+主验收为 OpenClaw/Hermes Desktop；其它现有 Engine 只做受影响协议/Adapter 兼容。不会扩成完整 Bot lifecycle、Desktop Service Artifact、全量 Pool 切流、原生参数注入或新增 MCP 恢复项目。前端离线 SkillSet 禁操作保持已接受方案；Backend 不新增 Desktop 特殊拒绝语义。
+
+研究依据包括两仓架构与模块约束；本审计仅反映固定源码，不包含业务修改或运行环境操作。
+
+## 能力分类与 G1–G4 映射
+
+分类：**共享** = 已有云端业务，不应复制 Desktop 实现；**设备** = 目标 Bot 设备适配及真实落地相关；**相邻/排除** = 非 Desktop 本期产品新增，仅受影响兼容或明确不承诺。下表“复用”不代表已经跑通。
+
+| 能力/use-case | 分类及当前事实 | 工程承接 | 必须保留的验收边界 |
+| --- | --- | --- | --- |
+| Bot Skill 列表、source=LOCAL、active、分页搜索 | 共享 Desired State 查询；`active` 不是设备观察 | G1 回归，G4 联调 | 离线可查；LOCAL 只含 owner+bot 的上传资产，不是用户全量 Local；含 Set/Direct 可达项。[H/skills/router.py:287–335] |
+| Bot Skill 详情、Center content、参数前置身份 | 共享身份/权限 + Center Query 缺口 | G1 修改；G3/G4 使用 | Center PUBLIC/Space 可见性、精确 PUBLISHED；不能照搬 Local ownership；Router 前置检查也通过。[C/services/skill_query_service.py:142, 207–226, 409–422] |
+| Bot Local ZIP/目录上传、同名替换、读取、删除 | 设备；既有上传/删除服务 | G1 既有 API 回归 + G2 bytes；G3/G4 映射兼容 | 内容实际落盘才是 Local 上传成功；替换不是新增 PUT Skill；删除仍 Local-only 并保留 inactive/引用约束。[H/skills/router.py:473–581, 684–722] |
+| 共享 README | Local 为设备读取，Repo 为共享读取；Center 仍缺失 | G1 单列，不能被 content 测试替代 | 无 Bot wire 与 Bot-content 的版本/权限语义不同；default 重名 owner 定位；Center 新支持范围须显式写清。[C/services/skill_query_service.py:311–360] |
+| 参数 GET/PUT | 设备存储 + 共享参数定义；当前加载错误会置空 | G1 错误保护 + G2 通道回归 | 单 Skill 完整替换、保留其它项；读失败零写；写失败失败；保留旧地址/JSON，原生消费 TBD。[C/services/skill_parameter_service.py:42–103；C/factories.py:817–834] |
+| Direct activate/deactivate | 共享 Desired State + 设备投影；Center 当前会被 Query 前置挡住 | G1 身份接通 + G3 单轮 + G4 恢复 | 既有 ownership/conflict/idempotency；API success 与 runtime_projection 分离。[H/skills/router.py:584–681] |
+| SkillSet CRUD/activate/deactivate/Skill membership | 共享 Desired State + 设备投影 | G1 回归 + G3/G4；前端离线禁用要有明确交付项 | Default exclusion、active/inactive Set、Direct 冲突、单次最终投影；不新增 Backend 离线特殊拒绝。[H/skill_sets/router.py:81–325, 468–507] |
+| Public Reference Operation | 共享异步导入/成员写入 + 设备投影 | 共享现有业务；G3/G4 接线/集成 | 创建/list/detail 都在范围；接受/物化/成员成功/设备收敛分开。内部专项另有审计，本文件不重复展开。[H/skill_sets/skill_center_references.py:131,169,209] |
+| Repo 发现、内容、引用、更新 | 共享 catalog/sync + 已有 Desktop Repo downloader | G1 共享入口回归，G3 受影响映射回归，G4 全链路 | global sync 完成不等于 Desktop 本地更新；复用既有整库 Repo 同步，不改造成 Center exact 下载政策。[H/repository_catalog.py:35–120；Engine skills_repo_download.py:606–681] |
+| TeamClaw/SC 市场、tags、手动 sync | 共享云端 | G1 回归、G4 取样串联；不另建 Desktop 市场 | tags/筛选、已物化资产巡检不是全市场下载；sync 与 Bot convergence 分开。[H/market/router.py:120,192,231,267] |
+| Space 身份/成员、列表、创建、收藏 | 共享云端 | G1 共享回归，G4 资产供给前置 | Space-owned 不因 URL 含 bots 变成 Bot-owned；收藏不等于安装/激活；不连 Desktop。[H/spaces/router.py:212–310,690–908] |
+| Space Skill identity/list/detail/consumable | 共享云端 | G1 回归 + G4 Published→引用 | Draft/identity 与可消费 PUBLISHED 区分，消费者权限不是 Owner/Manager 编辑授权。[H/spaces/skill_routes.py:114–330；C/services/space_skill_version_query_service.py:101–132] |
+| 文件夹/Git 创建、Draft 文件读写、upgrade/refresh/delete | 共享云端 Draft Store | G1 共用合同回归；G4 准备资产 | 不通过 G2 的 Desktop tunnel；revision/CAS/lease 与文件校验仍归原业务。[H/spaces/skill_routes.py:147–238；H/spaces/router.py:312–488] |
+| Published Version/detail/tree/file | 共享 Canonical | G1 共用回归/可复用底层，G4 版本对照 | Space Version 文件按指定 ordinal→exact 读取；不是 Bot Desired Version 或设备取证；非 UTF-8 文件仍按现有文本接口报错。[C/services/space_skill_version_query_service.py:58–99,134–154] |
+| Grant/managers/owner/editor-request/lease | 共享云端协作/授权 | G1 受影响回归；不做 Desktop 版本 | 保留 Space membership 与 Owner/Manager、租约 fencing 等既有区别。[H/spaces/router.py:489–689] |
+| publication-impact/create/list/detail/retry | 共享发布/任务 | G1 共享回归，G3 消费发布结果，G4 Track Latest | Attempt 恢复与 Desktop Skill 下载恢复不是同一 Task；retry 不等于再次创建发布。[H/spaces/publication_routes.py:81–223] |
+| offline-impact/offline/exact-version copy | 共享资产治理 | G1 共享回归，G4 引用保护 | Skill Offline 不等于 Desktop 设备 offline；不新增桌面离线缓存销毁；copy 产生新身份/Draft。[H/spaces/skill_routes.py:420–530] |
+| SkillSet MCP 权限/成员及 Skill dependencies | 相邻旧能力，与 Skill 操作组合 | 各包保现状兼容；G4 断言 Skill-only 重试零 MCP/Passport | 不新增 MCP 恢复，不承诺 V1 Link 与旧 MCP 环境原子保留。[H/skill_sets/router.py:328–465] |
+| Default CLI 展示 vs 独立 cli-tools | 两种相邻旧能力 | G1 查询回归、G2 受影响通道回归；非新增 CLI 项目 | resources 里的 CLI 来自 Passport；独立二进制工具安装不证明 Default CLI 已投影。[C/services/skill_set_management_service.py:803–839；H/bots/cli_tools.py:98–112] |
+| config-manifest/with-manifest | 明确非 Desktop 当前能力，云端共享 Skill 调用方 | G1/G2/G3 受影响云端回归，G4 基线核对 | Desktop 保持拒绝；不扩成整套 manifest 平台实现。[core/bot_config_manifest/capabilities.py:325–364] |
+
+## 需要在正式 Spec 写明的缺口与防漏条件
+
+### 1. G1 不能只修内容读取，必须走真实 Router
+
+目前的失败链是：`GET content / parameters / Direct` → Router `get_skill` → `_resolve` → `SkillAssetKind.SPACE` → `_UnavailableAssetAdapter.resolve` → `LocalSkillNotFoundError`。Bot Skill 列表能返回 Center 不证明这些单项路由可用。Repo Adapter 已展示一种“共享持久行不变、返回视图增加目标 owner+bot”的现有模式，但 Center 仍需自己的 PUBLIC/Space 消费校验，不得直接套 Repo 的 public 判断。[A: H/skills/router.py:369–470,584–666；C/services/skill_query_service.py:142,417,557–605]
+
+最低入口测试应同时覆盖详情/content/GET parameters/PUT parameters/Direct activate/deactivate，包含同一 Center exact 在云端与 Desktop、协作者/App grant、其它私有 Space、同名 default Bot、inactive 但可见的资产。只测 `CanonicalStore.read_version()` 或手工构造 Service 会漏掉这里的前置门禁。参数真正的设备 I/O 仍独立，不能因内容读取不需要设备就承诺参数离线可读写。
+
+README 的默认定位风险与 Center 支持范围分开处理：前者是现有 Local 入口的 owner+bot 一致性；后者因为入口没有目标 Bot，不能隐式选择“某个 Bot 的当前期望版本”。若正式范围仅维持 Local/Repo README，应把 Center README 排除写在能力矩阵；不要宣传该共享入口已随 Bot Center content 一并支持。
+
+### 2. G2 验收应该绑定 Local 产品流程，而不是只测隧道 echo
+
+OCB 最新代码仍有请求/响应文本转换点：`src/desktop/bdc-crates/bdc-core-runtime/src/stages/register_to_baas.rs:814` 使用 `String::from_utf8_lossy`，`bdc-core-plugins/src/container/plugin.rs:299` 使用 `String::from_utf8(...).unwrap_or_default()`，`bdc-core-plugins/src/container/manager.rs:432` 再做响应 lossy 转换；这些点应放到双向 bytes 合同覆盖中，而不是只改 Backend 封装。[O: 上述坐标]
+
+G2 需与既有 Local ZIP/文件夹上传、替换、二进制读取串联，覆盖 UTF-8、非 UTF-8、图片、ZIP、空文件及状态/Content-Type；以逐文件 bytes/hash 一致为验收。Space Draft 上传是 Backend→Draft Store 的共享链，不应被误接到 Desktop tunnel。Center 派生分发包是 Engine→OSS GET，也不是 BaaS 中转大包。
+
+### 3. Repo 是已有产品供给链，不能从 Center 完成推导它完成
+
+`POST P/skills/repository/sync` 是同步 global master fetch/DB scan/cache refresh，不是目标 Bot 的更新命令。[A: H/repository_catalog.py:103–120]
+
+Engine 已有 Desktop `skills_repo_download.py`，在 agentbox 内启动/周期读取下载元信息，ETag 未变化不下载；公开默认缺少分发配置时直接禁用。现有内容目标按 Engine layout 选择 Pool Repo 根。故验收要分别记录共享 catalog 更新、企业分发配置、Desktop 实际仓库版本/内容、有效映射；无需另造一个 Repo 恢复系统。[A: src/engine/src/engine/community/core/skills/skills_repo_download.py:65–120,131–155,606–681]
+
+OCB 已在 Corp DI 绑定 `ProdSkillRepoSyncPlugin`、`ProdSkillScanner`、SC Gateway 和 Space Source；不能拿 Community fake 的 catalog 或包结果当作企业端供给成功。[O: src/backend/src/agentclaw/corp/di/modules/infrastructure/corp/skill_center.py:25–78]
+
+### 4. 离线 UI 要有交付 owner，但不要增加 Backend 政策
+
+Q28/Q29 当前四包主要按 Backend/Desktop/Engine/任务组织，容易遗漏“前端 Desktop 离线禁止 SkillSet 变更”的已接受要求。应在 G1 或 G4 明列客户端/前端禁用与提示的交付 owner，并以现有 UI 入口核验；不能仅因为 Backend 暂时失败就称产品禁用已完成，也不能为了兜底反过来新增 Backend 的 Desktop 特殊拒绝。
+
+这是一条既定范围的交付索引补齐，不是要求本审计修改前端，也不重开已接受的离线残留链接限制。
+
+### 5. 最新 dev 变化：已有能力不能重复造，现有缺口不能宣称已修
+
+- Bot Skill `source=LOCAL` 已存在且按目标 Bot 查询，正式方案应复用。[A: H/skills/router.py:307–334]
+- Repo 正式 catalog/tree/detail/sync 已存在；Local raw ZIP 的正式入口是 `POST P/{bot_id}/skills`，不是重新设计 `/upload`。[A: H/repository_catalog.py:35–120；H/skills/router.py:473]
+- Reference 已有 POST 202 + collection/detail，不能恢复旧同步 batch 方案。本审计只列入口，内部专项由独立审计负责。[A: H/skill_sets/skill_center_references.py:131,169,209]
+- Center Query 的 SPACE 占位、README Center not-found、参数 load 吞错、Hermes local create allowlist 缺失，在 A 仍存在。[A: C/services/skill_query_service.py:142,334–340,594–605；C/services/skill_parameter_service.py:42–64；core/bot_inventory/policies/combo_policy.py:10,32–37]
+- Hermes 新入口不是 DTO 枚举问题：`LocalBotCreate.engine` 是字符串，Router 交给 Workflow；Workflow `start_create` 调 `assert_local_create`，allowlist 当前只有 openclaw/claude_code。G1 修的是入口政策与对应测试，不需要重做已支持的 Desktop runtime。[A: H/local/schemas.py:23–33；H/local/router.py:189–223；core/bot_inventory/services/local_bot_workflow.py:97–110]
+- A 相对 OCB gitlink I 的差异已含 `bots/config_manifest.py`、`apply/materialisers/skills.py`、`capabilities.py`、`support_matrix.py` 等。正式实现时应以匹配集成基线再核验该云端调用方，不把 I 的旧行为覆盖回 A，也不把 A 的新 Git/OSS 供给能力推广成 Desktop manifest 支持。
+
+## 完整入口附录
+
+下列是本范围内固定 A 的 Skill 主路由及明确相邻调用面，不是全仓 OpenAPI 清单。`共享/G1回归` 表示复用现有云端逻辑、承担相应回归，不表示要修改每一条路由。对 User/App/Delegated caller 的实际限制继续以 `H/authorization.py`、`H/admission.py` 为准，`REFUSED` 不能解释成整个产品接口关闭。正式 Router 装配及 legacy mount 见 `H/__init__.py:523–593`。
+
+### A. Bot Skills、共享 README/兼容发布状态、Repo
+
+源码：`H/skills/router.py`；除 Repo 表另注明外。路径均接在 P 后。
+
+| Method / path | 用例 | 分类 / G | L |
+| --- | --- | --- | --- |
+| GET `/skills/{skill_code}/publish/status` | 兼容 SC 发布状态查询，不是 Space Attempt | 共享/G1回归 | 100 |
+| GET `/skills/{skill_id}/readme` | 无 Bot 上下文的 Local/Repo README | 共享+设备/G1、G2 | 168 |
+| GET `/{bot_id}/skills` | 可达 Skill 列表、LOCAL/active/keyword/分页 | 共享/G1 | 287 |
+| GET `/{bot_id}/skills/{skill_id}` | Bot-facing 元数据/active | 共享/G1 | 338 |
+| GET `/{bot_id}/skills/{skill_id}/content` | SKILL.md 展示 | 共享+设备/G1、G2 | 369 |
+| GET `/{bot_id}/skills/{skill_id}/parameters` | 该 Bot 该 Skill 参数值 | 设备/G1、G2 | 403 |
+| PUT `/{bot_id}/skills/{skill_id}/parameters` | 完整替换单 Skill 参数 | 设备/G1、G2 | 437 |
+| POST `/{bot_id}/skills` | raw ZIP 创建/替换 Local | 设备/G1、G2、G3兼容 | 473 |
+| POST `/{bot_id}/skills/upload-folder` | multipart 目录创建/替换 Local | 设备/G1、G2、G3兼容 | 535 |
+| POST `/{bot_id}/skills/{skill_id}/activate` | Direct 激活 | 设备/G1、G3、G4 | 584 |
+| POST `/{bot_id}/skills/{skill_id}/deactivate` | Direct 停用 | 设备/G1、G3、G4 | 634 |
+| DELETE `/{bot_id}/skills/{skill_id}` | 删除 Local 内容/资产；非共享 Center DELETE | 设备/G1、G2、G3兼容 | 684 |
+
+Repo 源码：`H/repository_catalog.py`。
+
+| Method / path | 用例 | 分类 / G | L |
+| --- | --- | --- | --- |
+| GET `/skills/repository` | Repo 分页/排序/筛选 | 共享/G1回归 | 35 |
+| GET `/skills/repository/tree` | 共享仓库树 | 共享/G1回归 | 72 |
+| GET `/skills/repository/{skill_id}` | Repo 详情 | 共享/G1回归 | 85 |
+| POST `/skills/repository/sync` | global fetch/scan/cache 同步 | 共享/G1回归、G4串联 | 103 |
+
+### B. SkillSet 与 Reference
+
+源码：`H/skill_sets/router.py`。下表 S = `/{bot_id}/skill-sets`。
+
+| Method / path | 用例 | 分类 / G | L |
+| --- | --- | --- | --- |
+| GET `S` | Set 列表 | 共享/G1 | 81 |
+| POST `S` | 创建 Set | 共享/G1 | 100 |
+| GET `S/resources` | Set + MCP + Default CLI 聚合 | 共享/相邻/G1 | 124 |
+| GET `S/{set_id}` | Set 详情 | 共享/G1 | 153 |
+| PUT `S/{set_id}` | Set 元信息更新 | 共享/G1 | 174 |
+| DELETE `S/{set_id}` | 删除 Set 与相应生效变更 | 设备/G3、G4 | 198 |
+| GET `S/{set_id}/skills` | Skill 成员列表 | 共享/G1 | 219 |
+| PUT `S/{set_id}/skills/{skill_id}` | 已有资产加入 Set | 设备/G3、G4 | 250 |
+| DELETE `S/{set_id}/skills/{skill_id}` | 移除/Default exclusion | 设备/G3、G4 | 289 |
+| GET `S/{set_id}/mcps` | MCP 成员/依赖视图 | 相邻/G1回归 | 328 |
+| GET `S/{set_id}/mcp-permissions` | 检查 MCP 使用权限 | 相邻/G1回归 | 349 |
+| POST `S/{set_id}/mcp-permission-requests` | MCP 权限申请 | 相邻/保持现状 | 373 |
+| PUT `S/{set_id}/mcps/{server_code}` | 添加 MCP | 相邻/保持现状 | 402 |
+| DELETE `S/{set_id}/mcps/{server_code}` | 移除 MCP | 相邻/保持现状 | 435 |
+| POST `S/{set_id}/activate` | Set 激活 | 设备/G3、G4 | 468 |
+| POST `S/{set_id}/deactivate` | Set 停用 | 设备/G3、G4 | 489 |
+
+源码：`H/skill_sets/skill_center_references.py`。R = `S/{set_id}/skill-center-references`。
+
+| Method / path | 用例 | 分类 / G | L |
+| --- | --- | --- | --- |
+| POST `R` | 带 Idempotency-Key 创建异步 Public Reference | 共享+设备/G3、G4 | 131 |
+| GET `R` | Reference Operation 分页列表 | 共享/G1回归、G4 | 169 |
+| GET `R/{reference_id}` | Operation 与逐项结果 | 共享/G1回归、G4 | 209 |
+
+### C. 市场、Space 身份/协作与收藏
+
+源码：`H/market/router.py`。
+
+| Method / path | 用例 | 分类 / G | L |
+| --- | --- | --- | --- |
+| POST `/market/skills` | TeamClaw 市场查询 | 共享/G1回归 | 120 |
+| POST `/market/mcp-servers` | MCP 市场查询 | 相邻/保持现状 | 143 |
+| POST `/market/skill-center/skills` | SC Public 市场查询 | 共享/G1回归 | 192 |
+| POST `/market/skill-center/sync` | 已物化 Public 资产巡检 | 共享/G1回归、G4串联 | 231 |
+| GET `/market/skill-center/tags` | SC tags 初始化筛选 | 共享/G1回归 | 267 |
+
+源码：`H/spaces/router.py`。T = `/spaces/{space_id}`。本表只列身份/成员/收藏，Draft/Grant/Lease 见下一节。
+
+| Method / path | 用例 | 分类 / G | L |
+| --- | --- | --- | --- |
+| GET `/spaces` | 可访问 Space 列表 | 共享/G1回归 | 212 |
+| POST `/spaces/personal/initialize` | 初始化个人 Space | 共享/G1回归 | 244 |
+| POST `/spaces/create` | 创建团队 Space | 共享/G1回归 | 266 |
+| GET `T/members` | 成员列表 | 共享/G1回归 | 285 |
+| POST `T/members` | 添加成员 | 共享/G1回归 | 690 |
+| DELETE `T/members/{member_user_id}` | 移除成员 | 共享/G1回归 | 718 |
+| PUT `T/members/{member_user_id}/role` | 更新成员角色 | 共享/G1回归 | 748 |
+| POST `T/market-favorites` | 收藏指定市场目标 | 共享/G1回归 | 785 |
+| POST `T/market-favorites/cancel` | 取消收藏 | 共享/G1回归 | 817 |
+| POST `T/market-favorites/search` | 收藏列表/筛选 | 共享/G1回归 | 848 |
+| POST `T/market-favorites/status` | 批量查询收藏状态 | 共享/G1回归 | 881 |
+
+### D. Space Skill、Draft、版本、Grant、Lease
+
+源码：`H/spaces/skill_routes.py`。K = `T/skills/{skill_id}`。
+
+| Method / path | 用例 | 分类 / G | L |
+| --- | --- | --- | --- |
+| GET `T/skills` | Space Skill 列表 | 共享/G1回归 | 114 |
+| POST `T/skills` | 文件夹创建身份与 V1 Draft | 共享/G1回归 | 147 |
+| POST `T/skills/import-from-git` | Git 创建身份与 Draft | 共享/G1回归 | 203 |
+| GET `T/skills/consumable` | 可消费 Published 列表 | 共享/G1、G4桥接 | 239 |
+| GET `K` | Skill 身份/详情 | 共享/G1回归 | 275 |
+| GET `K/versions` | Published Version 列表 | 共享/G1回归 | 298 |
+| GET `K/versions/{version}` | 指定 Version 详情 | 共享/G1回归 | 331 |
+| GET `K/versions/{version}/files` | 精确版本文件树 | 共享/G1回归 | 360 |
+| GET `K/versions/{version}/files/{path:path}` | 精确版本文本文件 | 共享/G1回归 | 389 |
+| GET `K/offline-impact` | 下线影响面 | 共享/G1回归 | 420 |
+| POST `K/versions/{version}/copy` | 从下线已发布版本复制新身份/Draft | 共享/G1回归 | 454 |
+| POST `K/offline` | Skill 下线 | 共享/G1回归 | 490 |
+
+源码：`H/spaces/router.py`。
+
+| Method / path | 用例 | 分类 / G | L |
+| --- | --- | --- | --- |
+| GET `K/draft/files` | Draft 文件树 | 共享/G1回归 | 312 |
+| GET `K/draft/files/{path:path}` | Draft 文本文件读取 | 共享/G1回归 | 336 |
+| PUT `K/draft/files/{path:path}` | Draft 单文件写入/CAS | 共享/G1回归 | 364 |
+| POST `K/draft/upgrade` | 已发布版本建立后继 Draft | 共享/G1回归 | 397 |
+| POST `K/draft/refresh-from-git` | Git 刷新 Draft | 共享/G1回归 | 424 |
+| DELETE `K/draft` | 删除 Draft/按既有条件清理身份 | 共享/G1回归 | 451 |
+| GET `K/grants` | Owner/Manager grants | 共享/G1回归 | 489 |
+| PUT `K/managers/{manager_user_id}` | 添加 Manager | 共享/G1回归 | 510 |
+| DELETE `K/managers/{manager_user_id}` | 移除 Manager | 共享/G1回归 | 534 |
+| POST `K/owner-transfer` | 转移 Owner | 共享/G1回归 | 558 |
+| GET `K/draft/lease` | 查询编辑租约 | 共享/G1回归 | 583 |
+| PUT `K/draft/lease` | 获取编辑租约 | 共享/G1回归 | 600 |
+| DELETE `K/draft/lease` | 释放编辑租约 | 共享/G1回归 | 617 |
+| POST `K/draft/lease/takeover` | 接管编辑租约 | 共享/G1回归 | 640 |
+| POST `K/editor-requests` | 编辑协作权限申请 | 共享/G1回归 | 657 |
+
+不存在因为 Desktop 而需新增的 Draft replacement、独立 consume 或 package 下载 OpenAPI；本审计没有在上述正式 Router 中找到这些独立 endpoint。`consumable` 是候选资产查询，消费行为通过现有 Set/Direct 和 Runtime 完成；原生脚本执行不在此 HTTP 清单中。
+
+### E. Publication
+
+源码：`H/spaces/publication_routes.py`。
+
+| Method / path | 用例 | 分类 / G | L |
+| --- | --- | --- | --- |
+| GET `K/publication-impact` | 发布影响面 | 共享/G1回归 | 81 |
+| POST `K/publications` | 创建/重放发布 Attempt | 共享/G1回归、G4 Track Latest桥接 | 116 |
+| GET `K/publications` | Attempt 列表 | 共享/G1回归 | 143 |
+| GET `K/publications/{attempt_id}` | Attempt 详情/恢复指引 | 共享/G1回归 | 171 |
+| POST `K/publications/{attempt_id}/retry` | 同 Attempt 重试/恢复 | 共享/G1回归 | 197 |
+
+### F. 相邻 MCP、独立 CLI 与配置清单
+
+源码：`H/mcp/router.py`。保持现有能力；只覆盖 Skill 组合与受影响通道，不承诺新 MCP 恢复。
+
+| Method / path | 用例 | 分类 / G | L |
+| --- | --- | --- | --- |
+| GET `/{bot_id}/mcps` | Bot MCP 列表 | 相邻/G1回归 | 133 |
+| POST `/{bot_id}/mcps/{server_code}/activate` | Direct MCP 激活 | 相邻/保持现状 | 161 |
+| POST `/{bot_id}/mcps/{server_code}/deactivate` | Direct MCP 停用 | 相邻/保持现状 | 190 |
+| GET `/mcp/servers` | MCP server 目录 | 相邻/保持现状 | 342 |
+| GET `/mcp/tenants` | MCP tenant 目录 | 相邻/保持现状 | 386 |
+| GET `/mcp/servers/{server_code}` | Server 详情 | 相邻/保持现状 | 404 |
+| GET `/mcp/servers/{server_code}/permissions` | 权限检查 | 相邻/保持现状 | 430 |
+| GET `/mcp/servers/{server_code}/config` | 用户 MCP 配置 | 相邻/保持现状 | 473 |
+| PUT `/mcp/servers/{server_code}/config` | 替换用户 MCP 配置 | 相邻/保持现状 | 497 |
+
+源码：`H/bots/cli_tools.py`。与 Passport Default CLI 不合并；不新承诺 Desktop 工具安装上线。
+
+| Method / path | 用例 | 分类 / G | L |
+| --- | --- | --- | --- |
+| POST `/{bot_id}/cli-tools` | pinned 二进制工具安装 | 相邻/仅受影响回归 | 83 |
+| GET `/{bot_id}/cli-tools` | 平台安装记录列表 | 相邻/仅受影响回归 | 131 |
+| DELETE `/{bot_id}/cli-tools/{name}` | 删除工具 | 相邻/仅受影响回归 | 157 |
+
+配置清单的 Desktop 拒绝来自领域 capabilities，不应修改。下列仅说明为什么它是共享服务变更的云端消费者。
+
+| Method / path | 用例 | 源码 / L |
+| --- | --- | --- |
+| GET `/{bot_id}/config-manifest` | 读取配置文档 | `H/bots/config_manifest.py:70` |
+| PUT `/{bot_id}/config-manifest` | 校验/存储并启动 apply | 同文件 `101` |
+| DELETE `/{bot_id}/config-manifest` | 清除声明，不删除既有资产 | 同文件 `181` |
+| GET `/{bot_id}/config-manifest/capabilities` | construct/source 支持矩阵 | 同文件 `209` |
+| POST `/{bot_id}/config-manifest/apply` | dry-run/异步 apply | `H/bots/config_manifest_apply.py:86` |
+| GET `/{bot_id}/config-manifest/applies/{apply_id}` | 一次 apply 报告 | 同文件 `206` |
+| GET `/{bot_id}/config-manifest/last-apply` | 最近 apply 报告 | 同文件 `243` |
+| POST `/with-manifest` | 云端 Bot+manifest 创建组合 | `H/bots/create_with_manifest.py:129` |
+| GET `/{bot_id}/with-manifest/status` | 组合创建进度 | 同文件 `244` |
+
+原生参数消费：不是上述参数 GET/PUT 的实现承诺。只验收当前存储/回读和错误正确性；自动注入 prompt/env、Hermes 原生消费、Skill 脚本读取参数需要独立证据，未补证前保持 TBD。
+
+### G. Deprecated Skill OpenAPI 与创建前置入口
+
+源码：`H/deprecated/skills.py`。这些 route 通过 `legacy_route()` 注册，不会出现在仅扫描 `@router.get/post` 的清单里。它们是兼容面，不重新成为 Desktop 新合同。
+
+| Method / path | 用例 | L |
+| --- | --- | --- |
+| GET `/skills` | 旧 query bot_id/owner_entity_id 列表 | 190 |
+| POST `/skills/upload` | 旧 query Bot raw ZIP 上传 | 201 |
+| GET `/skills/{skill_id}` | 旧 Local 身份反查 Bot 的详情 | 324 |
+| DELETE `/skills/{skill_id}` | 旧 Local 删除 | 333 |
+| POST `/skills/{skill_id}/activate` | 旧 Local Direct 激活 | 342 |
+| POST `/skills/{skill_id}/deactivate` | 旧 Local Direct 停用 | 351 |
+
+本期主范围另包含 `POST P/local` 的 Hermes 创建入口，源码 `H/local/router.py:189`，政策缺口见上文。其它 Local Bot list/devices/files/authorization/lifecycle 不因本次审计一并成为完整验收项目；只验证初始化、绑定和启动恢复所必需的路径。
+
+Legacy `/api/skills`、`/api/skillsets` 属于 BFF 兼容面，不属于 P OpenAPI 附录，但 G1 Query/参数和 G3 共享投影改变时需要相关 endpoint 回归。通用文件 API、资源 API、Engine `/api/file/*` 是 G2 的依赖通道，亦不是新增 Skill 产品 endpoint。
+
+## 后续验证建议与证据边界
+
+1. G1：真实 OpenAPI Router→DI→Query 的 Center 权限/身份/content/参数/Direct 窄合同测试；Local/Repo/README/default/legacy 回归；Hermes create 政策测试。不要用手工拼 Service 绕过 Router grant。
+2. G2：OCB 双向 bytes 协议测试 + Local ZIP/目录上传/替换/读取逐文件 hash；保持 JSON/health 旧调用兼容。
+3. G3：一次 apply 的 mixed Local/Repo/Center、精确版本缓存、MOUNT/DOWNLOAD、部分 PENDING、显式 retired/实体保护；云端与旧端合同组合回归。G3 单独通过不等于自动最终收敛。
+4. G4：把上述产品入口连到实际 Desktop，并验证 Reference/Space Publication/Track Latest/Direct/Set 各条触发；首次冷包、重启、版本更新、取消、重绑定、错过唤醒和 finite-task 过期；Skill-only 重试零 MCP/Passport；前端离线禁用交付。共享 Space 辅助入口按变更风险回归，不要求每次都操作真实外部发布。
+5. 两仓集成：除了 A 的合同测试，还需匹配 OCB Corp DI/供给/存储/隧道，记录新的 gitlink、客户端与 Engine 版本。OCB 当前 DeviceSync 对 Desktop 使用 `DesktopBaasInvokeTransport`，其它 BaaS 使用 `BaasInvokeTransport`，不能用 provider=baas 一条假设代替两种传输验收。[O: src/backend/src/agentclaw/corp/di/modules/infrastructure/corp/device_sync.py:114–138]
+
+本审计只证明固定源码的入口和调用关系，以及方案仍需明写的覆盖项；没有执行单测、CI、评审、合并、部署或真实设备操作。这些阶段均保持未验证。

--- a/docs/specs/2026-09-08-desktop-skill-capabilities/plan.md
+++ b/docs/specs/2026-09-08-desktop-skill-capabilities/plan.md
@@ -1,0 +1,137 @@
+# Desktop Skill：四工程包交付计划
+
+状态：文档基线；实施工作尚未开始。目标：Avernet与OCB均基于`dev`；规范以[spec.md](spec.md)为准。
+
+## 1. 交付原则与顺序
+
+G1/G2为可独立验证的补齐，G3提供统一单轮交付，G4提供通用自动恢复和完整集成。每组自带测试，不能把全部测试推迟到G4。
+
+| 阶段 | 内容 | 进入下一阶段的条件 |
+| --- | --- | --- |
+| 开工核对 | 两仓最新dev、OCB实际gitlink、已合入修复、共享文件owner | 不重做已完成变更，不以公共dev等同企业部署。 |
+| G1/G2 | API兼容补齐、Desktop字节通道，可独立推进 | 各组窄合同/DI/测试及review完成；无需等待Center下载。 |
+| G3 | 分发包、统一apply/内容Adapter、单轮映射 | 跨两仓字段/错误/证据贯通；Mounted和Downloaded合同通过。 |
+| G4 | 单Bot恢复、所有触发源、扫漏、Track Latest隔离 | G3结果及后台准备Interface稳定，G1/G2最终版本用于集成。 |
+| 企业验收 | 实际OCB gitlink、客户端/Engine、预发+真实Desktop链路 | 关键产品矩阵有独立运行证据，不用CI代替。 |
+
+G3合同设计可在G1/G2实现期间推进；同文件改动须明确owner，不默认四组同时任意改DI/Projector。G4只依赖G3的明确Interface，不复制临时实现。
+
+预计基础PR结构为G1 Avernet、G2 OCB、G3 Avernet+OCB、G4 Avernet；若G1/G4确需企业专属装配/配置修改，则增加对应OCB配套PR。这个估算不是PR数量硬合同；以职责完整、少stack和可验证为准。
+
+## 2. G1 — Skill API/市场/工坊兼容与缺口补齐
+
+### 范围
+
+- Center Query真实Adapter：PUBLIC/Space可访问性、目标owner+bot、Bot-facing返回视图、精确Published解析；覆盖详情/content/parameters/Direct共同前置门禁。
+- Center内容与共享README分别落合同；Local README使用持久owner+bot，保留Local/Repo行为，不把共享资产写成Bot所有。
+- 参数加载错误保护及原Factory/FS兼容，读失败零写、写失败失败、单Skill替换保留其它项。
+- Hermes Desktop新创建入口的实际政策修复；不扩大Engine产品范围。
+- 按入口附录核对市场/收藏/Repo/Space完整生命周期/SkillSet/Direct/旧接口；现有共享业务以受影响回归为主，不逐路由重写。
+- 更新前端调用说明：已有资产PUT与Public Reference POST不同；Reference已添加与Runtime生效不同；不虚构retry/download/进度接口。
+
+### 主要现有seam与文件（定位提示，不是独立事实源）
+
+- Backend `SkillQueryServiceProtocol`及`core/skill_center/services/skill_query_service.py`。
+- `core/skill_center/services/skill_parameter_service.py`、`factories.py`及已有DeviceFileSystem。
+- `core/bot_inventory/policies/combo_policy.py`与Local Bot Workflow。
+- OpenAPI `skills`、`skill_sets`、`spaces`、`market`、`repository_catalog`及Authorization/Admission。
+- 既有SkillCenter/Space/Version DI；完整OCB Corp provider链必须核对，不只手工构造Service。
+
+### 验收与边界
+
+负责Spec A01–A05、A08–A15和A33中共享API部分。测试通过真实Router/DI运行；覆盖User/App及私有资产拒绝、不同owner的default、未安装但可消费Center。参数原生消费另行标记未验证。
+
+不改Runtime下载、MCP恢复、Space发布状态机、Source导入规则或Config Manifest Desktop支持。不因前端当前未开放Direct而不测其现有API。
+
+## 3. G2 — OCB Desktop双向bytes
+
+### 范围
+
+沿用BaaS外层base64，修复Rust内部有损String转换；请求和响应都必须端到端bytes。旧文本命令的JSON shape保留在原Adapter边界，启动health/其它JSON消费者按bytes解析。
+
+主要消费者：BaaS invoke-http、Desktop management API/container plugin/Engine HTTP manager及旧文本handler。对应OCB目录为`src/desktop/bdc-crates/`下的mng-api、core-runtime、core-plugins、adapter与plugin-api。Avernet的文件FS/HTTP契约作为对照，不为此另建上传系统。
+
+### 验收与边界
+
+负责A06/A07及A08/A33的通道回归。至少有从正式Desktop入口到测试Engine HTTP服务的双向集成，涵盖multipart图片/ZIP、非UTF8、空body、UTF8、状态/Content-Type及文本旧入口；再与真实Local上传/替换/读回逐文件hash对照。
+
+不经此通道传Center派生包；不修改Skill业务、OSS签名或云端协议。新客户端需实际发布安装才能证明修复，公共仓库CI不是客户端部署证据。
+
+## 4. G3 — Canonical到设备的共同交付
+
+### 范围
+
+- 一份精确派生分发能力，复用Canonical和对象存储；不是Draft Builder或Repo整库同步器的别名。
+- 分发Module必须提供轻量“已有描述读取”与后台“精确包准备”两类操作。前台只走前者；冷包重工作由G4调用后者，再使用共同投影。授权/签名留在可信目标交付中，不向任务暴露任意OSS key。
+- 固定派生归档格式/可复现输出、完整发布原语与缓存identity；尽量复用现有存储/安全能力。无新业务表、公开meta或Scanner。
+- `SkillRuntimeDelivery`集中获取同一DeviceContext并按bot_type装配可选`center_content`；不在各业务Router判断Desktop。
+- 公共Engine DTO/Protocol、OpenClaw Adapter、共享mapping contract、OCB wrapper/Hermes全链路传播字段及结果证据。
+- Engine Composition Root选择Mounted/Downloaded，后者承担下载、去重、安全校验与缓存生命周期；共用既有映射/retired/best-effort。
+- 旧端精确拒绝与未知结果分开；传输错误脱敏、无自动剥字段/换协议写入。
+
+### 主要现有seam
+
+Backend：CanonicalCenterVersionStore、ObjectStoragePlugin、SkillRuntimeDelivery、SkillsPoolRuntimeProtocol、DeviceContext/DeviceAdapterTransport、RuntimeProjectionResult。
+
+Engine：SkillsService/apply请求结果、content prepare Adapter、layout resolver、映射应用。OCB：Pool mapping payload wrapper、Hermes adapter、Desktop镜像/配置注入与企业OSS实现。
+
+具体代码入口见两份审计，避免用研究工作树的旧HEAD当当前文件。新字段schema由G3唯一负责，G4消费，不另起同义DTO。
+
+### 必须冻结的内部合同
+
+| 合同 | 最低内容 |
+| --- | --- |
+| 精确分发 | lookup与后台prepare的状态、namespace/格式/digest、完成发布、签名TTL/错误、并发复用。 |
+| apply扩展 | Spec D7互斥描述状态、字段校验、结果逐项关联、真实Adapter evidence与旧端拒绝。 |
+| 内容准备 | Mounted/Downloaded的Ready/Pending/Error、副作用、去重及进程生命周期。 |
+| 后台调用 | G4可以准备当前缺包而不在前台做重I/O；准备后应重新读取最新目标再正式投影。 |
+
+负责A16–A24、A31/A32、A34相关合同；与G1/G2执行可达入口集成。须证明正常在线V2下载中停用V1和首次下载中取消不复活；若原retired规则不满足，报告最小共享修复，禁止改成全目录接管。
+
+G3单独可以合并兼容的构件，但不把冷包PENDING、人工调用prepare或单测下载成功当完整功能上线。
+
+## 5. G4 — 通用Bot恢复与整体接线
+
+### 范围
+
+- 一个Desktop Skill恢复Module及一个task type，所有触发源共用；worker读当前Reader和当前绑定，不持久重放旧动作。
+- 在共同变更/投影收尾接入ensure，覆盖正式Reference最终add、Set/Direct、apply_plan，以及Bot未就绪/snapshot失败的提前PENDING。不能在每个HTTP Router各加队列实现。
+- 启动就绪/重连/扫漏使用相同Interface；不悄悄给健康扫描dry-run增加设备副作用。
+- 后台先准备当前需要的缺包；若准备发生等待/重工作，正式apply前再次读取最新期望。最终投影仍由共同Projector解析，不能复用准备前的旧激活计划。
+- 正常PENDING 5秒Reschedule、真实故障Retry、30分钟单轮期限、约10分钟分页扫漏；重复ensure、终态释放和最后检查竞态遵循原Queue限制。
+- Desktop Track Latest仅将新增Skill等待交接到此任务，保留真正MCP故障的现有处理。Skill任务自己不调用MCP/Passport。
+- 完整企业DI、任务启动注册、有效配置及生命周期装配；旧activation_sync骨架必须明确未被误当已接线实现。
+
+### 最重要的三个集成测试
+
+1. 市场先物化、fanout运行时零候选，随后active Set正式add返回PENDING：仍能ensure通用任务并自动下载建链。
+2. 同一Bot同时从市场、SkillSet和Track Latest触发：只有一条live恢复任务；最新Reader包含的所有相关Skill最终可处理，不各写一个入口Task。
+3. Engine下载完成前发生取消/改绑定：后续任务使用新事实；缓存完成回调不复活旧目标，任务不把旧签名和计划发送给新绑定。
+
+负责A10–A15的消费桥接、A25–A34整体链路。前端联调需核验既有离线禁用和升级前提、Reference结果文案，不新造Runtime进度表/API。
+
+## 6. 共享触点与并行冲突管理
+
+| 触点 | 主责 | 其它组如何使用 |
+| --- | --- | --- |
+| Query/参数/Local create及公开字段 | G1 | G2/G3不复制业务校验；字段变更生成OpenAPI由G1负责。 |
+| Rust HTTP body及文本边界 | G2 | G3内部apply JSON必须走兼容通道，不能另开专用socket。 |
+| 分发/apply/evidence/Engine内容接口 | G3 | G4按正式类型消费；不为测试复制同义类型。 |
+| 恢复任务key/outcome/触发及Track Latest | G4 | G1/G3仅通过共同窄Interface接入，不复制延迟/重试逻辑。 |
+| Skill DI/配置/生成产物 | 当前改动所属组 | 报告准确符号/路径，顺序集成，不把整个DI模块覆盖回旧版本。 |
+
+任何任务改动若涉及其它组主责seam，先同步最小合同变化；同一配置/协议只有一个定义，不能以最终resolve冲突为由并行建立两套算法。
+
+## 7. 验证、交付和发布边界
+
+每组依次运行贴近改动的UT/contract、Router/DI/architecture/类型门禁，再做Standards/Spec双轴review并修高优问题，最后按风险与仓库要求执行必要全量/CI。Backend全量不在每次小改后反复运行。真实Corp外部服务与真实Desktop分别验证，隔离实现不能冒充生产一致性。
+
+合并/发布时记录Avernet SHA、OCB SHA和实际gitlink、客户端版本、Engine镜像及有效配置。兼容构件可先集成，但完整能力验收要求G1–G4配套结果；发布/切流须另行授权，不新增灰度控制平台，不因本计划自动重启现存Bot。
+
+回退不删除DB期望态、共享资产、完整缓存或历史locator。旧Desktop或旧Backend不一定具备新Center能力，回退可以失去新能力但不得伪报成功；保留既有升级提示及云端兼容。禁止以全量清理磁盘或回滚业务表作为默认修复手段。
+
+## 8. 本轮产物与下一步
+
+本基线产物：正式Spec、四组计划、任务清单及覆盖/源码附录。文档PR不代表实施Issue已创建或功能已完成。
+
+下一步按组建立自包含实施Issue并记录依赖，再开始对应实现。每组任务在领取时重新核对最新两仓基线和本Spec，不以旧阶段编号G1/G2/G4或过去Phase 2同名分组误认这次Desktop工作已完成。

--- a/docs/specs/2026-09-08-desktop-skill-capabilities/spec.md
+++ b/docs/specs/2026-09-08-desktop-skill-capabilities/spec.md
@@ -1,0 +1,330 @@
+# Desktop Skill 能力适配 Spec
+
+版本：1.0，2026-09-09。状态：总体设计已定稿；本文为Q1–Q29最终决定的规范化整理，功能尚未实现、测试或部署。
+
+Owning Module：Skill Center。参与方：Avernet Backend/Engine/BaaS契约与OCB企业装配、Desktop客户端及Engine Adapter。目标分支：两仓`dev`。
+
+## Problem Statement
+
+用户希望在Desktop Bot上使用与云端一致的Skill产品能力：从TeamClaw或SkillCenter市场添加Skill、引用能力工坊已发布Skill、管理SkillSet、上传Local文件，以及在发布新版本后自动更新运行时。
+
+当前云端Center通过挂载内容库取得文件，Desktop没有同等OSS挂载。仅将逻辑映射推过去不能生成缺失的精确版本内容；首次启动或添加后即使返回PENDING，也不能依赖用户再次修改SkillSet来补齐。市场Reference的COMPLETED只表示添加成功，不能作为Desktop已生效的证据。
+
+同时存在共享Center Query占位、参数加载失败被视为空配置、Desktop二进制转发不保真和Hermes创建入口限制等缺口。必须接通完整入口及企业装配，而不是只实现一个下载器。
+
+## Solution
+
+保留一套Skill领域逻辑、Installation Reader和运行时投影。在现有逻辑apply下，为Desktop补齐按需精确版本下载：Backend准备/复用Canonical派生包及限时下载描述，Engine下载、校验、缓存并使用自己的布局解析建链。
+
+所有Desktop Skill入口共用一套Bot级后台恢复机制。它复用`ac_task_queue`，每轮读取最新期望并调用共同Projector；不为市场、SkillSet、Direct、启动和Track Latest各写一套恢复。已有云端挂载、Strict Pool迁移和Teclaw Whole Artifact行为不变。
+
+验收主目标是OpenClaw和Hermes Desktop。其它既有Engine保留受影响的合同兼容，不据此宣称所有Engine已完成Desktop产品上线。新增能力允许要求升级Desktop客户端及Engine；不要求现有云端容器统一升级或重启。
+
+## User Stories
+
+1. 作为Desktop用户，我希望使用产品已支持的OpenClaw或Hermes创建Bot，以便Skill入口与实际Engine能力一致。
+2. 作为用户，我希望查看当前Bot的可达Skill及active状态，以便区分期望启用与设备实际同步结果。
+3. 作为用户，我希望用LOCAL筛选当前Bot上传的Skill，以便不混入我的其它Bot资产。
+4. 作为用户，我希望搜索TeamClaw市场并引用已有Skill，以便继续使用既有Repo供给。
+5. 作为用户，我希望搜索SC市场、使用标签并查看现有详情，以便选择公共Skill而不先导入整个市场。
+6. 作为用户，我希望一次选择多个SC Skill加入SkillSet，以便用原有异步批量接口完成引用。
+7. 作为用户，我希望重发同一请求保持幂等，以便不重复创建共享资产或成员。
+8. 作为用户，我希望批量引用的一部分失败时保留成功项，以便逐项理解结果。
+9. 作为用户，我希望云端懒物化成功后正式检查最新权限与SkillSet状态，以便后台等待期间的变更仍受约束。
+10. 作为用户，我希望同一已物化版本被其它Bot引用时复用共享资产，以便避免重复导入。
+11. 作为用户，我希望向inactive SkillSet添加成员不会提前激活，以便组织内容与实际启用保持区分。
+12. 作为用户，我希望开启SkillSet后自动下载缺失的Center内容并建链，以便无需第二次操作。
+13. 作为用户，我希望引用能力工坊已发布Skill时沿用同一设备交付，以便不再经过Public市场懒加载。
+14. 作为工坊协作者，我希望原有Space、Draft、Grant、Lease、发布及重试接口保持一致，以便不学习Desktop专用资产流程。
+15. 作为工坊用户，我希望下线、影响面和复制沿用当前产品规则，以便Desktop引用也遵守共享资产治理。
+16. 作为用户，我希望查看有权访问的Center详情、内容和README，以便不因本地下载尚未完成而无法查看共享资产。
+17. 作为API调用者，我希望Direct操作复用已有权限与成员规则，以便Desktop不出现另一套激活语义。
+18. 作为用户，我希望首次启动和重启自动补齐所需版本，以便不手工刷新SkillSet。
+19. 作为用户，我希望已有精确缓存可跨重启复用，以便不反复下载相同文件。
+20. 作为用户，我希望单个Skill下载等待不阻断其它可执行项，以便混合Local/Repo/Center仍可部分生效。
+21. 作为用户，我希望V2未就绪时保留V1有效链接，以便不提前指向半成品目录。
+22. 作为用户，我希望下载期间取消激活后不会被迟到下载重新激活，以便最新期望始终有效。
+23. 作为用户，我希望断网恢复后系统继续同步，以便不依赖再次点击产品按钮。
+24. 作为用户，我希望签名URL过期后系统取得新凭证，以便不需重新发布或重新导入Skill。
+25. 作为用户，我希望升级Skill后所有适用Desktop自动跟随最新已发布版本，以便使用新内容。
+26. 作为用户，我希望看到PENDING、DEGRADED及具体问题，以便不把“已添加”误认为“已生效”。
+27. 作为用户，我希望Local文件夹中的图片、ZIP等内容完整上传、替换和读回，以便文件不被文本编码损坏。
+28. 作为用户，我希望参数保存保留其它Skill配置，以便一次读取异常不会清空整个配置文件。
+29. 作为用户，我希望参数读取/写入失败如实返回，以便不收到虚假的空配置或保存成功。
+30. 作为已有云端Bot用户，我希望此次Desktop改造不改变挂载、布局、历史制品和原有兼容路径。
+31. 作为平台维护者，我希望多个入口对同一Bot共用一个恢复工作项，以便控制重试成本并集中排障。
+32. 作为平台维护者，我希望Backend只表达逻辑映射，由Engine决定物理目录，以便Desktop与Legacy/Pool保持正交。
+33. 作为平台维护者，我希望验证实际OCB装配、客户端和Engine，而不只看到公共仓库Fake测试通过。
+34. 作为用户，我希望市场收藏只是收藏，以便不会因此下载、安装或激活内容。
+
+## Implementation Decisions
+
+以下条目是目标合同，不表示同名现有类已经实现；Implementation可以在保持合同的前提下使用现有小Module，不要求逐条新增Service。
+
+### D1. 事实、身份与成功层级
+
+- Bot地址始终是`owner_id + bot_id`，保留现有tenant/env作用域。actor不是owner，`default`不全局唯一。
+- `ac_bot_skill_installation`表示Bot当前active身份；Effective Read继续经过统一Reader及现行flush模式，不重新union Set/Default/exclusion。
+- Center运行时身份是内部`skill_uuid + sc_version_number`，逻辑入口使用`link_name`。外部SC code与名称都不能代替内部UUID；Public导入复用来源身份，不与同名Local/Repo合并。
+- 实际消费版本来自正式VersionResolver；不同Bot的Desired State、缓存和结果各自独立。MCP dependencies来自精确Version，不从下载文件重新Scanner扫描。
+- Publication成功以既有Canonical就绪及Version发布合同为准，不等待Desktop传播。
+- Reference COMPLETED表示正式添加完成，不代表Runtime CONVERGED。缓存Ready也不代表软链已经生效；列表active不代表设备观察结果。
+- 合法Set/Direct Desired State提交后不因Runtime PENDING/DEGRADED回滚。权限、DB和领域校验失败仍是真失败。Local文件上传和参数保存必须实际写入成功，不能套用Desired State的成功语义。
+
+### D2. 四个工程包及共享职责
+
+| 工程包 | 职责 | 不得另建的重复能力 |
+| --- | --- | --- |
+| G1 Skill API/市场/工坊兼容 | Center Query及相关入口、README、参数错误保护、Hermes创建、共享业务/旧接口回归与调用文档 | Desktop专属市场、Space、ACL或Installation实现 |
+| G2 Desktop文件通道 | 双向bytes保真、旧文本入口兼容、Local完整文件流程 | 新上传会话/分片/OSS中转系统 |
+| G3 Center统一交付 | 精确派生包/签名、共同apply扩展、MOUNT/DOWNLOAD Adapter、缓存及单轮映射 | 每Engine下载器、每入口物化服务、Backend路径表 |
+| G4 通用恢复与整体接线 | 一个Bot级Skill工作项、全部触发源、扫漏、Track Latest协调与集成验收 | 每入口Task、MCP恢复Task、Pool迁移替代者 |
+
+所有组自带测试。G3只证明一次交付/内容准备，G4提供无需用户再次操作的自动跟进；G3单独合并不等于功能完整上线。
+
+### D3. 市场与工坊的完整消费链
+
+既有TeamClaw市场资产和已发布Space Skill按内部`skill_id`加入Set。SC Public按外部`skill_codes`走专用异步Reference：解析exact版本、复用/创建资产及Version、云端物化、最终重新校验并调用正式SkillSetManagement。
+
+- 保留现有多code、去重、幂等冲突、逐项状态和部分失败合同；不新增独立Reference retry接口。同key重放不是重置终态FAILED，新key代表新命令。
+- active Set添加维护Membership/Installation并投影；inactive添加只维护成员，不因Reference完成提前下载。之后activate按届时期望投影。
+- 最终add失败保留可复用的共享资产；不得回滚其它成功Reference项或把失败伪装为Desktop等待。
+- 物化后的Track Latest可发生在最终add前，不作为首次目标Bot恢复保证；最终共同变更入口必须接入D8的恢复机制。
+- 周期/手动SC Sync继续只处理已物化Public资产，不全量导入市场，不新增webhook或Desktop同步器。新版本与Space发布同走既有通知/扇出，再交给共同投影。
+- 市场列表、标签、详情iframe、收藏、Repo目录/详情/同步及工坊辅助接口必须在验收索引中出现；已有共享逻辑不重写。
+
+### D4. Query、内容、README、参数和Local文件
+
+**Center Query**：补齐现有占位Adapter，使详情/content/parameters/Direct共用的前置解析、目标Bot记录及权限检查均成立。共享资产持久归属不变，只构建Bot-facing返回视图。Direct activate前可以没有Installation；不能用“已经安装”替代消费权限。
+
+**权限**：复用Bot owner/协作者与应用Grant，以及PUBLIC/Space可见和消费规则。Bot访问权不赋予任意私有Skill读取权；不新增编辑申请、Owner/Manager或Lease门槛作为普通查看条件。
+
+**Bot content**：同一Query与Canonical读取用于云端和Desktop，解析当前期望的精确Published Version，不要求设备在线或本地缓存Ready，不调用Engine、不准备下载包。期望V2而实际仍V1时允许展示V2，但不能据此称V2已运行。普通Asset/Draft/Version读取不新增flush；Bot active查询仍服从Reader。
+
+**共享README**：与Bot content分别覆盖。保留Local/Repo既有读取兼容并修复Local owner+bot定位；Center没有目标Bot时按共享资产可见性及最新合格Published Version展示，不猜某个Bot的版本、不展示Draft、不触发设备下载。显式版本内容继续走既有Version接口。资产Offline的展示与消费限制沿用正式资产规则，不借README恢复可消费性。
+
+**参数**：保留公开GET/PUT、按Skill name组织的JSON及历史地址。深化原参数Module：明确文件缺失才允许初始化；超时、拒绝、代理错误、非法JSON/结构均不能当空配置。PUT完整替换单Skill对象，保留其它合法项及元信息；读失败零写，写失败返回错误。维持既有参数名/必填校验，Center定义来自精确版本。复用原Factory/内部地址兼容及设备FS，不新增Engine参数API、DB表、分布式锁或自动注入。原生参数消费仍独立未验证，本期只保证存储与回读。
+
+**Local bytes**：沿用现有raw ZIP/文件夹上传、同名替换、删除与文件读取；Desktop内部HTTP body双向使用无损bytes，外层BaaS base64合同不变。旧文本/JSON命令在边界保留原wire，不把body改成JSON数字数组。状态、Content-Type、空文件及必要HTTP头保持正确；不吞解码/读取失败。不更改既有安全校验和Local文件迁移协调规则。
+
+### D5. Backend逻辑交付与Engine内容准备
+
+共同调用方向保持：正式业务命令 → Desired-State UoW → Reader/VersionResolver → 纯RuntimeProjectionResolver → BotRuntimeProjector → SkillRuntimeDelivery → Engine。
+
+| Seam | 责任与约束 |
+| --- | --- |
+| 既有SkillRuntimeDelivery | 接收逻辑计划/retired；集中解析可信目标、准备下载描述、调用apply并解释结果。调用者不传is_desktop、物理目录或下载策略。 |
+| Backend精确分发能力 | 依赖Canonical及对象存储Protocol，提供派生包就绪/失败结果和限时描述；不维护Installation或自行投影设备。 |
+| Engine内容准备Interface | Mounted与Downloaded两个真实Adapter；只回答精确内容可用性并在DOWNLOAD模式准备缓存。 |
+| Engine共同映射应用 | 根据内容Ready和当前合法逻辑计划做best-effort建链/退出；不由下载完成回调重放激活。 |
+| Desktop恢复Module | 统一ensure工作及执行轮次；依赖现有Queue/Reader/Projector，不复制它们的业务。 |
+
+Backend新分流集中在交付Module，依据owner-qualified DeviceContext的`bot_type == desktop`，不是provider、engine名或layout。分类、签名作用域和实际invoke复用同一次可信目标解析；身份/绑定异常不靠猜测签名。历史合法空bot_type保持现有兼容。
+
+Engine Composition Root复用已有agentbox配置事实选择内容Adapter，不让请求强制MOUNT改DOWNLOAD，不在业务层散落环境变量判断。OpenClaw/Hermes共享下载实现。Legacy/Pool与交付方式是独立维度；本期不切流、不迁移DB locator、不建立整库active桥。
+
+Mounted保持原挂载及检查行为，不下载、不修mount、不写只读仓库。Teclaw仍由现有Registry选择Whole Artifact，不被当成普通文件型MOUNT。
+
+### D6. Canonical派生包和设备缓存
+
+1. 首次被Desktop需要时才从Canonical exact内容生成派生ZIP；不从Draft、Publication staging或SC latest获取替代内容，不改变Version状态。
+2. ZIP身份包含内部UUID、精确版本、Canonical内容摘要及分发格式版本，跨Bot可复用。使用独立分发命名空间，不放入被云端挂载的Runtime内容树，不复用主Skill的Draft/staging字段。
+3. 冷包的重工作只在后台恢复执行中准备。前台投影只读取既有包描述或返回该项PENDING并确保后续工作；不能在用户请求中同步读取整版本、压缩上传后再返回。
+4. 构建结果只有完整验证并发布后才可签名。并发构建要保证精确身份结果一致、未完成对象不可读；采用可复现归档和既有对象存储一致性原语，不新增DB事实表或分布式锁框架。
+5. 只为当前desired Center签发精确对象GET URL，有效期3600秒；retired-only和云端请求不准备包/签名。地址来自部署配置，必须Desktop可达，不复制Repo的公开meta供私有内容使用。
+6. URL不写长期任务payload、普通日志或前端参数；不传长期OSS/SC凭证。更换URL不改变内容身份，不取消同identity/hash的有效下载；过期时后续投影更新凭证，不使Ready缓存过期。
+7. Engine直连OSS下载，包字节不经BaaS/Desktop HTTP隧道。只允许本合同可信来源描述，保留受控网络来源、超时、大小及并发限制；不能把此接口变成任意地址下载器。
+8. 下载/解包使用本Module独占临时空间；验证摘要、大小、精确身份、安全路径/链接条目、展开数量/体积和规范入口，完整后才发布为缓存Ready。不新增Scanner或MCP重推导。
+9. 首次/重新下载完整验证，缓存命中轻量检查；目录存在不等于Ready。内容就绪元信息只证明缓存完整，不记录软链所有权。轻量检查不承诺识别全部用户篡改。
+10. 同设备相同exact内容合并下载；限流未启动、正在下载、临时失败与已Ready应可区分。进程重启可由后续apply重新准备，下载器不是永久激活队列。
+11. 本期不做完整缓存TTL/LRU/keep-N及云端派生包自动GC。只安全清理自己已结束或可确认不再运行的临时工作，不清理未知/运行中目录，不以删除用户或在用文件腾空间。磁盘增长和不足保持可诊断。
+
+### D7. 共享apply内部合同
+
+继续使用`POST /api/skills/mappings/apply`。原`mappings`、`retired_mappings`、`source_layout`及Mapping v2/v3身份不变；本期不创建Mapping v4、产品下载Router或日常probe/ensure/verify组合。旧`center/ensure`仍只读，Strict迁移仍使用原合同。
+
+下载型请求可附带顶层`center_content`。以下字段是本Spec对已定语义的wire收敛；不是已部署DTO：
+
+| 字段 | 合同 |
+| --- | --- |
+| `contract_version` | 当前为1；与Mapping身份版本独立。 |
+| `packages` | 当前desired Center精确身份的内容描述集合，同exact去重；不包含仅退休项。 |
+| 每项`skill_uuid`、`sc_version_number` | 精确逻辑身份；必须能关联当前desired映射，不接受任意OSS key。 |
+| 每项`state` | `READY`、`PENDING`或`UNAVAILABLE`，只表示云端分发包描述，不表示设备就绪。 |
+| READY项 | 必填`package_sha256`、`package_size`、`signed_url`、`expires_at`；完整类型验证后才可下载。 |
+| PENDING项 | 包尚未准备完；不伪造空URL/hash，不阻断其它可执行映射；由恢复工作后台准备。 |
+| UNAVAILABLE项 | 携带稳定问题code和可恢复性；不得透出内部异常/URL，也不能将权限拒绝当正常下载中。 |
+
+状态采用互斥类型，READY必填字段不得被普遍扩大为optional以隐藏错误；不属于本状态的字段不能被消费。具体长度/数量/路径限制复用当前精确版本与包安全合同，并在对应DTO/配置及测试中统一，不另造不一致规则。
+
+响应沿用逐mapping的identity、action、status、code、retryable与用户问题明细。Downloaded Adapter在现有`evidence.center_content`中报告真正解释的合同版本和实际mode；不得由Router机械echo。该证据不代替缓存或软链成功。
+
+- 缺失/重复/不属于请求的结果、矛盾aggregate、缺有效合同识别证据均不得伪报CONVERGED。
+- Backend要求DOWNLOAD而实际配置MOUNT时明确报告配置/能力问题，不静默下载或改挂载；能安全执行的其它项仍按新端逐项规则。
+- 正常冷内容PENDING、下载失败、缓存Ready但建链失败必须保留区别；不增加单独进度查询RPC，apply同时观察内容状态并推动当前映射。
+- 所有Protocol、公共Engine Adapter、OCB wrapper/Hermes、请求和响应parser必须贯通扩展，不能手工重建payload丢字段。
+- 422等错误可能回显签名URL；传输Adapter需结构化、脱敏传播，不解析异常字符串猜合同版本，不日志记录原始validation输入。
+
+### D8. 一套Bot级恢复，而非每入口一个任务
+
+复用`ac_task_queue`底座，新增/补齐一个Desktop Skill task type和Handler。旧activation_sync骨架不是现成能力，也不因相似名称直接复制其历史动作payload。
+
+**调度身份**：Queue既有`env/app/task_type`作用域加`owner_id + bot_id`；同Bot至多一条live工作项，不按入口、Skill、Reference或版本拆长期任务。payload只承载逻辑目标及必要控制信息，不存签名URL、冻结版本清单或待重放的激活动作。
+
+**入口**：正式Set/Direct变更收尾（含Reference最终add）、共同投影、启动/重连及Track Latest都请求同一恢复Interface。Bot未就绪或snapshot失败导致未进入Engine的提前PENDING，也要进入这一共同机制。inactive SKIPPED不是下载理由，业务权限/DB失败不是重试历史命令的授权。
+
+**一次执行**：核对目标仍适用及当前绑定；Reader读取当前有效身份并解析精确版本；后台逐项准备尚缺派生包，单项准备失败不能阻断其它可执行项；重工作结束后重新读取最新期望，再调用共同Projector的Skill scope及Engine apply；按逐项结果决定本行Queue outcome。已退出的目标不继续安排下载，迟到内容不能重新激活；任务自身不再enqueue另一条任务来代替Reschedule。
+
+| 情况 | 后续 |
+| --- | --- |
+| 新建due-now工作 | 使用现有wake_on_enqueue及worker领取，首轮不等待扫漏。 |
+| 内容正常准备/下载中 | `Reschedule(5s)`，不因正常等待指数退避。 |
+| 网络/设备暂不可用 | 使用既有`Retry`退避；超时不能当已确认在下载。 |
+| 混合DEGRADED/PENDING | 看逐项可恢复工作，永久问题不能遮住其它等待项。 |
+| Skill域全部完成 | 结束快速跟进；不表示MCP/Passport全部完成。 |
+| 只剩不可自动解决的问题 | 停止该问题高频重试，保留具体DEGRADED，不能伪报成功。 |
+| 单轮达到30分钟deadline | 按现有Queue终态/释放live key机制处理；不回滚DB、不删除完整缓存。 |
+| 漏唤醒、过期或较长离线 | 约10分钟分页扫漏，幂等ensure同一类任务；不在扫描线程下载/投影。 |
+
+兜底不能只查现存任务或DB ACTIVE/状态跳变；必要时对目标范围内存活且有绑定的Desktop幂等再核对。允许已有完成Bot低频核对，不新增同步进度表。现有健康扫描只更新状态，不能偷换其dry-run/白名单保护或视为已经触发投影。Pool过渡期继续尊重既有迁移对映射的所有权，不让新任务抢写。
+
+5秒是下一次可领取时间；10分钟是扫描周期，均不是端到端SLA。deadline不是取消正在运行Handler的硬超时，租约续期不延长它。重复enqueue不更新payload、不提前run_at、不延deadline，亦不是所有前台命令的分布式锁。
+
+保留现有入队非事务窗口，以及最后一次读取至Complete之间出现新期望的窗口，由已定扫漏兜底。不得因此新增outbox、generation表、任务进度表或修改通用Queue基础设施。入队失败必须保留真实错误/日志，不能声称持久恢复已保证。
+
+### D9. 版本切换、退出和MCP
+
+- V2未Ready时保留V1有效链接；Ready后由基于最新Reader的正式apply切换。Engine下载完成回调只发布缓存，不重放旧激活。
+- 当前显式retired和best-effort保护保持共用，不新增持久退休账本、Engine链接回执或全命名空间清理；不能把指向某种内容根等同平台所有权。
+- 前端已确认Desktop离线禁用SkillSet开关/成员变更；Backend不新增专属offline拒绝，Direct API保持。前端禁用不是技术强一致保证；直接API、操作中断网仍可能丢失retired并残留链接，扫漏不能凭空恢复这些事实。
+- 正常在线“V1保留而V2下载中停用”与“首次下载中取消激活”必须验证。若原共享退出规则不足，提出最小一致性修复，不暗中升级为整库删除或回执系统。
+- Skill/MCP独立best-effort保持现状：V2等待时可能已应用新依赖，V1链接保留不保证旧MCP环境或业务零中断。
+- Desktop恢复只做Skill scope，后续轮次零MCP/Passport重推。Track Latest仅因Skill下载等待时转交共同恢复，不被这个新等待驱动原全域Retry；真正MCP失败的既有处理保留。不新增MCP专用任务。
+
+### D10. 兼容、升级与公开接口
+
+保持既有产品OpenAPI方法、请求身份、幂等和分页；不新增Desktop市场/下载/进度/参数接口。当前已有资产加Set是PUT，Public Reference是异步POST，二者不能混用；Local raw ZIP与Space文件夹合同分别保持。源码不存在的独立Reference retry或整包Draft replacement不可从旧Spec恢复。
+
+| 组合/情况 | 必须保持的行为 |
+| --- | --- |
+| 新Backend + 旧/新云端Engine | 不附下载扩展、不打包、不要求重启；MOUNT/原fallback不变。 |
+| 旧Backend + 新Engine | 既有无扩展云端/Local/Repo合同兼容；不承诺旧Backend能启动新Desktop Center下载。 |
+| 新Backend + 新Desktop | 一次apply，逐项best-effort，统一后台恢复。 |
+| 旧Desktop明确拒绝新增字段/能力 | 准确升级提示，停止该问题高频重试；DB期望保留。旧DTO整批拒绝时不能声称Local/Repo当次已执行。 |
+| 网络超时、5xx、代理404、非法响应/缺证据 | 表达结果未知/协议问题，不当升级证据，不切另一写协议。 |
+
+仅已识别的结构化unsupported/新增字段拒绝可以作升级依据，不是任意422。旧端整批拒绝不剥字段、不拆批补发。标准路由404+同目标health的原有窄识别可以保留，但需要新下载合同的请求绝不fallback到旧mount/publish路径；本次不增加正常稳态probe。
+
+Desktop既有产品升级门禁继续使用，不新增Backend最低版本表。门禁是用户确认的产品前提，不证明所有旧请求绝不可能到达；保护分支和组合测试必须保留。
+
+公开Router/DTO如实际变更，必须从Backend正式实现生成Gateway产物并执行合同检查；不能只修改生成JSON或只更新前端说明。签名扩展为内部Engine合同，不直接成为前端字段。
+
+## Testing Decisions
+
+以用户可观察行为、正式Service/Plugin Interface及真实Router→DI为测试面。Mock应模拟外部依赖而非跳过需要验证的Module；必须证明真实Adapter被调用。共享Mounted/Downloaded运行同一契约套件，具体实现可补充测试。
+
+测试分层：各组窄单测与协议/DI/架构门禁 → Standards/Spec双轴review并修高优问题 → 必要全量/CI收尾 → 匹配OCB gitlink与真实Desktop验证。已有CI要求不削弱；Fake/隔离测试不能代替真实设备。此文没有运行这些测试。
+
+### 验收索引
+
+| ID | 必须验证 | 主责 |
+| --- | --- | --- |
+| A01 | OpenClaw/Hermes Desktop创建、启动，现有其它Engine兼容 | G1/G4 |
+| A02 | Bot列表/LOCAL筛选/active/分页，owner+default隔离 | G1 |
+| A03 | Center详情/content/参数/Direct均通过真实Router前置身份与Grant | G1 |
+| A04 | 云端/Desktop同权限content一致且零Engine/下载；期望V2不代表实际V2 | G1 |
+| A05 | README无Bot语义、Center Published可见性、Local owner定位 | G1 |
+| A06 | Local文件夹/raw ZIP上传替换读取，文本/非UTF8/图片/空文件hash一致 | G2 |
+| A07 | 字节修复不破坏JSON/health、状态与Content-Type；失败不伪空 | G2 |
+| A08 | 参数读失败零写，写失败失败，替换A保留B及历史格式/地址 | G1/G2 |
+| A09 | 市场列表/tags/详情/收藏与Repo目录/详情/同步，零全市场物化 | G1 |
+| A10 | Public多codeReference从接收到云物化、最终add、Desktop软链完整链 | G1/G3/G4 |
+| A11 | 幂等重放/冲突、批量部分失败、已物化跨Bot复用；无伪retry接口 | G1/G4 |
+| A12 | 物化后权限/Offline/Set状态改变时最终检查；失败保留共享资产 | G1/G4 |
+| A13 | inactive引用不下载；后续activate下载；重复成员changed=false后仍可恢复 | G3/G4 |
+| A14 | Space已发布引用复用同一Center交付；Draft/Grant/Lease/发布重试等共享回归 | G1/G4 |
+| A15 | 下线影响面/复制按当前合同；不创建旧Spec中的自动Draft行为 | G1 |
+| A16 | 冷派生包后台构建、并发可复用、完整发布、无重复压缩/Scanner | G3 |
+| A17 | 签名1小时、过期刷新不重启有效下载/失效缓存、私有内容不公开meta | G3 |
+| A18 | hash/大小/路径/链接/数量校验，半成品不可见，安全临时清理 | G3 |
+| A19 | 缓存跨重启复用、轻量检查及磁盘不足可见；无完整版本自动GC | G3 |
+| A20 | mixed Local/Repo/Center逐项结果完整；一项PENDING不拦其它合法项 | G3 |
+| A21 | V2准备中保留V1；新目标停用/移除后迟到下载不复活 | G3/G4 |
+| A22 | apply扩展逐层透传、真实Adapter识别证据、缺项/重复/矛盾结果不伪成功 | G3 |
+| A23 | 旧云端/新云端/旧Backend/新Desktop组合，旧端拒绝不拆批补发 | G3 |
+| A24 | 分类依据bot_type且集中；同provider不同部署、Teclaw不误入文件apply | G3 |
+| A25 | 市场/Set/Direct/TrackLatest/启动同Bot共用一个live任务，读取最新期望 | G4 |
+| A26 | 先fanout零候选后final add，以及未到Engine的PENDING仍进入共同恢复 | G4 |
+| A27 | 下载中5秒、异常退避、混合DEGRADED/PENDING、完成判据及永久错误 | G4 |
+| A28 | 30分钟期限、重复ensure、终态释放/扫漏、最终检查竞态与当前绑定 | G4 |
+| A29 | 首次/重启/重连及漏唤醒自动补齐，不依赖用户第二次变更 | G4 |
+| A30 | 手动/周期SC Sync、Space发布→TrackLatest→Desktop新exact；恢复零MCP/Passport | G4 |
+| A31 | 不新增离线Backend政策/R1/R2/R3，正常显式退出与实体保护正确 | G3/G4 |
+| A32 | Strict Pool过渡所有权、Legacy/Pool正交、云端mount和历史Artifact不回归 | G3/G4 |
+| A33 | Legacy BFF/动态Deprecated OpenAPI、Default/MCP/CLI共享调用面回归 | 各组 |
+| A34 | OCB真实Protocol identity/DI、Task注册、签名网络、客户端/Engine版本与真实文件证据 | 各组/G4收口 |
+
+真机验收每条关键消费链至少记录：调用/trace及Reference/Attempt ID（适用时）、目标owner+bot、期望exact、任务状态、Engine版本与实际链接目标/可读内容hash。不得记录签名URL/长期凭证。分别报告本地测试、CI、评审、合并、部署及实机结果。
+
+## Out of Scope
+
+- 新增Desktop支持的Engine产品、Aix Engine重写、全量Pool切流、云端mount/启动脚本重构、#455剩余全部模块。
+- 整个Bot Config Manifest/CLI工具平台开放给Desktop、Desktop Service Artifact；只保护受影响云端共享调用面。
+- 新Desktop资产/Installation/参数/进度/退休表，通用Queue事务outbox/generation/锁基础设施，按入口恢复Task。
+- 独立Engine拉取Desired State接口、下载完成自动激活回调、SC webhook、整市场下载、重复SC Scanner。
+- 完整缓存自动GC、强制清理全部非期望链接、离线Backend专属禁令、追回已下载字节或失效URL即时终止已有流。
+- 新MCP持久恢复/Skill-MCP原子切换、原生参数注入或消费能力、参数全局并发CAS/断电原子性。
+- 新前端下载百分比/Runtime进度轮询API，重写已有市场详情iframe或将Reference COMPLETED改为设备全部Ready。
+- 承诺永久断网/权限拒绝/受保护实体冲突一定能成功，或将调度周期宣传为严格恢复SLA。
+
+## Further Notes
+
+### 参与模块的现行合同入口
+
+以下链接定义现有Module/协议。D7描述的是本次待实施的兼容扩展；阅读时先区分当前合同与目标合同，不能把本Spec的新增字段视为当前Engine已经接受。
+
+| Module/调用方向 | 现行合同 | 本次关联 |
+| --- | --- | --- |
+| Backend Skill Center | [模块维护约束](../../../src/backend/src/agentclaw/community/core/skill_center/AGENTS.md)、[Context Boundary](../../../src/backend/src/agentclaw/community/core/skill_center/README.md) | 统一Reader/Writer、资产与设备结果分离、DI和公开入口。 |
+| Backend调用Runtime | [Projector Service API](../../../src/backend/src/agentclaw/community/core/skill_center/bot_runtime_projector_protocol.py)、[Projection结果合同](../../../src/backend/src/agentclaw/community/core/skill_center/runtime_projection_contract.py)、[Runtime ports](../../../src/backend/src/agentclaw/community/core/skills_pool/ports.py) | G3/G4复用共同投影；兼容Strict Pool与原逻辑apply。 |
+| Backend内容与存储 | [Canonical Store](../../../src/backend/src/agentclaw/community/core/skill_center/canonical_center_store.py)、[ObjectStorage Plugin API](../../../src/backend/src/agentclaw/community/plugin_api/object_storage.py) | 精确内容读取、派生包和签名依赖；不复用Draft身份。 |
+| Engine Skill能力 | [SkillsService Protocol](../../../src/engine/src/engine/community/core/skills/protocol.py)、[当前HTTP DTO](../../../src/engine/src/engine/community/api/skills/schemas.py)、[异构Engine与mapping合同](../../../src/engine/docs/heterogeneous-engine-architecture.md) | 新扩展须透传到真实Adapter，旧ensure/迁移合同保留。 |
+| BaaS设备/PAAS调用 | [Device管理Service API](../../../src/baas/src/secbaas/community/api/device_manage/_protocols.py)、[PAAS Service API](../../../src/baas/src/secbaas/community/api/paas/_protocols.py) | `invoke_http_in_device`与设备地址作用域；保留既有HTTP/base64转发语义。 |
+
+OCB为企业私有仓库，不能用失效的本机相对链接冒充公共合同。配套固定ref为`384146cff15758dae2817e7069321b94bfdcee51`：Desktop现行请求/响应类型在`src/desktop/bdc-crates/bdc-mng-api/src/types.rs`，Container Interface在同crate的`container.rs`，内部bytes Plugin API在`src/desktop/bdc-crates/bdc-plugin-api/src/container.rs`；Engine透传消费者在`src/engine/src/engine/corp/engines/pool_mapping_payload.py`和`hermes/skills.py`。企业实现者按该ref及真实最终gitlink核验G2/G3，公共模块测试不替代这项检查。
+
+### 权威与追溯
+
+本文是本次Desktop改造的规范入口；[plan.md](plan.md)描述交付顺序，[tasks.md](tasks.md)为四组本地工作清单。[决策摘要](decisions.md)保留最终选择及关键取舍；实现以本文为规范入口，原始探索和被替代候选不是执行输入。新增用户决定仍优先，须同步本文，不能只更新聊天。
+
+[能力覆盖矩阵](capability-coverage-matrix.md)、[OpenAPI入口审计](openapi-capability-coverage-audit.md)、[市场专项](market-coverage-audit.md)提供代码事实和完整入口附录，不把审计时的缺口写成已实现。直接模块规范和既有公开wire仍须在实现时核验。
+
+本轮固定研究基线：Avernet `ca308268927f10df887ad3543d664244dbe6ce52`；OCB `658abdf1cc88b047c73463463c695510866b4759`；实际gitlink `137219270c46a3508daeaf92d9e660e5ee38aeb9`。两仓dev为后续目标，开工前必须重验；本文件没有宣称这组代码已部署。
+
+沿用[稳定Skill身份](../../adr/0001-stable-skill-identity-across-versions.md)、[Track Latest与历史制品](../../adr/0002-market-and-space-skills-track-latest.md)、[版本/发布/传播状态分离](../../adr/0009-separate-draft-attempt-version-and-propagation-state.md)、[托管Skill写入权威](../../adr/0010-teamclaw-is-authority-for-managed-skills.md)。不重定义Space生命周期或编辑租约；旧全局词汇表的Effective集合计算/租约等陈旧实现描述不能覆盖当前Installation/领域合同。
+
+### 决策追溯
+
+| 已定讨论 | 本Spec落点 |
+| --- | --- |
+| Q1–Q3 范围、升级、与#455正交 | Solution、D2/D5/D10、Out of Scope |
+| Q4–Q6 来源、成功边界、Hermes入口 | D1/D3/D4/D6 |
+| Q7–Q10 通用后台、部分结果、唤醒及频率 | D7/D8 |
+| Q11–Q13 完成判据、旧链接、退出KISS | D8/D9及A20/A21/A27/A31 |
+| Q14–Q19 包、签名、深Module、缓存 | D5/D6/D7及A16–A19/A24 |
+| Q20 单Bot工作项与Queue窗口 | D8及A25/A28 |
+| Q21 Skill/MCP过渡 | D9及A30 |
+| Q22–Q23 内部apply及旧端保护 | D5/D7/D10及A22–A24 |
+| Q24–Q25 内容/参数 | D4及A03–A05/A08 |
+| Q26 MCP保持现状 | D9及A30/A33 |
+| Q27 Local字节保真 | D4及A06/A07 |
+| Q28 全能力市场/工坊验收 | D3、User Stories、A01–A34及覆盖矩阵 |
+| Q29 四组、全部入口共用恢复 | D2/D8、plan/tasks、A25/A26/A34 |
+
+### 已接受风险与实施澄清
+
+Q13遗失retired、Q20任务窗口、Q21旧MCP过渡、Q25原生参数消费、Q19磁盘增长是有意识保留的限制，不是遗漏待补的隐形项目。真实前端离线禁变更/升级门禁仍需联调，不能当成Backend强制或不可达分支证明。
+
+签名/分发前缀、局部并发/网络限制及配置透传优先复用现有配置和存储原语；实现时在G3契约提交中记录有效值并覆盖测试，不额外构建配置平台。若源码事实使已批准权限、数据兼容或退出语义无法成立，先报告精确冲突，不扩大方案或带病声称交付。
+
+本变更只固定文档基线，不包含业务实现、部署配置、数据库或生成OpenAPI产物的变更。开发与运行验收状态以任务清单的证据记录为准。

--- a/docs/specs/2026-09-08-desktop-skill-capabilities/tasks.md
+++ b/docs/specs/2026-09-08-desktop-skill-capabilities/tasks.md
@@ -1,0 +1,87 @@
+# Desktop Skill：本地任务清单
+
+状态：全部待实施。本文件是工程分组的工作清单，不代替后续实施Issue、PR或阶段验收记录。
+
+Source of Truth：[spec.md](spec.md)。交付依赖：[plan.md](plan.md)。完整产品范围：[能力覆盖矩阵](capability-coverage-matrix.md)与[逐OpenAPI入口](openapi-capability-coverage-audit.md)。以下编号专用于本次Desktop改造，不与历史Phase 2分组混用。
+
+## 通用开工条件
+
+- [ ] B01 核对Avernet github/dev与OCB dev、实际ocb-public gitlink；记录新基线，确认已合入修复不重复做。
+- [ ] B02 将本组触及的公开/内部合同、消费者、Adapter、DI、配置和测试列清；协调共享文件owner。
+- [ ] B03 复核产品前提：OpenClaw/Hermes Desktop主验收、现有升级门禁和离线UI禁用；不据此删去旧端保护或新增Backend离线政策。
+
+## G1 — Skill API/市场/工坊兼容与缺口补齐
+
+可独立；主要Avernet，必须核验OCB装配。每项测试从正式Interface进入，不手工绕过Router前置校验。
+
+- [ ] G1.1 实现Center Query Adapter：PUBLIC/Space可见性、owner+bot与App/协作者校验、Bot-facing只读视图；测试未安装可消费和私有拒绝。对应A02/A03。
+- [ ] G1.2 接通Center详情/content和参数定义精确版本读取；云端/Desktop一致，零Engine下载，区分期望与实际版本。对应A03/A04。
+- [ ] G1.3 独立覆盖共享README：Center Published选择/权限、Local owner-qualified定位、Local/Repo兼容；不猜目标Bot。对应A05。
+- [ ] G1.4 深化原参数Module，明确缺失vs失败、读失败零写、单Skill替换保留其它项、写失败失败，保留地址/格式。对应A08。
+- [ ] G1.5 修Hermes Desktop创建政策和正式Workflow/Router测试，不扩大其它Engine产品范围。对应A01。
+- [ ] G1.6 将市场搜索/tags/收藏/Repo目录/同步、Public Reference、Space可消费和完整生命周期、Set/Direct/Default/exclusion、Deprecated/BFF分为共享回归或适配并落实测试责任。对应A09–A15/A33。
+- [ ] G1.7 更新前端调用手册及结果说明：已有资产PUT、Public批量异步POST、同key重放语义、Reference完成≠Runtime收敛、内容≠设备取证；不新增进度API。
+- [ ] G1.8 验证实际Protocol identity和完整DI；如公开Router/DTO改变，从Backend生成Gateway配置并核对无无关漂移。对应A34。
+- [ ] G1.9 完成本组窄门禁、Standards/Spec review、高优修复及必要最终CI；分别报告外部/实机未验证项。
+
+完成标准：Center各Bot入口实际通过共同身份链，不只是内容Store单测成功；已有云端/Local/Repo请求及参数数据不回归。
+
+## G2 — Desktop文件通道
+
+可与G1独立；主要OCB Desktop。外部BaaS base64与旧文本接口不变。
+
+- [ ] G2.1 枚举正式invoke-http请求/响应所有bytes↔String转换、旧文本入口与JSON/health消费者，界定内部类型变化。
+- [ ] G2.2 修内部双向bytes贯通，保留外部文本wire与合法解码；不能吞成空内容，不能改变Content-Type/状态语义。对应A07。
+- [ ] G2.3 增加正式Desktop入口到测试Engine的二进制双向合同测试，覆盖UTF8/非UTF8/multipart/空body/状态/头及JSON旧调用。
+- [ ] G2.4 与Local raw ZIP/文件夹上传、替换、读回联合测试，逐文件bytes/hash一致；覆盖参数文本和受影响通道。对应A06/A08/A33。
+- [ ] G2.5 完成OCB规范/合同review与本组门禁，记录必须更新的客户端版本；不将代码merge当用户安装完成。
+
+完成标准：完整通道和Local产品文件链保真，而不是仅一次echo或只修一个String转换点。
+
+## G3 — Center统一交付
+
+两仓配套；G3拥有分发/apply/结果及内容Adapter合同。G4消费这些合同。
+
+- [ ] G3.1 按Spec D6/D7冻结轻量描述lookup、后台prepare、互斥包状态、字段校验、错误与真实Adapter evidence；记录调用方和所有跨仓透传点。
+- [ ] G3.2 实现Canonical exact派生ZIP、独立分发namespace、可复现digest及完整发布/并发复用；不改Version、Draft/staging字段。对应A16。
+- [ ] G3.3 实现可信目标内签名/过期刷新，3600秒TTL、Desktop可达endpoint及脱敏；无Center/retired-only/云端零签名/打包。对应A17/A24。
+- [ ] G3.4 深化SkillRuntimeDelivery，在一处以DeviceContext.bot_type选择描述；复用同一目标上下文，公开业务不传Desktop/路径标记。
+- [ ] G3.5 贯通公共DTO/Protocol、OpenClaw Adapter、OCB mapping wrapper/Hermes、Backend parser；真实解释扩展才产生evidence。对应A22。
+- [ ] G3.6 实现共同内容Interface的Mounted/Downloaded选择、下载去重与有限资源占用；不重复OpenClaw/Hermes实现。对应A18/A19/A24。
+- [ ] G3.7 安全临时下载/解包、完整校验/原子可见缓存、跨重启命中/轻量检查/有限清理；不做完整版本GC或Scanner。对应A18/A19。
+- [ ] G3.8 接共同best-effort apply：Mixed部分结果、V2待就绪保留V1、取消不复活、显式retired/实体保护；必要最小共享修复显式报告。对应A20/A21/A31。
+- [ ] G3.9 实现旧端保护、结构化脱敏错误及兼容矩阵；无证据/未知结果不换写协议、不拆批剥字段。对应A22/A23。
+- [ ] G3.10 验证Mounted无下载、旧ensure只读、Strict Pool/Teclaw/云端Artifact不回归；与G1真实入口和OCB配置装配联合验证。对应A32/A34。
+- [ ] G3.11 完成本组窄contract/DI/类型/架构门禁与双轴review；冻结供G4消费的最终Interface及跨仓提交引用。
+
+完成标准：给定已授权当前逻辑计划，一次apply能正确准备/复用内容并返回逐项状态；冷包重工作可从后台独立驱动，前台不阻塞打包。不把此组完成等同自动恢复交付。
+
+## G4 — 通用恢复与全链路收口
+
+依赖G3正式合同；最终联合G1/G2。此组是开发任务，不是纯测试组。
+
+- [ ] G4.1 实现一个Desktop Skill恢复Module/Handler/task type；owner+bot在原Queue作用域内去重，payload不冻结版本/URL/命令。对应A25。
+- [ ] G4.2 在共同变更/投影收尾统一ensure，覆盖Reference最终add、Set/Direct、apply_plan以及未到Engine的提前PENDING；inactive SKIPPED与业务失败不误入队。对应A13/A26。
+- [ ] G4.3 worker准备当前缺包后重新读取最新Reader/当前绑定，再经共同Projector做Skill-only apply；不复用长耗时准备前旧计划。对应A21/A25/A28。
+- [ ] G4.4 实现5秒正常Reschedule、故障Retry、逐项完成/永久问题、30分钟期限与live-key既有限制；不创建新任务代替每轮outcome。对应A27/A28。
+- [ ] G4.5 接入首次启动/重连及约10分钟分页扫漏，使用同一恢复Interface；不只扫存活Task/DB ACTIVE，不改变健康扫描保护。对应A29。
+- [ ] G4.6 接Desktop TrackLatest：新增Skill等待转统一恢复；真实MCP错误仍按原行为，后续Skill轮次零MCP/Passport。对应A30。
+- [ ] G4.7 测试“先fanout零候选再最终add”及市场/Set/TrackLatest并发共用单Bot live工作项，不为每入口写一套Handler。对应A25/A26。
+- [ ] G4.8 测试任务终态后漏唤醒、当前绑定变化、下载中撤销/停用、权限/Offline后续变化及缓存复用；保留明确的retired限制。对应A12/A21/A28/A31。
+- [ ] G4.9 验证实际DI、HandlerRegistry/启动注册、worker/扫漏配置、局部限制和全套协议；旧activation_sync骨架不被误当已实现。对应A34。
+- [ ] G4.10 完成两种真实Desktop的市场→云懒物化→Set→Installation→下载→软链，以及Space发布→多Bot TrackLatest；记录逐阶段证据，非只记录202/COMPLETED。对应A10/A14/A29/A30。
+- [ ] G4.11 前端联调核验已有离线禁用、升级提示、iframe详情和已添加/已生效区别；原生参数消费明确未验证，不新造进度API。
+- [ ] G4.12 汇总A01–A34测试/CI/review/merge/deploy/runtime阶段状态与残余限制，完成最终整体Standards/Spec review及高优修复。
+
+完成标准：条件恢复时无需用户第二次变更即可自动补齐当前有效Skill，所有入口共用一个恢复机制；不保证永久不可达或未知历史退出能被清理，不掩盖MCP失败。
+
+## 最终交付记录（待实施填写）
+
+| 组 | 代码/PR | 本地与合同测试 | CI/评审 | 合并/OCB gitlink | 部署与实机 |
+| --- | --- | --- | --- | --- | --- |
+| G1 | 未开始 | 未执行 | 未执行 | 未执行 | 未执行 |
+| G2 | 未开始 | 未执行 | 未执行 | 未执行 | 未执行 |
+| G3 | 未开始 | 未执行 | 未执行 | 未执行 | 未执行 |
+| G4 | 未开始 | 未执行 | 未执行 | 未执行 | 未执行 |
+
+本轮只有文档产出，所有复选框保持未完成。任何后续勾选都要有对应代码/测试或阶段证据，不能因为Spec定稿而勾选开发项。


### PR DESCRIPTION
## Problem

Desktop Skill 的跨仓设计已经完成评审，但规范和任务清单仍分散在本地研究材料中。后续多个实现任务需要一份可版本化、可追溯的共同基线，避免遗漏市场引用、通用恢复或旧端兼容边界。

## Solution

- 固定 `docs/specs/2026-09-08-desktop-skill-capabilities/` 文档基线：README、正式Spec、最终决策摘要、四组计划、任务清单、能力覆盖矩阵、OpenAPI与市场源码审计。
- 正式Spec包含34条用户故事、A01–A34验收索引及Q1–Q29追溯；明确所有Desktop Skill入口共用一个Bot级恢复机制。
- 覆盖SC Public批量Reference → 云端懒物化 → 正式SkillSet/Installation → Desktop内容准备与软链生效；区分已添加和运行时已收敛。
- 按G1 API兼容、G2字节通道、G3统一交付、G4自动恢复组织后续工作；每组自带合同/DI/兼容验证。
- 原始长对话和本机研究路径不纳入提交；未采纳候选只保留必要取舍说明，不成为实施指令。

## Validation

- 文档相对链接与空白检查通过，未发现本机绝对路径。
- A01–A34验收编号唯一、Q1–Q29决策完整；所有实施任务保持未开始。
- `git diff --check`通过。
- `python3 scripts/ci/check_secrets.py --base 678be7ef0980aa00a09c32c502a08c33ebf4444d --head HEAD`通过。
- Standards/Spec双轴文档审查完成：Standards发现的1项模块合同索引缺口已修复并复核，剩余0项；Spec初审与最终增量复核均为0项。
- 仅Markdown变更，未运行业务测试；未进行数据库、OSS、Desktop或部署操作。GitHub CI状态独立报告。

## Compatibility and risk

不包含Backend/Engine/Desktop业务实现、数据库迁移、部署配置或生成OpenAPI产物变更。文档定稿不表示相关能力已上线；现有云端行为、MCP策略、历史locator和Pool迁移范围保持已批准边界。

PR基于Avernet `dev@678be7ef0980aa00a09c32c502a08c33ebf4444d`。创建时核对OCB `dev@384146cff15758dae2817e7069321b94bfdcee51`，实际gitlink为`ca308268927f10df887ad3543d664244dbe6ce52`；源码审计保留各自固定SHA，不冒充部署证明。本PR不修改OCB gitlink。

## Spec

入口：`docs/specs/2026-09-08-desktop-skill-capabilities/README.md`。

实现规范：同目录`spec.md`；交付顺序与后续工作：`plan.md`、`tasks.md`。

本PR只固定文档基线，不创建实施Issue或启动开发。合并后，后续实施Issue应引用合并提交下的规范。
