### PR TITLE
test(skills): cover Local upload filesystem bytes

### DIFF
--- a/src/backend/tests/community/core/skill_center/test_local_skill_upload_service.py
+++ b/src/backend/tests/community/core/skill_center/test_local_skill_upload_service.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import io
+import shutil
 import zipfile
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -148,6 +151,61 @@ class _Filesystem:
 
     async def exists(self, path):
         return any(file_path.startswith(f"{path}/") for file_path in self.files)
+
+
+class _DiskFilesystem:
+    """Minimal Local-device fixture that persists package bytes under ``tmp_path``."""
+
+    def __init__(self, root: Path, *, fail_writes=(), fail_reads=()):
+        self._root = root
+        self._fail_writes = set(fail_writes)
+        self._fail_reads = set(fail_reads)
+
+    def _path(self, device_path: str) -> Path:
+        relative = Path(device_path.lstrip("/"))
+        target = self._root / relative
+        if (
+            relative.is_absolute()
+            or ".." in relative.parts
+            or not target.resolve().is_relative_to(self._root.resolve())
+        ):
+            raise OSError("invalid Local Skill test path")
+        return target
+
+    async def write_file(self, path, content):
+        if path in self._fail_writes:
+            raise OSError(f"device write failed: {path}")
+        target = self._path(path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(content)
+
+    async def read_file(self, path):
+        if path in self._fail_reads:
+            raise OSError(f"device read failed: {path}")
+        target = self._path(path)
+        return target.read_bytes() if target.is_file() else None
+
+    async def list_dir(self, path, *, recursive=False):
+        directory = self._path(path)
+        if not directory.is_dir():
+            return None
+        entries = directory.rglob("*") if recursive else directory.iterdir()
+        return [
+            {
+                "relative_path": entry.relative_to(directory).as_posix(),
+                "is_dir": entry.is_dir(),
+            }
+            for entry in entries
+        ]
+
+    async def delete_tree(self, path):
+        directory = self._path(path)
+        if directory.exists():
+            shutil.rmtree(directory)
+        return True
+
+    async def exists(self, path):
+        return self._path(path).exists()
 
 
 class _Factory:
@@ -506,6 +564,18 @@ class _ReplacementFactory(_Factory):
         return _Storage(self._filesystem, locator)
 
 
+class _DiskStorageFactory(_ReplacementFactory):
+    """Use the production package-storage port over the temporary Local disk."""
+
+    def local_skill_package_storage(self, **kwargs):
+        directory, _ = super().local_skill_package_storage(**kwargs)
+        return directory, LocalSkillPackageStorage(self._filesystem, directory)
+
+    def local_skill_package_storage_for_locator(self, *, locator, **kwargs):
+        self.locator_calls.append({"locator": locator, **kwargs})
+        return LocalSkillPackageStorage(self._filesystem, locator)
+
+
 class _ReplacementRuntime:
     def __init__(self, results):
         self.results = iter(results)
@@ -540,6 +610,7 @@ def _replacement_service(
     runtime,
     _unused_cleanup=None,
     guard=None,
+    factory=None,
     *,
     provider="local",
 ):
@@ -547,7 +618,7 @@ def _replacement_service(
         repo,
         _Bot(),
         _Collaborators(),
-        _ReplacementFactory(filesystem),
+        factory or _ReplacementFactory(filesystem),
         _Audit(),
         guard or _Guard(),
         lambda: _DeviceResolver(provider),
@@ -765,6 +836,102 @@ async def test_directory_upload_uses_the_same_create_flow_as_raw_zip():
         "/private/skills-local/folder-skill/SKILL.md": _skill_md("folder-skill"),
         "/private/skills-local/folder-skill/scripts/main.py": b"print('ok')",
     }
+
+
+@pytest.mark.asyncio
+async def test_local_zip_folder_replace_and_io_failures_use_actual_filesystem(tmp_path):
+    """Exercise the Local ZIP/folder entry points over a real device directory.
+
+    This is intentionally a small product slice: the production validator,
+    create/replace service, and ``LocalSkillPackageStorage`` run unchanged;
+    only the device boundary is a temporary Local filesystem. The Desktop
+    invoke-http byte path has its matching Engine-facing contract test.
+    """
+    filesystem = _DiskFilesystem(tmp_path / "device")
+    factory = _DiskStorageFactory(filesystem)
+    raw_files = {
+        "SKILL.md": _skill_md("upload-skill", "raw archive"),
+        "docs/readme.txt": b"plain text\n",
+        "assets/icon.png": b"\x89PNG\r\n\x1a\n\xff\x00",
+        "assets/nonutf8.bin": b"\xff\x00\x80\xfe",
+        "assets/empty.txt": b"",
+    }
+    await _service(filesystem, factory=factory).upload_local_skill(
+        bot_id="bot",
+        owner_id="owner",
+        actor_id="owner",
+        package=_zip(raw_files),
+    )
+
+    folder_files = {
+        "SKILL.md": _skill_md("folder-skill", "folder upload"),
+        "scripts/run.py": b"print('ok')\n",
+        "assets/nonutf8.bin": b"\x80\xff\x00",
+        "assets/empty.txt": b"",
+    }
+    await _service(filesystem, factory=factory).upload_local_skill_files(
+        bot_id="bot",
+        owner_id="owner",
+        actor_id="owner",
+        files=[
+            (f"folder-skill/{path}", content) for path, content in folder_files.items()
+        ],
+    )
+
+    raw_storage = LocalSkillPackageStorage(
+        filesystem, "/private/skills-local/upload-skill"
+    )
+    folder_storage = LocalSkillPackageStorage(
+        filesystem, "/private/skills-local/folder-skill"
+    )
+    assert dict(await raw_storage.read_package_files()) == raw_files
+    assert dict(await folder_storage.read_package_files()) == folder_files
+
+    replacement_files = {
+        "SKILL.md": _skill_md("upload-skill", "replacement archive"),
+        "docs/readme.txt": b"replacement text\n",
+        "assets/icon.png": b"\x89PNG\r\n\x1a\n\x00\xff",
+        "assets/nonutf8.bin": b"\x50\x4b\x03\x04\xff\x00\x01",
+        "assets/empty.txt": b"",
+    }
+    replacement = await _replacement_service(
+        filesystem,
+        _ReplacementRepo([_existing_skill(active=False)]),
+        _ReplacementRuntime([True]),
+        factory=factory,
+    ).upload_local_skill(
+        bot_id="bot",
+        owner_id="owner",
+        actor_id="owner",
+        package=_zip(replacement_files),
+    )
+    assert replacement["operation"] == "updated"
+    actual_replacement = dict(await raw_storage.read_package_files())
+    assert {
+        path: hashlib.sha256(content).hexdigest()
+        for path, content in actual_replacement.items()
+    } == {
+        path: hashlib.sha256(content).hexdigest()
+        for path, content in replacement_files.items()
+    }
+
+    failed_write_path = "/private/failed/write.bin"
+    failed_write = LocalSkillPackageStorage(
+        _DiskFilesystem(tmp_path / "write-failure", fail_writes={failed_write_path}),
+        "/private/failed",
+    )
+    with pytest.raises(OSError, match="device write failed"):
+        await failed_write.write([("write.bin", b"no write")])
+
+    failed_read_path = "/private/read-failure/asset.bin"
+    failed_read_filesystem = _DiskFilesystem(tmp_path / "read-failure")
+    failed_read = LocalSkillPackageStorage(
+        failed_read_filesystem, "/private/read-failure"
+    )
+    await failed_read.write([("asset.bin", b"written first")])
+    failed_read_filesystem._fail_reads.add(failed_read_path)
+    with pytest.raises(OSError, match="device read failed"):
+        await failed_read.read_file("asset.bin")
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/community/endpoints/test_openapi_skill_upload.py
+++ b/src/backend/tests/community/endpoints/test_openapi_skill_upload.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import io
+from pathlib import Path
+import shutil
+import tempfile
 import time
 import zipfile
 
@@ -61,24 +64,90 @@ class _Resolver:
         return _Secret()
 
 
-class _Storage:
-    async def prepare(self) -> None:
-        return None
+_RAW_UPLOAD_FILES = {
+    "SKILL.md": b"name: raw-upload\ndescription: raw endpoint coverage\n",
+    "docs/notes.txt": "plain text\n".encode(),
+    "assets/icon.png": b"\x89PNG\r\n\x1a\n\xff\x00",
+    "assets/nonutf8.bin": b"\xff\x00\x80\xfe",
+    "assets/empty.txt": b"",
+}
+_FOLDER_UPLOAD_FILES = {
+    "SKILL.md": b"name: folder-upload\ndescription: folder coverage\n",
+    "docs/notes.txt": "plain text\n".encode(),
+    "assets/icon.png": b"\x89PNG\r\n\x1a\n\xff\x00",
+    "assets/nonutf8.bin": b"\xff\x00\x80\xfe",
+    "assets/empty.txt": b"",
+}
 
-    async def write(self, _files: list[tuple[str, bytes]]) -> None:
-        return None
 
-    async def cleanup(self) -> bool:
+class _Filesystem:
+    """Small Local-device fixture backed by a real temporary directory."""
+
+    def __init__(self, root: Path) -> None:
+        self._root = root
+
+    def _path(self, device_path: str) -> Path:
+        relative = Path(device_path.lstrip("/"))
+        target = self._root / relative
+        if (
+            relative.is_absolute()
+            or ".." in relative.parts
+            or not target.resolve().is_relative_to(self._root.resolve())
+        ):
+            raise OSError("invalid Local Skill test path")
+        return target
+
+    async def write_file(self, path: str, content: bytes) -> None:
+        target = self._path(path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(content)
+
+    async def read_file(self, path: str) -> bytes | None:
+        target = self._path(path)
+        return target.read_bytes() if target.is_file() else None
+
+    async def list_dir(self, path: str, *, recursive: bool = False):
+        directory = self._path(path)
+        if not directory.is_dir():
+            return None
+        entries = directory.rglob("*") if recursive else directory.iterdir()
+        return [
+            {
+                "relative_path": entry.relative_to(directory).as_posix(),
+                "is_dir": entry.is_dir(),
+            }
+            for entry in entries
+        ]
+
+    async def delete_tree(self, path: str) -> bool:
+        directory = self._path(path)
+        if directory.exists():
+            shutil.rmtree(directory)
         return True
+
+    async def exists(self, path: str) -> bool:
+        return self._path(path).exists()
 
 
 class _StorageFactory:
+    def __init__(self) -> None:
+        self._temporary_directory = tempfile.TemporaryDirectory()
+        self._root = Path(self._temporary_directory.name)
+        self._filesystem = _Filesystem(self._root)
+
     def local_skill_package_storage(
-        self, **_kwargs
+        self, *, name: str, directory_name: str | None = None, **_kwargs
     ) -> tuple[str, LocalSkillPackageStorage]:
-        # HTTP, tenant, and Core persistence are real here; filesystem faults
-        # belong to the Core fault-injection matrix.
-        return "test-local/raw-upload", _Storage()  # type: ignore[return-value]
+        directory = f"test-local/{directory_name or name}"
+        return directory, LocalSkillPackageStorage(self._filesystem, directory)
+
+    def files_for(self, name: str) -> dict[str, bytes]:
+        directory = self._root / "test-local" / name
+        return {
+            path.relative_to(directory).as_posix(): path.read_bytes()
+            for path in directory.rglob("*")
+            if path.is_file()
+        }
 
 
 class _RuntimeFactory:
@@ -114,10 +183,8 @@ class _Cleanup:
 def _package() -> bytes:
     payload = io.BytesIO()
     with zipfile.ZipFile(payload, "w") as archive:
-        archive.writestr(
-            "SKILL.md", "name: raw-upload\ndescription: raw endpoint coverage\n"
-        )
-        archive.writestr("scripts/main.py", "print('ok')\n")
+        for path, content in _RAW_UPLOAD_FILES.items():
+            archive.writestr(path, content)
     return payload.getvalue()
 
 
@@ -165,6 +232,7 @@ def _seed_uploadable_bot(world) -> None:
     init_principal_verifier_config(_Resolver(), "test-key", strict=False)
     storage_factory = _StorageFactory()
     world.injector.binder.bind(SkillServiceFactory, to=storage_factory, scope=None)
+    world.injector.binder.bind(_StorageFactory, to=storage_factory, scope=None)
     with avernet_tenant_scope(_TENANT):
         world.get(BotRepository).insert(
             {
@@ -232,6 +300,16 @@ def _assert_created_inactive_without_default_membership(response, world) -> None
         assert skill is not None and skill["active"] is False
 
 
+def _assert_raw_zip_bytes_reach_the_local_filesystem(response, world) -> None:
+    _assert_created_inactive_without_default_membership(response, world)
+    assert world.get(_StorageFactory).files_for("raw-upload") == _RAW_UPLOAD_FILES
+
+
+def _assert_folder_bytes_reach_the_local_filesystem(response, world) -> None:
+    _assert_created_inactive_without_default_membership(response, world)
+    assert world.get(_StorageFactory).files_for("folder-upload") == _FOLDER_UPLOAD_FILES
+
+
 @endpoint_test(
     method="POST",
     path="/openapi/v1/bots/{bot_id}/skills",
@@ -243,7 +321,7 @@ def _assert_created_inactive_without_default_membership(response, world) -> None
         raw_body=_package(),
     ),
     seed=_seed_uploadable_bot,
-    extra_assertions=(_assert_created_inactive_without_default_membership,),
+    extra_assertions=(_assert_raw_zip_bytes_reach_the_local_filesystem,),
     expect=ExpectSuccess(
         status=201,
         json_contains={
@@ -284,16 +362,15 @@ def multipart_upload_is_an_explicit_error_case():
         path_params={"bot_id": _BOT_ID},
         query_params={"user_id": _OWNER},
         headers={PRINCIPAL_HEADER: _principal()},
-        form_data={"file_paths": '["SKILL.md"]'},
+        form_data={
+            "file_paths": '["SKILL.md", "docs/notes.txt", "assets/icon.png", "assets/nonutf8.bin", "assets/empty.txt"]'
+        },
         files=[
-            (
-                "files",
-                ("SKILL.md", b"name: folder-upload\ndescription: folder coverage\n"),
-            )
+            ("files", (path, content)) for path, content in _FOLDER_UPLOAD_FILES.items()
         ],
     ),
     seed=_seed_uploadable_bot,
-    extra_assertions=(_assert_created_inactive_without_default_membership,),
+    extra_assertions=(_assert_folder_bytes_reach_the_local_filesystem,),
     expect=ExpectSuccess(
         status=201,
         json_contains={


### PR DESCRIPTION
## Problem

Desktop Local Skill uploads need evidence that raw ZIP and folder payload bytes survive Local storage, same-name replacement, and read/write failures without lossy text conversion.

## Solution

- Drive the formal raw ZIP and folder OpenAPI routes through production LocalSkillPackageStorage backed by a temporary filesystem.
- Add a focused Local upload service slice covering real files, replacement hashes, and read/write failures.
- Test only; no production behavior or public contract changes.

## Validation

- Rebased onto current `dev@43dc46c2c` after the previous Backend CI worker crashed.
- Previous CI failure was a native `Fatal Python error: Segmentation fault` in an existing `BaasPublishPoller` background thread querying SQLite; it was not an assertion failure in this PR. The run had already completed 18154 tests successfully.
- The two new endpoint cases passed 10 consecutive stress runs (20 endpoint executions total).
- `uv run pytest -o addopts='' tests/community/core/skill_center/test_local_skill_upload_service.py -q` (39 passed, 10 existing skips)
- `git diff --check` passed.
- A fresh GitHub CI run was triggered by the rebased push.

## Compatibility and risk

Test-only change. It uses temporary directories and does not contact a device or change runtime paths. No unrelated poller/SQLite lifecycle change is included in this PR.

## Related issues

Refs #2064
