### PR TITLE
fix(backend): prevent deletion of referenced Skill assets

### DIFF
--- a/docs/adr/0004-block-withdrawal-when-bots-reference-skill.md
+++ b/docs/adr/0004-block-withdrawal-when-bots-reference-skill.md
@@ -9,3 +9,17 @@ status: accepted
 发布或升级不采用相同阻断规则。发布前展示全部受影响 Bot 及 Owner，用户知晓后可以继续；发布成功后更新 Bot 草稿态解析和草稿容器，已经发布的服务 Bot Artifact 保持不变，直到服务 Bot 下次发布才使用新 Skill 版本。
 
 新版本发布后，旧版本成为历史版本，不等同于被下线或删除。既有 Artifact 仍可通过精确的 `skill_uuid + external_version_key` 获取其固化版本。
+
+Skill Asset Deletion 比 Offline 或 Retirement 更严格：只有在没有 Installation、SkillSet Membership、Draft、Publication、Version 或 Service Artifact 血缘引用时才允许删除。删除命令必须先锁定 Skill，并在同一事务中重新检查数据库 blocker；所有新增引用命令也必须遵循相同的 Skill 锁顺序，避免检查后并发新增引用。失败时返回 `409 SKILL_ASSET_IN_USE` 和不泄露跨用户信息的 blocker 计数，不能静默删除 Membership 或 Installation。Center Skill Offline 保留现有的 impact 预览、命令时重检和锁内 guard。
+
+仍在 BFF 使用的 legacy `ac_skill_member` 没有 tenant/env 字段。在该表正式退役前，匹配 `skill_uuid` 的成员关系按全局 Grant blocker fail closed；宁可跨环境保守阻断，也不能删除 Skill 后留下无法归属的成员行。
+
+当前可回放 Service Artifact 只保存 exact Center Skill ref，而每个可进入 Artifact 的 exact ref 必然来自不可变的 `ac_skill_version`。因此硬删除以 Version 作为 Artifact 的 dominant DB blocker，不在 Repository 内再次扫描可能 offload 的 Artifact；Offline/Retirement 的产品影响面仍使用 `ServiceArtifactLineageReader` 展示具体血缘。若未来 Artifact 支持不经过 Version 的 Skill corpus，必须先新增可事务校验的 lineage fact，不能绕过本约束。
+
+当受治理的 Git 源消失但引用仍存在时，保留 Skill 资产和 Desired State，不自动停用 Bot；Git Sync 将其报告为结构化 `SOURCE_MISSING_IN_USE` 失败，Runtime 使用现有的 `MANAGED_SOURCE_MISSING` / `PENDING` 表达，直到源恢复或引用被显式解除。本期不为此新增持久状态字段。
+
+Legacy BFF 的 Local Skill 删除统一委托可补偿的 `LocalSkillDeleteService`，不再使用先删 active/source 文件、后删数据库的旧路径。Bot 未 Ready 时返回冲突，不保留历史 metadata-only 删除 fallback；否则平台无法证明 Runtime、内容和数据库三者安全收敛。
+
+上述不变量适用于所有 Skill hard-delete primitive 及其调用方，不能只依赖 HTTP 层预检查。Bot 删除属于独立生命周期流程：先显式清理该 Bot 的 Installation，再删除 Bot-owned Skill；不能为了 Bot 清理而放宽普通 Asset Deletion。
+
+历史 dangling Installation 不能通过恢复不完整或已失去来源的 Skill 资产来掩盖。运维订正先导出审计证据，再同时删除指向不存在 Skill 的 Installation 与无效 Membership；若容器检查确认没有对应悬空 Runtime entry，则不修改容器文件，只在订正后执行 Effective Read / Runtime Projection 验证。该订正是对已损坏状态的显式修复，不是普通 Asset Deletion 隐式停用 Bot 的先例。

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/responses.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/responses.py
@@ -247,6 +247,7 @@ from agentclaw.community.core.skill_center.errors import (
     SkillEngineNotSupportedError,
     SkillParameterValidationError,
     SkillRuntimeNameConflictError,
+    SkillAssetInUseError,
     SkillOfflineBlockedError,
     SkillSetControlPlaneConflictError,
     SkillSetControlPlaneLockUnavailableError,
@@ -623,6 +624,7 @@ ENVELOPE_ERRORS: dict[type[Exception], tuple[int, str]] = {
     LocalSkillInvalidPackageError: (400, "Invalid Skill package"),
     LocalSkillNotReadyError: (409, "Bot is not ready"),
     LocalSkillActiveError: (409, "Skill is active"),
+    SkillAssetInUseError: (409, "Skill is still in use"),
     LocalSkillDuplicateError: (409, "Local Skill already exists"),
     LocalSkillTooLargeError: (413, "Skill package is too large"),
     LocalSkillStorageError: (502, "Skill storage operation failed"),
@@ -837,6 +839,7 @@ ENVELOPE_ERROR_CODES: dict[type[Exception], int] = {
     LocalSkillInvalidPackageError: 400101,
     LocalSkillNotReadyError: 409101,
     LocalSkillActiveError: 409102,
+    SkillAssetInUseError: 409105,
     LocalSkillDuplicateError: 409103,
     LocalSkillTooLargeError: 413101,
     LocalSkillStorageError: 502101,
@@ -1044,6 +1047,8 @@ def _error_data(exc: Exception) -> object | None:
     """
     if isinstance(exc, SkillOfflineBlockedError):
         return exc.impact
+    if isinstance(exc, SkillAssetInUseError):
+        return {"blockers": exc.blocker_counts}
     if isinstance(exc, ManifestValidationError):
         # The all-or-nothing refusal. The fixed message says a document was
         # rejected; this says which entries and why, in the caller's own terms.

--- a/src/backend/src/agentclaw/community/adapters/http/skill_center/batch_sync.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skill_center/batch_sync.py
@@ -1,51 +1,29 @@
 """Legacy SC batch routes.
 
-The old batch-sync writer is retired. Batch-delete remains unchanged and is
-outside the exact-version materialization flow.
+The old batch-sync writer and unsafe cross-system batch-delete operation are
+permanently retired.
 """
-import asyncio
-import os
-import uuid
-from datetime import datetime
-from pathlib import Path
-from typing import List
+from fastapi import APIRouter, HTTPException
 
-from fastapi import APIRouter, HTTPException, Query
-
-from agentclaw.community.adapters.http.skill_center.schemas import (
-    BatchSyncTaskResponse,
-    BatchSyncTaskStatusResponse,
-)
-from agentclaw.community.core.repository.protocols.skill_center import SkillRepository
-from agentclaw.community.di import Injected
-from agentclaw.community.log import get_logger
-from agentclaw.community.plugin_api.skill_center_client import SkillCenterClient
-
-logger = get_logger()
 router = APIRouter(prefix="/api/v1/skill-center", tags=["skill-center"])
-
-REPORT_DIR = Path(os.environ.get("BATCH_SYNC_REPORT_DIR", "/home/log/logs/batch_sync_report"))
-
-def _get_trace_id() -> str:
-    """从 SOFA Tracer 获取当前请求的 trace_id，获取失败则生成一个。"""
-    try:
-        import opentracing
-        scope = opentracing.tracer.scope_manager.active
-        if scope and scope.span:
-            return str(scope.span.context.trace_id)
-    except Exception:
-        pass
-    return datetime.now().strftime("%Y%m%d_%H%M%S") + "_" + uuid.uuid4().hex[:6]
 
 
 _BATCH_SYNC_RETIRED = (
     "Legacy batch sync is retired; use "
     "POST /openapi/v1/bots/market/skill-center/sync"
 )
+_BATCH_DELETE_RETIRED = (
+    "Legacy batch delete is retired; remove Skill references and use the "
+    "governed Skill lifecycle APIs"
+)
 
 
 def _retired_batch_sync() -> None:
     raise HTTPException(status_code=410, detail=_BATCH_SYNC_RETIRED)
+
+
+def _retired_batch_delete() -> None:
+    raise HTTPException(status_code=410, detail=_BATCH_DELETE_RETIRED)
 
 
 @router.post("/batch-sync", deprecated=True)
@@ -70,256 +48,23 @@ async def get_batch_sync_report(task_id: str) -> None:
     _retired_batch_sync()
 
 
-# ======================== 批量删除技能 ========================
-
-_batch_delete_tasks: dict[str, dict] = {}
-_batch_delete_reports: dict[str, str] = {}
-
-
-async def _run_batch_delete_background(
-    task_id: str, skill_codes: List[str], client: SkillCenterClient,
-    repo: SkillRepository,
-) -> None:
-    """后台执行批量删除，更新 _batch_delete_tasks 状态。
-
-    ``client`` and ``repo`` are captured at scheduling time
-    (route-level ``Injected``).
-    """
-    try:
-        trace_id = task_id
-        report_path = str(REPORT_DIR / f"{trace_id}_delete.md")
-
-        results = []
-        success_count = 0
-        failed_count = 0
-        blocked_count = 0
-
-        for skill_code in skill_codes:
-            try:
-                # 1. 检查是否被 Bot 关联的技能集引用
-                blocked_bots = repo.check_skill_blocked_by_bot(skill_code)
-                if blocked_bots:
-                    results.append({
-                        "skill_code": skill_code,
-                        "success": False,
-                        "status": "blocked",
-                        "error": f"Referenced by bot(s): {', '.join(blocked_bots)}",
-                    })
-                    blocked_count += 1
-                    logger.warning(
-                        "[batch_delete] skill=%s blocked: referenced by bots %s",
-                        skill_code, blocked_bots,
-                    )
-                    continue
-
-                # 2. 调 SC 删除
-                resp = client.delete_skill(skill_code)
-                if not resp.get("success"):
-                    error_msg = resp.get("message", resp.get("error", "Unknown error"))
-                    results.append({
-                        "skill_code": skill_code,
-                        "success": False,
-                        "status": "failed",
-                        "error": f"SC delete failed: {error_msg}",
-                    })
-                    failed_count += 1
-                    continue
-
-                # 3. SC 成功后，级联清理本地 DB
-                try:
-                    cascade = repo.delete_by_name_with_cascade(skill_code)
-                    logger.info(
-                        "[batch_delete] skill=%s cleaned locally: skills=%d, set_skill=%d, member=%d",
-                        skill_code,
-                        cascade.get("deleted_skill_count", 0),
-                        cascade.get("cleaned_set_skill", 0),
-                        cascade.get("cleaned_member", 0),
-                    )
-                except Exception as db_exc:
-                    logger.exception(
-                        "[batch_delete] skill=%s SC deleted OK but local DB cleanup failed: %s",
-                        skill_code, db_exc,
-                    )
-                    # SC 已成功，标记为成功，但记录 DB 清理警告
-                    results.append({
-                        "skill_code": skill_code,
-                        "success": True,
-                        "status": "deleted_with_warning",
-                        "error": f"Local DB cleanup failed: {db_exc}",
-                    })
-                    success_count += 1
-                    continue
-
-                results.append({
-                    "skill_code": skill_code,
-                    "success": True,
-                    "status": "deleted",
-                    "error": None,
-                })
-                success_count += 1
-            except Exception as exc:
-                logger.exception("delete_skill failed for %s: %s", skill_code, exc)
-                results.append({"skill_code": skill_code, "success": False, "status": "failed", "error": str(exc)})
-                failed_count += 1
-
-        # 生成报告
-        report_content = f"""# 批量删除技能报告
-
-**执行时间**: {datetime.now().isoformat()}
-**任务 ID**: {trace_id}
-
-## 统计信息
-
-- 总数：{len(skill_codes)}
-- 成功：{success_count}
-- 失败：{failed_count}
-- 跳过（被 Bot 引用）：{blocked_count}
-
-## 详细结果
-
-| skillCode | 状态 | 错误信息 |
-|-----------|------|----------|
-"""
-        status_map = {"deleted": "成功", "failed": "失败", "blocked": "跳过(被Bot引用)", "deleted_with_warning": "成功(有警告)"}
-        for r in results:
-            error_col = r.get("error", "") or "-"
-            display_status = status_map.get(r.get("status", ""), r.get("status", "-"))
-            report_content += f"| {r['skill_code']} | {display_status} | {error_col} |\n"
-
-        try:
-            REPORT_DIR.mkdir(parents=True, exist_ok=True)
-            Path(report_path).write_text(report_content, encoding="utf-8")
-            logger.info("Batch delete report written to %s", report_path)
-        except Exception as exc:
-            logger.warning("Failed to write delete report to %s: %s", report_path, exc)
-
-        _batch_delete_reports[trace_id] = report_path
-        result_data = {
-            "success": failed_count == 0,
-            "trace_id": trace_id,
-            "total": len(skill_codes),
-            "deleted": success_count,
-            "failed": failed_count,
-            "blocked": blocked_count,
-            "results": results,
-            "report_path": report_path,
-        }
-        _batch_delete_tasks[task_id] = {"status": "done", "progress": f"completed ({len(skill_codes)} skills)", "result": result_data, "error": ""}
-        logger.info(
-            "Background batch delete task %s completed: total=%d, success=%d, failed=%d, blocked=%d",
-            task_id, len(skill_codes), success_count, failed_count, blocked_count,
-        )
-    except Exception as exc:
-        logger.exception("Background batch delete task %s crashed: %s", task_id, exc)
-        _batch_delete_tasks[task_id] = {"status": "error", "progress": "", "result": None, "error": str(exc)}
+@router.post("/batch-delete", deprecated=True)
+async def batch_delete_post() -> None:
+    _retired_batch_delete()
 
 
-def _start_batch_delete_task(
-    skill_codes: List[str], client: SkillCenterClient, repo: SkillRepository,
-) -> BatchSyncTaskResponse:
-    """创建后台删除任务，立即返回 task_id。"""
-    task_id = _get_trace_id()
-    _batch_delete_tasks[task_id] = {"status": "running", "progress": "starting...", "result": None, "error": ""}
-    asyncio.create_task(_run_batch_delete_background(task_id, skill_codes, client, repo))
-    return BatchSyncTaskResponse(task_id=task_id, status="running", message="Batch delete started in background")
+@router.get("/batch-delete", deprecated=True)
+async def batch_delete_get() -> None:
+    _retired_batch_delete()
 
 
-@router.post("/batch-delete", response_model=BatchSyncTaskResponse)
-async def batch_delete_post(
-    request: dict,
-    client: SkillCenterClient = Injected(SkillCenterClient),
-    repo: SkillRepository = Injected(SkillRepository),
-):
-    """JSON body 调用批量删除（异步，立即返回 task_id）。
-
-    Body: { "skill_codes": ["skill-1", "skill-2"] }
-    """
-    skill_codes = request.get("skill_codes", [])
-    if not skill_codes:
-        raise HTTPException(status_code=400, detail="skill_codes is required")
-    return _start_batch_delete_task(skill_codes, client, repo)
+@router.get("/batch-delete/status/{task_id}", deprecated=True)
+async def get_batch_delete_status(task_id: str) -> None:
+    del task_id
+    _retired_batch_delete()
 
 
-@router.get("/batch-delete", response_model=BatchSyncTaskResponse)
-async def batch_delete_get(
-    skill_codes: str = Query(..., description="逗号分隔的技能列表"),
-    client: SkillCenterClient = Injected(SkillCenterClient),
-    repo: SkillRepository = Injected(SkillRepository),
-):
-    """浏览器直接访问触发批量删除（异步，立即返回 task_id）。"""
-    codes = [c.strip() for c in skill_codes.split(",") if c.strip()]
-    if not codes:
-        raise HTTPException(status_code=400, detail="skill_codes is required")
-    return _start_batch_delete_task(codes, client, repo)
-
-
-@router.get("/batch-delete/status/{task_id}", response_model=BatchSyncTaskStatusResponse)
-async def get_batch_delete_status(task_id: str):
-    """轮询批量删除任务状态。"""
-    task = _batch_delete_tasks.get(task_id)
-    if not task:
-        candidate = REPORT_DIR / f"{task_id}_delete.md"
-        if candidate.is_file():
-            try:
-                content = candidate.read_text(encoding="utf-8")
-                import re
-                success_match = re.search(r"成功：\s*(\d+)", content, re.IGNORECASE)
-                failed_match = re.search(r"失败：\s*(\d+)", content, re.IGNORECASE)
-                total_match = re.search(r"总数：\s*(\d+)", content, re.IGNORECASE)
-                blocked_match = re.search(r"跳过.*被\s*Bot.*引用.*：\s*(\d+)", content)
-
-                result_data = {
-                    "success": int(success_match.group(1)) if success_match else 0,
-                    "trace_id": task_id,
-                    "total": int(total_match.group(1)) if total_match else 0,
-                    "deleted": int(success_match.group(1)) if success_match else 0,
-                    "failed": int(failed_match.group(1)) if failed_match else 0,
-                    "blocked": int(blocked_match.group(1)) if blocked_match else 0,
-                    "results": [],
-                    "report_path": str(candidate),
-                }
-            except Exception:
-                result_data = {
-                    "success": True,
-                    "trace_id": task_id,
-                    "total": 0,
-                    "deleted": 0,
-                    "failed": 0,
-                    "blocked": 0,
-                    "results": [],
-                    "report_path": str(candidate),
-                }
-            return BatchSyncTaskStatusResponse(
-                task_id=task_id,
-                status="done",
-                progress="completed (from disk)",
-                result=result_data,
-                error="",
-            )
-        raise HTTPException(status_code=404, detail=f"Task not found: {task_id}")
-    return BatchSyncTaskStatusResponse(
-        task_id=task_id,
-        status=task["status"],
-        progress=task.get("progress", ""),
-        result=task.get("result"),
-        error=task.get("error", ""),
-    )
-
-
-@router.get("/batch-delete/report/{task_id}")
-async def get_batch_delete_report(task_id: str):
-    """查看指定 task_id 的删除报告。"""
-    report_path = _batch_delete_reports.get(task_id)
-    if not report_path:
-        candidate = REPORT_DIR / f"{task_id}_delete.md"
-        if candidate.is_file():
-            report_path = str(candidate)
-        else:
-            raise HTTPException(status_code=404, detail=f"Report not found: {task_id}")
-
-    try:
-        content = Path(report_path).read_text(encoding="utf-8")
-    except FileNotFoundError:
-        raise HTTPException(status_code=404, detail=f"Report file missing: {report_path}")
-
-    return {"task_id": task_id, "report_path": report_path, "content": content}
+@router.get("/batch-delete/report/{task_id}", deprecated=True)
+async def get_batch_delete_report(task_id: str) -> None:
+    del task_id
+    _retired_batch_delete()

--- a/src/backend/src/agentclaw/community/adapters/http/skill_center/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skill_center/schemas.py
@@ -344,7 +344,9 @@ class SyncSkillsResult(BaseModel):
     updated: int
     deleted: int
     failed: int
+    skipped: int = 0
     errors: List[str]
+    blocked: List[Dict[str, Any]] = Field(default_factory=list)
 
 
 class SyncSkillsResponse(BaseModel):

--- a/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
@@ -2404,11 +2404,56 @@ async def delete_skill(
         ("git://", "center://")
     )
     if is_governed_content_source:
-        service = skill_service_factory.create()
+        persisted_owner_id = str(skill.get("user_id") or "")
+        persisted_bot_id = str(skill.get("bolt_id") or "")
+        collaborator_authorized = bool(
+            ctx.metadata.get("skill_delete_collaborator_authorized")
+        )
+        if persisted_owner_id:
+            if not persisted_bot_id:
+                raise HTTPException(
+                    status_code=409,
+                    detail="Skill is missing its Bot identity",
+                )
+            if bot_id and bot_id != persisted_bot_id:
+                raise HTTPException(
+                    status_code=409,
+                    detail={
+                        "error_code": "SKILL_BOT_CONTEXT_MISMATCH",
+                        "message": "删除技能必须使用 Skill 持久化归属的 Bot",
+                        "bot_id": persisted_bot_id,
+                    },
+                )
+            scoped_bot = bot_repo.get_by_id_and_owner(
+                persisted_bot_id, persisted_owner_id
+            )
+            if not scoped_bot:
+                raise HTTPException(status_code=404, detail="Bot not found")
+            active_engine = str(
+                scoped_bot.get("active_engine") or DEFAULT_ENGINE_TYPE
+            )
+            if engine_type and engine_type != active_engine:
+                raise HTTPException(
+                    status_code=409,
+                    detail={
+                        "error_code": "SKILL_ENGINE_CONTEXT_MISMATCH",
+                        "message": "删除技能必须使用 Bot 当前的生效引擎",
+                        "active_engine": active_engine,
+                    },
+                )
+            service = skill_service_factory.create(
+                bot_id=persisted_bot_id,
+                bot_owner_id=persisted_owner_id,
+                engine_type=active_engine,
+            )
+        else:
+            service = skill_service_factory.create()
         try:
             success = await service.delete_skill(
                 skill_id,
                 user_id=current_user_id,
+                authorized_bot_owner_id=persisted_owner_id or None,
+                collaborator_authorization_verified=collaborator_authorized,
             )
             if not success:
                 raise HTTPException(status_code=404, detail="Skill not found")

--- a/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
@@ -94,20 +94,29 @@ from agentclaw.community.api.bot_service import BotServiceProtocol
 from agentclaw.community.api.skill_set_management_service import (
     SkillSetManagementServiceProtocol,
 )
+from agentclaw.community.api.local_skill_delete_service import (
+    LocalSkillDeleteServiceProtocol,
+)
 from agentclaw.community.core.repository.protocols.bot import BotRepository
 from agentclaw.community.core.bot_management.services.engine_resolver import (
     resolve_engine_for_bot,
     resolve_runtime_engine_for_bot,
 )
 from agentclaw.community.core.skill_center.errors import (
+    LocalSkillActiveError,
+    LocalSkillEditBusyError,
+    LocalSkillEditLockUnavailableError,
+    LocalSkillEditPausedError,
+    LocalSkillLayoutRollbackError,
     LocalSkillNotFoundError,
+    LocalSkillNotReadyError,
     LocalSkillRuntimeSyncError,
-    SkillDeleteConsistencyError,
+    LocalSkillStorageError,
+    SkillAssetInUseError,
     SkillReferencedBySkillSetError,
     SkillRuntimeNameConflictError,
     SkillSetControlPlaneConflictError,
 )
-from agentclaw.community.core.bot_management.errors import BotLookupAmbiguousError
 from agentclaw.community.core.skills_pool.edit_guard import (
     SkillsPoolEditGuard,
     SkillsPoolEditLockUnavailableError,
@@ -2360,12 +2369,12 @@ async def delete_skill(
     ctx: RequestContext = Depends(get_request_context),
     skill_repo: SkillRepository = Injected(SkillRepository),
     bot_repo: BotRepository = Injected(BotRepository),
-    path_factory: WorkspacePathFactory = Injected(WorkspacePathFactory),
     skill_service_factory: SkillServiceFactoryProtocol = Injected(
         SkillServiceFactoryProtocol
     ),
-    resolver: DeviceContextResolver = Injected(DeviceContextResolver),
-    edit_guard: SkillsPoolEditGuard = Injected(SkillsPoolEditGuard),
+    local_delete: LocalSkillDeleteServiceProtocol = Injected(
+        LocalSkillDeleteServiceProtocol
+    ),
 ) -> MessageResponse:
     """Delete a skill.
 
@@ -2416,6 +2425,15 @@ async def delete_skill(
                     "skill_set_ids": e.skill_set_ids,
                 },
             ) from e
+        except SkillAssetInUseError as e:
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "error_code": "SKILL_ASSET_IN_USE",
+                    "message": "请先解除该 Skill 的生效或能力集引用，再删除 Skill",
+                    "blockers": e.blocker_counts,
+                },
+            ) from e
         except ValueError as e:
             error_msg = str(e)
             if "无权删除" in error_msg or "Permission denied" in error_msg:
@@ -2435,124 +2453,69 @@ async def delete_skill(
             },
         )
 
-    try:
-        bot = (
-            bot_repo.get_by_id_and_entity(effective_bot_id, entity_id)
-            if entity_id
-            else bot_repo.get_unique_by_id(effective_bot_id)
-        )
-    except BotLookupAmbiguousError as e:
-        raise HTTPException(
-            status_code=409,
-            detail={
-                "error_code": "SKILL_BOT_CONTEXT_AMBIGUOUS",
-                "message": "历史 Bot ID 不唯一，请提供 entity_id 精确定位",
-                "bot_id": effective_bot_id,
-            },
-        ) from e
-    if not bot:
-        raise HTTPException(status_code=404, detail="Bot not found")
-
-    effective_entity_id = str(bot.get("entity_id") or bot.get("owner_id") or "")
-    effective_entity_type = str(bot.get("entity_type") or "staff")
-    effective_engine = str(bot.get("active_engine") or DEFAULT_ENGINE_TYPE)
-    runtime_engine = resolve_runtime_engine_for_bot(
-        bot_id=effective_bot_id,
-        owner_id=str(bot.get("owner_id") or effective_entity_id),
-        bot_repo=bot_repo,
-    )
-    if engine_type and engine_type != effective_engine:
-        raise HTTPException(
-            status_code=409,
-            detail={
-                "error_code": "SKILL_ENGINE_CONTEXT_MISMATCH",
-                "message": "删除技能必须使用 Bot 当前的生效引擎",
-                "active_engine": effective_engine,
-            },
-        )
-    is_desktop = bot.get("bot_type") == "desktop"
-
-    # teclaw deletes the skill files from the (draft) container; resolve provider
-    # so the device-fs path is the workspace-namespace form.
-    is_teclaw, local_skill_adapter = _resolve_teclaw_local_skill(
-        resolver, effective_bot_id, effective_entity_id
-    )
-
-    skills_dir = path_factory.get_bot_skills_dir(
-        effective_entity_id, effective_bot_id, runtime_engine, effective_entity_type
-    )
-    local_dir = path_factory.get_bot_skills_local_dir(
-        effective_entity_id,
-        effective_bot_id,
-        runtime_engine,
-        effective_entity_type,
-        is_desktop=is_desktop,
-        is_teclaw=is_teclaw,
-    )
-    repo_dir = path_factory.get_bot_skills_repo_dir(
-        effective_entity_id,
-        effective_bot_id,
-        runtime_engine,
-        effective_entity_type,
-        is_desktop=is_desktop,
-    )
-
-    service = skill_service_factory.create(
-        active_dir=skills_dir,
-        repo_dir=repo_dir,
-        local_dir=local_dir,
-        local_skill_path_adapter=local_skill_adapter,
-        entity_id=effective_entity_id,
-        bot_owner_id=str(bot.get("owner_id") or ""),
-        bot_id=effective_bot_id,
-        engine_type=effective_engine,
-    )
-    try:
-        edit_lease = edit_guard.acquire_for_edit(
-            scope=BotSkillLayoutScope(
-                env=str(bot["env"]),
-                entity_id=str(bot["entity_id"]),
-                bot_id=effective_bot_id,
+    if persisted_git_path.startswith("local://"):
+        if engine_type:
+            scoped_bot = bot_repo.get_by_id_and_owner(
+                effective_bot_id, str(skill.get("user_id") or "")
             )
-        )
+            if not scoped_bot:
+                raise HTTPException(status_code=404, detail="Bot not found")
+            active_engine = str(
+                scoped_bot.get("active_engine") or DEFAULT_ENGINE_TYPE
+            )
+            if engine_type != active_engine:
+                raise HTTPException(
+                    status_code=409,
+                    detail={
+                        "error_code": "SKILL_ENGINE_CONTEXT_MISMATCH",
+                        "message": "删除技能必须使用 Bot 当前的生效引擎",
+                        "active_engine": active_engine,
+                    },
+                )
         try:
-            # 路由已先通过 CollaboratorPermissionInterceptor；仍把持久化
-            # Bot owner 显式传给 Service 做 scope 双重校验，不能把协作者当成
-            # Skill metadata owner。
-            success = await service.delete_skill(
-                skill_id,
+            await local_delete.delete_local_skill(
+                skill_id=skill_id,
+                owner_id=str(skill.get("user_id") or ""),
                 user_id=current_user_id,
-                authorized_bot_owner_id=str(bot.get("owner_id") or ""),
-                collaborator_authorization_verified=bool(
-                    ctx.metadata.get("skill_delete_collaborator_authorized")
-                ),
             )
-        finally:
-            edit_guard.release(edit_lease)
-        if not success:
-            raise HTTPException(status_code=404, detail="Skill not found")
-        return MessageResponse(success=True, message="Skill deleted successfully")
-    except SkillsPoolEditPausedError as e:
-        raise HTTPException(status_code=409, detail=str(e)) from e
-    except SkillDeleteConsistencyError as e:
-        raise HTTPException(status_code=409, detail=str(e)) from e
-    except SkillReferencedBySkillSetError as e:
-        raise HTTPException(
-            status_code=409,
-            detail={
-                "error_code": "SKILL_REFERENCED_BY_SKILL_SET",
-                "message": "请先从所有技能集中移除该技能，再删除技能",
-                "skill_set_ids": e.skill_set_ids,
-            },
-        ) from e
-    except ValueError as e:
-        error_msg = str(e)
-        # 权限错误返回 403
-        if "无权删除" in error_msg or "Permission denied" in error_msg:
-            raise HTTPException(status_code=403, detail=error_msg)
-        # 其他值错误返回 400
-        raise HTTPException(status_code=400, detail=error_msg)
+            return MessageResponse(
+                success=True,
+                message="Skill deleted successfully",
+            )
+        except SkillAssetInUseError as e:
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "error_code": "SKILL_ASSET_IN_USE",
+                    "message": "请先解除该 Skill 的生效或能力集引用，再删除 Skill",
+                    "blockers": e.blocker_counts,
+                },
+            ) from e
+        except LocalSkillNotFoundError as e:
+            raise HTTPException(status_code=404, detail="Skill not found") from e
+        except (
+            LocalSkillActiveError,
+            LocalSkillEditBusyError,
+            LocalSkillEditPausedError,
+            LocalSkillLayoutRollbackError,
+        ) as e:
+            raise HTTPException(status_code=409, detail=str(e)) from e
+        except LocalSkillNotReadyError as e:
+            raise HTTPException(status_code=409, detail="Bot is not ready") from e
+        except LocalSkillEditLockUnavailableError as e:
+            raise HTTPException(status_code=503, detail=str(e)) from e
+        except LocalSkillStorageError as e:
+            raise HTTPException(
+                status_code=502, detail="Skill storage operation failed"
+            ) from e
 
+    raise HTTPException(
+        status_code=409,
+        detail={
+            "error_code": "SKILL_SOURCE_IDENTITY_INVALID",
+            "message": "历史 Skill 缺少可安全删除的内容定位，请联系管理员处理",
+        },
+    )
 
 # ==================== Skill Parameters Endpoints (设备文件版) ====================
 

--- a/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
@@ -2400,10 +2400,10 @@ async def delete_skill(
     if not skill:
         raise HTTPException(status_code=404, detail="Skill not found")
     persisted_git_path = str(skill.get("git_path") or "")
-    is_shared_source = not skill.get("user_id") and persisted_git_path.startswith(
+    is_governed_content_source = persisted_git_path.startswith(
         ("git://", "center://")
     )
-    if is_shared_source:
+    if is_governed_content_source:
         service = skill_service_factory.create()
         try:
             success = await service.delete_skill(

--- a/src/backend/src/agentclaw/community/core/bot_management/README.md
+++ b/src/backend/src/agentclaw/community/core/bot_management/README.md
@@ -36,6 +36,7 @@ consumes:
   - "BotSpaceAccessProtocol (implemented by the Spaces context)"
   - "SpaceAccessServiceProtocol"
   - "CachePlugin quota lock"
+  - "CapabilityDesiredStateRepositoryProtocol"
 internal_dependencies:
   - agentclaw.community.core.repository.protocols.bot    # repository contracts consumed by this module
   - agentclaw.community.core.repository.protocols.devices    # repository contracts consumed by this module
@@ -43,6 +44,7 @@ internal_dependencies:
   - agentclaw.community.core.repository.protocols.platform    # repository contracts consumed by this module
   - agentclaw.community.core.repository.protocols.publishing    # repository contracts consumed by this module
   - agentclaw.community.core.repository.protocols.skill_center    # repository contracts consumed by this module
+  - agentclaw.community.core.repository.protocols.capability_desired_state    # explicit Skill/MCP Installation purge during Bot deletion
   - agentclaw.community.core.base
   - agentclaw.community.core.bot_app_grant.protocols    # sweep contract: deletion withdraws the bot's app authorizations
   - agentclaw.community.core.bot_startup_script.protocols    # sweep contract: deletion removes the bot's stored startup script

--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -59,7 +59,6 @@ if TYPE_CHECKING:
     from agentclaw.community.core.cron.services.aicoding.cron_auto_setup import CronAutoSetupService
     from agentclaw.community.core.task_queue.services.task_queue_service import TaskQueueService
     from agentclaw.community.core.common_config.service import CommonConfigService
-    from agentclaw.community.core.devices.protocols import McpSyncProtocol
     from agentclaw.community.core.skill_center.runtime_projection_contract import (
         BotRuntimeProjectorProtocol as CoreBotRuntimeProjectorProtocol,
     )
@@ -4131,6 +4130,8 @@ class BotService(BotServiceProtocol):
             "skills_deleted": 0,
             "skill_sets_deleted": 0,
             "resources_deleted": 0,
+            "skill_installations_deleted": 0,
+            "mcp_installations_deleted": 0,
             "errors": []
         }
 
@@ -4141,12 +4142,27 @@ class BotService(BotServiceProtocol):
             result["skills_deleted"] = cleanup_result.get("skills_deleted", 0)
             result["skill_sets_deleted"] = cleanup_result.get("skill_sets_deleted", 0)
             result["resources_deleted"] = cleanup_result.get("resources_deleted", 0)
-
-            logger.info(
-                f"[bot_service._cleanup_bot_associated_data] Cleanup completed for bot {bot_id}: "
-                f"skills={result['skills_deleted']}, skill_sets={result['skill_sets_deleted']}, "
-                f"resources={result['resources_deleted']}"
+            result["skill_installations_deleted"] = cleanup_result.get(
+                "skill_installations_deleted", 0
             )
+            result["mcp_installations_deleted"] = cleanup_result.get(
+                "mcp_installations_deleted", 0
+            )
+            result["errors"].extend(cleanup_result.get("errors", []))
+
+            if result["errors"]:
+                logger.warning(
+                    "[bot_service._cleanup_bot_associated_data] Cleanup incomplete "
+                    "for bot %s: errors=%s",
+                    bot_id,
+                    result["errors"],
+                )
+            else:
+                logger.info(
+                    f"[bot_service._cleanup_bot_associated_data] Cleanup completed for bot {bot_id}: "
+                    f"skills={result['skills_deleted']}, skill_sets={result['skill_sets_deleted']}, "
+                    f"resources={result['resources_deleted']}"
+                )
 
         except Exception as e:
             error_msg = f"Cleanup error for bot {bot_id}: {e}"

--- a/src/backend/src/agentclaw/community/core/bot_management/services/cleanup_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/cleanup_service.py
@@ -14,6 +14,10 @@ from agentclaw.community.core.bot_startup_script.protocols import (
 )
 from agentclaw.community.core.repository.protocols.skill_center import SkillSetRepository
 from agentclaw.community.core.repository.protocols.skill_center import SkillRepository
+from agentclaw.community.core.repository.protocols.capability_desired_state import (
+    CapabilityDesiredStateRepositoryProtocol,
+)
+from agentclaw.community.utils.env_utils import get_current_env
 
 logger = get_logger()
 
@@ -26,17 +30,20 @@ class BotCleanupService:
         self,
         skill_repo: SkillRepository,
         skill_set_repo: SkillSetRepository,
+        desired_state_repo: CapabilityDesiredStateRepositoryProtocol,
         startup_script_purge: StartupScriptPurgeProtocol,
     ):
         """
         Args:
             skill_repo: SkillRepository 实例（支持 delete_by_bot_id）
             skill_set_repo: SkillSetRepository 实例（支持 delete_by_bot_id）
+            desired_state_repo: Bot lifecycle 的 Skill/MCP Installation 清理入口
             startup_script_purge: 启动脚本的删除side。必填而非可选——漏接的后果
                 是脚本行静默残留，正是本次要修的问题本身。
         """
         self._skill_repo = skill_repo
         self._skill_set_repo = skill_set_repo
+        self._desired_state_repo = desired_state_repo
         self._startup_script_purge = startup_script_purge
 
     def purge_startup_script(self, *, entity_id: str, bot_id: str) -> bool:
@@ -78,22 +85,41 @@ class BotCleanupService:
             "skills_deleted": 0,
             "skill_sets_deleted": 0,
             "resources_deleted": 0,
+            "skill_installations_deleted": 0,
+            "mcp_installations_deleted": 0,
             "errors": [],
         }
 
-        # 1. 清理技能
+        # 1. Bot lifecycle explicitly removes effective capability facts.
         try:
-            result["skills_deleted"] = self._skill_repo.delete_by_bot_id(bot_id)
+            purged = self._desired_state_repo.purge_bot_installations(
+                bot_id=bot_id, owner_id=user_id, env=get_current_env()
+            )
+            result["skill_installations_deleted"] = purged["skills"]
+            result["mcp_installations_deleted"] = purged["mcps"]
         except Exception as e:
-            error_msg = f"Cleanup skills error for bot {bot_id}: {e}"
+            error_msg = f"Cleanup installations error for bot {bot_id}: {e}"
+            logger.error(f"[BotCleanupService] {error_msg}")
+            result["errors"].append(error_msg)
+            return result
+
+        # 2. Remove saved SkillSet references before Bot-owned assets.
+        try:
+            result["skill_sets_deleted"] = self._skill_set_repo.delete_by_bot_id(
+                bot_id, user_id
+            )
+        except Exception as e:
+            error_msg = f"Cleanup skill_sets error for bot {bot_id}: {e}"
             logger.error(f"[BotCleanupService] {error_msg}")
             result["errors"].append(error_msg)
 
-        # 2. 清理技能集（含关联表）
+        # 3. Delete only assets owned by this exact owner + Bot scope.
         try:
-            result["skill_sets_deleted"] = self._skill_set_repo.delete_by_bot_id(bot_id)
+            result["skills_deleted"] = self._skill_repo.delete_by_bot_id(
+                bot_id, user_id
+            )
         except Exception as e:
-            error_msg = f"Cleanup skill_sets error for bot {bot_id}: {e}"
+            error_msg = f"Cleanup skills error for bot {bot_id}: {e}"
             logger.error(f"[BotCleanupService] {error_msg}")
             result["errors"].append(error_msg)
 

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/capability_desired_state.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/capability_desired_state.py
@@ -83,6 +83,19 @@ class CapabilityDesiredStateRepository(
     def __init__(self, db: DatabasePlugin) -> None:
         self._db = db
 
+    def purge_bot_installations(
+        self, *, bot_id: str, owner_id: str, env: str
+    ) -> dict[str, int]:
+        """Explicit Bot-lifecycle removal; never used by Asset Deletion."""
+        with self._db.transactional_orm_session() as session:
+            skills = skill_installations.uninstall_all(
+                session, bot_id=bot_id, owner_id=owner_id, env=env
+            )
+            mcps = mcp_installations.uninstall_all(
+                session, bot_id=bot_id, owner_id=owner_id, env=env
+            )
+            return {"skills": skills, "mcps": mcps}
+
     @staticmethod
     def _as_item(row: SkillSet) -> dict:
         return _item(row)

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill.py
@@ -19,11 +19,10 @@ statement shape and predicates:
   ac_skill_set have no soft-delete column). Single UPDATEs stay
   single. ``gmt_modified=func.now()`` matches prod's literal
   ``NOW()``.
-- ``delete_by_name_with_cascade`` / ``delete_by_bot_id`` /
-  ``set_active_skill_set`` keep prod's multi-statement shape; each
-  prod statement group runs in its own ``orm_session`` exactly as
-  prod opened a fresh connection per group (faithful reproduction —
-  not artificially fused).
+- Asset hard-delete methods now deliberately supersede the historical
+  cascade behavior: they lock exact Skill rows, reject durable references,
+  and delete only zero-reference assets in one transaction. They never
+  silently remove Installation or Membership rows.
 - ``add_default_mcp_exclusion`` is the **only** genuine upsert in S4
   (prod ``INSERT ... ON DUPLICATE KEY UPDATE`` on
   ``uk_user_bot_skillset_mcp``). Implemented with the live
@@ -53,7 +52,7 @@ from sqlalchemy import and_, func, or_
 
 from agentclaw.community.log import get_logger
 from agentclaw.community.core.skill_center.errors import (
-    ActiveSkillSetReferenceError,
+    SkillAssetInUseError,
     SkillSetControlPlaneConflictError,
 )
 from agentclaw.community.core.skill_center.offline_policy import require_skill_online
@@ -760,25 +759,156 @@ class SkillRepository(
         return self.get_by_id(skill_id)
 
     def delete(self, skill_id: str) -> bool:
-        """Delete one Skill and its set associations as one transaction.
-
-        This remains a bulk-delete repository method, so SQLAlchemy cannot
-        apply ``Skill.skill_sets``' ORM cascade. Remove matching association
-        rows explicitly before deleting the Skill. A real transaction keeps
-        association cleanup and the Skill-row delete atomic and propagates
-        every database error to the caller.
-        """
+        """Delete one unreferenced Skill, or fail closed."""
         with self._db.transactional_orm_session() as db:
-            self._delete_skill_set_associations(db, int(skill_id))
-            rowcount = (
+            skill = (
                 db.query(self.Skill)
                 .filter(
                     self.Skill.id == int(skill_id),
                     self.Skill.env == get_current_env(),
                 )
-                .delete(synchronize_session=False)
+                .with_for_update()
+                .one_or_none()
             )
-            return rowcount > 0
+            if skill is None:
+                return False
+            self._require_unreferenced_for_delete(db, skill)
+            db.delete(skill)
+            db.flush()
+            return True
+
+    def require_unreferenced_for_delete(self, skill_id: str) -> None:
+        """Preflight external cleanup; ``delete`` repeats this under its lock."""
+        with self._db.transactional_orm_session() as db:
+            skill = (
+                db.query(self.Skill)
+                .filter(
+                    self.Skill.id == int(skill_id),
+                    self.Skill.env == get_current_env(),
+                )
+                .with_for_update()
+                .one_or_none()
+            )
+            if skill is not None:
+                self._require_unreferenced_for_delete(db, skill)
+
+    @staticmethod
+    def _require_unreferenced_for_delete(db, skill, *, env: str | None = None) -> None:
+        """Recheck database blockers while the exact Skill row is locked."""
+        from agentclaw.community.core.models import (
+            BotSkillInstallation,
+            SkillDraftEditLease,
+            SkillGrant,
+            SkillPublicationAttempt,
+            SkillSetSkill,
+            SkillSpaceBinding,
+            SkillVersion,
+        )
+        from agentclaw.community.core.models.space_skill import (
+            SkillDraftUpgradeRequest,
+        )
+        from agentclaw.community.core.models.skill import AcSkillMember
+
+        effective_env = env or get_current_env()
+        installation_count = (
+            db.query(BotSkillInstallation.id)
+            .filter(
+                BotSkillInstallation.env == effective_env,
+                BotSkillInstallation.skill_id == int(skill.id),
+            )
+            .count()
+        )
+        membership_identity = SkillSetSkill.skill_id == int(skill.id)
+        if skill.skill_uuid:
+            membership_identity = or_(
+                membership_identity,
+                SkillSetSkill.skill_uuid == skill.skill_uuid,
+            )
+        membership_count = (
+            db.query(SkillSetSkill.id)
+            .filter(
+                SkillSetSkill.env == effective_env,
+                membership_identity,
+            )
+            .count()
+        )
+        # ac_skill_member predates tenant/env columns. It is still served by
+        # the legacy member APIs, so a matching UUID remains a global,
+        # fail-closed grant blocker until that table is retired.
+        grant_count = 0
+        if skill.skill_uuid:
+            grant_count = (
+                db.query(AcSkillMember.id)
+                .filter(AcSkillMember.skill_uuid == skill.skill_uuid)
+                .count()
+            )
+        space_binding_count = (
+            db.query(SkillSpaceBinding.id)
+            .filter(
+                SkillSpaceBinding.env == effective_env,
+                SkillSpaceBinding.skill_id == int(skill.id),
+            )
+            .count()
+        )
+        grant_count += (
+            db.query(SkillGrant.id)
+            .filter(
+                SkillGrant.env == effective_env,
+                SkillGrant.skill_id == int(skill.id),
+            )
+            .count()
+        )
+        version_count = (
+            db.query(SkillVersion.id)
+            .filter(
+                SkillVersion.env == effective_env,
+                SkillVersion.skill_id == int(skill.id),
+            )
+            .count()
+        )
+        # Replayable Service Artifacts carry exact Center refs only. Every
+        # such ref is produced from an immutable SkillVersion, so Version is
+        # the dominant database blocker for hard deletion. Offline impact
+        # still scans Artifact lineage to show the authorized product detail;
+        # the repository intentionally does not depend on service_bot I/O.
+        publication_count = (
+            db.query(SkillPublicationAttempt.id)
+            .filter(
+                SkillPublicationAttempt.env == effective_env,
+                SkillPublicationAttempt.skill_id == int(skill.id),
+            )
+            .count()
+        )
+        draft_count = int(skill.draft_status is not None)
+        draft_count += (
+            db.query(SkillDraftEditLease.id)
+            .filter(
+                SkillDraftEditLease.env == effective_env,
+                SkillDraftEditLease.skill_id == int(skill.id),
+            )
+            .count()
+        )
+        draft_count += (
+            db.query(SkillDraftUpgradeRequest.id)
+            .filter(
+                SkillDraftUpgradeRequest.env == effective_env,
+                SkillDraftUpgradeRequest.skill_id == int(skill.id),
+            )
+            .count()
+        )
+        blockers = {
+            "installation": installation_count,
+            "membership": membership_count,
+            "grant": grant_count,
+            "space_binding": space_binding_count,
+            "draft": draft_count,
+            "publication": publication_count,
+            "version": version_count,
+        }
+        if any(blockers.values()):
+            raise SkillAssetInUseError(
+                blockers
+            )
 
     def replace_bot_local_skill(
         self,
@@ -816,16 +946,6 @@ class SkillRepository(
             db.flush()
             return _skill_to_dict(skill)
 
-    @staticmethod
-    def _delete_skill_set_associations(db, skill_id: int) -> None:
-        """Apply #684's association cleanup inside the caller's transaction."""
-        from agentclaw.community.core.models import SkillSetSkill
-
-        db.query(SkillSetSkill).filter(
-            SkillSetSkill.skill_id == skill_id,
-            SkillSetSkill.env == get_current_env(),
-        ).delete(synchronize_session=False)
-
     def delete_bot_local_skill(
         self,
         *,
@@ -834,42 +954,29 @@ class SkillRepository(
         bot_id: str,
     ) -> bool | None:
         """Atomically delete one inactive Local Skill and its scoped state."""
-        from agentclaw.community.core.models import SkillSetSkill
         from agentclaw.community.core.skill_center.orm import DefaultSkillsetSkillExclusion
 
         with self._db.transactional_orm_session() as db:
-            skill = db.query(self.Skill).filter(
-                self.Skill.id == int(skill_id),
-                self.Skill.env == get_current_env(),
-                self.Skill.user_id == _normalize_user_id(owner_id),
-                self.Skill.bolt_id == bot_id,
-                self.Skill.git_path.like("local://%"),
-            ).one_or_none()
-            if skill is None:
-                return None
-            active_custom_reference = (
-                db.query(self.SkillSet.id)
-                .join(SkillSetSkill, SkillSetSkill.skill_set_id == self.SkillSet.id)
+            skill = (
+                db.query(self.Skill)
                 .filter(
-                    SkillSetSkill.skill_id == int(skill_id),
-                    SkillSetSkill.env == get_current_env(),
-                    self.SkillSet.env == get_current_env(),
-                    self.SkillSet.user_id == _normalize_user_id(owner_id),
-                    self.SkillSet.bolt_id == bot_id,
-                    self.SkillSet.is_default == False,  # noqa: E712
-                    self.SkillSet.is_active == True,  # noqa: E712
+                    self.Skill.id == int(skill_id),
+                    self.Skill.env == get_current_env(),
+                    self.Skill.user_id == _normalize_user_id(owner_id),
+                    self.Skill.bolt_id == bot_id,
+                    self.Skill.git_path.like("local://%"),
                 )
                 .with_for_update()
-                .first()
+                .one_or_none()
             )
-            if active_custom_reference is not None:
-                raise ActiveSkillSetReferenceError()
+            if skill is None:
+                return None
+            self._require_unreferenced_for_delete(db, skill)
             db.query(DefaultSkillsetSkillExclusion).filter(
                 DefaultSkillsetSkillExclusion.user_id == _normalize_user_id(owner_id),
                 DefaultSkillsetSkillExclusion.bot_id == bot_id,
                 DefaultSkillsetSkillExclusion.skill_id == int(skill_id),
             ).delete(synchronize_session=False)
-            self._delete_skill_set_associations(db, int(skill_id))
             db.delete(skill)
             db.flush()
             return True
@@ -906,57 +1013,30 @@ class SkillRepository(
     def delete_by_name_with_cascade(
         self, name: str, env: Optional[str] = None
     ) -> dict:
-        from agentclaw.community.core.models import SkillSetSkill
-        from agentclaw.community.core.models.skill import AcSkillMember
-
         effective_env = env or get_current_env()
-
-        # 1. collect skill_uuids (own session — prod opens fresh conn)
-        with self._db.orm_session() as db:
-            uuids = [
-                r[0]
-                for r in db.query(self.Skill.skill_uuid)
-                .filter(
-                    self.Skill.name == name,
-                    self.Skill.env == effective_env,
-                )
-                .distinct()
-                .all()
-                if r[0]
-            ]
-
-        cleaned_set_skill = 0
-        cleaned_member = 0
-
-        # 2. clean association tables by skill_uuid (one transaction)
-        if uuids:
-            with self._db.orm_session() as db:
-                cleaned_set_skill = (
-                    db.query(SkillSetSkill)
-                    .filter(SkillSetSkill.skill_uuid.in_(uuids))
-                    .delete(synchronize_session=False)
-                )
-                cleaned_member = (
-                    db.query(AcSkillMember)
-                    .filter(AcSkillMember.skill_uuid.in_(uuids))
-                    .delete(synchronize_session=False)
-                )
-
-        # 3. delete the main table (all versions)
-        with self._db.orm_session() as db:
-            deleted_count = (
+        with self._db.transactional_orm_session() as db:
+            skills = (
                 db.query(self.Skill)
                 .filter(
                     self.Skill.name == name,
                     self.Skill.env == effective_env,
                 )
-                .delete(synchronize_session=False)
+                .order_by(self.Skill.id)
+                .with_for_update()
+                .all()
             )
+            for skill in skills:
+                self._require_unreferenced_for_delete(
+                    db, skill, env=effective_env
+                )
+            for skill in skills:
+                db.delete(skill)
+            db.flush()
 
         return {
-            "deleted_skill_count": deleted_count,
-            "cleaned_set_skill": cleaned_set_skill,
-            "cleaned_member": cleaned_member,
+            "deleted_skill_count": len(skills),
+            "cleaned_set_skill": 0,
+            "cleaned_member": 0,
         }
 
     def update_risk_tags(
@@ -997,23 +1077,26 @@ class SkillRepository(
             )
         return self.get_by_id(skill_id)
 
-    def delete_by_bot_id(self, bot_id: str) -> int:
+    def delete_by_bot_id(self, bot_id: str, owner_id: str) -> int:
         env = get_current_env()
-        with self._db.orm_session() as db:
-            count = (
+        with self._db.transactional_orm_session() as db:
+            skills = (
                 db.query(self.Skill)
                 .filter(
                     self.Skill.bolt_id == bot_id,
+                    self.Skill.user_id == _normalize_user_id(owner_id),
                     self.Skill.env == env,
                 )
-                .count()
+                .order_by(self.Skill.id)
+                .with_for_update()
+                .all()
             )
-            if count > 0:
-                db.query(self.Skill).filter(
-                    self.Skill.bolt_id == bot_id,
-                    self.Skill.env == env,
-                ).delete(synchronize_session=False)
-            return count
+            for skill in skills:
+                self._require_unreferenced_for_delete(db, skill, env=env)
+            for skill in skills:
+                db.delete(skill)
+            db.flush()
+            return len(skills)
 
     def list_skill_set_references(
         self,
@@ -2441,7 +2524,7 @@ class SkillSetRepository(
                 )
             )
 
-    def delete_by_bot_id(self, bot_id: str) -> int:
+    def delete_by_bot_id(self, bot_id: str, owner_id: str) -> int:
         env = get_current_env()
         with self._db.orm_session() as db:
             ids = [
@@ -2449,6 +2532,7 @@ class SkillSetRepository(
                 for r in db.query(self.SkillSet.id)
                 .filter(
                     self.SkillSet.bolt_id == bot_id,
+                    self.SkillSet.user_id == _normalize_user_id(owner_id),
                     self.SkillSet.env == env,
                 )
                 .all()
@@ -2485,6 +2569,7 @@ class SkillSetRepository(
                     raise
             db.query(self.SkillSet).filter(
                 self.SkillSet.bolt_id == bot_id,
+                self.SkillSet.user_id == _normalize_user_id(owner_id),
                 self.SkillSet.env == env,
             ).delete(synchronize_session=False)
             return count

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/space_skill_draft.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/space_skill_draft.py
@@ -16,7 +16,6 @@ from agentclaw.community.core.models.space_skill import (
     SkillGrant,
     SkillSpaceBinding,
     SkillPublicationAttempt,
-    SkillPublicationAttemptStatus,
     SkillVersion,
 )
 from agentclaw.community.core.repository.protocols.skill_center import (
@@ -555,10 +554,7 @@ class SpaceSkillDraftRepository(SpaceSkillDraftRepositoryProtocol):
                 .all()
             )
             external = (
-                any(
-                    attempt.status != SkillPublicationAttemptStatus.FAILED
-                    for attempt in publication_attempts
-                )
+                bool(publication_attempts)
                 or any(
                     session.query(model)
                     .filter(model.skill_id == skill_id, model.env == env)

--- a/src/backend/src/agentclaw/community/core/repository/protocols/capability_desired_state.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/capability_desired_state.py
@@ -20,6 +20,13 @@ class CapabilityDesiredStateRepositoryProtocol(Protocol):
     """Tenant/env-scoped atomic SkillSet desired-state operations."""
 
     @abstractmethod
+    def purge_bot_installations(
+        self, *, bot_id: str, owner_id: str, env: str
+    ) -> dict[str, int]:
+        """Remove both Installation tables during explicit Bot deletion."""
+        ...
+
+    @abstractmethod
     def list_sets(
         self,
         *,

--- a/src/backend/src/agentclaw/community/core/repository/protocols/skill_center.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/skill_center.py
@@ -473,6 +473,11 @@ class SkillRepository(Protocol):
     def delete(self, skill_id: str) -> bool: ...
 
     @abstractmethod
+    def require_unreferenced_for_delete(self, skill_id: str) -> None:
+        """Fail closed before a caller performs external deletion work."""
+        ...
+
+    @abstractmethod
     def list_skill_set_references(
         self,
         skill_id: str,
@@ -501,8 +506,11 @@ class SkillRepository(Protocol):
 
     @abstractmethod
     def delete_by_name_with_cascade(self, name: str, env: str | None = None) -> dict:
-        """Delete the skill by name and cascade related rows; returns a
-        summary dict of what was removed."""
+        """Delete zero-reference same-name assets without removing references.
+
+        The legacy method name and summary keys remain wire-compatible; the
+        cleaned-reference counts are always zero under Asset Deletion rules.
+        """
         ...
 
     @abstractmethod
@@ -521,11 +529,12 @@ class SkillRepository(Protocol):
         ...
 
     @abstractmethod
-    def delete_by_bot_id(self, bot_id: str) -> int:
+    def delete_by_bot_id(self, bot_id: str, owner_id: str) -> int:
         """Delete all skills associated with a bot.
 
         Args:
             bot_id: Bot ID (maps to bolt_id column)
+            owner_id: Exact Bot owner; ``bot_id`` is not globally unique.
 
         Returns:
             Number of deleted records
@@ -754,7 +763,7 @@ class SkillSetRepository(Protocol):
     def get_all_user_mcps(self, user_id: str) -> list[dict]: ...
 
     @abstractmethod
-    def delete_by_bot_id(self, bot_id: str) -> int:
+    def delete_by_bot_id(self, bot_id: str, owner_id: str) -> int:
         """Delete all skill sets and their associations for a bot.
 
         Deletes from junction tables (skill_set_skill, skill_set_mcp_server)
@@ -762,6 +771,7 @@ class SkillSetRepository(Protocol):
 
         Args:
             bot_id: Bot ID (maps to bolt_id column)
+            owner_id: Exact Bot owner; ``bot_id`` is not globally unique.
 
         Returns:
             Number of deleted skill set records
@@ -954,8 +964,6 @@ class SkillCategoryRepository(Protocol):
     def list_descendant_codes(self, path: str) -> list[str]:
         """列出 path 前缀匹配的所有启用类目的 code（含自身）。"""
         ...
-        ...
-
 
 @runtime_checkable
 class SkillCenterSyncLogRepository(Protocol):

--- a/src/backend/src/agentclaw/community/core/skill_center/AGENTS.md
+++ b/src/backend/src/agentclaw/community/core/skill_center/AGENTS.md
@@ -200,6 +200,14 @@ Engine 拥有物理布局。Backend 通过 `community/core/skills_pool/` 的版�
 - Offline 只记录离线状态并保留历史 Version，不自动生成 Vn+1 Draft，不调用 SC 删除。
 - Offline 原身份不能直接升级/发布；Copy 读取选定已发布版本，创建新的 Skill UUID 和独立 V1 Draft。新副本发布使用新 UUID 作为 SC code。
 
+### Asset Deletion
+
+- Asset Deletion 只能删除零引用 Skill；Installation、任意 active/inactive SkillSet Membership、Space Binding/Grant、Draft、Publication Attempt 和 Version 都是 blocker。
+- 所有硬删除 primitive 必须先锁 exact Skill，再在同一事务内重检 blocker；不能依赖 Router 或 Service 的一次性预检查，也不能顺手删除 Membership/Installation。
+- Bot 删除是独立生命周期：按 exact `owner_id + bot_id + env` 先清 Skill/MCP Installation，再删 SkillSet，最后删 Bot-owned Skill。`bot_id=default` 不能单独作为删除范围。
+- Git 源消失且存在 blocker 时保留 Skill 和 Desired State，返回 `SOURCE_MISSING_IN_USE`；Runtime 继续使用既有 `MANAGED_SOURCE_MISSING` / `PENDING`，不要新增同义状态。
+- Service Artifact 当前只引用 exact Center Version；硬删除由 `SkillVersion` 作为 dominant blocker，Offline 影响展示才扫描 Artifact。新增无 Version 的 Artifact Skill 引用前，必须先补可事务校验的 lineage fact。
+
 ## 9. DI 与 Legacy 兼容入口
 
 装配从 `community/di/container.py` 核对：

--- a/src/backend/src/agentclaw/community/core/skill_center/CONTEXT.md
+++ b/src/backend/src/agentclaw/community/core/skill_center/CONTEXT.md
@@ -1,0 +1,37 @@
+# Skill Center
+
+The Skill Center context governs Skill assets, their references, and the capabilities a Bot is intended to use.
+
+## Language
+
+**Effective Capability**:
+A Skill or MCP that a Bot is intended to use. Its desired state is independent of whether Runtime delivery has converged.
+_Avoid_: Active file, mounted asset
+
+**Installation**:
+The fact that one capability is currently effective for one Bot. Absence is the inactive state.
+_Avoid_: Runtime link, membership
+
+**Membership**:
+A durable organizational reference from a SkillSet to a capability. Membership alone does not imply that the capability is effective.
+_Avoid_: Installation, activation
+
+**Deactivation**:
+The explicit removal of an Effective Capability from a Bot while retaining the Skill asset and its other references.
+_Avoid_: Delete, retire, offline
+
+**Skill Offline**:
+A recoverable lifecycle state that prevents new consumption while preserving the Skill asset, versions, and historical references.
+_Avoid_: Delete, deactivate
+
+**Asset Deletion**:
+The irreversible destruction of an unreferenced Skill asset. It must not implicitly change any Bot's Effective Capabilities or remove saved references.
+_Avoid_: Deactivation, offline, retirement
+
+**Blocking Reference**:
+Any Installation, Membership, published Service Artifact lineage, Draft, Publication, or Version relationship that prevents Asset Deletion.
+_Avoid_: Warning, impact hint
+
+**Missing Source**:
+A Skill whose governed source content is unavailable while its asset or references remain. Missing Source is a recoverable delivery problem, not permission to deactivate or delete the Skill.
+_Avoid_: Deleted Skill, inactive Skill

--- a/src/backend/src/agentclaw/community/core/skill_center/errors.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/errors.py
@@ -23,6 +23,16 @@ class SkillDeleteConsistencyError(RuntimeError):
     """A Skill delete could not safely converge filesystem and database state."""
 
 
+class SkillAssetInUseError(RuntimeError):
+    """Asset Deletion found durable references that must be removed first."""
+
+    def __init__(self, blocker_counts: dict[str, int]) -> None:
+        self.blocker_counts = {
+            kind: count for kind, count in blocker_counts.items() if count > 0
+        }
+        super().__init__("SKILL_ASSET_IN_USE")
+
+
 class SkillReferencedBySkillSetError(RuntimeError):
     """A Skill cannot be deleted while any SkillSet still references it."""
 

--- a/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_delete_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_delete_service.py
@@ -23,6 +23,7 @@ from agentclaw.community.core.skill_center.errors import (
     LocalSkillNotFoundError,
     LocalSkillNotReadyError,
     LocalSkillStorageError,
+    SkillAssetInUseError,
 )
 from agentclaw.community.core.skill_center.factories import SkillServiceFactory
 from agentclaw.community.core.repository.protocols.skill_center import (
@@ -94,24 +95,7 @@ class LocalSkillDeleteService(LocalSkillDeleteServiceProtocol):
                 raise LocalSkillNotFoundError()
             if not is_bot_ready(bot):
                 raise LocalSkillNotReadyError()
-            if bool(skill["active"]):
-                raise LocalSkillActiveError()
-            active_custom_set_ids = {
-                str(skill_set["id"])
-                for skill_set in self._skill_set_repo.get_all_active_skill_sets_for_env(
-                    user_id=resolved_owner_id,
-                    bolt_id=bot_id,
-                    engine_type=bot.get("active_engine"),
-                    env=str(bot["env"]),
-                )
-                if not skill_set.get("is_default")
-            }
-            referenced_set_ids = {
-                reference["skill_set_id"]
-                for reference in self._skill_repo.list_skill_set_references(skill_id)
-            }
-            if active_custom_set_ids & referenced_set_ids:
-                raise LocalSkillActiveError()
+            self._skill_repo.require_unreferenced_for_delete(skill_id)
             locator = str(skill["git_path"])[len("local://") :]
             is_teclaw = self._is_teclaw(bot_id=bot_id, owner_id=resolved_owner_id)
             package = self._package_for_locator(
@@ -156,6 +140,8 @@ class LocalSkillDeleteService(LocalSkillDeleteServiceProtocol):
                     raise LocalSkillStorageError() from exc
                 if isinstance(exc, ActiveSkillSetReferenceError):
                     raise LocalSkillActiveError() from exc
+                if isinstance(exc, SkillAssetInUseError):
+                    raise
                 raise LocalSkillStorageError() from exc
             await self._discard(quarantine)
         finally:

--- a/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_upload_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_upload_service.py
@@ -32,6 +32,7 @@ from agentclaw.community.core.skill_center.errors import (
     LocalSkillLayoutRollbackError,
     LocalSkillNotReadyError,
     LocalSkillStorageError,
+    SkillAssetInUseError,
     LocalSkillTooLargeError,
 )
 from agentclaw.community.core.skill_center.factories import (
@@ -294,6 +295,8 @@ class LocalSkillUploadService(LocalSkillUploadServiceProtocol):
             if skill is not None:
                 try:
                     self._skill_repo.delete(skill["id"])
+                except SkillAssetInUseError as conflict:
+                    raise conflict from exc
                 except Exception:
                     pass
             try:

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_service.py
@@ -27,8 +27,8 @@ if TYPE_CHECKING:
 
 from agentclaw.community.core.access.admin_scopes import skill_admin
 from agentclaw.community.core.skill_center.errors import (
+    SkillAssetInUseError,
     SkillDeleteConsistencyError,
-    SkillReferencedBySkillSetError,
 )
 from agentclaw.community.core.repository.protocols.skill_center import SkillRepository
 from agentclaw.community.core.repository.protocols.skill_center import SkillCategoryRepository
@@ -2207,20 +2207,10 @@ class SkillService:
             raise ValueError("无权删除此技能：您不是该技能的创建者，且没有管理员权限")
 
         git_path = skill.get('git_path') or ''
-        published_center_uuid = (
-            skill.get("skill_uuid")
-            if git_path.startswith("center://")
-            and str(skill.get("status") or "").upper() == "PUBLISHED"
-            else None
-        )
-        references = self._skill_repo.list_skill_set_references(
-            skill_id,
-            skill_uuid=published_center_uuid,
-        )
-        if references:
-            raise SkillReferencedBySkillSetError(
-                [str(ref["skill_set_id"]) for ref in references]
-            )
+        # Fail before any filesystem or upstream work. ``delete`` repeats the
+        # same check while holding the exact Skill lock, so an internal caller
+        # cannot bypass the invariant.
+        self._skill_repo.require_unreferenced_for_delete(skill_id)
 
         # 获取技能名称和路径
         skill_name = skill.get('name')
@@ -2345,7 +2335,7 @@ class SkillService:
 
         Git market skills are system-wide and have no user_id or bolt_id.
         """
-        results = {"created": 0, "updated": 0, "deleted": 0, "failed": 0, "skipped": 0, "errors": []}
+        results = {"created": 0, "updated": 0, "deleted": 0, "failed": 0, "skipped": 0, "errors": [], "blocked": []}
         git_renames = git_renames or {}
 
         # Resolve scan target. In cloud mode, _resolve_sync_scan_target raises
@@ -2595,8 +2585,25 @@ class SkillService:
                     skill.get('name'),
                     skill_path,
                 )
-                self._skill_repo.delete(skill['id'])
-                results["deleted"] += 1
+                try:
+                    self._skill_repo.delete(skill['id'])
+                    results["deleted"] += 1
+                except SkillAssetInUseError as exc:
+                    results["failed"] += 1
+                    blocked = {
+                        "code": "SOURCE_MISSING_IN_USE",
+                        "skill_id": str(skill["id"]),
+                        "git_path": skill_path,
+                        "blockers": exc.blocker_counts,
+                    }
+                    results["blocked"].append(blocked)
+                    logger.warning(
+                        "[sync_skills_from_git] SOURCE_MISSING_IN_USE "
+                        "skill_id=%s git_path=%s blockers=%s",
+                        skill["id"],
+                        skill_path,
+                        exc.blocker_counts,
+                    )
 
         # 刷新市场缓存（同步完成后）
         logger.info(f"[sync_skills_from_git] Sync completed: created={results['created']}, updated={results['updated']}, deleted={results['deleted']}, skipped={results['skipped']}, failed={results['failed']}")

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_service.py
@@ -2217,16 +2217,17 @@ class SkillService:
         bolt_id = skill.get('bolt_id')
         skill_user_id = skill.get('user_id') or user_id
         device_owner_id = self._device_owner_id or skill_user_id
-        is_shared_source = (
-            not skill.get('user_id')
-            and git_path.startswith(("git://", "center://"))
-        )
+        # Repo and Center content is governed outside the Bot's writable
+        # Local store. Ownership affects authorization, not filesystem
+        # placement: legacy BFF rows may legitimately keep ``user_id`` while
+        # using either locator. Never resolve a DeviceFS for these sources.
+        is_governed_content_source = git_path.startswith(("git://", "center://"))
 
         logger.info(f"[SkillService] Deleting skill: id={skill_id}, name={skill_name}, git_path={git_path}")
         logger.info(f"[SkillService] local_dir: {self.local_dir}, active_dir: {self.active_dir}")
 
         device_fs = None
-        if not is_shared_source:
+        if not is_governed_content_source:
             try:
                 device_fs = self._device_fs_factory(bolt_id, device_owner_id)
             except Exception as e:

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_skills_endpoints.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_skills_endpoints.py
@@ -54,9 +54,9 @@ from agentclaw.community.core.repository.implementations.skill_center.capability
     CapabilityDesiredStateRepository,
 )
 from agentclaw.community.core.skill_center.errors import (
-    LocalSkillActiveError,
     LocalSkillNotFoundError,
     LocalSkillOwnerAmbiguousError,
+    SkillAssetInUseError,
 )
 from agentclaw.community.core.skill_center.orm import DefaultSkillsetSkillExclusion
 from agentclaw.community.core.skill_center.services.bot_capability_state_reader import (
@@ -442,11 +442,11 @@ def test_delete_derives_scope_from_skill_id_and_returns_standard_deleted_payload
     }
 
 
-def test_delete_active_error_uses_the_fixed_public_conflict_envelope():
+def test_delete_active_error_uses_the_asset_in_use_conflict_envelope():
     class _ActiveDelete(_Delete):
         async def delete_local_skill(self, **kwargs):
             self.args = kwargs
-            raise LocalSkillActiveError()
+            raise SkillAssetInUseError({"installation": 1})
 
     response = _client(_Query(), delete=_ActiveDelete()).delete(
         "/openapi/v1/bots/bot-1/skills/8"
@@ -454,9 +454,28 @@ def test_delete_active_error_uses_the_fixed_public_conflict_envelope():
 
     assert response.status_code == 409
     assert response.json() == {
-        "code": 409102,
-        "message": "Skill is active",
-        "data": None,
+        "code": 409105,
+        "message": "Skill is still in use",
+        "data": {"blockers": {"installation": 1}},
+        "request_id": "",
+    }
+
+
+def test_delete_referenced_error_returns_safe_blocker_counts():
+    class _ReferencedDelete(_Delete):
+        async def delete_local_skill(self, **kwargs):
+            self.args = kwargs
+            raise SkillAssetInUseError({"installation": 2, "membership": 1})
+
+    response = _client(_Query(), delete=_ReferencedDelete()).delete(
+        "/openapi/v1/bots/bot-1/skills/8"
+    )
+
+    assert response.status_code == 409
+    assert response.json() == {
+        "code": 409105,
+        "message": "Skill is still in use",
+        "data": {"blockers": {"installation": 2, "membership": 1}},
         "request_id": "",
     }
 

--- a/src/backend/tests/community/api/skill_center/test_batch_sync_router.py
+++ b/src/backend/tests/community/api/skill_center/test_batch_sync_router.py
@@ -3,7 +3,9 @@
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from agentclaw.community.adapters.http.skill_center.batch_sync import router
+from agentclaw.community.adapters.http.skill_center import batch_sync
+
+router = batch_sync.router
 
 
 def _client() -> TestClient:
@@ -34,3 +36,24 @@ def test_every_batch_sync_surface_is_permanently_retired() -> None:
             "Legacy batch sync is retired; use "
             "POST /openapi/v1/bots/market/skill-center/sync"
         )
+
+
+def test_every_legacy_batch_delete_surface_is_permanently_retired() -> None:
+    client = _client()
+
+    responses = (
+        client.post(
+            "/api/v1/skill-center/batch-delete",
+            json={"skill_codes": ["legacy-delete"]},
+        ),
+        client.get(
+            "/api/v1/skill-center/batch-delete",
+            params={"skill_codes": "legacy-delete"},
+        ),
+        client.get("/api/v1/skill-center/batch-delete/status/old-task"),
+        client.get("/api/v1/skill-center/batch-delete/report/old-task"),
+    )
+
+    assert {response.status_code for response in responses} == {410}
+    for response in responses:
+        assert response.json()["detail"] == batch_sync._BATCH_DELETE_RETIRED

--- a/src/backend/tests/community/api/skill_center/test_delete_skill_context.py
+++ b/src/backend/tests/community/api/skill_center/test_delete_skill_context.py
@@ -476,6 +476,91 @@ async def test_owner_can_delete_unreferenced_governed_content_without_device_io(
 
 
 @pytest.mark.asyncio
+async def test_authorized_collaborator_can_delete_owner_governed_content():
+    skill_repo = MagicMock()
+    skill_repo.get_by_id.return_value = {
+        "id": SKILL_ID,
+        "name": "owned-center-skill",
+        "git_path": "center://owned-center-skill",
+        "bolt_id": BOT_ID,
+        "user_id": OWNER_ID,
+    }
+    skill_repo.delete.return_value = True
+    device_fs = MagicMock()
+
+    response, _, factory = await _call_delete(
+        device_fs=device_fs,
+        skill_repo=skill_repo,
+        current_user_id="authorized-collaborator",
+        verified_collaborator=True,
+    )
+
+    assert response.success is True
+    assert factory.calls == [
+        {
+            "bot_id": BOT_ID,
+            "bot_owner_id": OWNER_ID,
+            "engine_type": "hermes",
+        }
+    ]
+    skill_repo.delete.assert_called_once_with(SKILL_ID)
+    assert factory.device_fs_calls == []
+
+
+@pytest.mark.asyncio
+async def test_unverified_collaborator_cannot_delete_owner_governed_content():
+    skill_repo = MagicMock()
+    skill_repo.get_by_id.return_value = {
+        "id": SKILL_ID,
+        "name": "owned-git-skill",
+        "git_path": "git://owner/owned-git-skill",
+        "bolt_id": BOT_ID,
+        "user_id": OWNER_ID,
+    }
+    device_fs = MagicMock()
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _call_delete(
+            device_fs=device_fs,
+            skill_repo=skill_repo,
+            current_user_id="unverified-collaborator",
+        )
+
+    assert exc_info.value.status_code == 403
+    skill_repo.delete.assert_not_called()
+    device_fs.exists.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_owner_governed_content_still_maps_asset_blockers_to_conflict():
+    skill_repo = MagicMock()
+    skill_repo.get_by_id.return_value = {
+        "id": SKILL_ID,
+        "name": "owned-center-skill",
+        "git_path": "center://owned-center-skill",
+        "bolt_id": BOT_ID,
+        "user_id": OWNER_ID,
+    }
+    skill_repo.require_unreferenced_for_delete.side_effect = SkillAssetInUseError(
+        {"version": 1, "space_binding": 1}
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _call_delete(
+            device_fs=MagicMock(),
+            skill_repo=skill_repo,
+        )
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.detail["error_code"] == "SKILL_ASSET_IN_USE"
+    assert exc_info.value.detail["blockers"] == {
+        "version": 1,
+        "space_binding": 1,
+    }
+    skill_repo.delete.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_shared_delete_does_not_trust_query_user_id_for_admin_permission():
     skill_repo = MagicMock()
     skill_repo.get_by_id.return_value = {

--- a/src/backend/tests/community/api/skill_center/test_delete_skill_context.py
+++ b/src/backend/tests/community/api/skill_center/test_delete_skill_context.py
@@ -448,6 +448,34 @@ async def test_admin_can_delete_unreferenced_shared_market_skill():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("git_path", ["git://owner/repo-skill", "center://owner-skill"])
+async def test_owner_can_delete_unreferenced_governed_content_without_device_io(
+    git_path,
+):
+    skill_repo = MagicMock()
+    skill_repo.get_by_id.return_value = {
+        "id": SKILL_ID,
+        "name": "owned-skill",
+        "git_path": git_path,
+        "bolt_id": "default",
+        "user_id": OWNER_ID,
+    }
+    skill_repo.delete.return_value = True
+    device_fs = MagicMock()
+
+    response, _, factory = await _call_delete(
+        device_fs=device_fs,
+        skill_repo=skill_repo,
+    )
+
+    assert response.success is True
+    skill_repo.require_unreferenced_for_delete.assert_called_once_with(SKILL_ID)
+    skill_repo.delete.assert_called_once_with(SKILL_ID)
+    assert factory.device_fs_calls == []
+    device_fs.exists.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_shared_delete_does_not_trust_query_user_id_for_admin_permission():
     skill_repo = MagicMock()
     skill_repo.get_by_id.return_value = {

--- a/src/backend/tests/community/api/skill_center/test_delete_skill_context.py
+++ b/src/backend/tests/community/api/skill_center/test_delete_skill_context.py
@@ -10,6 +10,10 @@ from agentclaw.community.adapters.http.dependencies import RequestContext
 from agentclaw.community.adapters.http.skill_center.skills import delete_skill
 from agentclaw.community.core.bot_management.errors import BotLookupAmbiguousError
 from agentclaw.community.core.skill_center.services.skill_service import SkillService
+from agentclaw.community.core.skill_center.errors import (
+    LocalSkillStorageError,
+    SkillAssetInUseError,
+)
 
 
 BOT_ID = "20260731_yh7d4xom"
@@ -84,6 +88,7 @@ async def _call_delete(
     bot_repo=None,
     bot_record=None,
     verified_collaborator=False,
+    local_delete=None,
 ):
     bot_repo = bot_repo or MagicMock()
     resolved_bot = bot_record or _bot_record()
@@ -103,6 +108,10 @@ async def _call_delete(
     edit_guard = MagicMock()
     edit_guard.acquire_for_edit.return_value = MagicMock()
     factory = _SkillServiceFactory(skill_repo=skill_repo, device_fs=device_fs)
+    if local_delete is None:
+        local_delete = MagicMock()
+        local_delete.delete_local_skill = AsyncMock()
+    factory.local_delete = local_delete
 
     endpoint = getattr(delete_skill, "__wrapped__", delete_skill)
     response = await endpoint(
@@ -122,18 +131,15 @@ async def _call_delete(
             ),
         ),
         bot_repo=bot_repo,
-        path_factory=path_factory,
         skill_service_factory=factory,
-        resolver=resolver,
-        edit_guard=edit_guard,
         skill_repo=skill_repo,
+        local_delete=local_delete,
     )
     return response, path_factory, factory
 
 
 @pytest.mark.asyncio
-async def test_delete_without_bot_query_uses_skill_bot_and_engine_paths():
-    """DELETE derives the physical context from the persisted Skill, not default."""
+async def test_delete_without_bot_query_delegates_exact_persisted_scope():
     skill_repo = MagicMock()
     skill_repo.get_by_id.return_value = _skill_record()
     skill_repo.list_skill_set_references.return_value = []
@@ -148,38 +154,38 @@ async def test_delete_without_bot_query_uses_skill_bot_and_engine_paths():
     )
 
     assert response.success is True
-    path_factory.get_bot_skills_dir.assert_called_once_with(
-        OWNER_ID, BOT_ID, "hermes", "staff"
+    factory.local_delete.delete_local_skill.assert_awaited_once_with(
+        skill_id=SKILL_ID,
+        owner_id=OWNER_ID,
+        user_id=OWNER_ID,
     )
-    assert factory.calls[0]["bot_id"] == BOT_ID
-    assert factory.calls[0]["engine_type"] == "hermes"
-    assert device_fs.delete_tree.await_args_list[0].args[0] == (
-        f"{ACTIVE_ROOT}/find-skills"
-    )
-    assert device_fs.delete_tree.await_args_list[1].args[0] == (
-        f"{POOL_LOCAL}/find-skills"
-    )
+    path_factory.get_bot_skills_dir.assert_not_called()
+    device_fs.delete_tree.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_delete_fails_closed_when_existing_active_entry_cannot_be_removed():
-    """An active-link deletion failure keeps Pool source and DB intact."""
+async def test_delete_maps_recoverable_local_storage_failure():
     skill_repo = MagicMock()
     skill_repo.get_by_id.return_value = _skill_record()
     skill_repo.list_skill_set_references.return_value = []
     skill_repo.delete.return_value = True
     device_fs = MagicMock()
     device_fs.exists = AsyncMock(return_value=True)
-    device_fs.delete_tree = AsyncMock(return_value=False)
+    local_delete = MagicMock()
+    local_delete.delete_local_skill = AsyncMock(
+        side_effect=LocalSkillStorageError()
+    )
 
     with pytest.raises(HTTPException) as exc_info:
-        await _call_delete(device_fs=device_fs, skill_repo=skill_repo)
+        await _call_delete(
+            device_fs=device_fs,
+            skill_repo=skill_repo,
+            local_delete=local_delete,
+        )
 
-    assert exc_info.value.status_code == 409
+    assert exc_info.value.status_code == 502
     skill_repo.delete.assert_not_called()
-    device_fs.delete_tree.assert_awaited_once_with(
-        f"{ACTIVE_ROOT}/find-skills"
-    )
+    device_fs.delete_tree.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -187,22 +193,26 @@ async def test_delete_rejects_skill_referenced_by_any_skill_set():
     """Active and inactive SkillSet references both block metadata deletion."""
     skill_repo = MagicMock()
     skill_repo.get_by_id.return_value = _skill_record()
-    skill_repo.list_skill_set_references.return_value = [
-        {"skill_set_id": "1113652"},
-        {"skill_set_id": "1113653"},
-    ]
+    local_delete = MagicMock()
+    local_delete.delete_local_skill = AsyncMock(
+        side_effect=SkillAssetInUseError({"membership": 2})
+    )
     device_fs = MagicMock()
     device_fs.exists = AsyncMock(return_value=True)
     device_fs.delete_tree = AsyncMock(return_value=True)
 
     with pytest.raises(HTTPException) as exc_info:
-        await _call_delete(device_fs=device_fs, skill_repo=skill_repo)
+        await _call_delete(
+            device_fs=device_fs,
+            skill_repo=skill_repo,
+            local_delete=local_delete,
+        )
 
     assert exc_info.value.status_code == 409
     assert exc_info.value.detail == {
-        "error_code": "SKILL_REFERENCED_BY_SKILL_SET",
-        "message": "请先从所有技能集中移除该技能，再删除技能",
-        "skill_set_ids": ["1113652", "1113653"],
+        "error_code": "SKILL_ASSET_IN_USE",
+        "message": "请先解除该 Skill 的生效或能力集引用，再删除 Skill",
+        "blockers": {"membership": 2},
     }
     skill_repo.delete.assert_not_called()
     device_fs.exists.assert_not_awaited()
@@ -210,11 +220,11 @@ async def test_delete_rejects_skill_referenced_by_any_skill_set():
 
 
 @pytest.mark.asyncio
-async def test_delete_uses_bot_owner_when_skill_was_authored_by_collaborator():
+async def test_delete_uses_persisted_local_skill_owner_scope():
     skill_repo = MagicMock()
     skill_repo.get_by_id.return_value = {
         **_skill_record(),
-        "user_id": "405935",
+        "user_id": OWNER_ID,
     }
     skill_repo.list_skill_set_references.return_value = []
     skill_repo.delete.return_value = True
@@ -226,13 +236,16 @@ async def test_delete_uses_bot_owner_when_skill_was_authored_by_collaborator():
         device_fs=device_fs,
         skill_repo=skill_repo,
         current_user_id="405935",
+        verified_collaborator=True,
     )
 
     assert response.success is True
-    path_factory.get_bot_skills_dir.assert_called_once_with(
-        OWNER_ID, BOT_ID, "hermes", "staff"
+    factory.local_delete.delete_local_skill.assert_awaited_once_with(
+        skill_id=SKILL_ID,
+        owner_id=OWNER_ID,
+        user_id="405935",
     )
-    assert factory.device_fs_calls == [(BOT_ID, OWNER_ID)]
+    path_factory.get_bot_skills_dir.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -254,11 +267,15 @@ async def test_authorized_collaborator_can_delete_owner_owned_skill():
     )
 
     assert response.success is True
-    assert factory.device_fs_calls == [(BOT_ID, OWNER_ID)]
+    factory.local_delete.delete_local_skill.assert_awaited_once_with(
+        skill_id=SKILL_ID,
+        owner_id=OWNER_ID,
+        user_id="authorized-collaborator",
+    )
 
 
 @pytest.mark.asyncio
-async def test_delete_project_bot_uses_entity_paths_and_owner_device_binding():
+async def test_delete_project_bot_still_uses_persisted_skill_scope():
     skill_repo = MagicMock()
     skill_repo.get_by_id.return_value = _skill_record()
     skill_repo.list_skill_set_references.return_value = []
@@ -279,12 +296,12 @@ async def test_delete_project_bot_uses_entity_paths_and_owner_device_binding():
     )
 
     assert response.success is True
-    path_factory.get_bot_skills_dir.assert_called_once_with(
-        "project-42", BOT_ID, "hermes", "proj"
+    factory.local_delete.delete_local_skill.assert_awaited_once_with(
+        skill_id=SKILL_ID,
+        owner_id=OWNER_ID,
+        user_id=OWNER_ID,
     )
-    assert factory.calls[0]["entity_id"] == "project-42"
-    assert factory.calls[0]["bot_owner_id"] == OWNER_ID
-    assert factory.device_fs_calls == [(BOT_ID, OWNER_ID)]
+    path_factory.get_bot_skills_dir.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -302,10 +319,8 @@ async def test_delete_rejects_malformed_skill_id_with_400():
             ctx=RequestContext(user_id=OWNER_ID, bot_id="default"),
             skill_repo=MagicMock(),
             bot_repo=MagicMock(),
-            path_factory=MagicMock(),
             skill_service_factory=MagicMock(),
-            resolver=MagicMock(),
-            edit_guard=MagicMock(),
+            local_delete=MagicMock(delete_local_skill=AsyncMock()),
         )
 
     assert exc_info.value.status_code == 400
@@ -334,7 +349,7 @@ async def test_delete_rejects_engine_override_that_differs_from_bot():
 
 
 @pytest.mark.asyncio
-async def test_delete_uses_entity_to_disambiguate_legacy_bot_id():
+async def test_local_delete_does_not_need_legacy_global_bot_lookup():
     skill_repo = MagicMock()
     skill_repo.get_by_id.return_value = _skill_record()
     skill_repo.list_skill_set_references.return_value = []
@@ -352,31 +367,46 @@ async def test_delete_uses_entity_to_disambiguate_legacy_bot_id():
     )
 
     assert response.success is True
-    bot_repo.get_by_id_and_entity.assert_called_once_with(BOT_ID, OWNER_ID)
+    bot_repo.get_by_id_and_entity.assert_not_called()
     bot_repo.get_unique_by_id.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_delete_rejects_ambiguous_legacy_bot_without_entity():
+async def test_local_delete_ignores_ambiguous_global_bot_lookup():
     skill_repo = MagicMock()
     skill_repo.get_by_id.return_value = _skill_record()
     bot_repo = MagicMock()
     bot_repo.get_unique_by_id.side_effect = BotLookupAmbiguousError
 
+    response, _, factory = await _call_delete(
+        device_fs=MagicMock(),
+        skill_repo=skill_repo,
+        bot_repo=bot_repo,
+    )
+
+    assert response.success is True
+    bot_repo.get_unique_by_id.assert_not_called()
+    factory.local_delete.delete_local_skill.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_owner_skill_without_canonical_local_locator_fails_before_device_io():
+    skill_repo = MagicMock()
+    skill_repo.get_by_id.return_value = {
+        **_skill_record(),
+        "git_path": "",
+    }
+    device_fs = MagicMock()
+
     with pytest.raises(HTTPException) as exc_info:
         await _call_delete(
-            device_fs=MagicMock(),
+            device_fs=device_fs,
             skill_repo=skill_repo,
-            bot_repo=bot_repo,
         )
 
     assert exc_info.value.status_code == 409
-    assert exc_info.value.detail == {
-        "error_code": "SKILL_BOT_CONTEXT_AMBIGUOUS",
-        "message": "历史 Bot ID 不唯一，请提供 entity_id 精确定位",
-        "bot_id": BOT_ID,
-    }
-    skill_repo.delete.assert_not_called()
+    assert exc_info.value.detail["error_code"] == "SKILL_SOURCE_IDENTITY_INVALID"
+    device_fs.delete_tree.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -409,10 +439,7 @@ async def test_admin_can_delete_unreferenced_shared_market_skill():
             ctx=RequestContext(user_id=OWNER_ID, bot_id="default"),
             skill_repo=skill_repo,
             bot_repo=MagicMock(),
-            path_factory=MagicMock(),
-            skill_service_factory=factory,
-            resolver=MagicMock(),
-            edit_guard=MagicMock(),
+                skill_service_factory=factory,
         )
 
     assert response.success is True
@@ -450,10 +477,7 @@ async def test_shared_delete_does_not_trust_query_user_id_for_admin_permission()
             ctx=RequestContext(user_id="ordinary-user", bot_id="default"),
             skill_repo=skill_repo,
             bot_repo=MagicMock(),
-            path_factory=MagicMock(),
-            skill_service_factory=factory,
-            resolver=MagicMock(),
-            edit_guard=MagicMock(),
+                skill_service_factory=factory,
         )
 
     assert exc_info.value.status_code == 403

--- a/src/backend/tests/community/contracts/gateway/test_service_backed_api_contracts.py
+++ b/src/backend/tests/community/contracts/gateway/test_service_backed_api_contracts.py
@@ -1160,13 +1160,9 @@ class TestServiceBackedSkillCrudApiContracts:
             params={"entity_id": OWNER_ID, "bot_id": BOT_ID, "engine_type": ENGINE_TYPE},
         )
         delete_body = delete_resp.json()
-        assert_success(delete_body, "service-backed DELETE /api/skills/{id}")
-        assert_api_response_contract(
-            delete_body,
-            "service_backed_rule10_DELETE_api_skills_id",
-            update=contract_snapshot_update,
-        )
-        assert delete_body["message"] == "Skill deleted successfully"
+        assert delete_resp.status_code == 502
+        assert delete_body == {"detail": "Skill storage operation failed"}
+        assert world.get(SkillRepository).get_by_id(skill_id) is not None
 
 
 class TestServiceBackedBotPublicApiContracts:

--- a/src/backend/tests/community/core/bot_management/services/test_cleanup_service_startup_script.py
+++ b/src/backend/tests/community/core/bot_management/services/test_cleanup_service_startup_script.py
@@ -22,6 +22,11 @@ def _make_service() -> BotCleanupService:
     return BotCleanupService(
         skill_repo=MagicMock(delete_by_bot_id=MagicMock(return_value=0)),
         skill_set_repo=MagicMock(delete_by_bot_id=MagicMock(return_value=0)),
+        desired_state_repo=MagicMock(
+            purge_bot_installations=MagicMock(
+                return_value={"skills": 0, "mcps": 0}
+            )
+        ),
         startup_script_purge=MagicMock(delete=MagicMock(return_value=True)),
     )
 
@@ -65,3 +70,46 @@ class TestStartupScriptPurge:
             BotCleanupService(  # type: ignore[call-arg]
                 skill_repo=MagicMock(), skill_set_repo=MagicMock()
             )
+
+
+def test_bot_cleanup_purges_installations_and_sets_before_owned_skill_assets():
+    events = []
+    service = _make_service()
+    service._desired_state_repo.purge_bot_installations.side_effect = (
+        lambda **kwargs: events.append(("installations", kwargs))
+        or {"skills": 2, "mcps": 1}
+    )
+    service._skill_set_repo.delete_by_bot_id.side_effect = (
+        lambda bot_id, owner_id: events.append(("sets", bot_id, owner_id)) or 1
+    )
+    service._skill_repo.delete_by_bot_id.side_effect = (
+        lambda bot_id, owner_id: events.append(("skills", bot_id, owner_id)) or 3
+    )
+
+    result = service.cleanup_single_bot_data("default", "owner")
+
+    assert events == [
+        (
+            "installations",
+            {"bot_id": "default", "owner_id": "owner", "env": "dev"},
+        ),
+        ("sets", "default", "owner"),
+        ("skills", "default", "owner"),
+    ]
+    assert result["skill_installations_deleted"] == 2
+    assert result["mcp_installations_deleted"] == 1
+
+
+def test_bot_cleanup_stops_when_installations_cannot_be_purged():
+    service = _make_service()
+    service._desired_state_repo.purge_bot_installations.side_effect = RuntimeError(
+        "db unavailable"
+    )
+
+    result = service.cleanup_single_bot_data("default", "owner")
+
+    assert result["errors"] == [
+        "Cleanup installations error for bot default: db unavailable"
+    ]
+    service._skill_set_repo.delete_by_bot_id.assert_not_called()
+    service._skill_repo.delete_by_bot_id.assert_not_called()

--- a/src/backend/tests/community/core/skill_center/services/test_skill_service.py
+++ b/src/backend/tests/community/core/skill_center/services/test_skill_service.py
@@ -5,6 +5,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from agentclaw.community.core.skill_center.services.skill_service import SkillService
+from agentclaw.community.core.skill_center.errors import SkillAssetInUseError
+from agentclaw.community.adapters.http.skill_center.schemas import SyncSkillsResult
 
 
 # ── helpers ──────────────────────────────────────────────────────────
@@ -33,6 +35,27 @@ def _make_skill_dir(base: Path, rel_path: str, *, skill_md_content: str = "") ->
     )
     (d / "SKILL.md").write_text(content, encoding="utf-8")
     return d
+
+
+def test_sync_http_contract_preserves_structured_blocked_results():
+    payload = SyncSkillsResult(
+        created=0,
+        updated=0,
+        deleted=0,
+        failed=1,
+        skipped=0,
+        errors=[],
+        blocked=[
+            {
+                "code": "SOURCE_MISSING_IN_USE",
+                "skill_id": "2",
+                "git_path": "git://old/removed",
+                "blockers": {"installation": 1},
+            }
+        ],
+    ).model_dump()
+
+    assert payload["blocked"][0]["code"] == "SOURCE_MISSING_IN_USE"
 
 
 # ── TestSkillServiceLinkName ─────────────────────────────────────────
@@ -140,6 +163,40 @@ class TestSkillServiceSync:
         result = svc.sync_skills_from_git()
         assert result["deleted"] == 1
         mock_skill_repo.delete.assert_called_once_with("2")
+
+    def test_sync_preserves_referenced_skill_when_git_source_disappears(
+        self, skill_dirs, mock_skill_repo
+    ):
+        mock_skill_repo.list_skills.return_value = [
+            {"id": "2", "git_path": "git://old/removed", "name": "removed"},
+        ]
+        mock_skill_repo.delete.side_effect = SkillAssetInUseError(
+            {"installation": 2, "membership": 1}
+        )
+        svc = SkillService(
+            skill_repo=mock_skill_repo,
+            skill_repo_sync=_lenient_skill_repo_sync(),
+            category_repo=MagicMock(),
+            active_dir=skill_dirs["active_dir"],
+            repo_dir=skill_dirs["repo_dir"],
+            local_dir=skill_dirs["local_dir"],
+            market_cache=MagicMock(),
+            device_fs_factory=MagicMock(),
+            git_sync_service_factory=MagicMock(),
+        )
+
+        result = svc.sync_skills_from_git()
+
+        assert result["deleted"] == 0
+        assert result["failed"] == 1
+        assert result["blocked"] == [
+            {
+                "code": "SOURCE_MISSING_IN_USE",
+                "skill_id": "2",
+                "git_path": "git://old/removed",
+                "blockers": {"installation": 2, "membership": 1},
+            }
+        ]
 
     def test_sync_updates_git_renamed_skill_instead_of_delete_create(
         self, skill_dirs, mock_skill_repo

--- a/src/backend/tests/community/core/skill_center/services/test_skill_service_delete.py
+++ b/src/backend/tests/community/core/skill_center/services/test_skill_service_delete.py
@@ -54,18 +54,17 @@ def test_collaborator_delete_requires_explicit_verified_authorization():
 class TestDeleteSkillStep1:
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        ("git_path", "status", "expected_uuid"),
+        ("git_path", "status"),
         [
-            ("center://uuid", "PUBLISHED", "uuid"),
-            ("", "DEVELOPING", None),
-            ("center://uuid", "OFFLINE", None),
+            ("center://uuid", "PUBLISHED"),
+            ("", "DEVELOPING"),
+            ("center://uuid", "OFFLINE"),
         ],
     )
-    async def test_delete_checks_uuid_only_for_published_center_version(
+    async def test_delete_preflights_the_canonical_asset_guard(
         self,
         git_path,
         status,
-        expected_uuid,
     ):
         device_fs = MagicMock()
         device_fs.exists = AsyncMock(return_value=False)
@@ -85,10 +84,7 @@ class TestDeleteSkillStep1:
         ), patch.object(svc._skill_repo, "delete", return_value=True):
             assert await svc.delete_skill("sk-1", user_id="u-1") is True
 
-        svc._skill_repo.list_skill_set_references.assert_called_once_with(
-            "sk-1",
-            skill_uuid=expected_uuid,
-        )
+        svc._skill_repo.require_unreferenced_for_delete.assert_called_once_with("sk-1")
 
     @pytest.mark.asyncio
     async def test_legacy_delete_keeps_metadata_only_fallback_without_device(self):

--- a/src/backend/tests/community/core/skill_center/services/test_skill_service_delete.py
+++ b/src/backend/tests/community/core/skill_center/services/test_skill_service_delete.py
@@ -53,6 +53,30 @@ def test_collaborator_delete_requires_explicit_verified_authorization():
 
 class TestDeleteSkillStep1:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("git_path", ["git://owner/skill", "center://uuid"])
+    async def test_owned_governed_content_delete_never_resolves_device_fs(
+        self, git_path
+    ):
+        svc, _ = _make_service(MagicMock())
+        svc._device_fs_factory = MagicMock(
+            side_effect=AssertionError("governed content must not use DeviceFS")
+        )
+        skill = {
+            "id": "sk-1",
+            "name": "x",
+            "git_path": git_path,
+            "bolt_id": "bolt-1",
+            "user_id": "u-1",
+        }
+
+        with patch.object(svc, "get_skill", return_value=skill), patch.object(
+            svc, "_can_delete_skill", return_value=True
+        ), patch.object(svc._skill_repo, "delete", return_value=True):
+            assert await svc.delete_skill("sk-1", user_id="u-1") is True
+
+        svc._device_fs_factory.assert_not_called()
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         ("git_path", "status"),
         [
@@ -159,7 +183,7 @@ class TestDeleteSkillStep1:
         skill = {
             "id": "sk-1",
             "name": "my-skill",
-            "git_path": "git://x/y",
+            "git_path": "local:///skills-local/my-skill",
             "bolt_id": "bolt-1",
             "user_id": "u-1",
         }

--- a/src/backend/tests/community/core/skill_center/test_local_skill_delete_service.py
+++ b/src/backend/tests/community/core/skill_center/test_local_skill_delete_service.py
@@ -14,6 +14,7 @@ from agentclaw.community.core.skill_center.errors import (
     LocalSkillLayoutRollbackError,
     LocalSkillNotReadyError,
     LocalSkillStorageError,
+    SkillAssetInUseError,
 )
 from agentclaw.community.core.skill_center.services.local_skill_delete_service import (
     LocalSkillDeleteService,
@@ -74,11 +75,13 @@ class _Files:
 
 class _Skills:
     def __init__(
-        self, *, active=False, fail_delete=False, active_during_delete=False
+        self, *, active=False, fail_delete=False, active_during_delete=False,
+        delete_error=None,
     ) -> None:
         self.active = active
         self.fail_delete = fail_delete
         self.active_during_delete = active_during_delete
+        self.delete_error = delete_error
         self.deleted = False
         self.pending_work = None
 
@@ -98,6 +101,8 @@ class _Skills:
         return {**self.get_by_id("9"), "name": "one", "active": self.active}
 
     def delete_bot_local_skill(self, **_kwargs):
+        if self.delete_error is not None:
+            raise self.delete_error
         if self.fail_delete:
             raise RuntimeError("database write failed")
         if self.active_during_delete:
@@ -105,6 +110,10 @@ class _Skills:
         self.pending_work = _kwargs
         self.deleted = True
         return 1
+
+    def require_unreferenced_for_delete(self, _skill_id):
+        if self.active:
+            raise SkillAssetInUseError({"installation": 1})
 
     def list_skill_set_references(self, _skill_id):
         return []
@@ -253,12 +262,14 @@ def _service(
     status="ACTIVE",
     provider="local",
     guard_error=None,
+    delete_error=None,
 ):
     files = _Files()
     skills = _Skills(
         active=active,
         fail_delete=fail_delete,
         active_during_delete=active_during_delete,
+        delete_error=delete_error,
     )
     guard = _Guard(on_acquire)
     if guard_error is not None:
@@ -350,11 +361,12 @@ async def test_delete_fails_closed_when_device_context_cannot_be_resolved():
 async def test_active_delete_is_rejected_before_quarantine_or_database_mutation():
     service, files, skills, _guard, cleanup = _service(active=True)
 
-    with pytest.raises(LocalSkillActiveError):
+    with pytest.raises(SkillAssetInUseError) as raised:
         await service.delete_local_skill(
             skill_id="9", owner_id="owner", user_id="owner"
         )
 
+    assert raised.value.blocker_counts == {"installation": 1}
     assert skills.deleted is False
     assert files.files == {"/skills/one/SKILL.md": b"name: one\ndescription: One\n"}
     assert cleanup.work == []
@@ -407,7 +419,7 @@ async def test_database_failure_restores_verified_package_before_fixed_storage_e
 
 
 @pytest.mark.asyncio
-async def test_transactional_active_recheck_restores_package_and_returns_active_error():
+async def test_transactional_active_recheck_restores_package_and_returns_conflict():
     service, files, skills, _guard, _cleanup = _service(active_during_delete=True)
 
     with pytest.raises(LocalSkillActiveError):
@@ -415,6 +427,21 @@ async def test_transactional_active_recheck_restores_package_and_returns_active_
             skill_id="9", owner_id="owner", user_id="owner"
         )
 
+    assert skills.deleted is False
+    assert files.files == {"/skills/one/SKILL.md": b"name: one\ndescription: One\n"}
+
+
+@pytest.mark.asyncio
+async def test_reference_race_restores_package_and_preserves_asset_in_use_error():
+    conflict = SkillAssetInUseError({"membership": 1})
+    service, files, skills, _guard, _cleanup = _service(delete_error=conflict)
+
+    with pytest.raises(SkillAssetInUseError) as raised:
+        await service.delete_local_skill(
+            skill_id="9", owner_id="owner", user_id="owner"
+        )
+
+    assert raised.value is conflict
     assert skills.deleted is False
     assert files.files == {"/skills/one/SKILL.md": b"name: one\ndescription: One\n"}
 
@@ -696,7 +723,7 @@ async def test_lock_rereads_active_state_before_any_package_mutation():
     service._skill_repo = skills
     service._skill_set_repo = _Sets(skills)
 
-    with pytest.raises(LocalSkillActiveError):
+    with pytest.raises(SkillAssetInUseError):
         await service.delete_local_skill(
             skill_id="9", owner_id="owner", user_id="owner"
         )

--- a/src/backend/tests/community/core/skill_center/test_local_skill_upload_service.py
+++ b/src/backend/tests/community/core/skill_center/test_local_skill_upload_service.py
@@ -16,6 +16,7 @@ from agentclaw.community.core.skill_center.errors import (
     LocalSkillNotReadyError,
     LocalSkillRuntimeSyncError,
     LocalSkillStorageError,
+    SkillAssetInUseError,
 )
 from agentclaw.community.core.skill_center.factories import LocalSkillPackageStorage
 from agentclaw.community.core.skill_center.services import (
@@ -855,6 +856,24 @@ async def test_failed_rollback_step_does_not_stop_package_cleanup():
     assert service._skill_service_factory._filesystem.deleted == [
         "/private/skills-local/upload-skill"
     ]
+
+
+@pytest.mark.asyncio
+async def test_compensation_preserves_package_when_asset_gained_a_reference():
+    package = _zip({"SKILL.md": _skill_md()})
+    repo = _Repo()
+    repo.delete = lambda *_args: (_ for _ in ()).throw(
+        SkillAssetInUseError({"membership": 1})
+    )
+    service = _service(_Filesystem(), repo=repo, audit=_FailAudit())
+
+    with pytest.raises(SkillAssetInUseError):
+        await service.upload_local_skill(
+            bot_id="bot", owner_id="owner", actor_id="owner", package=package
+        )
+
+    assert repo.created
+    assert service._skill_service_factory._filesystem.deleted == []
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/community/endpoints/test_openapi_skill_delete.py
+++ b/src/backend/tests/community/endpoints/test_openapi_skill_delete.py
@@ -174,10 +174,10 @@ def _seed_delete(world, *, active: bool) -> None:
                 "source_type": "upload",
             }
         )
-        world.get(SkillSetRepository).add_skill_to_set(
-            default_set["id"], skill["id"], user_id=_OWNER
-        )
         if active:
+            world.get(SkillSetRepository).add_skill_to_set(
+                default_set["id"], skill["id"], user_id=_OWNER
+            )
             with world.get(DatabasePlugin).transactional_orm_session() as session:
                 skill_installations.install(
                     session, env="dev", owner_id=_OWNER, bot_id=_BOT_ID,
@@ -235,6 +235,29 @@ def _seed_inactive_skill_in_active_custom_set(world) -> None:
         )
 
 
+def _seed_inactive_skill_in_inactive_custom_set(world) -> None:
+    _seed_delete(world, active=False)
+    with avernet_tenant_scope(_TENANT):
+        skill = world.get(SkillRepository).get_bot_local_skill(
+            skill_id="1", bot_id=_BOT_ID, user_id=_OWNER
+        )
+        assert skill is not None
+        inactive_set = world.get(SkillSetRepository).create(
+            {
+                "name": "Saved custom",
+                "user_id": _OWNER,
+                "bolt_id": _BOT_ID,
+                "is_default": False,
+                "is_builtin": False,
+                "is_active": False,
+                "engine_type": "openclaw",
+            }
+        )
+        world.get(SkillSetRepository).add_skill_to_set(
+            inactive_set["id"], skill["id"], user_id=_OWNER
+        )
+
+
 @endpoint_test(
     method="DELETE",
     path="/openapi/v1/bots/{bot_id}/skills/{skill_id}",
@@ -263,7 +286,11 @@ def delete_inactive_local_skill():
     seed=_seed_active_delete,
     expect=ExpectError(
         status=409,
-        json_contains={"code": 409102, "message": "Skill is active", "data": None},
+        json_contains={
+            "code": 409105,
+            "message": "Skill is still in use",
+            "data": {"blockers": {"installation": 1, "membership": 1}},
+        },
     ),
 )
 def delete_active_local_skill_is_rejected():
@@ -282,11 +309,38 @@ def delete_active_local_skill_is_rejected():
     seed=_seed_inactive_skill_in_active_custom_set,
     expect=ExpectError(
         status=409,
-        json_contains={"code": 409102, "message": "Skill is active", "data": None},
+        json_contains={
+            "code": 409105,
+            "message": "Skill is still in use",
+            "data": {"blockers": {"membership": 1}},
+        },
     ),
 )
 def delete_skill_referenced_by_active_custom_set_is_rejected():
     """Default exclusion cannot override an active custom SkillSet reference."""
+
+
+@endpoint_test(
+    method="DELETE",
+    path="/openapi/v1/bots/{bot_id}/skills/{skill_id}",
+    scenario="rejects_skill_referenced_only_by_inactive_set",
+    input=CaseInput(
+        path_params={"bot_id": _BOT_ID, "skill_id": "1"},
+        query_params={"user_id": _OWNER},
+        headers=_HEADERS,
+    ),
+    seed=_seed_inactive_skill_in_inactive_custom_set,
+    expect=ExpectError(
+        status=409,
+        json_contains={
+            "code": 409105,
+            "message": "Skill is still in use",
+            "data": {"blockers": {"membership": 1}},
+        },
+    ),
+)
+def delete_skill_referenced_by_inactive_set_is_rejected():
+    """Saved inactive configuration is a reference, not deletion cleanup."""
 
 
 # The retiring address, driven for the same reason as the state commands: it
@@ -322,7 +376,11 @@ def legacy_delete_resolves_the_bot_from_the_skill():
     seed=_seed_active_delete,
     expect=ExpectError(
         status=409,
-        json_contains={"code": 409102, "message": "Skill is active", "data": None},
+        json_contains={
+            "code": 409105,
+            "message": "Skill is still in use",
+            "data": {"blockers": {"installation": 1, "membership": 1}},
+        },
     ),
 )
 def legacy_delete_active_local_skill_is_rejected():

--- a/src/backend/tests/community/repository/skill_center/test_capability_desired_state_uow.py
+++ b/src/backend/tests/community/repository/skill_center/test_capability_desired_state_uow.py
@@ -65,6 +65,40 @@ class _Database:
             session.close()
 
 
+def test_purge_bot_installations_is_exactly_owner_bot_env_scoped() -> None:
+    db = _Database()
+    with db.transactional_orm_session() as session:
+        session.add_all(
+            [
+                BotSkillInstallation(
+                    owner_id="owner", bot_id="default", skill_id=1, env="dev"
+                ),
+                BotSkillInstallation(
+                    owner_id="other", bot_id="default", skill_id=2, env="dev"
+                ),
+                BotMCPInstallation(
+                    owner_id="owner", bot_id="default", server_code="mcp.mine", env="dev"
+                ),
+                BotMCPInstallation(
+                    owner_id="other", bot_id="default", server_code="mcp.other", env="dev"
+                ),
+            ]
+        )
+
+    result = CapabilityDesiredStateRepository(db).purge_bot_installations(
+        owner_id="owner", bot_id="default", env="dev"
+    )
+
+    assert result == {"skills": 1, "mcps": 1}
+    with db.orm_session() as session:
+        assert [row.owner_id for row in session.query(BotSkillInstallation)] == [
+            "other"
+        ]
+        assert [row.owner_id for row in session.query(BotMCPInstallation)] == [
+            "other"
+        ]
+
+
 def test_legacy_scope_resolution_returns_only_ordinary_set_address() -> None:
     db = _Database()
     with db.transactional_orm_session() as session:

--- a/src/backend/tests/community/repository/skill_center/test_skill_repository_unified.py
+++ b/src/backend/tests/community/repository/skill_center/test_skill_repository_unified.py
@@ -18,9 +18,21 @@ from sqlalchemy import create_engine, event
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import sessionmaker
 
-from agentclaw.community.core.models import BotSkillInstallation, Skill, SkillSet, SkillSetSkill
+from agentclaw.community.core.models import (
+    BotSkillInstallation,
+    Skill,
+    SkillDraftEditLease,
+    SkillGrant,
+    SkillPublicationAttempt,
+    SkillSet,
+    SkillSetSkill,
+    SkillSpaceBinding,
+    SkillVersion,
+)
+from agentclaw.community.core.models.space_skill import SkillDraftUpgradeRequest
 from agentclaw.community.core.skill_center.errors import (
     ActiveSkillSetReferenceError,
+    SkillAssetInUseError,
     SkillOfflineError,
 )
 from agentclaw.community.core.models.mcp import SkillSetMCPServer
@@ -74,6 +86,12 @@ def db(tmp_path):
         DefaultSkillsetSkillExclusion,
         BotModel,
         AcSkillMember,
+        SkillSpaceBinding,
+        SkillGrant,
+        SkillDraftEditLease,
+        SkillDraftUpgradeRequest,
+        SkillVersion,
+        SkillPublicationAttempt,
     ):
         m.__table__.create(engine)
     return _FileSqliteDB(engine)
@@ -127,7 +145,7 @@ def test_legacy_add_refuses_offline_skill_before_membership_write(skills, sets, 
         assert session.query(SkillSetSkill).count() == 0
 
 
-def test_delete_removes_all_associations_for_active_and_inactive_local_skills(
+def test_delete_rejects_active_and_inactive_memberships_without_changing_state(
     skills, sets, db
 ):
     active_skill = skills.create(
@@ -151,12 +169,17 @@ def test_delete_removes_all_associations_for_active_and_inactive_local_skills(
         )
     sets.add_skill_to_set(inactive_set["id"], inactive_skill["id"])
 
-    assert skills.delete(active_skill["id"]) is True
-    assert skills.delete(inactive_skill["id"]) is True
+    with pytest.raises(SkillAssetInUseError) as active_error:
+        skills.delete(active_skill["id"])
+    with pytest.raises(SkillAssetInUseError) as inactive_error:
+        skills.delete(inactive_skill["id"])
+
+    assert active_error.value.blocker_counts == {"membership": 2}
+    assert inactive_error.value.blocker_counts == {"membership": 1}
 
     with db.orm_session() as session:
-        assert session.query(SkillSetSkill).count() == 0
-        assert session.query(Skill).count() == 0
+        assert session.query(SkillSetSkill).count() == 3
+        assert session.query(Skill).count() == 2
 
 
 def test_delete_succeeds_for_skill_without_an_association(skills, db):
@@ -171,35 +194,140 @@ def test_delete_succeeds_for_skill_without_an_association(skills, db):
         assert session.query(Skill).count() == 0
 
 
-def test_delete_rolls_back_when_association_cleanup_fails(skills, sets, db):
-    skill = skills.create({"name": "rollback-association"})
-    skill_set = sets.create({"name": "set"})
-    sets.add_skill_to_set(skill_set["id"], skill["id"])
-
-    def fail_association_delete(
-        _conn, _cursor, statement, _parameters, _context, _executemany
-    ):
-        if statement.lstrip().lower().startswith("delete from ac_skill_set_skill"):
-            raise RuntimeError("injected association delete failure")
-
-    event.listen(db.engine, "before_cursor_execute", fail_association_delete)
-    try:
-        with pytest.raises(RuntimeError, match="injected association delete failure"):
-            skills.delete(skill["id"])
-    finally:
-        event.remove(db.engine, "before_cursor_execute", fail_association_delete)
-
+def test_delete_rejects_an_installed_skill_without_changing_state(skills, db):
+    skill = skills.create({"name": "installed", "git_path": "git://installed"})
     with db.orm_session() as session:
-        assert session.query(SkillSetSkill).count() == 1
+        session.add(
+            BotSkillInstallation(
+                env="dev",
+                owner_id="owner",
+                bot_id="bot",
+                skill_id=int(skill["id"]),
+                avernet_tenant="teamclaw",
+            )
+        )
+
+    with pytest.raises(SkillAssetInUseError) as raised:
+        skills.delete(skill["id"])
+
+    assert raised.value.blocker_counts == {"installation": 1}
+    with db.orm_session() as session:
         assert session.query(Skill).count() == 1
+        assert session.query(BotSkillInstallation).count() == 1
 
 
-def test_delete_rolls_back_association_cleanup_when_skill_delete_fails(
+def test_delete_rejects_published_version_lineage(skills, db):
+    skill = skills.create(
+        {"name": "published", "skill_uuid": "published-uuid", "status": "PUBLISHED"}
+    )
+    with db.orm_session() as session:
+        session.add(
+            SkillVersion(
+                skill_id=int(skill["id"]),
+                version_ordinal=1,
+                status="PUBLISHED",
+                sc_version_number="1.0.0",
+                name="published",
+                created_by="owner",
+                env="dev",
+            )
+        )
+
+    with pytest.raises(SkillAssetInUseError) as raised:
+        skills.delete(skill["id"])
+
+    assert raised.value.blocker_counts == {"version": 1}
+
+
+def test_delete_reports_space_draft_publication_and_governance_blockers(skills, db):
+    skill = skills.create(
+        {
+            "name": "space-draft",
+            "skill_uuid": "space-draft-uuid",
+            "draft_status": "EDITING",
+        }
+    )
+    skill_id = int(skill["id"])
+    with db.orm_session() as session:
+        session.query(Skill).filter(Skill.id == skill_id).one().draft_status = "EDITING"
+        session.add_all(
+            [
+                SkillSpaceBinding(skill_id=skill_id, space_id=7, created_by="owner", env="dev"),
+                SkillGrant(
+                    skill_id=skill_id,
+                    user_id="owner",
+                    role="OWNER",
+                    status="ACTIVE",
+                    owner_slot=1,
+                    granted_by="owner",
+                    env="dev",
+                ),
+                SkillDraftEditLease(skill_id=skill_id, fencing_token=1, env="dev"),
+                SkillDraftUpgradeRequest(
+                    skill_id=skill_id,
+                    space_id=7,
+                    request_id="upgrade-1",
+                    target_version_ordinal=2,
+                    status="ACTIVE",
+                    created_by="owner",
+                    env="dev",
+                ),
+                SkillPublicationAttempt(
+                    skill_id=skill_id,
+                    request_id="publish-1",
+                    target_version_ordinal=1,
+                    status="FAILED",
+                    created_by="owner",
+                    env="dev",
+                ),
+            ]
+        )
+
+    with pytest.raises(SkillAssetInUseError) as raised:
+        skills.delete(skill["id"])
+
+    assert raised.value.blocker_counts == {
+        "grant": 1,
+        "space_binding": 1,
+        "draft": 3,
+        "publication": 1,
+    }
+
+
+def test_bot_local_delete_rejects_an_inactive_membership_without_changing_state(
     skills, sets, db
 ):
+    skill = skills.create(
+        {
+            "name": "local-member",
+            "git_path": "local:///skills/local-member",
+            "user_id": "owner",
+            "bolt_id": "bot",
+        }
+    )
+    skill_set = sets.create(
+        {
+            "name": "saved",
+            "user_id": "owner",
+            "bolt_id": "bot",
+            "is_active": False,
+        }
+    )
+    sets.add_skill_to_set(skill_set["id"], skill["id"], user_id="owner")
+
+    with pytest.raises(SkillAssetInUseError) as raised:
+        skills.delete_bot_local_skill(
+            skill_id=skill["id"], owner_id="owner", bot_id="bot"
+        )
+
+    assert raised.value.blocker_counts == {"membership": 1}
+    with db.orm_session() as session:
+        assert session.query(Skill).count() == 1
+        assert session.query(SkillSetSkill).count() == 1
+
+
+def test_delete_rolls_back_when_skill_delete_fails(skills, db):
     skill = skills.create({"name": "rollback-skill"})
-    skill_set = sets.create({"name": "set"})
-    sets.add_skill_to_set(skill_set["id"], skill["id"])
 
     def fail_skill_delete(
         _conn, _cursor, statement, _parameters, _context, _executemany
@@ -215,7 +343,6 @@ def test_delete_rolls_back_association_cleanup_when_skill_delete_fails(
         event.remove(db.engine, "before_cursor_execute", fail_skill_delete)
 
     with db.orm_session() as session:
-        assert session.query(SkillSetSkill).count() == 1
         assert session.query(Skill).count() == 1
 
 
@@ -568,21 +695,55 @@ def test_delete_by_name_with_cascade(skills, db):
                             skill_uuid="cu1"))
         s.add(AcSkillMember(skill_uuid="cu1", user_id="u",
                             role="member"))
-    res = skills.delete_by_name_with_cascade("casc")
-    assert res["deleted_skill_count"] == 1
-    assert res["cleaned_set_skill"] == 1
-    assert res["cleaned_member"] == 1
+    with pytest.raises(SkillAssetInUseError) as raised:
+        skills.delete_by_name_with_cascade("casc")
+    assert raised.value.blocker_counts == {"membership": 1, "grant": 1}
     with db.orm_session() as s:
-        assert s.query(SkillSetSkill).count() == 0
-        assert s.query(AcSkillMember).count() == 0
-        assert s.query(Skill).count() == 0
+        assert s.query(SkillSetSkill).count() == 1
+        assert s.query(AcSkillMember).count() == 1
+        assert s.query(Skill).count() == 1
+
+
+def test_delete_by_name_with_cascade_deletes_only_unreferenced_assets(skills, db):
+    skills.create({"name": "unreferenced-cascade", "skill_uuid": "cu2"})
+
+    result = skills.delete_by_name_with_cascade("unreferenced-cascade")
+
+    assert result == {
+        "deleted_skill_count": 1,
+        "cleaned_set_skill": 0,
+        "cleaned_member": 0,
+    }
+    with db.orm_session() as session:
+        assert session.query(Skill).count() == 0
+
+
+def test_delete_rejects_live_legacy_member_reference(skills, db):
+    skill = skills.create(
+        {"name": "legacy-member", "skill_uuid": "legacy-member-uuid"}
+    )
+    with db.orm_session() as session:
+        session.add(
+            AcSkillMember(
+                skill_uuid="legacy-member-uuid", user_id="member", role="member"
+            )
+        )
+
+    with pytest.raises(SkillAssetInUseError) as raised:
+        skills.delete(skill["id"])
+
+    assert raised.value.blocker_counts == {"grant": 1}
+    with db.orm_session() as session:
+        assert session.query(Skill).count() == 1
+        assert session.query(AcSkillMember).count() == 1
 
 
 def test_delete_by_bot_id(skills):
-    skills.create({"name": "b1", "bolt_id": "bot-x"})
-    skills.create({"name": "b2", "bolt_id": "bot-x"})
-    assert skills.delete_by_bot_id("bot-x") == 2
-    assert skills.list_skills(bolt_id="bot-x") == []
+    skills.create({"name": "b1", "bolt_id": "bot-x", "user_id": "owner"})
+    skills.create({"name": "b2", "bolt_id": "bot-x", "user_id": "owner"})
+    skills.create({"name": "other", "bolt_id": "bot-x", "user_id": "other"})
+    assert skills.delete_by_bot_id("bot-x", "owner") == 2
+    assert [row["name"] for row in skills.list_skills(bolt_id="bot-x")] == ["other"]
 
 
 def test_list_skill_set_references_includes_active_and_inactive_sets(
@@ -981,11 +1142,11 @@ def test_get_excluded_skills_empty(sets, db):
 
 
 def test_skillset_delete_by_bot_id_cascade(sets, db):
-    s1 = sets.create({"name": "s1", "bolt_id": "botz"})
+    s1 = sets.create({"name": "s1", "bolt_id": "botz", "user_id": "owner"})
     sets.add_mcp_to_set(s1["id"], "mcp.a", "A")
     with db.orm_session() as s:
         s.add(SkillSetSkill(skill_set_id=int(s1["id"]), skill_id=1))
-    assert sets.delete_by_bot_id("botz") == 1
+    assert sets.delete_by_bot_id("botz", "owner") == 1
     with db.orm_session() as s:
         assert s.query(SkillSet).count() == 0
         assert s.query(SkillSetSkill).count() == 0

--- a/src/backend/tests/community/repository/skill_center/test_space_skill_draft_repository.py
+++ b/src/backend/tests/community/repository/skill_center/test_space_skill_draft_repository.py
@@ -241,7 +241,7 @@ def test_delete_first_draft_removes_the_whole_unreferenced_skill_aggregate():
         )
 
 
-def test_delete_first_draft_after_failed_publication_removes_whole_skill():
+def test_failed_publication_lineage_prevents_whole_skill_deletion():
     db = _Database()
     space_id, skill_id = _seed(db, space_type="TEAM")
     with db.orm_session() as session:
@@ -267,23 +267,18 @@ def test_delete_first_draft_after_failed_publication_removes_whole_skill():
         env="test",
     )
 
-    assert result["deleted_scope"] == "SKILL"
+    assert result["deleted_scope"] == "DRAFT"
     with db.orm_session() as session:
-        assert session.query(Skill).filter_by(id=skill_id).one_or_none() is None
+        skill = session.query(Skill).filter_by(id=skill_id).one()
+        assert skill.draft_status is None
         assert (
             session.query(SkillPublicationAttempt)
             .filter_by(skill_id=skill_id)
             .count()
-            == 0
+            == 1
         )
-        assert (
-            session.query(SkillDraftEditLease).filter_by(skill_id=skill_id).count()
-            == 0
-        )
-        assert session.query(SkillGrant).filter_by(skill_id=skill_id).count() == 0
-        assert (
-            session.query(SkillSpaceBinding).filter_by(skill_id=skill_id).count() == 0
-        )
+        assert session.query(SkillGrant).filter_by(skill_id=skill_id).count() == 1
+        assert session.query(SkillSpaceBinding).filter_by(skill_id=skill_id).count() == 1
 
 
 def test_delete_upgrade_draft_preserves_published_skill_history():


### PR DESCRIPTION
## Problem

Skill hard-delete primitives could remove `ac_skill` while Bot Installations or other durable references still existed. This created dangling `ac_bot_skill_installation` rows that could no longer resolve to a runtime Skill asset. Several legacy deletion paths also silently removed SkillSet membership or performed external/device work before the database deletion invariant was rechecked.

## Solution

- Add one fail-closed deletion invariant at `SkillRepository`: lock the exact Skill row, count durable blockers, and reject deletion with `SKILL_ASSET_IN_USE` when Installation, SkillSet membership, legacy grants, Space binding/grants, Draft facts, Versions, or Publication Attempts still reference the asset.
- Reuse the same guard from generic, Bot-local, Git-sync, legacy cascade, and Bot cleanup paths.
- Make Bot cleanup explicitly purge that Bot's Skill/MCP Installations before deleting owner-scoped SkillSets and Local Skills; stop cleanup if the purge fails.
- Route BFF Local deletion through the canonical Local delete service so storage quarantine and DB deletion compensate safely. Unknown historical locators fail closed before device I/O.
- Preserve source-missing Repo assets when they remain referenced and return structured Git-sync blocker details.
- Permanently retire the unsafe legacy batch-delete surfaces with HTTP 410.
- Keep Space Skill identity when any Publication Attempt exists, including failed attempts.
- Map the conflict to an explicit OpenAPI/BFF 409 response and document the invariant and ownership boundary.

## Validation

- Focused post-rebase suite: `202 passed, 27 skipped`.
- Broader affected suites before final rebase: `1754 passed, 27 skipped`.
- Backend full suite reached completion once: `18167 passed, 60 skipped, 2 failed`; both failures were caused by this change (safe offline-Local delete contract and module-size gate), were fixed, and their exact tests now pass.
- A second full local run was stopped at `5423 passed, 15 skipped` at the user's request to create the PR and use GitHub CI as the final full gate.
- Changed Python Ruff: passed.
- `git diff --check`: passed.
- Standards/Spec dual review: no remaining P0-P2 findings.

Real overlapping `SELECT ... FOR UPDATE` behavior cannot be proven by the local SQLite suite; row-lock ordering is covered structurally and should be exercised by the relational integration/CI environment.

## Compatibility and risk

- No schema migration and no historical data mutation.
- Unreferenced canonical assets remain deletable.
- Referenced assets now return a deterministic conflict instead of being deleted.
- A Local Skill whose storage cannot be safely located is retained rather than metadata-only deleted.
- Legacy batch-delete endpoints now return 410 and require callers to migrate to canonical per-asset lifecycle APIs.
- OCB contains no independent Corp hard-delete implementation for this seam; enterprise deployment still requires the normal OCB gitlink bump after this PR is merged.

## Spec

- `docs/adr/0004-block-withdrawal-when-bots-reference-skill.md`
- `src/backend/src/agentclaw/community/core/skill_center/CONTEXT.md`

## Related issues

Closes #2061
