### PR TITLE
fix(backend): serialize git-sync bootstrap repair and recover stale shallow.lock

### DIFF
--- a/src/backend/src/agentclaw/community/core/skill_center/services/git_sync.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/git_sync.py
@@ -169,6 +169,14 @@ class GitSyncConfig:
         self.sync_jitter_seconds = int(os.getenv("SYNC_JITTER_SECONDS", "60"))
         # 抢不到 bootstrap 锁的 worker 轮询等待 bare repo 就绪的超时（秒）
         self.bootstrap_wait_timeout = int(os.getenv("BOOTSTRAP_WAIT_TIMEOUT", "60"))
+        # Wall-clock cap on one ``git fetch``. Without it a hung fetch holds
+        # the bare repo's ``shallow.lock`` forever and every later fetch dies
+        # on "File exists"; with it the fetch is killed, and the kill is what
+        # makes the stale-lock reaper below both necessary and sound — no lock
+        # older than this bound can belong to a fetch this service still runs.
+        self.git_fetch_timeout_seconds = int(
+            os.getenv("GIT_FETCH_TIMEOUT_SECONDS", "300")
+        )
         self.archive_cron = "0 0 * * *"  # Daily at 00:00
         self.archive_max_age_hours = 24
 
@@ -451,7 +459,17 @@ class GitSyncService(LifecycleBase, GitSyncServiceProtocol):
         return result
 
     async def _ensure_skills_subtree_ready(self) -> dict[str, Any]:
-        """Ensure skills working tree exists when the bare repo already exists."""
+        """Ensure skills working tree exists when the bare repo already exists.
+
+        Serialized on the **same** distributed lock the periodic sync takes
+        (``skill_repo_sync``), because it fetches the same bare repo. The
+        clone path's ``git_sync_bootstrap`` lock is deliberately not reused:
+        it does not exclude a periodic sync, and this repair races that far
+        more often than it races another clone. Every worker process reaches
+        this path on startup — the repo already exists, so the clone branch
+        and its lock are skipped entirely — so without a lock here N workers
+        fetch one repo at once and all but one die on ``shallow.lock``.
+        """
         skills_subtree = next(
             (
                 subtree
@@ -463,7 +481,10 @@ class GitSyncService(LifecycleBase, GitSyncServiceProtocol):
         target_dir = skills_subtree["target_dir"]
         version_file = target_dir / skills_subtree["version_file"]
 
-        if target_dir.is_dir() and version_file.is_file():
+        def _subtree_ready() -> bool:
+            return target_dir.is_dir() and version_file.is_file()
+
+        if _subtree_ready():
             return {"success": True, "method": "existing"}
 
         logger.warning(
@@ -471,6 +492,51 @@ class GitSyncService(LifecycleBase, GitSyncServiceProtocol):
             "is missing/incomplete at %s; repairing",
             target_dir,
         )
+
+        cache = self._cache_plugin
+        lock_key = f"skill_repo_sync:{_get_env()}"
+        lock_value = await self._run_sync(
+            functools.partial(cache.acquire_lock, lock_key, ttl=600)
+        )
+        if not lock_value:
+            # Someone else holds the repo. Do not fetch alongside them — that
+            # is the collision. Wait for their repair instead, then re-check
+            # the tree rather than trusting that they repaired what we need.
+            logger.info(
+                "[GitSyncService] Bootstrap: repo sync lock held by another "
+                "worker; waiting for the skills subtree to become ready"
+            )
+            waited = 0
+            while not _subtree_ready():
+                if waited >= self.config.bootstrap_wait_timeout:
+                    return {
+                        "success": False,
+                        "method": "existing_repair_failed",
+                        "error": (
+                            "Skills subtree still missing after waiting "
+                            f"{self.config.bootstrap_wait_timeout}s for the "
+                            "lock holder's repair"
+                        ),
+                    }
+                await asyncio.sleep(2)
+                waited += 2
+            logger.info(
+                "[GitSyncService] Bootstrap: skills subtree repaired by the "
+                "lock holder"
+            )
+            return {"success": True, "method": "existing_repaired_by_peer"}
+
+        try:
+            return await self._repair_skills_subtree(skills_subtree)
+        finally:
+            await self._run_sync(
+                functools.partial(cache.release_lock, lock_key, lock_value)
+            )
+
+    async def _repair_skills_subtree(
+        self, skills_subtree: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Fetch and re-extract the skills subtree. Caller holds the repo lock."""
         fetch_result = await self._git_fetch()
         if not fetch_result["success"]:
             return {
@@ -989,20 +1055,84 @@ class GitSyncService(LifecycleBase, GitSyncServiceProtocol):
             logger.info("[GitSyncService] _git_fetch: self-heal bootstrap succeeded, retrying fetch")
         return await self._run_sync(self._sync_git_fetch)
 
+    def _reap_stale_shallow_lock(self, bare_repo: Path) -> None:
+        """Remove a ``shallow.lock`` no live fetch can still own.
+
+        ``git fetch --depth`` guards the ``shallow`` file with this lock and
+        never cleans it up after a crash or a kill, so one interrupted fetch
+        makes every later fetch fail with "Unable to create ... File exists"
+        until a human deletes the file. Age is a sound owner test here because
+        the fetch below is bounded: a lock older than that bound plus a margin
+        cannot belong to a fetch this service still has running.
+
+        Deliberately narrow — only ``shallow.lock``. Ref and index locks are
+        left alone: git has its own recovery for those, and deleting a lock
+        that *is* held corrupts the repo this is meant to protect.
+        """
+        lock_file = bare_repo / "shallow.lock"
+        try:
+            age = time.time() - lock_file.stat().st_mtime
+        except FileNotFoundError:
+            return
+        except OSError as e:  # unreadable mtime — leave it for a human
+            logger.warning("[GitSyncService] Fetch: cannot stat %s: %s", lock_file, e)
+            return
+
+        if age <= self.config.git_fetch_timeout_seconds + 60:
+            # Young enough that a fetch may legitimately still hold it; the
+            # fetch below will fail loudly rather than race the holder.
+            return
+
+        try:
+            lock_file.unlink()
+        except FileNotFoundError:
+            return  # the owner cleaned up between the stat and here
+        except OSError as e:
+            logger.error(
+                "[GitSyncService] Fetch: failed to remove stale lock %s: %s",
+                lock_file, e,
+            )
+            return
+
+        logger.warning(
+            "[GitSyncService] Fetch: removed stale shallow.lock (age %.0fs) at "
+            "%s — a previous fetch was killed or crashed holding it",
+            age, lock_file,
+        )
+
     def _sync_git_fetch(self) -> dict[str, Any]:
         bare_repo = self.config.local_bare_repo
 
         if not bare_repo.exists():
             return {"success": False, "error": "Bare repo not found, run bootstrap first"}
 
+        self._reap_stale_shallow_lock(bare_repo)
+
         # Use --force to handle non-fast-forward cases (e.g., remote was force-pushed)
-        result = subprocess.run(
-            ["git", "fetch", self.config.remote_name,
-             f"{self.config.branch}:{self.config.branch}", "--depth=1", "--force"],
-            cwd=bare_repo,
-            capture_output=True,
-            text=True
-        )
+        try:
+            result = subprocess.run(
+                ["git", "fetch", self.config.remote_name,
+                 f"{self.config.branch}:{self.config.branch}", "--depth=1", "--force"],
+                cwd=bare_repo,
+                capture_output=True,
+                text=True,
+                timeout=self.config.git_fetch_timeout_seconds,
+            )
+        except subprocess.TimeoutExpired:
+            # The child is killed on the way out, which can leave the
+            # shallow.lock behind; the reaper above clears it once it ages past
+            # this same bound, so the repo recovers without human hands.
+            logger.error(
+                "[GitSyncService] Fetch: timed out after %ss",
+                self.config.git_fetch_timeout_seconds,
+            )
+            return {
+                "success": False,
+                "error": (
+                    "git fetch timed out after "
+                    f"{self.config.git_fetch_timeout_seconds}s"
+                ),
+            }
 
         if result.returncode != 0:
             return {"success": False, "error": result.stderr}

--- a/src/backend/tests/community/core/skill_center/services/test_git_sync_bootstrap.py
+++ b/src/backend/tests/community/core/skill_center/services/test_git_sync_bootstrap.py
@@ -1,7 +1,11 @@
 import asyncio
 import logging
+import os
+import subprocess
+import time
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
+from agentclaw.community.core.skill_center.services import git_sync as git_sync_module
 from agentclaw.community.core.skill_center.services.git_sync import GitSyncService
 
 
@@ -84,3 +88,207 @@ async def test_bootstrap_clone_failure_logs_error_and_releases_lock(caplog):
     svc._cache_plugin.release_lock.assert_called_once()
     assert any(r.levelno >= logging.ERROR for r in caplog.records)
     assert result["success"] is False
+
+
+# ==========================================================================
+# Bootstrap repair path: serialized on the periodic sync's repo lock.
+#
+# Every worker process reaches this path on startup (the bare repo already
+# exists, so the clone branch and its lock are skipped), so an unlocked fetch
+# here means N workers fetch one bare repo at once and all but one die on
+# "Unable to create ... shallow.lock: File exists".
+# ==========================================================================
+
+
+def _make_repair_service(tmp_path, *, lock_value="lock-1"):
+    """A service whose skills subtree is missing, so the repair path runs."""
+    svc = GitSyncService.__new__(GitSyncService)
+    svc.config = MagicMock()
+    svc._repo_url = "https://example.test/aiworkbench.git"
+    svc.config.bootstrap_wait_timeout = 6  # 测试用短超时
+    target_dir = tmp_path / "skills-repo"
+    svc.config.subtrees = [
+        {
+            "name": "skills",
+            "target_dir": target_dir,
+            "version_file": ".skills-version",
+        }
+    ]
+    svc._cache_plugin = MagicMock()
+    svc._cache_plugin.acquire_lock.return_value = lock_value
+
+    async def _run_sync(func, *a, **k):
+        return func(*a, **k)
+
+    svc._run_sync = _run_sync
+    return svc, target_dir
+
+
+@pytest.mark.asyncio
+async def test_repair_holds_repo_sync_lock_across_fetch(tmp_path):
+    """The fetch runs under the lock, and it is the periodic sync's own key —
+    a different key would not exclude a concurrent sync on the same repo."""
+    svc, _ = _make_repair_service(tmp_path)
+    observed = {}
+
+    async def _fetch():
+        observed["acquired_before_fetch"] = svc._cache_plugin.acquire_lock.call_count
+        observed["released_before_fetch"] = svc._cache_plugin.release_lock.call_count
+        return {"success": True}
+
+    svc._git_fetch = _fetch
+    svc._sync_subtree = AsyncMock(return_value={"success": True})
+
+    result = await svc._ensure_skills_subtree_ready()
+
+    assert result["method"] == "existing_repaired"
+    assert observed == {"acquired_before_fetch": 1, "released_before_fetch": 0}
+    lock_key = svc._cache_plugin.acquire_lock.call_args.args[0]
+    assert lock_key.startswith("skill_repo_sync:")
+    svc._cache_plugin.release_lock.assert_called_once_with(lock_key, "lock-1")
+
+
+@pytest.mark.asyncio
+async def test_repair_releases_lock_when_fetch_fails(tmp_path):
+    svc, _ = _make_repair_service(tmp_path)
+    svc._git_fetch = AsyncMock(return_value={"success": False, "error": "boom"})
+
+    result = await svc._ensure_skills_subtree_ready()
+
+    assert result["success"] is False
+    assert result["method"] == "existing_repair_failed"
+    assert "boom" in result["error"]
+    svc._cache_plugin.release_lock.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_repair_without_lock_waits_instead_of_fetching(tmp_path):
+    """Not getting the lock must not mean fetching anyway — that is the bug."""
+    svc, target_dir = _make_repair_service(tmp_path, lock_value=None)
+    svc._git_fetch = AsyncMock()
+
+    async def _sleep_then_peer_repairs(*_args, **_kwargs):
+        target_dir.mkdir(parents=True, exist_ok=True)
+        (target_dir / ".skills-version").write_text("deadbeef")
+        await _real_sleep(0)
+
+    with patch("asyncio.sleep", new=_sleep_then_peer_repairs):
+        result = await svc._ensure_skills_subtree_ready()
+
+    assert result == {"success": True, "method": "existing_repaired_by_peer"}
+    svc._git_fetch.assert_not_awaited()
+    svc._cache_plugin.release_lock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_repair_without_lock_times_out_without_fetching(tmp_path):
+    svc, _ = _make_repair_service(tmp_path, lock_value=None)
+    svc._git_fetch = AsyncMock()
+
+    with patch("asyncio.sleep", new=_instant_sleep):
+        result = await svc._ensure_skills_subtree_ready()
+
+    assert result["success"] is False
+    assert result["method"] == "existing_repair_failed"
+    assert "6s" in result["error"]
+    svc._git_fetch.assert_not_awaited()
+    svc._cache_plugin.release_lock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_repair_skips_everything_when_subtree_already_present(tmp_path):
+    svc, target_dir = _make_repair_service(tmp_path)
+    target_dir.mkdir(parents=True)
+    (target_dir / ".skills-version").write_text("deadbeef")
+    svc._git_fetch = AsyncMock()
+
+    result = await svc._ensure_skills_subtree_ready()
+
+    assert result == {"success": True, "method": "existing"}
+    svc._git_fetch.assert_not_awaited()
+    svc._cache_plugin.acquire_lock.assert_not_called()
+
+
+# ==========================================================================
+# Bounded fetch + stale shallow.lock recovery
+# ==========================================================================
+
+
+def _make_fetch_service(tmp_path, *, timeout=300):
+    svc = GitSyncService.__new__(GitSyncService)
+    svc.config = MagicMock()
+    svc.config.git_fetch_timeout_seconds = timeout
+    svc.config.remote_name = "origin"
+    svc.config.branch = "master"
+    bare = tmp_path / "aiworkbench.git"
+    bare.mkdir(parents=True)
+    svc.config.local_bare_repo = bare
+    return svc, bare
+
+
+def test_reaper_removes_shallow_lock_no_live_fetch_can_own(tmp_path):
+    svc, bare = _make_fetch_service(tmp_path, timeout=300)
+    lock = bare / "shallow.lock"
+    lock.write_text("")
+    stale = time.time() - (300 + 60 + 1)
+    os.utime(lock, (stale, stale))
+
+    svc._reap_stale_shallow_lock(bare)
+
+    assert not lock.exists()
+
+
+def test_reaper_keeps_lock_a_running_fetch_may_still_hold(tmp_path):
+    svc, bare = _make_fetch_service(tmp_path, timeout=300)
+    lock = bare / "shallow.lock"
+    lock.write_text("")
+
+    svc._reap_stale_shallow_lock(bare)
+
+    assert lock.exists()
+
+
+def test_reaper_is_a_noop_without_a_lock_file(tmp_path):
+    svc, bare = _make_fetch_service(tmp_path)
+
+    svc._reap_stale_shallow_lock(bare)  # must not raise
+
+    assert not (bare / "shallow.lock").exists()
+
+
+def test_sync_git_fetch_bounds_the_subprocess(tmp_path):
+    svc, _ = _make_fetch_service(tmp_path, timeout=11)
+    completed = MagicMock(returncode=0, stderr="")
+
+    with patch.object(git_sync_module.subprocess, "run", return_value=completed) as run:
+        result = svc._sync_git_fetch()
+
+    assert result["success"] is True
+    assert run.call_args.kwargs["timeout"] == 11
+
+
+def test_sync_git_fetch_reports_timeout_instead_of_raising(tmp_path):
+    svc, _ = _make_fetch_service(tmp_path, timeout=7)
+    boom = subprocess.TimeoutExpired(cmd=["git", "fetch"], timeout=7)
+
+    with patch.object(git_sync_module.subprocess, "run", side_effect=boom):
+        result = svc._sync_git_fetch()
+
+    assert result["success"] is False
+    assert "timed out after 7s" in result["error"]
+
+
+def test_sync_git_fetch_reaps_stale_lock_before_fetching(tmp_path):
+    """A repo poisoned by an earlier killed fetch recovers on the next cycle."""
+    svc, bare = _make_fetch_service(tmp_path, timeout=300)
+    lock = bare / "shallow.lock"
+    lock.write_text("")
+    stale = time.time() - (300 + 60 + 1)
+    os.utime(lock, (stale, stale))
+    completed = MagicMock(returncode=0, stderr="")
+
+    with patch.object(git_sync_module.subprocess, "run", return_value=completed):
+        result = svc._sync_git_fetch()
+
+    assert result["success"] is True
+    assert not lock.exists()


### PR DESCRIPTION
## Problem

`GitSyncService` bootstrap fails on startup with:

```
GitSyncService bootstrap: {'success': False, 'method': 'existing_repair_failed',
 'duration': 0, 'error': "Git fetch failed while repairing skills subtree:
 fatal: Unable to create '/home/admin/aiworkbench/aiworkbench.git/shallow.lock':
 File exists. ..."}
```

The skills subtree repair path fetches the shared bare repo with **no lock**.
`sync_bootstrap` acquires its distributed lock only on the *clone* branch; when
the bare repo already exists it returns through `_bootstrap_existing_result`
before that lock is ever reached, and `_ensure_skills_subtree_ready` then calls
`_git_fetch` unserialized.

Every worker process takes that branch on startup (`workers: 6` in
`application.yaml`), so all of them fetch one bare repo at once and all but one
die on `shallow.lock`. Workers that block waiting for the clone lock holder are
worse: they all fall through to the repair at the same instant the bare repo
appears. Meanwhile the periodic sync does hold a distributed lock
(`skill_repo_sync`) for the same fetch — the repair simply bypasses it.

Two further gaps turned a transient collision into a permanent one:

- `_sync_git_fetch` passed no `timeout` to `subprocess.run`, so a hung fetch
  held `shallow.lock` indefinitely.
- Nothing ever removed a lock left behind by a killed or crashed fetch. `git
  fetch --depth` never cleans `shallow.lock` up itself, so one interrupted fetch
  poisons the repo and every later fetch fails until a human deletes the file.

Observed on bot `20260908_ybr6ourf`; the failure blocks skill delivery for any
bot whose skills subtree needs repair.

## Solution

**Serialize the repair on the periodic sync's own lock.** `_ensure_skills_subtree_ready`
now takes `skill_repo_sync:{env}` before fetching and releases it in a `finally`.
That key rather than the bootstrap key is deliberate: the repair races a periodic
sync on the same repo far more often than it races another clone, and the
bootstrap key does not exclude one. A worker that cannot get the lock waits for
the holder's repair and **re-checks the tree** rather than fetching alongside it
(`existing_repaired_by_peer`), reusing the existing `bootstrap_wait_timeout`
budget and its 2s poll. The fetch/extract body moves to `_repair_skills_subtree`
so the locking reads as one block.

**Bound the fetch.** `GIT_FETCH_TIMEOUT_SECONDS` (default 300s) caps the
subprocess; `TimeoutExpired` becomes a normal failure dict instead of an
exception escaping into the bootstrap result.

**Reap the stale lock.** `_reap_stale_shallow_lock` runs before every fetch and
removes `shallow.lock` when it is older than that bound plus a 60s margin. The
bound is what makes age a sound owner test — no lock older than it can belong to
a fetch this service still has running — so the two changes are load-bearing for
each other, not independent cleanups. Kept deliberately narrow to `shallow.lock`:
git has its own recovery for ref and index locks, and deleting a lock that *is*
held would corrupt the repo this is meant to protect.

Rejected alternatives: reusing the `git_sync_bootstrap` lock (does not exclude
the periodic sync, which is the more common racer); reaping by scanning for live
git processes (`ps` parsing is fragile and platform-specific — the timeout gives
a sounder test); reaping every `*.lock` (risks corrupting a repo mid-write).

## Validation

Ran with an ad-hoc venv, because this environment's network policy blocks the
`mirrors.aliyun.com` index pinned in `pyproject.toml` (403 on CONNECT). Installed
the exact `uv.lock` pins from PyPI via `uv export | uv pip install`; `pyproject.toml`
and `uv.lock` are unmodified in this PR.

- `tests/community/core/skill_center/services/test_git_sync_bootstrap.py` — **14 passed**
  (3 pre-existing + 11 new).
- `tests/community/core/skill_center/` — **1154 passed, 25 skipped**, no regressions.
- `tests/community/architecture/` — **290 passed**.
- `scripts/ci/python_sast_local.sh` block rules
  (`E999,E902,E117,F405,E712,E701,E702,F821,F822,F823,F831`) over both changed
  files — clean. Full pyflakes (`--select F,E9`) — clean.
- **Fix actually tested:** stashing only the source change makes **10 of the 11
  new tests fail**. The 11th guards the untouched early-return and passes either
  way by design.

New tests cover: the fetch running while the lock is held and under the periodic
sync's key; release on both the success and failure paths; a lockless worker
waiting instead of fetching (`_git_fetch.assert_not_awaited()` — the actual bug);
wait timeout; reaping a lock past the bound; keeping one a running fetch may still
hold; no lock file present; the timeout reaching `subprocess.run`; and
`TimeoutExpired` reported rather than raised.

Not run: the singlebox coverage gate and changed-line coverage, which need a
spawned product stack this container cannot provide. CI covers both.

## Compatibility and risk

No schema, contract, or API change. One new env knob,
`GIT_FETCH_TIMEOUT_SECONDS`, defaulting to 300s — unset behaviour is the previous
behaviour plus a bound. `_ensure_skills_subtree_ready` gains one success value,
`existing_repaired_by_peer`; existing `method` values are unchanged and failures
still report `existing_repair_failed`, so log/alert matching on those keeps
working.

Worth flagging for review: a repair now waits up to `bootstrap_wait_timeout` (60s
default) when another worker holds the repo, where before it fetched immediately
and usually failed. That is the intended trade — a bounded wait instead of a
guaranteed collision — but it does add up to 60s to a contended startup.

Rollback is a straight revert; no state is migrated. Deployed instances already
poisoned by a stale lock self-heal on the first fetch after the lock ages past
the bound, with no manual `rm` needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016jhthH7ediC3oCTDa77LNj

---
_Generated by [Claude Code](https://claude.ai/code/session_016jhthH7ediC3oCTDa77LNj)_