### PR TITLE
fix(resources): show complete workspace tree

### DIFF
--- a/src/backend/src/agentclaw/community/core/services/resource_file_service.py
+++ b/src/backend/src/agentclaw/community/core/services/resource_file_service.py
@@ -12,8 +12,8 @@ What the service owns (moved out of ``adapters/http/resources/file_router.py``):
 - resolve the device context (draft via ``resolve_for_bot``; publish-stage via
   ``resolve_for_binding`` — added in a follow-up task) and dispatch by the
   ``workspace`` namespace;
-- the file-browser rules: dotfile / hidden-dir / hidden-file filtering, read-only
-  flagging, the ``skills-local`` root injection;
+- directory-listing projection and read-only path classification; listings preserve
+  the provider's real entries, while search/archive keep their own curated policies;
 - the ``absolute_path`` field: the device's own absolute path for the entry — the
   engine returns it per listing entry (``path``: container path for arca/openclaw/
   aicoding/claude_code, host path for local). teclaw doesn't expose an absolute path
@@ -29,7 +29,6 @@ The HTTP adapter maps the returned plain dicts / bytes to its response schemas.
 from __future__ import annotations
 
 from datetime import datetime
-from pathlib import Path
 from typing import Any, AsyncIterator
 
 from injector import inject
@@ -69,22 +68,21 @@ from agentclaw.community.log import get_logger
 logger = get_logger()
 
 
-# ── File-browser rules (shared with the sibling search/zip router) ────────────
+# -- Search/archive and write-policy rules -----------------------------------
 
-# "skills" is hidden, but "skills/skills-local" is injected into root listings so
-# users can browse/edit their local skill files (arca/local layout). teclaw keeps
-# local skills flat at /workspace/skills-local, so it needs no injection.
+# Search and archive operations retain their curated view of local skill files.
+# Directory listings themselves expose the provider's real workspace hierarchy.
 _SKILLS_LOCAL_RELPATH = "skills/skills-local"
 _POOL_SKILLS_LOCAL_RELPATH = "skills-pool/skills-local"
 
-# System files hidden from the resource browser (OpenClaw identity/config .md files).
+# System files excluded from search/archive and protected from deletion.
 _HIDDEN_BASENAMES = {
     "AGENTS.md", "RULES.md", "OKR.md", "SAFETY.md", "SOUL.md",
     "OUTPUT.md", "MEMORY.md", "IDENTITY.md", "USER.md", "TOOLS.md",
     "HEARTBEAT.md", "BOOTSTRAP.md",
 }
 
-# Hidden directories (system state, skill symlinks, per-engine config dirs).
+# System directories excluded from search/archive.
 _HIDDEN_DIRNAMES = {
     "state",
     "skills",
@@ -362,9 +360,10 @@ class ResourceFileService:
     ) -> list[dict[str, Any]]:
         """List a directory under the workspace, provider-blind.
 
-        Returns plain dicts shaped for the ``FileItem`` schema. Applies the
-        dotfile / hidden-dir / hidden-file filtering, read-only flagging, and the
-        ``skills-local`` root injection (non-teclaw).
+        Returns plain dicts shaped for the ``FileItem`` schema. Entries preserve
+        the provider's real directory contents, including dotfiles and system
+        paths; no synthetic shortcut nodes are added. ``readonly`` remains an
+        operation policy rather than a visibility policy.
 
         ``device_uuid`` (optional) locks a specific instance for multi-instance
         service bots; omitted → provider auto-selects an active instance.
@@ -385,13 +384,7 @@ class ResourceFileService:
         items: list[dict[str, Any]] = []
         for e in entries:
             name = e.get("name", "")
-            if name.startswith("."):
-                continue
             is_dir = e.get("is_dir", False)
-            if is_dir and not path and name in _HIDDEN_DIRNAMES:
-                continue
-            if not path and name in _HIDDEN_BASENAMES:
-                continue
             rel = self._rel_path(path, e)
             items.append({
                 "name": name,
@@ -405,52 +398,6 @@ class ResourceFileService:
                 "size_human": e.get("size_human") if not is_dir else None,
                 "modified_at": e.get("modified_at"),
             })
-
-        # skills-local injection (arca/local nest it under the hidden "skills" dir,
-        # so it must be injected; teclaw keeps it flat at /workspace/skills-local and
-        # lists naturally; baas/desktop never injected — don't probe it for them).
-        if not path and ctx.provider in ("arca", "local", "baas"):
-            for local_relpath in (
-                _SKILLS_LOCAL_RELPATH,
-                _POOL_SKILLS_LOCAL_RELPATH,
-            ):
-                parent = local_relpath.rsplit("/", 1)[0]
-                try:
-                    skills_entries = await device_fs.list_dir(
-                        f"{WORKSPACE_NS}/{parent}"
-                    )
-                except Exception as e:
-                    # Either layout may be absent. Keep probing the other one
-                    # and never fail the root listing for this optional entry.
-                    logger.warning(
-                        "[list_dir] skills-local probe skipped path=%s: %s",
-                        parent,
-                        e,
-                    )
-                    continue
-                skill_local = next(
-                    (
-                        entry
-                        for entry in skills_entries or []
-                        if entry.get("name") == "skills-local"
-                        and entry.get("is_dir", False)
-                    ),
-                    None,
-                )
-                if skill_local is not None:
-                    items.append({
-                        "name": "skills-local",
-                        "path": local_relpath,
-                        # the probed entry's own absolute path (logic-view fallback).
-                        "absolute_path": skill_local.get("path")
-                        or self._logical(local_relpath),
-                        "is_dir": True,
-                        "readonly": False,
-                        "size": None,
-                        "size_human": None,
-                        "modified_at": None,
-                    })
-                    break
 
         return items
 
@@ -505,11 +452,9 @@ class ResourceFileService:
         level-by-level because no engine's ``recursive`` flag is trusted
         anywhere in the repo.
 
-        Filtering mirrors ``list_dir``: dotfiles skipped at every level, the
-        hidden system names only at the workspace root — a root download
-        contains what the file browser shows, no more. The ``skills-local``
-        injection is *not* reproduced: it is a listing-level synthetic, and a
-        download must contain what the device actually holds.
+        Directory downloads intentionally retain their curated archive policy:
+        dotfiles are skipped at every level and system names at the workspace
+        root. Interactive listings are independent and expose the real entries.
 
         Caps are enforced twice — from the listing's sizes before any byte is
         read, then against the bytes actually streamed — and both raise
@@ -545,10 +490,8 @@ class ResourceFileService:
                 if name.startswith("."):
                     continue
                 is_dir = bool(entry.get("is_dir", False))
-                # The hidden system names are a *workspace-root* rule in
-                # ``list_dir`` — the first level of a root walk is exactly
-                # that listing; deeper levels and sub-directory walks keep
-                # everything non-dot.
+                # Hidden system names are excluded only from a workspace-root
+                # archive; deeper levels and sub-directory archives keep them.
                 if not current and not path:
                     if is_dir and name in _HIDDEN_DIRNAMES:
                         continue
@@ -675,10 +618,9 @@ class ResourceFileService:
         answering "not a directory" — so probing directly would turn every file
         delete into an error.
 
-        Uses the raw device listing, not this class's filtered ``list_dir``, so
-        the hidden system names stay deletable exactly as before. A listing
-        failure answers "not a directory": the delete then takes the file
-        branch, which is what it did unconditionally until now.
+        Uses the device listing directly to avoid an extra context resolution and
+        projection pass. A listing failure answers "not a directory": the delete
+        then takes the file branch, which is what it did unconditionally until now.
         """
         parent, _, leaf = path.rpartition("/")
         try:

--- a/src/backend/tests/community/adapters/http/openapi_v1/resources/test_resources_handlers.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/resources/test_resources_handlers.py
@@ -333,6 +333,8 @@ async def test_list_returns_workspace_entries():
     """Entries come from the workspace. A record-backed listing could not see a
     file the bot produced itself — it has no record and never will."""
     file_svc = _StubListFileService([
+        _listed(".env", rel=".env", size=3),
+        _listed("state", rel="state", is_dir=True),
         _listed("notes.md", rel="notes.md", size=12),
         _listed("docs", rel="docs", is_dir=True),
     ])
@@ -348,8 +350,10 @@ async def test_list_returns_workspace_entries():
         request=_request_without_trace(),
     )
 
-    assert env.data.total == 2
+    assert env.data.total == 4
     by_name = {i.name: i for i in env.data.items}
+    assert by_name[".env"].type == OpenapiType.FILE
+    assert by_name["state"].type == OpenapiType.FOLDER
     assert by_name["notes.md"].type == OpenapiType.FILE
     assert by_name["notes.md"].path == "notes.md"
     assert by_name["notes.md"].size == 12

--- a/src/backend/tests/community/core/resources/test_cli_tools_absent_from_listings.py
+++ b/src/backend/tests/community/core/resources/test_cli_tools_absent_from_listings.py
@@ -70,15 +70,8 @@ def test_a_tools_object_key_is_not_under_a_workspace_namespace() -> None:
         assert "/identity/" not in key
 
 
-def test_the_hidden_dirname_filter_was_not_used_and_is_unchanged() -> None:
-    """Recorded because it was the obvious wrong answer.
-
-    ``_HIDDEN_DIRNAMES`` guards the **root listing only** — the check is
-    ``if is_dir and not path and name in _HIDDEN_DIRNAMES`` — so a name hidden
-    there is still reachable one directory down. Relying on it would have made
-    the isolation a filter with a hole rather than a property. W9 added nothing
-    to it.
-    """
+def test_archive_hidden_dirnames_do_not_include_cli_tools() -> None:
+    """CLI-tool isolation stays structural, not part of archive filtering."""
     assert "cli" not in resource_file_service._HIDDEN_DIRNAMES
     assert "cli-tools" not in resource_file_service._HIDDEN_DIRNAMES
     assert "cli_tools" not in resource_file_service._HIDDEN_DIRNAMES

--- a/src/backend/tests/community/core/resources/test_resource_file_service.py
+++ b/src/backend/tests/community/core/resources/test_resource_file_service.py
@@ -2,8 +2,8 @@
 
 The service addresses every file by ``workspace/<rel>`` and lets the dispatcher's
 per-provider mapper compose the real address. These tests pin: logical addressing of
-each op, the logic-view ``absolute_path``, file-browser filtering, the
-``skills-local`` root injection (non-teclaw), and the arca download size guard.
+each op, the logic-view ``absolute_path``, exact directory-listing projection, and
+the arca download size guard.
 """
 from __future__ import annotations
 
@@ -111,169 +111,48 @@ async def test_path_falls_back_to_name_without_relative_path():
     assert items[0]["path"] == "sub/x.csv"
 
 
-# ── browser filtering ────────────────────────────────────────────────────────
+# ── exact directory projection ────────────────────────────────────────────────
 
 
 @pytest.mark.asyncio
-async def test_root_listing_filters_hidden_and_dotfiles():
+@pytest.mark.parametrize("provider", ["arca", "local", "baas", "teclaw"])
+async def test_root_listing_preserves_real_entries_without_synthetic_nodes(provider: str):
     device_fs = MagicMock()
-    device_fs.list_dir = AsyncMock(side_effect=[
-        [  # workspace root
-            {"name": ".hidden", "is_dir": False},
-            {"name": "state", "is_dir": True},
-            {"name": "skills", "is_dir": True},
-            {"name": "AGENTS.md", "is_dir": False},
-            {"name": "data", "is_dir": True},
-            {"name": "report.csv", "is_dir": False, "size": 10},
-        ],
-        [],  # workspace/skills probe → nothing to inject
+    device_fs.list_dir = AsyncMock(return_value=[
+        {"name": ".hidden", "is_dir": False},
+        {"name": "state", "is_dir": True},
+        {"name": "skills", "is_dir": True},
+        {"name": "skills-pool", "is_dir": True},
+        {"name": "AGENTS.md", "is_dir": False},
+        {"name": "data", "is_dir": True},
+        {"name": "report.csv", "is_dir": False, "size": 10},
     ])
-    svc, _ = _svc(provider="arca", device_fs=device_fs)
+    svc, _ = _svc(provider=provider, device_fs=device_fs)
+
     items = await svc.list_dir(**_COORDS, path="")
-    names = {i["name"] for i in items}
-    assert names == {"data", "report.csv"}
+
+    assert [item["name"] for item in items] == [
+        ".hidden",
+        "state",
+        "skills",
+        "skills-pool",
+        "AGENTS.md",
+        "data",
+        "report.csv",
+    ]
+    device_fs.list_dir.assert_awaited_once_with("workspace")
 
 
 @pytest.mark.asyncio
-async def test_subdir_listing_does_not_filter_hidden_names():
-    # hidden-name filtering only applies at the workspace root.
+async def test_subdir_listing_preserves_hidden_names():
     device_fs = MagicMock()
-    device_fs.list_dir = AsyncMock(return_value=[{"name": "state", "is_dir": True}])
+    device_fs.list_dir = AsyncMock(return_value=[
+        {"name": ".cache", "is_dir": True},
+        {"name": "state", "is_dir": True},
+    ])
     svc, _ = _svc(provider="arca", device_fs=device_fs)
     items = await svc.list_dir(**_COORDS, path="sub")
-    assert [i["name"] for i in items] == ["state"]
-
-
-# ── skills-local injection ───────────────────────────────────────────────────
-
-
-@pytest.mark.asyncio
-async def test_skills_local_injected_for_arca_when_present():
-    device_fs = MagicMock()
-    device_fs.list_dir = AsyncMock(side_effect=[
-        [{"name": "data", "is_dir": True}],          # root
-        [{"name": "skills-local", "is_dir": True,    # workspace/skills probe
-          "path": "/home/admin/.openclaw/workspace/skills/skills-local"}],
-    ])
-    svc, _ = _svc(provider="arca", device_fs=device_fs)
-    items = await svc.list_dir(**_COORDS, path="")
-    injected = [i for i in items if i["path"] == "skills/skills-local"]
-    assert len(injected) == 1
-    assert injected[0]["is_dir"] is True
-    # absolute_path comes from the probed entry's own path
-    assert injected[0]["absolute_path"] == "/home/admin/.openclaw/workspace/skills/skills-local"
-
-
-@pytest.mark.asyncio
-async def test_pool_skills_local_is_injected_when_legacy_bridge_is_retired():
-    device_fs = MagicMock()
-    device_fs.list_dir = AsyncMock(side_effect=[
-        [
-            {"name": "skills-pool", "is_dir": True},
-            {"name": "data", "is_dir": True},
-        ],
-        [],
-        [
-            {
-                "name": "skills-local",
-                "is_dir": True,
-                "path": (
-                    "/home/admin/.openclaw/workspace/"
-                    "skills-pool/skills-local"
-                ),
-            }
-        ],
-    ])
-    svc, _ = _svc(provider="arca", device_fs=device_fs)
-
-    items = await svc.list_dir(**_COORDS, path="")
-
-    assert {item["name"] for item in items} == {"data", "skills-local"}
-    injected = next(item for item in items if item["name"] == "skills-local")
-    assert injected["path"] == "skills-pool/skills-local"
-    assert injected["absolute_path"].endswith("/skills-pool/skills-local")
-
-
-@pytest.mark.asyncio
-async def test_root_returns_only_one_skills_local_when_both_layouts_exist():
-    device_fs = MagicMock()
-    device_fs.list_dir = AsyncMock(side_effect=[
-        [{"name": "data", "is_dir": True}],
-        [
-            {
-                "name": "skills-local",
-                "is_dir": True,
-                "path": (
-                    "/home/admin/.openclaw/workspace/skills/skills-local"
-                ),
-            }
-        ],
-        [
-            {
-                "name": "skills-local",
-                "is_dir": True,
-                "path": (
-                    "/home/admin/.openclaw/workspace/"
-                    "skills-pool/skills-local"
-                ),
-            }
-        ],
-    ])
-    svc, _ = _svc(provider="arca", device_fs=device_fs)
-
-    items = await svc.list_dir(**_COORDS, path="")
-
-    injected = [item for item in items if item["name"] == "skills-local"]
-    assert len(injected) == 1
-    assert injected[0]["path"] == "skills/skills-local"
-    assert device_fs.list_dir.await_count == 2
-
-
-@pytest.mark.asyncio
-async def test_skills_local_not_injected_for_teclaw():
-    device_fs = MagicMock()
-    device_fs.list_dir = AsyncMock(return_value=[{"name": "skills-local", "is_dir": True}])
-    svc, _ = _svc(provider="teclaw", device_fs=device_fs)
-    items = await svc.list_dir(**_COORDS, path="")
-    # teclaw lists skills-local naturally; no synthetic "skills/skills-local" entry,
-    # and no second probe call.
-    assert all(i["path"] != "skills/skills-local" for i in items)
-    assert device_fs.list_dir.await_count == 1
-
-
-@pytest.mark.asyncio
-async def test_skills_local_injected_for_baas_when_present():
-    # openclaw runs on the baas provider and nests skills-local under the hidden
-    # "skills" dir (like arca), so baas must probe workspace/skills and inject it.
-    device_fs = MagicMock()
-    device_fs.list_dir = AsyncMock(side_effect=[
-        [{"name": "data", "is_dir": True}],          # root
-        [{"name": "skills-local", "is_dir": True,    # workspace/skills probe
-          "path": "/home/admin/.openclaw/workspace/skills/skills-local"}],
-    ])
-    svc, _ = _svc(provider="baas", device_fs=device_fs)
-    items = await svc.list_dir(**_COORDS, path="")
-    injected = [i for i in items if i["path"] == "skills/skills-local"]
-    assert len(injected) == 1
-    assert injected[0]["is_dir"] is True
-    assert device_fs.list_dir.await_count == 2
-
-
-@pytest.mark.asyncio
-async def test_root_listing_survives_skills_probe_404():
-    # container without a "skills" dir → engine 404 → device raises. the optional
-    # skills-local probe must be swallowed so the root listing returns instead of 500.
-    device_fs = MagicMock()
-    device_fs.list_dir = AsyncMock(side_effect=[
-        [{"name": "data", "is_dir": True}],                 # root → 200
-        FileNotFoundError("workspace/skills not found"),    # skills probe → 404
-        FileNotFoundError("workspace/skills-pool not found"),
-    ])
-    svc, _ = _svc(provider="baas", device_fs=device_fs)
-    items = await svc.list_dir(**_COORDS, path="")
-    assert [i["name"] for i in items] == ["data"]
-    assert all(i["path"] != "skills/skills-local" for i in items)
-    assert device_fs.list_dir.await_count == 3
+    assert [i["name"] for i in items] == [".cache", "state"]
 
 
 # ── read / download-limit forwarding ─────────────────────────────────────────
@@ -384,9 +263,7 @@ async def test_delete_falls_back_to_the_file_branch_when_the_listing_fails():
 
 @pytest.mark.asyncio
 async def test_delete_still_reaches_hidden_system_names():
-    """The probe uses the raw device listing rather than this class's filtered
-    ``list_dir``, which drops dotfiles and the hidden system directories — those
-    stay as deletable as they were before."""
+    """Directory probing continues to address hidden system names directly."""
     device_fs = _fs_listing({"name": "state", "is_dir": True})
     svc, _ = _svc(provider="arca", device_fs=device_fs)
 

--- a/src/backend/tests/community/endpoints/test_resource_file_router_local.py
+++ b/src/backend/tests/community/endpoints/test_resource_file_router_local.py
@@ -1,9 +1,9 @@
 """End-to-end read-path tests for the resources file routes on a local bot.
 
 Covers the thin ``file_router`` → ``ResourceFileService`` delegation for a local
-(pathlib) bot: directory listing (with hidden-file filtering + skills-local
-injection), preview, download, delete, and mkdir — plus the per-provider
-``absolute_path`` presentation (host workspace path for local). teclaw/arca write
+(pathlib) bot: exact directory listing, preview, download, delete, and mkdir — plus
+the per-provider ``absolute_path`` presentation (host workspace path for local).
+teclaw/arca write
 paths are covered in test_resources_teclaw_writes.py; teclaw reads in
 test_resources_teclaw_reads.py.
 
@@ -44,24 +44,23 @@ def _seed_local_bot(world) -> None:
     ws = _ws(world)
     (ws / "data").mkdir(parents=True, exist_ok=True)
     (ws / "data" / "report.csv").write_bytes(_CSV)
-    (ws / "AGENTS.md").write_text("identity", encoding="utf-8")   # hidden basename at root
-    (ws / ".hidden").write_text("x", encoding="utf-8")            # dotfile
-    # skills-local lives under the hidden "skills" dir → must be injected at root
+    (ws / "AGENTS.md").write_text("identity", encoding="utf-8")
+    (ws / ".hidden").write_text("x", encoding="utf-8")
     (ws / "skills" / "skills-local").mkdir(parents=True, exist_ok=True)
 
 
-# ── list (root): filtering + skills-local injection + absolute_path ───────────
+# ── list (root): exact entries + absolute_path ───────────────────────────────
 
 
 def _assert_root_listing(response, world) -> None:
     body = response.json()
     assert body["success"] is True
     by_path = {i["path"]: i for i in body["items"]}
-    # hidden basename + dotfile filtered; real dir kept; skills-local injected
-    assert "AGENTS.md" not in by_path
-    assert ".hidden" not in by_path
+    assert "AGENTS.md" in by_path
+    assert ".hidden" in by_path
     assert "data" in by_path
-    assert "skills/skills-local" in by_path
+    assert "skills" in by_path
+    assert "skills/skills-local" not in by_path
     # absolute_path is the device's own absolute path — for a local bot that's the
     # host workspace path (the pathlib entry's ``path``).
     assert by_path["data"]["absolute_path"] == f"{_ws(world)}/data"
@@ -80,7 +79,7 @@ def _assert_root_listing(response, world) -> None:
     extra_assertions=(_assert_root_listing,),
 )
 def local_list_root():
-    """Root listing filters hidden files, keeps real dirs, injects skills-local."""
+    """Root listing preserves the workspace's real entries and hierarchy."""
 
 
 # ── preview ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

The resource browser hides dotfiles, system directories, and root identity files, and replaces nested local-skill paths with a synthetic `skills-local` root node. The current requirement is for both legacy and OpenAPI resource pages to show the workspace exactly as stored.

## Solution

- Preserve every directory entry returned by the device filesystem, including dotfiles and system paths.
- Remove the synthetic `skills-local` root projection so real `skills/skills-local` and `skills-pool/skills-local` hierarchies are visible.
- Keep path traversal checks, read-only write/delete policy, and directory-download filtering unchanged.
- Update shared-service, legacy-route, and OpenAPI-route tests.

## Validation

- `uv run ruff check` on all changed Python files: passed.
- Resource-related backend suites: 324 passed.
- Pre-push plaintext-secret scan and Python SAST: passed.

## Compatibility and risk

Both `/api/resources/files` and `/openapi/v1/bots/{bot_id}/resources` intentionally adopt the same unfiltered listing behavior. Response schemas and file operation permissions are unchanged.