### PR TITLE
fix(workflow): align draft saves, releases, and version UI

### DIFF
--- a/src/evolverun/clawweb/public/app/clawweb/web/style.css
+++ b/src/evolverun/clawweb/public/app/clawweb/web/style.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@source "../../../modules/workflow/web";
 
 body {
   margin: 0;

--- a/src/evolverun/clawweb/public/modules/workflow/server/repositories/workflow-deploy-history-repository.ts
+++ b/src/evolverun/clawweb/public/modules/workflow/server/repositories/workflow-deploy-history-repository.ts
@@ -56,10 +56,11 @@ export class WorkflowDeployHistoryRepository {
     );
   }
 
-  async listHistory(workflowId: string, limit: number): Promise<Omit<WorkflowDeployHistoryRow, "spec_json">[]> {
+  async listHistory(workflowId: string, limit: number, options?: { releaseOnly?: boolean }): Promise<Omit<WorkflowDeployHistoryRow, "spec_json">[]> {
+    const releaseClause = options?.releaseOnly ? " AND action <> 'edit'" : "";
     return this.db.query<Omit<WorkflowDeployHistoryRow, "spec_json">>(
       `SELECT id, pack_id, workflow_id, deploy_number, version, tag_name, action, from_deploy_number, note, bot_id, owner_id, is_active, gmt_create, gmt_modified
-       FROM workflow_deploy_history WHERE workflow_id = ? ORDER BY deploy_number DESC LIMIT ?`,
+       FROM workflow_deploy_history WHERE workflow_id = ?${releaseClause} ORDER BY deploy_number DESC LIMIT ?`,
       [workflowId, limit],
     );
   }

--- a/src/evolverun/clawweb/public/modules/workflow/server/routes/__tests__/workflow-history.test.ts
+++ b/src/evolverun/clawweb/public/modules/workflow/server/routes/__tests__/workflow-history.test.ts
@@ -22,9 +22,10 @@ type HistoryRow = Omit<WorkflowDeployHistoryRow, "spec_json"> & { spec_json: str
 function makeFakeRepo(rows: HistoryRow[]) {
   return {
     async insert() { /* noop */ },
-    async listHistory(workflowId: string, limit: number) {
+    async listHistory(workflowId: string, limit: number, options?: { releaseOnly?: boolean }) {
       return rows
         .filter((r) => r.workflow_id === workflowId)
+        .filter((r) => !options?.releaseOnly || r.action !== "edit")
         .sort((a, b) => b.deploy_number - a.deploy_number)
         .slice(0, limit)
         .map((r) => {
@@ -175,6 +176,14 @@ describe("workflow version history (read-only)", () => {
       await startApp(null);
       const res = await fetch(`${baseUrl}/api/workflows/tech-research/history`);
       expect(res.status).toBe(503);
+    });
+
+    it("filters old edit records before applying the release-history limit", async () => {
+      const res = await fetch(`${baseUrl}/api/workflows/tech-research/history?limit=1&releaseOnly=true`);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.history).toHaveLength(1);
+      expect(body.history[0]).toMatchObject({ deployNumber: 3, action: "deploy" });
     });
   });
 

--- a/src/evolverun/clawweb/public/modules/workflow/server/routes/internal/__tests__/version-contract.test.ts
+++ b/src/evolverun/clawweb/public/modules/workflow/server/routes/internal/__tests__/version-contract.test.ts
@@ -79,4 +79,20 @@ describe("ClawMind workflow version wire contract", () => {
     const response = await fetch(`${baseUrl}/deploy-history/other/versions/2/snapshot`);
     expect(await response.json()).toEqual({ found: false });
   });
+
+  it("activates the rollback target when the caller sends isActive", async () => {
+    const response = await fetch(`${baseUrl}/deploy-history`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        packId: "pack", workflowId: "demo", deployNumber: 6, version: 1,
+        tagName: "deploy/demo/#1", action: "rollback", fromDeployNumber: 5,
+        specJson: '{"id":"demo","version":1}', isActive: true,
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(raw.prepare("SELECT version, is_active FROM workflow_deploy_history WHERE workflow_id = 'demo' ORDER BY deploy_number").all())
+      .toEqual([{ version: 2, is_active: 0 }, { version: 1, is_active: 1 }]);
+  });
 });

--- a/src/evolverun/clawweb/public/modules/workflow/server/routes/workflows.ts
+++ b/src/evolverun/clawweb/public/modules/workflow/server/routes/workflows.ts
@@ -443,7 +443,8 @@ export function createWorkflowsRouter(
     if (!await requireWorkflowAccess(req, res, botPermRepo, workflowId, "view")) return;
     const limit = Math.min(100, Math.max(1, parseInt(req.query.limit as string ?? "20", 10)));
     if (isNaN(limit)) { res.status(400).json({ error: "Bad Request" }); return; }
-    const rows = await wfdhRepo.listHistory(workflowId, limit);
+    const releaseOnly = String(req.query.releaseOnly ?? "") === "true";
+    const rows = await wfdhRepo.listHistory(workflowId, limit, { releaseOnly });
     const history = rows.map((r) => ({
       deployNumber: r.deploy_number,
       version: r.version,

--- a/src/evolverun/clawweb/public/modules/workflow/web/components/WorkflowHistoryPanel.tsx
+++ b/src/evolverun/clawweb/public/modules/workflow/web/components/WorkflowHistoryPanel.tsx
@@ -60,7 +60,9 @@ export default function WorkflowHistoryPanel({ workflowId, onClose }: WorkflowHi
     setError(null)
     api.workflows
       .getHistory(workflowId)
-      .then((r) => setHistory(r.history ?? []))
+      // `edit` rows are from the old browser-save flow. They have no Git tag and
+      // cannot run as a version, so do not present them as release history.
+      .then((r) => setHistory((r.history ?? []).filter((item) => item.action !== 'edit')))
       .catch((err) => setError(err instanceof Error ? err.message : '加载历史失败'))
       .finally(() => setLoading(false))
   }, [workflowId])
@@ -158,7 +160,7 @@ export default function WorkflowHistoryPanel({ workflowId, onClose }: WorkflowHi
       {loading ? (
         <div className="p-4 text-sm text-gray-500">加载中…</div>
       ) : history.length === 0 ? (
-        <div className="p-8 text-center text-sm text-gray-400">暂无部署记录</div>
+        <div className="p-8 text-center text-sm text-gray-400">暂无已发布版本</div>
       ) : (
         <div className="flex flex-1 overflow-hidden">
           {/* History list */}

--- a/src/evolverun/clawweb/public/modules/workflow/web/components/WorkflowHistoryPanel.tsx
+++ b/src/evolverun/clawweb/public/modules/workflow/web/components/WorkflowHistoryPanel.tsx
@@ -59,7 +59,7 @@ export default function WorkflowHistoryPanel({ workflowId, onClose }: WorkflowHi
     setLoading(true)
     setError(null)
     api.workflows
-      .getHistory(workflowId)
+      .getHistory(workflowId, 50, true)
       // `edit` rows are from the old browser-save flow. They have no Git tag and
       // cannot run as a version, so do not present them as release history.
       .then((r) => setHistory((r.history ?? []).filter((item) => item.action !== 'edit')))

--- a/src/evolverun/clawweb/public/modules/workflow/web/components/WorkflowVersionDiff.tsx
+++ b/src/evolverun/clawweb/public/modules/workflow/web/components/WorkflowVersionDiff.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import { parse as parseYaml, stringify as stringifyYaml } from 'yaml'
 import { api } from '@avernet/clawweb-shared/web/api/client'
 import type { VersionDiffResult } from '@avernet/clawweb-shared/web/types'
 
@@ -71,6 +72,33 @@ export function unifiedDiff(fromText: string, toText: string): DiffLine[] {
   return lines
 }
 
+/** Turn stored JSON (or the legacy { content: yaml } wrapper) into readable YAML.
+ * The history API deliberately returns the original snapshot; formatting it here
+ * keeps the raw snapshot lossless while making line-level diff useful. */
+export function formatSpecForDiff(specJson: string): string {
+  try {
+    const parsed = JSON.parse(specJson)
+    if (parsed && typeof parsed === 'object' && typeof parsed.content === 'string' && !Array.isArray(parsed.nodes)) {
+      return parsed.content
+    }
+    return stringifyYaml(parsed, { lineWidth: 0 })
+  } catch {
+    return specJson
+  }
+}
+
+function topLevelChanges(fromText: string, toText: string): string[] {
+  try {
+    const from = parseYaml(fromText) as Record<string, unknown>
+    const to = parseYaml(toText) as Record<string, unknown>
+    if (!from || !to || Array.isArray(from) || Array.isArray(to)) return []
+    return [...new Set([...Object.keys(from), ...Object.keys(to)])]
+      .filter((key) => JSON.stringify(from[key]) !== JSON.stringify(to[key]))
+  } catch {
+    return []
+  }
+}
+
 function formatTime(epochSec: number): string {
   if (!epochSec) return '-'
   return new Date(epochSec * 1000).toLocaleString()
@@ -118,9 +146,12 @@ export default function WorkflowVersionDiff({
     return null
   }
 
-  const diffLines = unifiedDiff(result.from.specJson ?? '', result.to.specJson ?? '')
+  const fromText = formatSpecForDiff(result.from.specJson ?? '')
+  const toText = formatSpecForDiff(result.to.specJson ?? '')
+  const diffLines = unifiedDiff(fromText, toText)
   const additions = diffLines.filter((l) => l.type === 'add').length
   const deletions = diffLines.filter((l) => l.type === 'del').length
+  const changedFields = topLevelChanges(fromText, toText)
 
   return (
     <div className="flex h-full flex-col">
@@ -144,6 +175,17 @@ export default function WorkflowVersionDiff({
           <span className="text-red-500">-{deletions}</span>
         </div>
       </div>
+
+      {changedFields.length > 0 && (
+        <div className="border-b border-blue-100 bg-blue-50 px-3 py-2 text-xs text-slate-600">
+          <span className="mr-2 font-medium text-slate-700">变更字段</span>
+          {changedFields.map((field) => (
+            <span key={field} className="mr-1 inline-block rounded bg-white px-1.5 py-0.5 font-mono text-[11px] text-blue-700">
+              {field}
+            </span>
+          ))}
+        </div>
+      )}
 
       {/* Unified diff body */}
       <div className="flex-1 overflow-auto bg-gray-900 font-mono text-xs leading-relaxed">

--- a/src/evolverun/clawweb/public/modules/workflow/web/components/__tests__/WorkflowVersionDiff.test.ts
+++ b/src/evolverun/clawweb/public/modules/workflow/web/components/__tests__/WorkflowVersionDiff.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { formatSpecForDiff, unifiedDiff } from '../WorkflowVersionDiff'
+
+describe('WorkflowVersionDiff', () => {
+  it('formats JSON snapshots as multiline YAML before calculating the diff', () => {
+    const from = formatSpecForDiff('{"id":"support","title":"旧标题","nodes":[]}')
+    const to = formatSpecForDiff('{"id":"support","title":"新标题","nodes":[]}')
+
+    expect(from).toContain('title: 旧标题')
+    expect(to).toContain('title: 新标题')
+    expect(unifiedDiff(from, to)).toEqual(expect.arrayContaining([
+      expect.objectContaining({ type: 'del', text: 'title: 旧标题' }),
+      expect.objectContaining({ type: 'add', text: 'title: 新标题' }),
+    ]))
+  })
+
+  it('keeps legacy YAML content snapshots readable', () => {
+    const yaml = 'id: support\ntitle: 支持\n'
+    expect(formatSpecForDiff(JSON.stringify({ content: yaml }))).toBe(yaml)
+  })
+})

--- a/src/evolverun/clawweb/public/modules/workflow/web/components/workflow-workspace/CreateWorkflowModal.tsx
+++ b/src/evolverun/clawweb/public/modules/workflow/web/components/workflow-workspace/CreateWorkflowModal.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
+import { parse as parseYaml } from 'yaml'
 import type { WorkflowSpec } from '@avernet/clawweb-shared/web/types'
 
 interface CreateWorkflowModalProps {
@@ -13,6 +14,7 @@ interface CreateWorkflowModalProps {
 }
 
 const COMMAND_PATTERN = /^[a-z0-9][a-z0-9_-]*[a-z0-9]$|^[a-z0-9]$/
+type CreateSource = 'blank' | 'paste' | 'file'
 
 function buildInitialSpec(workflowId: string, title: string): WorkflowSpec {
   return {
@@ -36,6 +38,8 @@ export default function CreateWorkflowModal({ open, onClose, onSubmit, isPending
   const [remark, setRemark] = useState('')
   const [commandError, setCommandError] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const [source, setSource] = useState<CreateSource>('blank')
+  const [yamlInput, setYamlInput] = useState('')
 
   useEffect(() => {
     if (open) {
@@ -45,6 +49,8 @@ export default function CreateWorkflowModal({ open, onClose, onSubmit, isPending
       setRemark('')
       setCommandError(null)
       setError(null)
+      setSource('blank')
+      setYamlInput('')
     }
   }, [open])
 
@@ -70,8 +76,9 @@ export default function CreateWorkflowModal({ open, onClose, onSubmit, isPending
   }, [command])
 
   const canSubmit = useMemo(() => {
+    if (source !== 'blank') return !!yamlInput.trim()
     return !!workflowId.trim() && !!title.trim() && !idError && !commandError
-  }, [workflowId, title, idError, commandError])
+  }, [source, yamlInput, workflowId, title, idError, commandError])
 
   const handleClose = useCallback(() => {
     if (isPending) return
@@ -80,19 +87,39 @@ export default function CreateWorkflowModal({ open, onClose, onSubmit, isPending
 
   const handleSubmit = useCallback(async () => {
     if (!canSubmit || isPending) return
-    const id = workflowId.trim()
-    const displayTitle = title.trim() || id
-    const cmd = command.trim()
-    const facade = cmd ? { command: cmd, remark: remark.trim() || undefined } : undefined
-    const spec = buildInitialSpec(id, displayTitle)
-
     try {
-      await onSubmit({ workflowId: id, spec: spec as WorkflowSpec, facade })
+      if (source !== 'blank') {
+        const parsed = parseYaml(yamlInput) as WorkflowSpec
+        if (!parsed?.id || !parsed?.title || !parsed?.version || !Array.isArray(parsed.nodes)) {
+          throw new Error('YAML 必须包含 id、version、title 和 nodes。')
+        }
+        const facade = parsed.facade?.command
+          ? { command: parsed.facade.command, remark: parsed.facade.remark }
+          : undefined
+        await onSubmit({ workflowId: parsed.id, spec: parsed, facade })
+      } else {
+        const id = workflowId.trim()
+        const displayTitle = title.trim() || id
+        const cmd = command.trim()
+        const facade = cmd ? { command: cmd, remark: remark.trim() || undefined } : undefined
+        await onSubmit({ workflowId: id, spec: buildInitialSpec(id, displayTitle), facade })
+      }
       onClose()
     } catch (err) {
       setError(err instanceof Error ? err.message : '创建工作流失败')
     }
-  }, [canSubmit, isPending, workflowId, title, command, remark, onSubmit, onClose])
+  }, [canSubmit, isPending, source, yamlInput, workflowId, title, command, remark, onSubmit, onClose])
+
+  const handleImportFile = useCallback((file?: File) => {
+    if (!file) return
+    const reader = new FileReader()
+    reader.onload = () => {
+      setYamlInput(String(reader.result ?? ''))
+      setSource('file')
+      setError(null)
+    }
+    reader.readAsText(file)
+  }, [])
 
   if (!open) return null
 
@@ -118,11 +145,29 @@ export default function CreateWorkflowModal({ open, onClose, onSubmit, isPending
             </button>
           </div>
           <p className="mt-1 text-sm text-gray-500">
-            创建一个空白工作流，之后在编辑器中继续设计节点。
+            选择创建方式；已有工作流只在画布或 YAML 中修改。
           </p>
         </div>
 
         <div className="space-y-4 px-6 py-5">
+          <div className="grid grid-cols-3 gap-2" role="group" aria-label="创建方式">
+            {([
+              ['blank', '空白工作流'],
+              ['paste', '粘贴 YAML'],
+              ['file', '导入 YAML'],
+            ] as const).map(([value, label]) => (
+              <button
+                key={value}
+                type="button"
+                onClick={() => { setSource(value); setError(null) }}
+                className={`rounded-lg border px-2 py-2 text-xs font-medium transition-colors ${source === value ? 'border-blue-500 bg-blue-50 text-blue-700' : 'border-slate-200 text-slate-600 hover:bg-slate-50'}`}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+
+          {source === 'blank' ? <>
           <div>
             <label className="mb-1.5 block text-sm font-medium text-gray-700">
               工作流 ID <span className="text-red-500">*</span>
@@ -195,6 +240,36 @@ export default function CreateWorkflowModal({ open, onClose, onSubmit, isPending
               className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm outline-none transition-colors focus:border-blue-500 focus:ring-2 focus:ring-blue-200 disabled:bg-gray-50"
             />
           </div>
+          </> : (
+            <div>
+              {source === 'paste' ? (
+                <>
+                  <label className="mb-1.5 block text-sm font-medium text-gray-700">Workflow YAML</label>
+                  <textarea
+                    value={yamlInput}
+                    onChange={(event) => setYamlInput(event.target.value)}
+                    rows={12}
+                    disabled={isPending}
+                    placeholder={'id: my-workflow\nversion: 1.0.0\ntitle: 我的工作流\nnodes: []'}
+                    className="w-full rounded-md border border-gray-300 px-3 py-2 font-mono text-xs leading-5 outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200 disabled:bg-gray-50"
+                  />
+                  <p className="mt-1 text-xs text-gray-400">YAML 中的 ID、名称和节点配置会原样创建为草稿。</p>
+                </>
+              ) : (
+                <>
+                  <label className="mb-1.5 block text-sm font-medium text-gray-700">选择 YAML 文件</label>
+                  <input
+                    type="file"
+                    accept=".yaml,.yml,text/yaml,application/x-yaml"
+                    disabled={isPending}
+                    onChange={(event) => handleImportFile(event.target.files?.[0])}
+                    className="block w-full rounded-md border border-dashed border-slate-300 px-3 py-3 text-sm text-slate-600 file:mr-3 file:rounded-md file:border-0 file:bg-blue-50 file:px-3 file:py-1.5 file:text-xs file:font-medium file:text-blue-700 hover:border-blue-300"
+                  />
+                  {yamlInput && <p className="mt-2 text-xs text-emerald-700">已读取 YAML，可创建工作流。</p>}
+                </>
+              )}
+            </div>
+          )}
 
           {error && (
             <div className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-700">{error}</div>
@@ -220,7 +295,7 @@ export default function CreateWorkflowModal({ open, onClose, onSubmit, isPending
                 创建中…
               </>
             ) : (
-              '创建'
+              source === 'blank' ? '创建' : '从 YAML 创建'
             )}
           </button>
         </div>

--- a/src/evolverun/clawweb/public/modules/workflow/web/pages/Editor.tsx
+++ b/src/evolverun/clawweb/public/modules/workflow/web/pages/Editor.tsx
@@ -297,7 +297,7 @@ export default function Editor({ embedded = false, initialWorkflowId }: EditorPr
           >
             部署
           </button>
-          <div className="relative">
+          {!embedded && <div className="relative">
             <button type="button" aria-label="更多操作" aria-expanded={showMore} onClick={() => setShowMore((open) => !open)} className="rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-600 hover:bg-slate-50">更多 ···</button>
             {showMore && <><button type="button" aria-label="关闭更多操作" className="fixed inset-0 z-40 cursor-default" onClick={() => setShowMore(false)} /><div role="menu" className="absolute right-0 top-full z-50 mt-2 w-44 overflow-hidden rounded-xl border border-slate-200 bg-white p-1.5 shadow-[0_16px_40px_rgba(15,23,42,0.16)]">
               <button role="menuitem" onClick={() => { setShowNewDialog(true); setShowMore(false) }} className="block w-full rounded-lg px-3 py-2 text-left text-xs text-slate-700 hover:bg-slate-50">新建工作流</button>
@@ -305,7 +305,7 @@ export default function Editor({ embedded = false, initialWorkflowId }: EditorPr
               <button role="menuitem" onClick={() => { handleImportFile(); setShowMore(false) }} className="block w-full rounded-lg px-3 py-2 text-left text-xs text-slate-700 hover:bg-slate-50">导入 YAML 文件</button>
               <button role="menuitem" onClick={() => { handleYamlExport(); setShowMore(false) }} disabled={!spec} className="block w-full rounded-lg px-3 py-2 text-left text-xs text-slate-700 hover:bg-slate-50 disabled:text-slate-300">导出 YAML</button>
             </div></>}
-          </div>
+          </div>}
           <button
             onClick={handleOpenSaveDialog}
             disabled={!spec}

--- a/src/evolverun/clawweb/public/modules/workflow/web/pages/Editor.tsx
+++ b/src/evolverun/clawweb/public/modules/workflow/web/pages/Editor.tsx
@@ -85,7 +85,7 @@ export default function Editor({ embedded = false, initialWorkflowId }: EditorPr
     }
     let cancelled = false
     api.workflows
-      .getHistory(selectedWorkflowId, 50)
+      .getHistory(selectedWorkflowId, 50, true)
       .then((r) => {
         if (!cancelled) setLatestDeploy(r.history?.find((item) => item.action !== 'edit') ?? null)
       })

--- a/src/evolverun/clawweb/public/modules/workflow/web/pages/Editor.tsx
+++ b/src/evolverun/clawweb/public/modules/workflow/web/pages/Editor.tsx
@@ -85,9 +85,9 @@ export default function Editor({ embedded = false, initialWorkflowId }: EditorPr
     }
     let cancelled = false
     api.workflows
-      .getHistory(selectedWorkflowId, 1)
+      .getHistory(selectedWorkflowId, 50)
       .then((r) => {
-        if (!cancelled) setLatestDeploy(r.history?.[0] ?? null)
+        if (!cancelled) setLatestDeploy(r.history?.find((item) => item.action !== 'edit') ?? null)
       })
       .catch(() => {
         if (!cancelled) setLatestDeploy(null)
@@ -138,6 +138,8 @@ export default function Editor({ embedded = false, initialWorkflowId }: EditorPr
         facade,
         originalWorkflowId: originalId,
         botOwnerId: user.userId,
+        // A browser edit is a DB draft. Git-backed save/deploy history is written by ClawMind.
+        skipDeployHistory: true,
       })
       if (id !== spec.id || title !== spec.title) {
         useEditorStore.getState().updateSpecField('id', id)

--- a/src/evolverun/clawweb/public/modules/workflow/web/pages/Editor.tsx
+++ b/src/evolverun/clawweb/public/modules/workflow/web/pages/Editor.tsx
@@ -40,6 +40,8 @@ export default function Editor({ embedded = false, initialWorkflowId }: EditorPr
   const [showMore, setShowMore] = useState(false)
   const [viewMode, setViewMode] = useState<ViewMode>('visual')
   const [showHistory, setShowHistory] = useState(false)
+  const [showDeployGuide, setShowDeployGuide] = useState(false)
+  const [deployCommandCopied, setDeployCommandCopied] = useState(false)
   const [latestDeploy, setLatestDeploy] = useState<DeployHistoryItem | null>(null)
 
   const { spec, isDirty, selectedNodeId, validationErrors, loadSpec, createNew, importYaml, selectNode, markClean } = useEditorStore()
@@ -212,6 +214,17 @@ export default function Editor({ embedded = false, initialWorkflowId }: EditorPr
     setSelectedWorkflowId(null)
   }, [newId, newTitle, createNew])
 
+  const handleCopyDeployCommand = useCallback(async () => {
+    if (!selectedWorkflowId) return
+    try {
+      await navigator.clipboard.writeText(`/workflow deploy ${selectedWorkflowId}`)
+      setDeployCommandCopied(true)
+      setTimeout(() => setDeployCommandCopied(false), 2000)
+    } catch {
+      setSaveMessage({ type: 'error', text: '复制发布命令失败，请手动复制。' })
+    }
+  }, [selectedWorkflowId])
+
   // Keyboard shortcut: Ctrl/Cmd+S saves the current workflow.
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -266,6 +279,22 @@ export default function Editor({ embedded = false, initialWorkflowId }: EditorPr
               YAML
             </button>
           </div>
+          <button
+            type="button"
+            onClick={() => setShowHistory(true)}
+            disabled={!selectedWorkflowId}
+            className="rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-600 hover:bg-slate-50 disabled:text-slate-300"
+          >
+            版本历史
+          </button>
+          <button
+            type="button"
+            onClick={() => setShowDeployGuide(true)}
+            disabled={!selectedWorkflowId}
+            className="rounded-lg border border-emerald-300 bg-emerald-50 px-3 py-1.5 text-xs font-medium text-emerald-700 hover:bg-emerald-100 disabled:text-slate-300"
+          >
+            部署
+          </button>
           <div className="relative">
             <button type="button" aria-label="更多操作" aria-expanded={showMore} onClick={() => setShowMore((open) => !open)} className="rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-600 hover:bg-slate-50">更多 ···</button>
             {showMore && <><button type="button" aria-label="关闭更多操作" className="fixed inset-0 z-40 cursor-default" onClick={() => setShowMore(false)} /><div role="menu" className="absolute right-0 top-full z-50 mt-2 w-44 overflow-hidden rounded-xl border border-slate-200 bg-white p-1.5 shadow-[0_16px_40px_rgba(15,23,42,0.16)]">
@@ -273,8 +302,6 @@ export default function Editor({ embedded = false, initialWorkflowId }: EditorPr
               <button role="menuitem" onClick={() => { setShowYamlImport(true); setYamlInput(''); setShowMore(false) }} className="block w-full rounded-lg px-3 py-2 text-left text-xs text-slate-700 hover:bg-slate-50">粘贴 YAML</button>
               <button role="menuitem" onClick={() => { handleImportFile(); setShowMore(false) }} className="block w-full rounded-lg px-3 py-2 text-left text-xs text-slate-700 hover:bg-slate-50">导入 YAML 文件</button>
               <button role="menuitem" onClick={() => { handleYamlExport(); setShowMore(false) }} disabled={!spec} className="block w-full rounded-lg px-3 py-2 text-left text-xs text-slate-700 hover:bg-slate-50 disabled:text-slate-300">导出 YAML</button>
-              <div className="my-1 border-t border-slate-100" />
-              <button role="menuitem" onClick={() => { setShowHistory(true); setShowMore(false) }} disabled={!selectedWorkflowId} className="block w-full rounded-lg px-3 py-2 text-left text-xs text-slate-700 hover:bg-slate-50 disabled:text-slate-300">版本历史</button>
             </div></>}
           </div>
           <button
@@ -525,6 +552,31 @@ export default function Editor({ embedded = false, initialWorkflowId }: EditorPr
               workflowId={selectedWorkflowId}
               onClose={() => setShowHistory(false)}
             />
+          </div>
+        </div>
+      )}
+
+      {/* Publishing owns a remote Git tag and read-only Pack, which are created by ClawMind rather than this browser. */}
+      {showDeployGuide && selectedWorkflowId && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 p-6">
+          <div className="w-full max-w-lg rounded-lg bg-white p-6 shadow-xl">
+            <h3 className="text-lg font-semibold text-gray-900">部署工作流</h3>
+            <p className="mt-2 text-sm leading-6 text-gray-600">
+              部署会把最近一次保存的快照打 Git tag，并准备对应的只读 Pack。该操作需要 ClawMind 的 Git 凭据，网页端不会只写数据库来伪造一次发布。
+            </p>
+            <div className="mt-4 rounded-md border border-slate-200 bg-slate-50 p-3">
+              <div className="text-xs text-slate-500">在对应 Bot 对话中执行</div>
+              <code className="mt-1 block select-all font-mono text-sm text-slate-800">/workflow deploy {selectedWorkflowId}</code>
+            </div>
+            <p className="mt-3 text-xs leading-5 text-slate-500">
+              如果尚未保存过快照，请先执行 <code>/workflow save {selectedWorkflowId}</code>。
+            </p>
+            <div className="mt-5 flex justify-end gap-2">
+              <button onClick={() => setShowDeployGuide(false)} className="rounded-md border border-gray-300 px-4 py-1.5 text-sm text-gray-700 hover:bg-gray-50">关闭</button>
+              <button onClick={() => void handleCopyDeployCommand()} className="rounded-md bg-emerald-600 px-4 py-1.5 text-sm font-medium text-white hover:bg-emerald-700">
+                {deployCommandCopied ? '已复制' : '复制部署命令'}
+              </button>
+            </div>
           </div>
         </div>
       )}

--- a/src/evolverun/clawweb/public/modules/workflow/web/pages/WorkflowWorkspace.tsx
+++ b/src/evolverun/clawweb/public/modules/workflow/web/pages/WorkflowWorkspace.tsx
@@ -127,12 +127,12 @@ export default function WorkflowWorkspace() {
                   type="button"
                   aria-label="新建工作流"
                   onClick={() => setCreateOpen(true)}
-                  className="inline-flex items-center gap-1 rounded-lg border border-slate-200 bg-white px-2 py-1 text-xs font-medium text-slate-600 shadow-sm transition hover:border-blue-200 hover:bg-blue-50 hover:text-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/30"
+                  className="inline-flex items-center gap-1.5 rounded-lg bg-blue-600 px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition hover:bg-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/30"
                 >
                   <svg aria-hidden="true" className="h-3.5 w-3.5" fill="none" stroke="currentColor" strokeWidth="1.8" viewBox="0 0 24 24">
                     <path d="M12 5v14M5 12h14" strokeLinecap="round" />
                   </svg>
-                  <span>新建</span>
+                  <span>新建工作流</span>
                 </button>
               </div>
               <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-slate-400">

--- a/src/evolverun/clawweb/public/shared/web/api/client.ts
+++ b/src/evolverun/clawweb/public/shared/web/api/client.ts
@@ -1422,6 +1422,8 @@ export const api = {
         originalWorkflowId?: string
         botOwnerId?: string
         botId?: string
+        /** Save the DB draft only; the caller owns any separately recorded release history. */
+        skipDeployHistory?: boolean
       },
     ): Promise<WorkflowSpec> {
       return fetchJson<WorkflowSpec>(`${BASE}/workflows/save`, {
@@ -1434,6 +1436,7 @@ export const api = {
           originalWorkflowId: options?.originalWorkflowId,
           botOwnerId: options?.botOwnerId,
           botId: options?.botId,
+          skipDeployHistory: options?.skipDeployHistory,
         }),
       })
     },

--- a/src/evolverun/clawweb/public/shared/web/api/client.ts
+++ b/src/evolverun/clawweb/public/shared/web/api/client.ts
@@ -1449,8 +1449,10 @@ export const api = {
     },
 
     /** GET /api/workflows/:wf/history — deploy history list (no spec_json). */
-    getHistory(workflowId: string, limit = 50): Promise<{ workflowId: string; history: DeployHistoryItem[] }> {
-      return fetchJson(`${BASE}/workflows/${encodeURIComponent(workflowId)}/history?limit=${limit}`)
+    getHistory(workflowId: string, limit = 50, releaseOnly = false): Promise<{ workflowId: string; history: DeployHistoryItem[] }> {
+      const query = new URLSearchParams({ limit: String(limit) })
+      if (releaseOnly) query.set('releaseOnly', 'true')
+      return fetchJson(`${BASE}/workflows/${encodeURIComponent(workflowId)}/history?${query.toString()}`)
     },
 
     getAccess(workflowId: string): Promise<{ workflowId: string; canView: boolean; canEdit: boolean }> {

--- a/src/evolverun/clawweb/public/shared/web/api/hooks.ts
+++ b/src/evolverun/clawweb/public/shared/web/api/hooks.ts
@@ -318,6 +318,7 @@ export function useCreateWorkflow() {
         facade,
         botOwnerId,
         botId,
+        skipDeployHistory: true,
       }),
     onSuccess: (_data, variables) => {
       void queryClient.invalidateQueries({ queryKey: ['workflow-types'] })

--- a/src/evolverun/clawweb/public/shared/web/api/hooks.ts
+++ b/src/evolverun/clawweb/public/shared/web/api/hooks.ts
@@ -282,7 +282,7 @@ export function useDbWorkflow(workflowId: string) {
 export function useSaveWorkflowToDb() {
   const queryClient = useQueryClient()
   return useMutation({
-    mutationFn: ({ workflowId, spec, packId, facade, originalWorkflowId, botOwnerId, botId }: {
+    mutationFn: ({ workflowId, spec, packId, facade, originalWorkflowId, botOwnerId, botId, skipDeployHistory }: {
       workflowId: string
       spec: WorkflowSpec
       packId?: string
@@ -290,8 +290,9 @@ export function useSaveWorkflowToDb() {
       originalWorkflowId?: string
       botOwnerId?: string
       botId?: string
+      skipDeployHistory?: boolean
     }) =>
-      api.workflows.save(workflowId, spec, { packId, facade, originalWorkflowId, botOwnerId, botId }),
+      api.workflows.save(workflowId, spec, { packId, facade, originalWorkflowId, botOwnerId, botId, skipDeployHistory }),
     onSuccess: (_data, variables) => {
       void queryClient.invalidateQueries({ queryKey: ['db-workflows'] })
       void queryClient.invalidateQueries({ queryKey: ['facade-bindings'] })


### PR DESCRIPTION
This fixes the workflow release path and makes the editor match the save/deploy model.

- Keep draft saves out of release history; old `edit` records are not shown as runnable versions.
- Activate the selected version on rollback and keep the active version update in the generic deploy-history write.
- Surface version history and a deploy entry in the editor; the entry uses the actual ClawMind command because tag creation and read-only Pack preparation require ClawMind Git credentials.
- Render history diffs as formatted YAML with changed-field summary.
- Simplify creation to one prominent header action with blank, pasted YAML, and imported YAML sources.
- Include Workflow module Tailwind sources in the ClawWeb app build.

Validation:
- `npm run build --workspace @avernet/clawweb-shared`
- `npm run build --workspace @avernet/workflow`
- `npm run build` in `public/app/clawweb`
- Workflow component and navigation tests: 12 passed.