### PR TITLE
feat(backend): expose Center skills to desktop bots

### DIFF
--- a/src/backend/docs/openapi-v1/README.md
+++ b/src/backend/docs/openapi-v1/README.md
@@ -1694,27 +1694,37 @@ bounds the response, not the device round trip, and a later page costs what the
 first one costs. That is proportionate only because listing is non-recursive; a
 `recursive=true` option would have to revisit it._
 
-### 🟪 totalfrank + lucas-xzp · P3 — skills, co-owned (six ratified operations) · `openapi_v1/skills/router.py`
+### 🟪 totalfrank + lucas-xzp · P3 — skills, co-owned · `openapi_v1/skills/router.py`
 
-The public surface is a Bot-owned `local://` Local Skill lifecycle. It is not a
-catalog, marketplace, Git/Center installation surface, or a general Skill Set
-API. The collection's optional `active` filter is the only Active-list
-mechanism. Every operation requires a verified principal, is owner/Bot scoped,
-and uses the standard `Envelope` / `Page` contract.
+For the Desktop shared-Center detail, content, parameters, Direct desired-state,
+and asynchronous Reference integration contract, see the
+[Chinese frontend guide](desktop-center-skills.zh-CN.md).
+
+Upload and delete are the Bot-owned `local://` lifecycle. Authorized Local,
+Repo, and Center assets share detail, content, parameters, and Direct desired
+state; catalog, marketplace, publication, asynchronous Center Reference, and
+general SkillSet operations retain their separate APIs. The collection's
+optional `active` filter is the Active-list mechanism. Every operation requires
+a verified principal, is owner/Bot scoped, and uses the standard `Envelope` /
+`Page` contract.
 
 | Method | Path | Purpose | Success |
 |---|---|---|---|
 | GET | `/openapi/v1/bots/{bot_id}/skills` | List exact Bot-owned Local Skill metadata (`bot_id`, optional owner locator, `active`, `keyword`, paged) | `Envelope[Page[Skill]]` |
 | POST | `/openapi/v1/bots/{bot_id}/skills` | Create or safely replace one raw `application/zip` Local Skill package | `201 Envelope[SkillUpload]` / `200` replacement |
+| POST | `/openapi/v1/bots/{bot_id}/skills/upload-folder` | Create or replace one browser-selected Local Skill directory | `201 Envelope[SkillUpload]` / `200` replacement |
 | GET | `/openapi/v1/bots/{bot_id}/skills/{skill_id}` | Read public metadata for one deployment-wide Skill ID | `Envelope[Skill]` |
+| GET | `/openapi/v1/bots/{bot_id}/skills/{skill_id}/content` | Read the authorized asset's expected content | `Envelope[SkillContent]` |
+| GET/PUT | `/openapi/v1/bots/{bot_id}/skills/{skill_id}/parameters` | Read or replace this Bot's name-keyed parameters | `Envelope[SkillParameters]` |
 | POST | `/openapi/v1/bots/{bot_id}/skills/{skill_id}/activate` | Set desired Active state and synchronously reconcile runtime | `Envelope[SkillState]` |
 | POST | `/openapi/v1/bots/{bot_id}/skills/{skill_id}/deactivate` | Set desired Inactive state and synchronously reconcile runtime | `Envelope[SkillState]` |
 | DELETE | `/openapi/v1/bots/{bot_id}/skills/{skill_id}` | Recoverably delete one Inactive Local Skill | `Envelope[Deleted]` |
+| GET | `/openapi/v1/bots/skills/{skill_id}/readme` | Read visible shared or Local documentation without selecting a Bot | `Envelope[SkillContent]` |
 
 `413101` is documented only on raw ZIP upload. The stable Local Skill business
 subcodes are `400101`, `404000`, `409101`–`409104`, `413101`, `502101`, and
 `502102`; existing public categories retain their `xxx000` codes. Generated
-OpenAPI is contract-tested to expose exactly these six operations.
+OpenAPI remains derived from the Backend Router and DTOs.
 
 **Release gate — do not mark Track B complete yet.** The cleanup-work table DDL
 from #725 must be applied and verified before application rollout, and the real

--- a/src/backend/docs/openapi-v1/README.zh-CN.md
+++ b/src/backend/docs/openapi-v1/README.zh-CN.md
@@ -963,24 +963,33 @@ _注：这里的 `Page` 是后端在整个目录列表上做的切片——engin
 与第一页开销相同。这只有在列表非递归时才成比例；若将来加 `recursive=true`，必须
 一并重新审视分页。_
 
-### 🟪 totalfrank + lucas-xzp · P3 —— skills，共担（六个已定案操作）· `openapi_v1/skills/router.py`
+### 🟪 totalfrank + lucas-xzp · P3 —— skills，共担 · `openapi_v1/skills/router.py`
 
-公共面是 Bot-owned `local://` Local Skill 生命周期，不是目录、市场、Git/Center 安装面或通用
-Skill Set API。collection 的可选 `active` filter 是唯一 Active-list 机制。所有操作均要求
-verified principal、按 owner/Bot 作用域处理，并使用标准 `Envelope` / `Page`。
+Desktop 对共享 Center Skill 的详情、内容、参数、Direct desired-state 与
+异步 Reference 接入约束见 [Desktop Center Skill 前端接入说明](desktop-center-skills.zh-CN.md)。
+
+上传与删除属于 Bot-owned `local://` 生命周期；经授权的 Local、Repo、Center
+资产共用详情、内容、参数与 Direct desired-state。目录、市场、发布、异步 Center
+Reference 和通用 SkillSet 操作仍使用各自独立 API。collection 的可选 `active`
+filter 是 Active-list 机制。所有操作均要求 verified principal、按 owner/Bot
+作用域处理，并使用标准 `Envelope` / `Page`。
 
 | 方法 | 路径 | 用途 | 成功响应 |
 |---|---|---|---|
 | GET | `/openapi/v1/bots/{bot_id}/skills` | 列出精确 Bot-owned Local Skill 元数据（`bot_id`、可选 owner locator、`active`、`keyword`、分页） | `Envelope[Page[Skill]]` |
 | POST | `/openapi/v1/bots/{bot_id}/skills` | 创建或安全替换一个原始 `application/zip` Local Skill 包 | `201 Envelope[SkillUpload]` / 替换时 `200` |
+| POST | `/openapi/v1/bots/{bot_id}/skills/upload-folder` | 创建或替换浏览器选择的 Local Skill 目录 | `201 Envelope[SkillUpload]` / 替换时 `200` |
 | GET | `/openapi/v1/bots/{bot_id}/skills/{skill_id}` | 读取一个部署范围 Skill ID 的公开元数据 | `Envelope[Skill]` |
+| GET | `/openapi/v1/bots/{bot_id}/skills/{skill_id}/content` | 读取已授权资产的当前期望内容 | `Envelope[SkillContent]` |
+| GET/PUT | `/openapi/v1/bots/{bot_id}/skills/{skill_id}/parameters` | 读取或替换该 Bot 上按 name 存储的参数 | `Envelope[SkillParameters]` |
 | POST | `/openapi/v1/bots/{bot_id}/skills/{skill_id}/activate` | 设为 Active desired state 并同步 runtime | `Envelope[SkillState]` |
 | POST | `/openapi/v1/bots/{bot_id}/skills/{skill_id}/deactivate` | 设为 Inactive desired state 并同步 runtime | `Envelope[SkillState]` |
 | DELETE | `/openapi/v1/bots/{bot_id}/skills/{skill_id}` | 可恢复地删除一个 Inactive Local Skill | `Envelope[Deleted]` |
+| GET | `/openapi/v1/bots/skills/{skill_id}/readme` | 不选择 Bot，读取可见的共享或 Local 文档 | `Envelope[SkillContent]` |
 
 `413101` 只在原始 ZIP upload 上公开。稳定 Local Skill subcode 为 `400101`、`404000`、
 `409101`–`409104`、`413101`、`502101`、`502102`；既有公共类别保持原有 `xxx000` code。
-Generated OpenAPI 已由合同测试锁定为恰好这六个操作。
+Generated OpenAPI 继续由 Backend Router 与 DTO 派生。
 
 **发布闸口：现在不得标记 Track B complete。** #725 的 cleanup-work DDL 必须先部署并验证，
 真实 owner/collaborator 预发验收仍需要已授权凭据与 Bot container。见英文

--- a/src/backend/docs/openapi-v1/desktop-center-skills.zh-CN.md
+++ b/src/backend/docs/openapi-v1/desktop-center-skills.zh-CN.md
@@ -1,0 +1,70 @@
+# Desktop Center Skill 前端接入说明
+
+本说明覆盖 OpenClaw/Hermes Desktop 复用既有 Skill 产品 API 的 G1
+边界。所有 Bot-scoped 请求都携带 `user_id`；操作共享 Bot 时同时传
+`owner_id`。外层 HTTP 200 只表示本次 API 成功，不能替代响应信封、
+Reference 状态或 Runtime 状态的判断。
+
+## 读取与参数
+
+前端从市场、Space 或 Bot Skill 列表取得内部十进制 `skill_id` 后，使用：
+
+| 目的 | 方法与路径 |
+| --- | --- |
+| Bot-facing 详情 | `GET /openapi/v1/bots/{bot_id}/skills/{skill_id}` |
+| Published 内容 | `GET /openapi/v1/bots/{bot_id}/skills/{skill_id}/content` |
+| Bot 参数 | `GET /openapi/v1/bots/{bot_id}/skills/{skill_id}/parameters` |
+| 整体替换该 Skill 参数 | `PUT /openapi/v1/bots/{bot_id}/skills/{skill_id}/parameters` |
+| 无 Bot 的共享 README | `GET /openapi/v1/bots/skills/{skill_id}/readme` |
+
+Center content/README 返回数据库最新 `PUBLISHED` Version 对应的精确
+Canonical 内容。读取不会访问 Desktop Engine、不会触发下载，因此设备离线也不应
+使其失败；它表示当前期望内容，不表示设备正在运行的实际版本。共享 README 没有
+Bot 语义，但仍校验 PUBLIC 或当前用户的 Space membership。
+
+参数 body 保持既有结构：`{"parameters": {"name": value}}`。PUT 替换的是
+当前 Skill 名称对应的对象，不得先 GET 全文件再由前端回写；Backend 会保留其它
+Skill 和文件根元信息。参数读写仍落到 Bot Engine 的历史
+`skill_parameters.json`，不是 Center Version 内容，也不是 observed-runtime 接口。
+
+## Direct desired state
+
+- `POST /openapi/v1/bots/{bot_id}/skills/{skill_id}/activate`
+- `POST /openapi/v1/bots/{bot_id}/skills/{skill_id}/deactivate`
+
+对当前 Bot 可见的 Center Skill 可以在尚无 Installation 时直接 activate。成功响应
+里的 `desired_state` 与 `runtime_projection` 必须分别展示；`PENDING` 或
+`DEGRADED` 不能渲染成“设备已生效”。权限顺序是 Bot owner/member 或 App grant，
+再校验 PUBLIC/Space 可见性。共享资产只形成 Bot-facing 视图，不会改写其持久 owner。
+
+## 已有内部 Skill 与外部 SC code 不是同一个入口
+
+已有内部 `skill_id` 加入 Set：
+
+```text
+PUT /openapi/v1/bots/{bot_id}/skill-sets/{set_id}/skills/{skill_id}
+```
+
+用户从 Skill Center 市场只拿到外部 `skill_code` 时，走持久异步 Reference：
+
+```text
+POST /openapi/v1/bots/{bot_id}/skill-sets/{set_id}/skill-center-references
+Idempotency-Key: <stable command key>
+
+{"skill_codes": ["external-code"]}
+```
+
+POST 返回 202 后，使用 collection 或 `/{reference_id}` GET 轮询。每项进入
+`COMPLETED` 只表示精确版本已物化并成功加入目标 Set；Runtime 投影结果应从相应
+desired-state/runtime 入口判断，不能把 COMPLETED 单独显示为“已在设备生效”。
+
+当前没有 Reference retry API、Desktop 下载/下载进度 API，也没有 Draft 整包替换
+API；前端不得虚构按钮或轮询地址。Space Draft、Grant、Lease、Publication、retry、
+offline、copy 继续使用各自现有产品入口，G1 不新增 Desktop 专用版本业务。
+
+## 错误与隔离
+
+不存在、跨 owner/Bot、无 App grant、无 Space membership、Offline 或矛盾的
+Center 归属均按 not-found 处理，前端不能据此推断其它租户或 Space 的资产存在。
+参数文件明确不存在时 GET 返回空对象；拒绝、损坏、读取异常或写入失败是错误，
+不能展示为“已清空”或“保存成功”。

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/skills/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/skills/router.py
@@ -1,8 +1,9 @@
-"""Public lifecycle routes for Bot-owned Local Skills.
+"""Public Bot-facing Skill routes.
 
-This router deliberately exposes only the six ratified Local Skill operations.
-Git, Center, marketplace, and install semantics remain on their separate,
-non-public surfaces.
+Upload and delete remain Local-only lifecycle operations. Shared Repo and
+Center assets reuse the read, parameter, and Direct desired-state operations;
+their catalogue, publication, and asynchronous reference semantics remain on
+their existing market, Space, and SkillSet surfaces.
 """
 
 from __future__ import annotations
@@ -178,7 +179,7 @@ async def get_skill_readme(
         SkillQueryServiceProtocol
     ),
 ) -> Envelope[SkillContent]:
-    """Read a Local or public-market Skill by its stable Skill ID."""
+    """Read a visible shared or Local Skill without selecting a Bot."""
     content = await query_service.get_readme_by_skill(
         skill_id=skill_id,
         actor_id=caller_owner_id(principal),
@@ -352,7 +353,7 @@ async def get_skill(
         SkillQueryServiceProtocol
     ),
 ) -> Envelope[Skill]:
-    """Get public metadata for one Local Skill; the Skill ID selects its Bot."""
+    """Get Bot-facing metadata for one Local, Repo, or Center Skill."""
     record = query_service.get_skill(
         skill_id=skill_id,
         bot_id=bot_id,

--- a/src/backend/src/agentclaw/community/core/bot_inventory/policies/combo_policy.py
+++ b/src/backend/src/agentclaw/community/core/bot_inventory/policies/combo_policy.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from agentclaw.community.core.bot_inventory.types import DeployMode
 from agentclaw.community.core.workspace.constants import SUPPORTED_ENGINE_TYPES
 
-LOCAL_CAPABLE_ENGINES = frozenset({"openclaw", "claude_code"})
+LOCAL_CAPABLE_ENGINES = frozenset({"openclaw", "claude_code", "hermes"})
 PERSONAL_CLOUD_CAPABLE_ENGINES = frozenset(SUPPORTED_ENGINE_TYPES)
 SERVICE_CAPABLE_ENGINES = frozenset({"openclaw", "claude_code", "teclaw"})
 APPLICATION_CODING_ENGINES = frozenset({"claude_code"})

--- a/src/backend/src/agentclaw/community/core/devices/services/baas_device_filesystem.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/baas_device_filesystem.py
@@ -90,7 +90,11 @@ class BaasDeviceFileSystem(DeviceFileSystem):
         self._bot_uuid: str = conn_info.get("paas_device_id", "")
 
     async def read_file(
-        self, file_path: str, *, enforce_download_limit: bool = False
+        self,
+        file_path: str,
+        *,
+        enforce_download_limit: bool = False,
+        preserve_read_errors: bool = False,
     ) -> bytes | None:
         # ``enforce_download_limit`` is for whole-file-into-memory impls (Arca); the
         # transport here streams, so it is ignored.

--- a/src/backend/src/agentclaw/community/core/devices/services/device_filesystem.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/device_filesystem.py
@@ -28,7 +28,11 @@ class DeviceFileSystem(Protocol):
     """Read / write / delete files on a device filesystem."""
 
     async def read_file(
-        self, file_path: str, *, enforce_download_limit: bool = False
+        self,
+        file_path: str,
+        *,
+        enforce_download_limit: bool = False,
+        preserve_read_errors: bool = False,
     ) -> bytes | None:
         """Read file content.
 
@@ -38,6 +42,9 @@ class DeviceFileSystem(Protocol):
                 memory (Arca) checks the size **before** reading and raises
                 :class:`FileTooLargeError` if it exceeds the impl's cap. Other impls
                 ignore the flag.
+            preserve_read_errors: When True, distinguish transport/permission
+                failures from a missing file. Read-modify-write flows use this
+                to prevent an unreadable file from being treated as empty.
 
         Returns:
             File content as bytes, or None if file does not exist.

--- a/src/backend/src/agentclaw/community/core/devices/services/local_device_filesystem.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/local_device_filesystem.py
@@ -97,14 +97,21 @@ class LocalDeviceFileSystem(DeviceFileSystem):
     # ── Public API: dispatches to _baas_* or _pathlib_* per ctor mode ──
 
     async def read_file(
-        self, file_path: str, *, enforce_download_limit: bool = False
+        self,
+        file_path: str,
+        *,
+        enforce_download_limit: bool = False,
+        preserve_read_errors: bool = False,
     ) -> bytes | None:
         # ``enforce_download_limit`` is for whole-file-into-memory impls (Arca); both
         # local modes here ignore it.
         file_path = self._path_mapper(file_path)
         if self._is_baas_mode:
             return await self._baas_read_file(file_path)
-        return await self._pathlib_read_file(file_path)
+        return await self._pathlib_read_file(
+            file_path,
+            preserve_read_errors=preserve_read_errors,
+        )
 
     async def write_file(self, file_path: str, content: bytes) -> None:
         file_path = self._path_mapper(file_path)
@@ -134,7 +141,12 @@ class LocalDeviceFileSystem(DeviceFileSystem):
 
     # ── Pathlib fallback (unchanged historical impl) ──────────────────
 
-    async def _pathlib_read_file(self, file_path: str) -> bytes | None:
+    async def _pathlib_read_file(
+        self,
+        file_path: str,
+        *,
+        preserve_read_errors: bool = False,
+    ) -> bytes | None:
         p = Path(file_path)
         logger.info("[LocalDeviceFileSystem.pathlib.read_file] %s (exists=%s, is_file=%s)", file_path, p.exists(), p.is_file())
         if not p.is_file():
@@ -145,6 +157,8 @@ class LocalDeviceFileSystem(DeviceFileSystem):
             return data
         except OSError as e:
             logger.warning("[LocalDeviceFileSystem.pathlib.read_file] %s: %s", file_path, e)
+            if preserve_read_errors:
+                raise
             return None
 
     async def _pathlib_write_file(self, file_path: str, content: bytes) -> None:

--- a/src/backend/src/agentclaw/community/core/devices/services/teclaw_device_filesystem.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/teclaw_device_filesystem.py
@@ -160,7 +160,11 @@ class TeclawDeviceFileSystem(DeviceFileSystem):
         )
 
     async def read_file(
-        self, file_path: str, *, enforce_download_limit: bool = False
+        self,
+        file_path: str,
+        *,
+        enforce_download_limit: bool = False,
+        preserve_read_errors: bool = False,
     ) -> bytes | None:
         # ``enforce_download_limit`` only applies to whole-file-into-memory impls
         # (Arca); the engine read here streams, so it is ignored.
@@ -187,9 +191,13 @@ class TeclawDeviceFileSystem(DeviceFileSystem):
                     "[TeclawDeviceFileSystem.read_file] HTTP %d: %s",
                     e.response.status_code, file_path,
                 )
+                if preserve_read_errors:
+                    raise
             return None
         except Exception as e:
             logger.error("[TeclawDeviceFileSystem.read_file] error: %s", e)
+            if preserve_read_errors:
+                raise
             return None
 
     async def list_dir(

--- a/src/backend/src/agentclaw/community/core/repository/README.md
+++ b/src/backend/src/agentclaw/community/core/repository/README.md
@@ -157,6 +157,7 @@ provides:
   - BotPublishRepositoryProtocol
   - PublishOperationRepository    # an ABC, not a Protocol — same role, same surface
   # skill_center
+  - CenterSkillAccessRepositoryProtocol
   - SkillCategoryRepository
   - SkillCenterSyncLogRepository
   - SkillMemberRepository

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill_version.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill_version.py
@@ -11,11 +11,15 @@ from agentclaw.community.core.models.skill import (
     SkillSetSkill,
 )
 from agentclaw.community.core.models.space_skill import SkillSpaceBinding, SkillVersion
+from agentclaw.community.core.repository.protocols.center_skill_access import (
+    CenterSkillAccessRepositoryProtocol,
+)
 from agentclaw.community.core.repository.protocols.skill_center import (
     SkillVersionMaterializationRepositoryProtocol,
     SkillVersionRepositoryProtocol,
 )
 from agentclaw.community.core.repository.protocols.skill_center_types import (
+    CenterSkillAccessRecord,
     SkillVersionRecord,
 )
 from agentclaw.community.core.repository.implementations.skill_center.skill_version_lock import (
@@ -26,9 +30,11 @@ from agentclaw.community.core.skill_center.materialization_contract import (
     PublishedMaterializedSkillVersion,
 )
 from agentclaw.community.plugin_api.database import DatabasePlugin
+from agentclaw.community.utils.avernet_tenant import get_current_avernet_tenant
 
 
 class SkillVersionRepository(
+    CenterSkillAccessRepositoryProtocol,
     SkillVersionRepositoryProtocol,
     SkillVersionMaterializationRepositoryProtocol,
 ):
@@ -37,6 +43,59 @@ class SkillVersionRepository(
     @inject
     def __init__(self, db: DatabasePlugin) -> None:
         self._db = db
+
+    def get_access(self, *, env: str, skill_id: int) -> CenterSkillAccessRecord | None:
+        """Return Center ownership facts without granting actor access.
+
+        Public imports are unbound ``is_public`` rows.  Space-managed Skills
+        are bound to exactly one Space and are never inferred public merely
+        because their Canonical content exists.
+        """
+        tenant = get_current_avernet_tenant()
+        with self._db.orm_session() as session:
+            result = (
+                session.query(Skill, SkillSpaceBinding)
+                .outerjoin(
+                    SkillSpaceBinding,
+                    (SkillSpaceBinding.skill_id == Skill.id)
+                    & (SkillSpaceBinding.env == env)
+                    & (SkillSpaceBinding.avernet_tenant == tenant),
+                )
+                .filter(
+                    Skill.id == skill_id,
+                    Skill.env == env,
+                    Skill.avernet_tenant == tenant,
+                )
+                .one_or_none()
+            )
+            if result is None:
+                return None
+            skill, binding = result
+            source = str(skill.git_path or "")
+            skill_uuid = str(skill.skill_uuid or "")
+            if (
+                not source.startswith("center://")
+                or not source[len("center://") :]
+                or not skill_uuid
+            ):
+                return None
+            if binding is None:
+                if not bool(skill.is_public):
+                    return None
+                visibility = "PUBLIC"
+                space_id = None
+            else:
+                if bool(skill.is_public):
+                    return None
+                visibility = "SPACE"
+                space_id = int(binding.space_id)
+            return CenterSkillAccessRecord(
+                skill_id=int(skill.id),
+                skill_uuid=skill_uuid,
+                visibility=visibility,
+                space_id=space_id,
+                offline_at=skill.offline_at,
+            )
 
     def list_latest_published(
         self, *, env: str, skill_ids: tuple[int, ...]

--- a/src/backend/src/agentclaw/community/core/repository/protocols/center_skill_access.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/center_skill_access.py
@@ -1,0 +1,18 @@
+"""Persistence facts needed to authorize one governed Center Skill."""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import Protocol, runtime_checkable
+
+from .skill_center_types import CenterSkillAccessRecord
+
+
+@runtime_checkable
+class CenterSkillAccessRepositoryProtocol(Protocol):
+    """Read ownership facts without deciding actor access or Version choice."""
+
+    @abstractmethod
+    def get_access(
+        self, *, env: str, skill_id: int
+    ) -> CenterSkillAccessRecord | None: ...

--- a/src/backend/src/agentclaw/community/core/repository/protocols/skill_center_types.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/skill_center_types.py
@@ -32,6 +32,16 @@ class SpaceRecord(TypedDict):
     env: str
 
 
+class CenterSkillAccessRecord(TypedDict):
+    """Persisted facts used to adjudicate a shared Center Skill read."""
+
+    skill_id: int
+    skill_uuid: str
+    visibility: Literal["PUBLIC", "SPACE"]
+    space_id: int | None
+    offline_at: datetime | None
+
+
 class SpaceSkillCreateData(TypedDict):
     name: str
     env: str

--- a/src/backend/src/agentclaw/community/core/skill_center/AGENTS.md
+++ b/src/backend/src/agentclaw/community/core/skill_center/AGENTS.md
@@ -91,7 +91,7 @@ Bot 定位必须携带 `owner_id + bot_id`，并保持 Repository 的 tenant/env
 - `center://<skill_code>`：SC 外部定位。`skill_code` 可为普通字符串，不要求 UUID，也不等于运行时名称。
 - `ac_skill.skill_uuid`：TeamClaw 内部稳定身份。Space 自建 Skill 发布时使用该 UUID 作为 SC code；Public 导入由 `public_center_identity.py` 基于 tenant/env/code 确定性派生内部 UUID。复用资产按来源身份，不能按名称复用 Local/Repo。
 - `ac_skill.name`：运行时名称，允许与 SC code 不同。Canonical 内容按内部 UUID + 精确 `sc_version_number` 寻址，不使用 name、latest/current 目录。
-- `SkillAssetKind.SPACE` 是当前 Center 消费分类；Space 管理权限仍需真实 Space Binding/Grant，不能从该分类推出“属于团队空间”。
+- `SkillAssetKind.CENTER` 是 Center 消费分类；Space 管理权限仍需真实 Space Binding/Grant，不能从该分类推出“属于团队空间”。
 
 ## 5. Space Draft、授权与发布
 
@@ -219,11 +219,12 @@ Engine 拥有物理布局。Backend 通过 `community/core/skills_pool/` 的版�
 
 Legacy `/api/skills`、`/api/skillsets` 位于 `community/adapters/http/skill_center/`，继续复用 Query、DirectActivation、SkillSetManagement。Legacy scope/reference resolution 与 Factory 负责旧参数、Default/exclusion、设备路径适配；保留其 wire compatibility，不恢复第二条 Installation 写路径。
 
-## 10. 当前缺口：不得写成已交付能力
+## 10. 当前边界：不得扩大成未交付能力
 
-- `SkillQueryService._kind_for` 将 Center 分类为 SPACE，但 `_adapters` 中 SPACE 仍注册 `_UnavailableAssetAdapter`。这不影响 Reader 的精确 Version 解析，却意味着通用 Bot 内容解析不能仅凭路由存在就认定支持 Center；Space Version 文件读取是另一条已实现链路。
-- `get_readme_by_skill` 当前支持 Repo 和 Local，Center 返回 not-found；Local 分支仍调用 `get_unique_by_id(bot_id)`，与 owner+bot 的目标约束不一致，shared default 需专项修复。文档更新不改变该行为。
-- Legacy Factory/fallback、配置迁移 gate、TaskQueue 提交窗口仍存在。以上规则描述如何维护当前实现，不表示历史数据全量迁移、运行时全引擎验收或发布消费端都已经验证。
+- `SkillQueryService` 已支持 Bot-facing Center 详情、内容、参数前置解析与 Direct 操作，并支持无 Bot 的共享 README。Center 内容只读最新 PUBLISHED 数据库 Version 对应的 Canonical 精确版本；读取不调用 Engine、不下载，也不证明 Runtime 已应用该版本。
+- Center 的 PUBLIC/Space/offline 事实由 `CenterSkillAccessRepositoryProtocol` 提供；Bot owner/member 与 Space member 分别校验。返回值可投影为当前 Bot 的只读视图，但不得修改共享 `ac_skill.user_id/bolt_id`。PRIVATE 且没有唯一 Space binding、PUBLIC 同时绑定 Space 等矛盾状态必须 fail closed。
+- 参数仍保存在 Bot Engine 的历史 name-keyed `skill_parameters.json`；它不是新数据库、原生注入或 observed-runtime 接口。只有明确缺失才能初始化为空，读取拒绝、损坏或异常必须零写；替换一个 Skill 时保留其它 Skill 与根元信息。
+- Local shared README 从 Skill 行的 `owner_id + bot_id` 精确定位，不使用全局唯一 bot_id 假设。Legacy Factory/fallback、配置迁移 gate、TaskQueue 提交窗口仍存在；上述实现不表示历史数据全量迁移、运行时全引擎验收或发布消费端都已经验证。
 
 ## 11. 修改后的验证与文档维护
 

--- a/src/backend/src/agentclaw/community/core/skill_center/README.md
+++ b/src/backend/src/agentclaw/community/core/skill_center/README.md
@@ -114,6 +114,7 @@ consumes:
   - "SpaceSkillDraftRepository"
   - "SpaceSkillReadRepository"
   - "SkillVersionRepositoryProtocol"
+  - "CenterSkillAccessRepositoryProtocol"
   - "SkillVersionMaterializationRepositoryProtocol"
   - "SpaceSkillPublicationRepositoryProtocol"
   - "HttpClient"
@@ -122,6 +123,7 @@ internal_dependencies:
   - agentclaw.community.core.bot_config_surface    # BotConfigCoords, the shared config-category address type
   - agentclaw.community.core.repository.protocols.bot    # repository contracts consumed by this module
   - agentclaw.community.core.repository.protocols.skill_center    # repository contracts consumed by this module
+  - agentclaw.community.core.repository.protocols.center_skill_access
   - agentclaw.community.core.repository.protocols.space_skill_version # published Space Skill read contract consumed by this module
   - agentclaw.community.core.repository.protocols.skill_center_types # query projection types consumed by this module
   - agentclaw.community.core.repository.protocols.space_skill_publication # Publication aggregate persistence contract
@@ -233,6 +235,18 @@ owned by their existing services and are not changed by this trust boundary.
 Publication and SC Reference producers consume the public
 Materializer Service API; Runtime reads consume only PUBLISHED Versions through
 `SkillVersionResolver`.
+
+Bot-facing Center reads consume `CenterSkillAccessRepositoryProtocol` only for
+tenant/env-scoped asset facts: PUBLIC or one bound Space, stable Skill UUID,
+and offline state. `SkillQueryService` separately proves Bot access and live
+Space membership, delegates latest-PUBLISHED selection to the formal
+`SkillVersionResolverProtocol`, and reads the exact
+`skill_uuid + sc_version_number` from `CanonicalCenterVersionStore`.
+Only the returned view is enriched with the addressed Bot and owner; the shared
+`ac_skill` row is never rebound. Content and shared README reads do not call
+Engine or download from Skill Center. Bot parameters retain their historical
+name-keyed Engine file and describe desired configuration, not observed
+runtime.
 
 `SpaceSkillPublicationService` freezes the current immutable Draft Revision and
 persists its `frozen_draft_locator` on the durable Attempt before enqueueing;

--- a/src/backend/src/agentclaw/community/core/skill_center/services/direct_activation_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/direct_activation_service.py
@@ -20,7 +20,6 @@ from agentclaw.community.core.repository.protocols.bot import (
 from agentclaw.community.core.repository.protocols.capability_desired_state import (
     CapabilityDesiredStateRepositoryProtocol,
 )
-from agentclaw.community.core.repository.protocols.skill_center import SkillRepository
 from agentclaw.community.core.skill_center.authorization_hook import (
     BotCapabilityAuthorizationHookProtocol,
 )
@@ -54,6 +53,9 @@ from agentclaw.community.core.skill_center.services._mutation_flow import (
 )
 from agentclaw.community.plugin_api.mcp_center import MCPCenterPlugin
 from agentclaw.community.core.skill_center.direct_activation_service_protocol import DirectActivationServiceProtocol
+from agentclaw.community.core.skill_center.skill_query_service_protocol import (
+    SkillQueryServiceProtocol,
+)
 
 
 class DirectActivationService(DirectActivationServiceProtocol):
@@ -70,7 +72,7 @@ class DirectActivationService(DirectActivationServiceProtocol):
         self,
         repository: CapabilityDesiredStateRepositoryProtocol,
         bot_repo: BotRepository,
-        skill_repo: SkillRepository,
+        skill_query: SkillQueryServiceProtocol,
         runtime: BotRuntimeProjectorProtocol,
         authorization: BotCapabilityAuthorizationHookProtocol,
         audit_log_repo: BotCollabLogRepositoryProtocol,
@@ -80,7 +82,7 @@ class DirectActivationService(DirectActivationServiceProtocol):
     ) -> None:
         self._repository = repository
         self._bot_repo = bot_repo
-        self._skill_repo = skill_repo
+        self._skill_query = skill_query
         self._authorization = authorization
         self._audit_log_repo = audit_log_repo
         self._mcp_center = mcp_center
@@ -167,37 +169,16 @@ class DirectActivationService(DirectActivationServiceProtocol):
     ) -> tuple[dict[str, Any], dict[str, Any]]:
         """Resolve the asset and authorize the actor against the Bot.
 
-        A Local row carries its own Bot/owner, so the addressed pair must be
-        exactly it; shared governed Repo rows are system-owned and take the
-        addressed pair. Authorization failure masks as not-found — the Local
-        wire's published behavior.
+        The query module owns Local, Repo and Center addressing and asset
+        visibility. Reusing it here prevents Direct writes from growing a
+        second source classifier or treating an Installation as permission.
         """
-        if not skill_id.isdecimal():
-            raise LocalSkillNotFoundError()
-        raw = self._skill_repo.get_by_id(skill_id)
-        if raw is None:
-            raise LocalSkillNotFoundError()
-        git_path = str(raw.get("git_path") or "")
-        if git_path.startswith("local://"):
-            if (
-                str(raw.get("user_id") or "") != owner_id
-                or str(raw.get("bolt_id") or "") != bot_id
-                or not raw.get("user_id")
-            ):
-                raise LocalSkillNotFoundError()
-            skill = self._skill_repo.get_bot_local_skill(
-                skill_id=skill_id, bot_id=bot_id, user_id=owner_id
-            )
-            if skill is None:
-                raise LocalSkillNotFoundError()
-        elif git_path.startswith("git://"):
-            # The old scanner persisted ``bolt_id=default`` on some rows; it
-            # is a storage sentinel, never ownership.
-            if raw.get("user_id"):
-                raise LocalSkillNotFoundError()
-            skill = {**raw, "bolt_id": bot_id, "user_id": owner_id}
-        else:
-            raise LocalSkillNotFoundError()
+        skill = self._skill_query.resolve_skill(
+            skill_id=skill_id,
+            bot_id=bot_id,
+            owner_id=owner_id,
+            user_id=actor_id,
+        )
         bot = self._bot_repo.get_by_id_and_owner(bot_id, owner_id)
         if bot is None:
             raise LocalSkillNotFoundError()

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_parameter_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_parameter_service.py
@@ -4,24 +4,30 @@
 存储位置：SKILL_PARAMETERS_FILE_PATH（容器内固定路径）
 通过 DeviceFileSystem 读写，自动适配 local/arca
 """
+
 import json
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 
 from agentclaw.community.log import get_logger
+from agentclaw.community.core.skill_center.errors import LocalSkillStorageError
 
 
 logger = get_logger()
 
 # 容器内的参数文件路径 (用于 Arca 模式)
-SKILL_PARAMETERS_FILE_PATH = "/home/admin/.openclaw/workspace/skills/skill_parameters.json"
+SKILL_PARAMETERS_FILE_PATH = (
+    "/home/admin/.openclaw/workspace/skills/skill_parameters.json"
+)
 DEFAULT_PARAMETERS_PATH = SKILL_PARAMETERS_FILE_PATH
 
 
 class SkillParameterService:
     """技能参数管理服务 - 通过 DeviceFileSystem 读写文件"""
 
-    def __init__(self, device_fs, file_path: str | None = None, *, engine_io_enabled: bool = True):
+    def __init__(
+        self, device_fs, file_path: str | None = None, *, engine_io_enabled: bool = True
+    ):
         """
         初始化服务
 
@@ -43,25 +49,44 @@ class SkillParameterService:
         """异步加载参数文件"""
         if not self._engine_io_enabled:
             self._data = {"parameters": {}}
-            logger.info("[SkillParameterService] engine IO disabled (teclaw); skipping load")
+            logger.info(
+                "[SkillParameterService] engine IO disabled (teclaw); skipping load"
+            )
             return
         try:
-            content = await self._device_fs.read_file(self._file_path)
-            if content:
-                self._data = json.loads(content.decode("utf-8"))
-                logger.info(f"[SkillParameterService] Loaded parameters, size={len(content)}")
-            else:
+            content = await self._device_fs.read_file(
+                self._file_path,
+                preserve_read_errors=True,
+            )
+            if content is None:
                 self._data = {"parameters": {}}
-                logger.info("[SkillParameterService] No existing parameters, initialized empty")
+                logger.info(
+                    "[SkillParameterService] No existing parameters, initialized empty"
+                )
+                return
+            value = json.loads(content.decode("utf-8"))
+            if not isinstance(value, dict) or not isinstance(
+                value.get("parameters"), dict
+            ):
+                raise ValueError("parameter file must contain an object 'parameters'")
+            if any(
+                not isinstance(name, str) or not isinstance(parameters, dict)
+                for name, parameters in value["parameters"].items()
+            ):
+                raise ValueError("each Skill parameter value must be an object")
+            self._data = value
+            logger.info(
+                "[SkillParameterService] Loaded parameters, size=%d", len(content)
+            )
         except FileNotFoundError:
             self._data = {"parameters": {}}
             logger.info("[SkillParameterService] File not found, initialized empty")
-        except json.JSONDecodeError as e:
-            logger.warning(f"[SkillParameterService] Failed to parse parameters JSON: {e}")
-            self._data = {"parameters": {}}
-        except Exception as e:
-            logger.warning(f"[SkillParameterService] Failed to load parameters: {e}")
-            self._data = {"parameters": {}}
+        except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
+            logger.warning("[SkillParameterService] Invalid parameters file: %s", exc)
+            raise LocalSkillStorageError() from exc
+        except Exception as exc:
+            logger.warning("[SkillParameterService] Failed to load parameters: %s", exc)
+            raise LocalSkillStorageError() from exc
 
     async def async_save(self) -> bool:
         """异步保存参数文件
@@ -70,13 +95,23 @@ class SkillParameterService:
             bool: 保存是否成功
         """
         if not self._engine_io_enabled:
-            logger.info("[SkillParameterService] engine IO disabled (teclaw); skipping save")
+            logger.info(
+                "[SkillParameterService] engine IO disabled (teclaw); skipping save"
+            )
             return False
         try:
-            self._data["updated_at"] = datetime.utcnow().isoformat()
-            content = json.dumps(self._data, indent=2, ensure_ascii=False).encode("utf-8")
+            candidate = {
+                **self._data,
+                "updated_at": datetime.now(UTC).isoformat(),
+            }
+            content = json.dumps(candidate, indent=2, ensure_ascii=False).encode(
+                "utf-8"
+            )
             await self._device_fs.write_file(self._file_path, content)
-            logger.info(f"[SkillParameterService] Saved parameters, size={len(content)}")
+            self._data = candidate
+            logger.info(
+                f"[SkillParameterService] Saved parameters, size={len(content)}"
+            )
             return True
         except Exception as e:
             logger.error(f"[SkillParameterService] Failed to save parameters: {e}")
@@ -86,7 +121,9 @@ class SkillParameterService:
         """获取指定技能的参数（同步方法，需要先调用 async_load）"""
         return self._data.get("parameters", {}).get(skill_name, {})
 
-    async def save_skill_parameters(self, skill_name: str, parameters: dict[str, Any]) -> bool:
+    async def save_skill_parameters(
+        self, skill_name: str, parameters: dict[str, Any]
+    ) -> bool:
         """保存指定技能的参数
 
         Args:
@@ -96,11 +133,18 @@ class SkillParameterService:
         Returns:
             bool: 保存是否成功
         """
-        if "parameters" not in self._data:
-            self._data["parameters"] = {}
-
-        self._data["parameters"][skill_name] = parameters
-        return await self.async_save()
+        previous = self._data
+        self._data = {
+            **previous,
+            "parameters": {
+                **previous.get("parameters", {}),
+                skill_name: parameters,
+            },
+        }
+        saved = await self.async_save()
+        if not saved:
+            self._data = previous
+        return saved
 
     async def delete_skill_parameters(self, skill_name: str) -> bool:
         """删除指定技能的参数
@@ -109,15 +153,23 @@ class SkillParameterService:
             bool: 保存是否成功
         """
         if "parameters" in self._data:
-            self._data["parameters"].pop(skill_name, None)
-            return await self.async_save()
+            previous = self._data
+            remaining = dict(previous["parameters"])
+            remaining.pop(skill_name, None)
+            self._data = {**previous, "parameters": remaining}
+            saved = await self.async_save()
+            if not saved:
+                self._data = previous
+            return saved
         return True
 
     def get_all_parameters(self) -> dict[str, dict[str, Any]]:
         """获取所有技能参数（同步方法，需要先调用 async_load）"""
         return self._data.get("parameters", {})
 
-    def check_parameters_required(self, skill_name: str, parameter_schema: list) -> tuple:
+    def check_parameters_required(
+        self, skill_name: str, parameter_schema: list
+    ) -> tuple:
         """检查技能是否需要配置参数
 
         Returns: (是否需要配置，未配置的参数列表)
@@ -129,7 +181,7 @@ class SkillParameterService:
 
         missing_params = []
         for param in parameter_schema:
-            if param.get('required') and not user_parameters.get(param['name']):
+            if param.get("required") and not user_parameters.get(param["name"]):
                 missing_params.append(param)
 
         return len(missing_params) > 0, missing_params

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_query_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_query_service.py
@@ -17,14 +17,24 @@ from typing import Any, Callable, Protocol, TYPE_CHECKING
 
 from injector import inject
 
-from agentclaw.community.core.skill_center.skill_query_service_protocol import SkillQueryServiceProtocol
+from agentclaw.community.core.skill_center.skill_query_service_protocol import (
+    SkillQueryServiceProtocol,
+)
 from agentclaw.community.core.bot_config_surface.coords import BotConfigCoords
 from agentclaw.community.core.bot_collaborator.models import PermissionLevel
 from agentclaw.community.core.bot_collaborator.protocols import (
     CollaboratorServiceProtocol,
 )
 from agentclaw.community.core.repository.protocols.bot import BotRepository
+from agentclaw.community.core.repository.protocols.center_skill_access import (
+    CenterSkillAccessRepositoryProtocol,
+)
 from agentclaw.community.core.repository.protocols.skill_center import SkillRepository
+from agentclaw.community.core.skill_center.canonical_center_store import (
+    CanonicalCenterVersionIdentity,
+    CanonicalCenterVersionRef,
+    CanonicalCenterVersionStore,
+)
 from agentclaw.community.core.skill_center.capability_state_contract import (
     BotCapabilityStateReaderProtocol,
 )
@@ -39,6 +49,13 @@ from agentclaw.community.core.skill_center.factories import (
     SkillServiceFactory,
 )
 from agentclaw.community.core.skill_center.services.skill_parser import SkillParser
+from agentclaw.community.core.skill_center.version_resolution_contract import (
+    SkillVersionResolutionError,
+    SkillVersionResolverProtocol,
+)
+from agentclaw.community.core.spaces.errors import SpaceError
+from agentclaw.community.core.spaces.protocols import SpaceAccessServiceProtocol
+from agentclaw.community.utils.env_utils import get_current_env
 
 if TYPE_CHECKING:
     from agentclaw.community.core.devices.services.device_context_resolver import (
@@ -101,7 +118,7 @@ def skill_coords_from_spec(bot_id: str, owner_id: str) -> BotConfigCoords:
 class SkillAssetKind(StrEnum):
     LOCAL = "LOCAL"
     REPO = "REPO"
-    SPACE = "SPACE"
+    CENTER = "CENTER"
 
 
 class _AssetAdapter(Protocol):
@@ -128,6 +145,10 @@ class SkillQueryService(SkillQueryServiceProtocol):
         skill_service_factory: SkillServiceFactory,
         parameter_service_factory: SkillParameterServiceFactory,
         device_context_resolver_provider: Callable[[], "DeviceContextResolver"],
+        center_access: CenterSkillAccessRepositoryProtocol,
+        version_resolver: SkillVersionResolverProtocol,
+        canonical_store: CanonicalCenterVersionStore,
+        space_access: SpaceAccessServiceProtocol,
     ) -> None:
         self._skill_repo = skill_repo
         self._bot_repo = bot_repo
@@ -136,10 +157,14 @@ class SkillQueryService(SkillQueryServiceProtocol):
         self._skill_service_factory = skill_service_factory
         self._parameter_service_factory = parameter_service_factory
         self._device_context_resolver_provider = device_context_resolver_provider
+        self._center_access = center_access
+        self._version_resolver = version_resolver
+        self._canonical_store = canonical_store
+        self._space_access = space_access
         self._adapters: dict[SkillAssetKind, _AssetAdapter] = {
             SkillAssetKind.LOCAL: _LocalAssetAdapter(self),
             SkillAssetKind.REPO: _RepoAssetAdapter(self),
-            SkillAssetKind.SPACE: _UnavailableAssetAdapter(),
+            SkillAssetKind.CENTER: _CenterAssetAdapter(self),
         }
 
     # ── Listing ─────────────────────────────────────────────────────
@@ -225,6 +250,18 @@ class SkillQueryService(SkillQueryServiceProtocol):
             "active": any(asset.skill_id == int(skill_id) for asset in installed),
         }
 
+    def resolve_skill(
+        self, *, skill_id: str, bot_id: str, owner_id: str, user_id: str
+    ) -> dict[str, Any]:
+        """Resolve a Bot-facing asset without reading or flushing desired state."""
+        skill, _bot, _owner_id = self._resolve(
+            skill_id=skill_id,
+            bot_id=bot_id,
+            owner_id=owner_id,
+            user_id=user_id,
+        )
+        return skill
+
     # ── Legacy reference resolution ─────────────────────────────────
 
     def resolve_legacy_skill_id(
@@ -292,16 +329,19 @@ class SkillQueryService(SkillQueryServiceProtocol):
             owner_id=owner_id,
             user_id=user_id,
         )
-        if self._kind_for(skill) is SkillAssetKind.REPO:
+        kind = self._kind_for(skill)
+        if kind is SkillAssetKind.REPO:
             # Repo assets are read from the global skills-repo corpus, never a
             # Bot workspace and never the historical README fallback.
             content = self._skill_service_factory.create().get_repository_skill_content(
                 skill_id
             )
-        else:
+        elif kind is SkillAssetKind.LOCAL:
             content = await self._local_storage(skill, bot, owner_id).read_file(
                 "SKILL.md"
             )
+        else:
+            content = self._center_content(skill=skill, actor_id=user_id)
         if content is None:
             raise LocalSkillNotFoundError()
         if isinstance(content, str):
@@ -331,17 +371,21 @@ class SkillQueryService(SkillQueryServiceProtocol):
                 raise LocalSkillNotFoundError()
             return content
 
+        if kind is SkillAssetKind.CENTER:
+            return SkillParser.decode_content_for_display(
+                self._center_content(skill=skill, actor_id=actor_id)
+            )
         if kind is not SkillAssetKind.LOCAL:
             raise LocalSkillNotFoundError()
 
         bot_id = str(skill.get("bolt_id") or "")
-        if not bot_id:
+        owner_id = str(skill.get("user_id") or "")
+        if not bot_id or not owner_id:
             raise LocalSkillNotFoundError()
-        bot = self._bot_repo.get_unique_by_id(bot_id)
+        bot = self._bot_repo.get_by_id_and_owner(bot_id, owner_id)
         if bot is None:
             raise LocalSkillNotFoundError()
-        owner_id = str(bot.get("owner_id") or "")
-        if not owner_id:
+        if str(bot.get("owner_id") or "") != owner_id:
             raise LocalSkillNotFoundError()
         if actor_id != owner_id:
             permission = self._collaborators.check_collaborator_permission(
@@ -495,7 +539,7 @@ class SkillQueryService(SkillQueryServiceProtocol):
         if source.startswith("git://"):
             return SkillAssetKind.REPO
         if source.startswith("center://"):
-            return SkillAssetKind.SPACE
+            return SkillAssetKind.CENTER
         raise LocalSkillNotFoundError()
 
     def _local_storage(self, skill: dict[str, Any], bot: dict[str, Any], owner_id: str):
@@ -513,6 +557,47 @@ class SkillQueryService(SkillQueryServiceProtocol):
             is_teclaw=context.provider == "teclaw",
             locator=locator,
         )
+
+    def _require_center_access(
+        self, *, skill: dict[str, Any], actor_id: str
+    ) -> dict[str, Any]:
+        skill_id = skill.get("id")
+        if not isinstance(skill_id, (str, int)) or not str(skill_id).isdecimal():
+            raise LocalSkillNotFoundError()
+        access = self._center_access.get_access(
+            env=get_current_env(), skill_id=int(skill_id)
+        )
+        if access is None or access["offline_at"] is not None:
+            raise LocalSkillNotFoundError()
+        if access["visibility"] == "SPACE":
+            space_id = access["space_id"]
+            if space_id is None:
+                raise LocalSkillNotFoundError()
+            try:
+                self._space_access.require_space_member(
+                    space_id=space_id, user_id=actor_id
+                )
+            except SpaceError as exc:
+                raise LocalSkillNotFoundError() from exc
+        return access
+
+    def _center_content(self, *, skill: dict[str, Any], actor_id: str) -> bytes:
+        access = self._require_center_access(skill=skill, actor_id=actor_id)
+        try:
+            version = self._version_resolver.resolve_latest_published(
+                env=get_current_env(), skill_id=int(skill["id"])
+            )
+        except SkillVersionResolutionError as exc:
+            raise LocalSkillNotFoundError() from exc
+
+        return self._canonical_store.read_version(
+            CanonicalCenterVersionRef(
+                CanonicalCenterVersionIdentity(
+                    skill_uuid=access["skill_uuid"],
+                    sc_version_number=version.sc_version_number,
+                )
+            )
+        ).skill_md
 
     @staticmethod
     def _validate_parameters(manifest: str, parameters: dict[str, Any]) -> None:
@@ -591,8 +676,11 @@ class _RepoAssetAdapter:
         return {**skill, "bolt_id": bot_id, "user_id": owner_id}, bot, owner_id
 
 
-class _UnavailableAssetAdapter:
-    """Explicit P1-01 registration point for P1-02/Phase-2 asset readers."""
+class _CenterAssetAdapter:
+    """Authorize a shared Center asset without changing its persisted owner."""
+
+    def __init__(self, service: SkillQueryService) -> None:
+        self._service = service
 
     def resolve(
         self,
@@ -602,4 +690,8 @@ class _UnavailableAssetAdapter:
         owner_id: str,
         user_id: str,
     ):
-        raise LocalSkillNotFoundError()
+        bot = self._service._require_view_access(
+            bot_id=bot_id, owner_id=owner_id, actor_id=user_id
+        )
+        self._service._require_center_access(skill=skill, actor_id=user_id)
+        return {**skill, "bolt_id": bot_id, "user_id": owner_id}, bot, owner_id

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_version_resolver.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_version_resolver.py
@@ -31,6 +31,19 @@ class SkillVersionResolver:
     def __init__(self, versions: SkillVersionRepositoryProtocol) -> None:
         self._versions = versions
 
+    def resolve_latest_published(
+        self,
+        *,
+        env: str,
+        skill_id: int,
+    ) -> PublishedSkillVersion:
+        rows = self._versions.list_latest_published(env=env, skill_ids=(skill_id,))
+        if len(rows) != 1:
+            raise SkillVersionResolutionError(
+                "Center Skill has no PUBLISHED Version"
+            )
+        return self._published(rows[0])
+
     def resolve_latest_runtime_assets(
         self,
         *,

--- a/src/backend/src/agentclaw/community/core/skill_center/skill_query_service_protocol.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/skill_query_service_protocol.py
@@ -34,12 +34,16 @@ class SkillQueryServiceProtocol(Protocol):
     def get_local_skill(self, *, skill_id: str, actor_id: str) -> dict[str, Any]: ...
 
     @abstractmethod
-    async def get_readme_by_skill(self, *, skill_id: str, actor_id: str) -> str: ...
-
-    @abstractmethod
     def get_skill(
         self, *, skill_id: str, bot_id: str, owner_id: str, user_id: str
     ) -> dict[str, Any]: ...
+
+    @abstractmethod
+    def resolve_skill(
+        self, *, skill_id: str, bot_id: str, owner_id: str, user_id: str
+    ) -> dict[str, Any]:
+        """Resolve visibility and addressing without synchronizing state."""
+        ...
 
     @abstractmethod
     def resolve_legacy_skill_id(

--- a/src/backend/src/agentclaw/community/core/skill_center/version_resolution_contract.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/version_resolution_contract.py
@@ -34,6 +34,13 @@ class PublishedSkillVersion:
 class SkillVersionResolverProtocol(Protocol):
     """Resolve latest or exact PUBLISHED Versions without side effects."""
 
+    def resolve_latest_published(
+        self,
+        *,
+        env: str,
+        skill_id: int,
+    ) -> PublishedSkillVersion: ...
+
     def resolve_latest_runtime_assets(
         self,
         *,

--- a/src/backend/src/agentclaw/community/di/modules/skill_center_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/skill_center_module.py
@@ -71,6 +71,9 @@ from agentclaw.community.core.repository.protocols.bot import (
     BotCollabLogRepositoryProtocol,
 )
 from agentclaw.community.core.repository.protocols.bot import BotRepository
+from agentclaw.community.core.repository.protocols.center_skill_access import (
+    CenterSkillAccessRepositoryProtocol,
+)
 from agentclaw.community.core.repository.protocols.skill_center import (
     SkillEditorRequestRepositoryProtocol,
     SkillCategoryRepository,
@@ -78,6 +81,10 @@ from agentclaw.community.core.repository.protocols.skill_center import (
 from agentclaw.community.core.repository.protocols.skill_center import (
     SkillCenterSyncLogRepository,
 )
+from agentclaw.community.core.skill_center.canonical_center_store import (
+    CanonicalCenterVersionStore,
+)
+from agentclaw.community.core.spaces.protocols import SpaceAccessServiceProtocol
 from agentclaw.community.core.repository.protocols.skill_center import (
     SkillMemberRepository,
 )
@@ -112,6 +119,9 @@ from agentclaw.community.core.skill_center.capability_state_contract import (
 from agentclaw.community.core.skill_center.runtime_projection_contract import (
     BotRuntimeProjectorProtocol as CoreBotRuntimeProjectorProtocol,
     ProjectionScope,
+)
+from agentclaw.community.core.skill_center.version_resolution_contract import (
+    SkillVersionResolverProtocol,
 )
 from agentclaw.community.core.skill_center.services.runtime_projections.registry import (
     EngineRuntimeProjectionRegistry,
@@ -464,6 +474,10 @@ class SkillCenterModule(
         reader: CoreBotCapabilityStateReaderProtocol,
         skill_service_factory: SkillServiceFactory,
         parameter_service_factory: SkillParameterServiceFactoryProtocol,
+        center_access: CenterSkillAccessRepositoryProtocol,
+        version_resolver: SkillVersionResolverProtocol,
+        canonical_store: CanonicalCenterVersionStore,
+        space_access: SpaceAccessServiceProtocol,
         injector: Injector,
     ) -> SkillQueryServiceProtocol:
         """Bind the one Bot-Skill query seam (listing/detail/content/params)."""
@@ -475,6 +489,10 @@ class SkillCenterModule(
             skill_service_factory,
             parameter_service_factory,
             lambda: injector.get(DeviceContextResolver),
+            center_access,
+            version_resolver,
+            canonical_store,
+            space_access,
         )
 
     @singleton
@@ -726,7 +744,10 @@ class SkillCenterModule(
     @singleton
     @provider
     def local_skill_storage(self) -> LocalSkillStorageResolver:
-        from agentclaw.community.plugins.local_skill_storage import ConfiguredLocalSkillStorage
+        from agentclaw.community.plugins.local_skill_storage import (
+            ConfiguredLocalSkillStorage,
+        )
+
         return ConfiguredLocalSkillStorage()
 
     @singleton

--- a/src/backend/src/agentclaw/community/di/modules/skill_version_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/skill_version_module.py
@@ -7,6 +7,9 @@ from injector import Binder, Module, inject, provider, singleton
 from agentclaw.community.core.repository.implementations.skill_center.skill_version import (
     SkillVersionRepository,
 )
+from agentclaw.community.core.repository.protocols.center_skill_access import (
+    CenterSkillAccessRepositoryProtocol,
+)
 from agentclaw.community.core.repository.protocols.skill_center import (
     SkillVersionMaterializationRepositoryProtocol,
     SkillVersionRepositoryProtocol,
@@ -56,6 +59,16 @@ class SkillVersionModule(Module):
             to=SkillVersionRepository,
             scope=singleton,
         )
+
+    @singleton
+    @provider
+    @inject
+    def center_skill_access_repository(
+        self,
+        versions: SkillVersionRepositoryProtocol,
+    ) -> CenterSkillAccessRepositoryProtocol:
+        """Expose access facts from the exact same Version repository instance."""
+        return versions
 
     @singleton
     @provider

--- a/src/backend/src/agentclaw/community/plugin_api/sandbox_runtime.py
+++ b/src/backend/src/agentclaw/community/plugin_api/sandbox_runtime.py
@@ -41,6 +41,10 @@ class SandboxRuntimeUnavailableError(Exception):
     """Raised by impls for runtimes that are not available in this deployment."""
 
 
+class SandboxFileReadError(Exception):
+    """A sandbox file read failed for a reason other than file absence."""
+
+
 class SandboxRuntimeClient(Plugin, Protocol):
     """Create and operate bot sandboxes on a container runtime."""
 
@@ -121,8 +125,19 @@ class SandboxRuntimeClient(Plugin, Protocol):
     # ``path`` is already mapped by the caller (no ``path_mapper`` here). Return
     # types are neutral; the impl talks to the runtime's file API at its boundary.
 
-    async def read_file(self, *, sandbox_id: str, path: str) -> bytes | None:
-        """Read ``path`` in ``sandbox_id``; ``None`` if missing / unreadable."""
+    async def read_file(
+        self,
+        *,
+        sandbox_id: str,
+        path: str,
+        preserve_read_errors: bool = False,
+    ) -> bytes | None:
+        """Read a file; ``None`` means missing.
+
+        Compatibility callers may leave ``preserve_read_errors`` false and
+        receive ``None`` for other unreadable outcomes. When true, an adapter
+        must raise :class:`SandboxFileReadError` for non-missing failures.
+        """
         ...
 
     async def write_file(self, *, sandbox_id: str, path: str, content: bytes) -> None:

--- a/src/backend/src/agentclaw/community/plugins/local/sandbox_client.py
+++ b/src/backend/src/agentclaw/community/plugins/local/sandbox_client.py
@@ -50,7 +50,13 @@ class NoopSandboxClient(MockSeam, SandboxRuntimeClient):
     def build_proxy_request(self, *, sandbox_id: str, api_path: str, port: int = 20003) -> ProxyRequest:
         return ProxyRequest(url=f"http://noop-sandbox:{port}{api_path}", headers={})
 
-    async def read_file(self, *, sandbox_id: str, path: str) -> bytes | None:
+    async def read_file(
+        self,
+        *,
+        sandbox_id: str,
+        path: str,
+        preserve_read_errors: bool = False,
+    ) -> bytes | None:
         return b""
 
     async def write_file(self, *, sandbox_id: str, path: str, content: bytes) -> None:

--- a/src/backend/tests/community/adapters/http/openapi_v1/local/test_local_handlers.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/local/test_local_handlers.py
@@ -152,6 +152,23 @@ def test_create_local_bot_returns_pending_authorization(client, desktop_service)
     assert desktop_service.apply_passport_before_create.call_args.kwargs["user_id"] == "u1"
 
 
+def test_create_local_hermes_uses_the_formal_desktop_workflow(client, desktop_service):
+    response = client.post(
+        "/openapi/v1/bots/local",
+        json={"bot_name": "Hermes", "machine_id": "m1", "engine": "hermes"},
+    )
+
+    assert response.status_code == 202, response.text
+    assert desktop_service.apply_passport_before_create.call_args.kwargs == {
+        "bot": {"bot_name": "Hermes", "bot_desc": None},
+        "user_id": "u1",
+        "machine_id": "m1",
+        "mount_path": None,
+        "avatar_url": None,
+        "engine_type": "hermes",
+    }
+
+
 def test_create_local_bot_rejects_non_personal_space(client):
     resp = client.post(
         "/openapi/v1/bots/local",

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_skills_endpoints.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_skills_endpoints.py
@@ -684,7 +684,17 @@ def _real_query_service(db, bots, skills) -> SkillQueryService:
         PassthroughSkillVersionResolver(),
     )
     return SkillQueryService(
-        skills, bots, object(), reader, object(), object(), lambda: object()
+        skills,
+        bots,
+        object(),
+        reader,
+        object(),
+        object(),
+        lambda: object(),
+        object(),
+        object(),
+        object(),
+        object(),
     )
 
 
@@ -1054,7 +1064,7 @@ async def test_state_command_cannot_cross_the_real_tenant_guard(tmp_path):
     service = DirectActivationService(
         object(),
         bots,
-        skills,
+        _real_query_service(db, bots, skills),
         factory.runtime,
         object(),
         object(),
@@ -1065,7 +1075,9 @@ async def test_state_command_cannot_cross_the_real_tenant_guard(tmp_path):
     with avernet_tenant_scope("tenant-b"):
         with pytest.raises(LocalSkillNotFoundError):
             await service.activate_skill(
-                skill_id=skill["id"], bot_id="bot", owner_id="owner",
+                skill_id=skill["id"],
+                bot_id="bot",
+                owner_id="owner",
                 actor_id="owner",
             )
     assert factory.runtime.calls == 0

--- a/src/backend/tests/community/core/bot_inventory/policies/test_combo_policy.py
+++ b/src/backend/tests/community/core/bot_inventory/policies/test_combo_policy.py
@@ -38,16 +38,16 @@ def test_personal_cloud_rejects_unknown_engine_and_invalid_space() -> None:
 
 @pytest.mark.unit
 def test_local_supported_engine_matrix() -> None:
-    assert LOCAL_CAPABLE_ENGINES == frozenset({"openclaw", "claude_code"})
+    assert LOCAL_CAPABLE_ENGINES == frozenset({"openclaw", "claude_code", "hermes"})
     for engine in LOCAL_CAPABLE_ENGINES:
         assert assert_local_create(engine, "personal").ok
 
 
 @pytest.mark.unit
 def test_local_rejects_unknown_engine_and_non_personal_space() -> None:
-    unsupported = assert_local_create("hermes", "personal")
+    unsupported = assert_local_create("unknown", "personal")
     assert not unsupported.ok
-    assert unsupported.reason == "local bot does not support engine: hermes"
+    assert unsupported.reason == "local bot does not support engine: unknown"
 
     invalid_space = assert_local_create("openclaw", "team")
     assert not invalid_space.ok

--- a/src/backend/tests/community/core/skill_center/services/test_skill_parameter_service.py
+++ b/src/backend/tests/community/core/skill_center/services/test_skill_parameter_service.py
@@ -1,4 +1,5 @@
 """Tests for SkillParameterService (async, DeviceFileSystemPlugin-based)."""
+
 import json
 from unittest.mock import AsyncMock
 
@@ -8,6 +9,7 @@ from agentclaw.community.core.skill_center.services.skill_parameter_service impo
     DEFAULT_PARAMETERS_PATH,
     SkillParameterService,
 )
+from agentclaw.community.core.skill_center.errors import LocalSkillStorageError
 
 
 @pytest.fixture
@@ -25,19 +27,28 @@ def svc(mock_device_fs):
 
 # ---------- async_load ----------
 
+
 @pytest.mark.asyncio
-async def test_async_load_returns_empty_when_read_file_returns_none(svc, mock_device_fs):
+async def test_async_load_returns_empty_when_read_file_returns_none(
+    svc, mock_device_fs
+):
     """read_file returns None → _data initialises with empty parameters."""
     mock_device_fs.read_file.return_value = None
     await svc.async_load()
     assert svc._data == {"parameters": {}}
-    mock_device_fs.read_file.assert_awaited_once_with(DEFAULT_PARAMETERS_PATH)
+    mock_device_fs.read_file.assert_awaited_once_with(
+        DEFAULT_PARAMETERS_PATH,
+        preserve_read_errors=True,
+    )
 
 
 @pytest.mark.asyncio
 async def test_async_load_parses_valid_json(svc, mock_device_fs):
     """read_file returns valid JSON → _data is populated correctly."""
-    payload = {"parameters": {"my_skill": {"key": "val"}}, "updated_at": "2025-01-01T00:00:00"}
+    payload = {
+        "parameters": {"my_skill": {"key": "val"}},
+        "updated_at": "2025-01-01T00:00:00",
+    }
     mock_device_fs.read_file.return_value = json.dumps(payload).encode("utf-8")
     await svc.async_load()
     assert svc._data == payload
@@ -45,11 +56,29 @@ async def test_async_load_parses_valid_json(svc, mock_device_fs):
 
 
 @pytest.mark.asyncio
-async def test_async_load_handles_invalid_json(svc, mock_device_fs):
-    """read_file returns garbage bytes → _data falls back to empty."""
+async def test_async_load_rejects_invalid_json_without_treating_it_as_empty(
+    svc, mock_device_fs
+):
     mock_device_fs.read_file.return_value = b"NOT JSON{{"
-    await svc.async_load()
-    assert svc._data == {"parameters": {}}
+    with pytest.raises(LocalSkillStorageError):
+        await svc.async_load()
+    assert svc._data == {}
+    mock_device_fs.write_file.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_async_load_rejects_invalid_structure_and_read_failures(
+    svc, mock_device_fs
+):
+    mock_device_fs.read_file.return_value = b'{"parameters": []}'
+    with pytest.raises(LocalSkillStorageError):
+        await svc.async_load()
+    mock_device_fs.write_file.assert_not_awaited()
+
+    mock_device_fs.read_file.side_effect = TimeoutError("device timed out")
+    with pytest.raises(LocalSkillStorageError):
+        await svc.async_load()
+    mock_device_fs.write_file.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -60,10 +89,11 @@ async def test_async_load_custom_path():
     custom = "/tmp/custom/params.json"
     svc = SkillParameterService(device_fs=fs, file_path=custom)
     await svc.async_load()
-    fs.read_file.assert_awaited_once_with(custom)
+    fs.read_file.assert_awaited_once_with(custom, preserve_read_errors=True)
 
 
 # ---------- save_skill_parameters ----------
+
 
 @pytest.mark.asyncio
 async def test_save_skill_parameters_writes_json(svc, mock_device_fs):
@@ -80,7 +110,25 @@ async def test_save_skill_parameters_writes_json(svc, mock_device_fs):
     assert "updated_at" in written
 
 
+@pytest.mark.asyncio
+async def test_save_replaces_only_one_skill_and_preserves_metadata(svc, mock_device_fs):
+    payload = {
+        "format_version": 1,
+        "parameters": {"a": {"old": True}, "b": {"kept": 2}},
+        "updated_at": "2025-01-01T00:00:00",
+    }
+    mock_device_fs.read_file.return_value = json.dumps(payload).encode()
+    await svc.async_load()
+
+    assert await svc.save_skill_parameters("a", {"new": False}) is True
+
+    written = json.loads(mock_device_fs.write_file.await_args.args[1])
+    assert written["format_version"] == 1
+    assert written["parameters"] == {"a": {"new": False}, "b": {"kept": 2}}
+
+
 # ---------- delete_skill_parameters ----------
+
 
 @pytest.mark.asyncio
 async def test_delete_skill_parameters_removes_key(svc, mock_device_fs):
@@ -107,6 +155,7 @@ async def test_delete_nonexistent_skill_is_noop(svc, mock_device_fs):
 
 # ---------- sync readers ----------
 
+
 def test_get_skill_parameters_empty(svc):
     """Before load, returns empty dict."""
     assert svc.get_skill_parameters("anything") == {}
@@ -117,6 +166,7 @@ def test_get_all_parameters_empty(svc):
 
 
 # ---------- check_parameters_required ----------
+
 
 @pytest.mark.asyncio
 async def test_check_parameters_required_finds_missing(svc, mock_device_fs):

--- a/src/backend/tests/community/core/skill_center/test_direct_activation_service.py
+++ b/src/backend/tests/community/core/skill_center/test_direct_activation_service.py
@@ -119,6 +119,18 @@ class _Skills:
             return {**row, "active": False}
         return None
 
+    def resolve_skill(
+        self, *, skill_id: str, bot_id: str, owner_id: str, user_id: str
+    ) -> dict:
+        row = self._ROWS.get(skill_id)
+        if row is None:
+            raise LocalSkillNotFoundError()
+        if str(row["git_path"]).startswith("local://") and (
+            row["bolt_id"] != bot_id or row["user_id"] != owner_id
+        ):
+            raise LocalSkillNotFoundError()
+        return {**row, "bolt_id": bot_id, "user_id": owner_id, "active": False}
+
 
 class _Authorization:
     def __init__(self, allowed: bool = True) -> None:
@@ -456,7 +468,7 @@ async def test_a_not_ready_bot_commits_desired_state_and_returns_pending():
 
 
 @pytest.mark.asyncio
-async def test_a_space_asset_and_a_mismatched_local_row_are_masked_as_not_found():
+async def test_a_visible_center_asset_is_directly_activatable_but_local_addressing_stays_exact():
     class _MoreSkills(_Skills):
         _ROWS = {
             **_Skills._ROWS,
@@ -476,12 +488,11 @@ async def test_a_space_asset_and_a_mismatched_local_row_are_masked_as_not_found(
         _PlatformDefaultMcpPolicy(),
     )
 
-    # A Space (center://) asset has no direct-activation wire.
-    with pytest.raises(LocalSkillNotFoundError):
-        await service.activate_skill(
-            skill_id="9", bot_id="bot-1", owner_id="true-owner",
-            actor_id="true-owner",
-        )
+    result = await service.activate_skill(
+        skill_id="9", bot_id="bot-1", owner_id="true-owner",
+        actor_id="true-owner",
+    )
+    assert result["active"] is True
     # A Local row carries its own Bot: addressing it through another Bot
     # must not resolve.
     with pytest.raises(LocalSkillNotFoundError):
@@ -489,7 +500,7 @@ async def test_a_space_asset_and_a_mismatched_local_row_are_masked_as_not_found(
             skill_id="7", bot_id="another-bot", owner_id="true-owner",
             actor_id="true-owner",
         )
-    assert repository.install_skill_calls == []
+    assert [call["skill_id"] for call in repository.install_skill_calls] == ["9"]
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/community/core/skill_center/test_skill_query_service.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_query_service.py
@@ -112,6 +112,15 @@ class _Collaborators:
         return {"has_permission": self._allowed}
 
 
+class _NoCenterAccess:
+    def get_access(self, **_kwargs):
+        return None
+
+
+def _unused_center_dependencies():
+    return (_NoCenterAccess(), object(), object(), object())
+
+
 def _listing_service(
     *,
     bridge: InstallationFlushPlan,
@@ -130,6 +139,7 @@ def _listing_service(
         object(),
         object(),
         lambda: object(),
+        *_unused_center_dependencies(),
     )
     return service, skills, sets, bots
 
@@ -264,6 +274,7 @@ class _AssetBots:
         if (bot_id, owner_id) != ("bot", "owner"):
             return None
         return {
+            "owner_id": "owner",
             "entity_id": "owner",
             "entity_type": "staff",
             "active_engine": "openclaw",
@@ -335,6 +346,7 @@ def _asset_service(*, save_result: bool = True):
         _Factory(),
         parameters,
         lambda: _Resolver(),
+        *_unused_center_dependencies(),
     )
     return service, parameters, reader
 
@@ -389,7 +401,9 @@ class _RepoReader:
 
 class _UnexpectedBotRepository:
     def __getattr__(self, name):
-        raise AssertionError(f"public Repo README unexpectedly used BotRepository.{name}")
+        raise AssertionError(
+            f"public Repo README unexpectedly used BotRepository.{name}"
+        )
 
 
 class _RepoFactory:
@@ -407,6 +421,7 @@ async def test_skill_only_readme_reads_public_repo_without_bot_lookup() -> None:
         _RepoFactory(),
         object(),
         lambda: object(),
+        *_unused_center_dependencies(),
     )
 
     assert await service.get_readme_by_skill(skill_id="43", actor_id="caller") == (
@@ -553,7 +568,14 @@ def test_a_bridged_skill_is_active_in_detail_before_any_listing_ran(tmp_path):
         PassthroughSkillVersionResolver(),
     )
     service = SkillQueryService(
-        skills, bots, object(), reader, object(), object(), lambda: object()
+        skills,
+        bots,
+        object(),
+        reader,
+        object(),
+        object(),
+        lambda: object(),
+        *_unused_center_dependencies(),
     )
 
     record = service.get_skill(
@@ -580,6 +602,27 @@ class _ReadmeBotRepository:
 
     def get_unique_by_id(self, _bot_id: str):
         return self.bot
+
+    def get_by_id_and_owner(self, _bot_id: str, owner_id: str):
+        if self.bot is None or self.bot.get("owner_id") != owner_id:
+            return None
+        return self.bot
+
+
+class _DuplicateDefaultBots:
+    def get_unique_by_id(self, _bot_id: str):
+        return {"owner_id": "other-owner", "entity_id": "other-owner"}
+
+    def get_by_id_and_owner(self, bot_id: str, owner_id: str):
+        if (bot_id, owner_id) != ("default", "owner"):
+            return None
+        return {
+            "bot_id": bot_id,
+            "owner_id": owner_id,
+            "entity_id": owner_id,
+            "entity_type": "staff",
+            "active_engine": "openclaw",
+        }
 
 
 class _ReadmeStorage:
@@ -610,6 +653,34 @@ class _ReadmeResolver:
 
 
 @pytest.mark.asyncio
+async def test_local_readme_uses_persisted_owner_to_disambiguate_default_bot():
+    service = SkillQueryService(
+        _ReadmeSkillRepository(
+            {
+                "1": {
+                    "id": "1",
+                    "git_path": "local://owned",
+                    "bolt_id": "default",
+                    "user_id": "owner",
+                }
+            }
+        ),
+        _DuplicateDefaultBots(),
+        _Collaborators(allowed=False),
+        object(),
+        _ReadmeFactory(None, "# owner content"),
+        object(),
+        _ReadmeResolver,
+        *_unused_center_dependencies(),
+    )
+
+    assert (
+        await service.get_readme_by_skill(skill_id="1", actor_id="owner")
+        == "# owner content"
+    )
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "skill_id, skills",
     [
@@ -629,6 +700,7 @@ async def test_skill_only_readme_masks_unresolvable_skill_rows(skill_id, skills)
         _ReadmeFactory(),
         object(),
         _ReadmeResolver,
+        *_unused_center_dependencies(),
     )
 
     with pytest.raises(LocalSkillNotFoundError):
@@ -637,7 +709,7 @@ async def test_skill_only_readme_masks_unresolvable_skill_rows(skill_id, skills)
 
 @pytest.mark.asyncio
 async def test_skill_only_readme_masks_missing_bot_owner_and_denied_collaborator():
-    skill = {"git_path": "local://x", "bolt_id": "bot"}
+    skill = {"git_path": "local://x", "bolt_id": "bot", "user_id": "owner"}
     service = SkillQueryService(
         _ReadmeSkillRepository({"1": skill}),
         _ReadmeBotRepository({"entity_id": "e", "owner_id": "", "active_engine": "x"}),
@@ -646,18 +718,22 @@ async def test_skill_only_readme_masks_missing_bot_owner_and_denied_collaborator
         _ReadmeFactory(),
         object(),
         _ReadmeResolver,
+        *_unused_center_dependencies(),
     )
     with pytest.raises(LocalSkillNotFoundError):
         await service.get_readme_by_skill(skill_id="1", actor_id="actor")
 
     service = SkillQueryService(
         _ReadmeSkillRepository({"1": skill}),
-        _ReadmeBotRepository({"entity_id": "e", "owner_id": "owner", "active_engine": "x"}),
+        _ReadmeBotRepository(
+            {"entity_id": "e", "owner_id": "owner", "active_engine": "x"}
+        ),
         _Collaborators(allowed=False),
         object(),
         _ReadmeFactory(),
         object(),
         _ReadmeResolver,
+        *_unused_center_dependencies(),
     )
     with pytest.raises(LocalSkillNotFoundError):
         await service.get_readme_by_skill(skill_id="1", actor_id="actor")
@@ -673,6 +749,7 @@ async def test_skill_only_readme_masks_missing_public_repo_content():
         _ReadmeFactory(None),
         object(),
         _ReadmeResolver,
+        *_unused_center_dependencies(),
     )
     with pytest.raises(LocalSkillNotFoundError):
         await service.get_readme_by_skill(skill_id="1", actor_id="actor")
@@ -681,7 +758,9 @@ async def test_skill_only_readme_masks_missing_public_repo_content():
 @pytest.mark.asyncio
 async def test_skill_only_readme_returns_string_content():
     service = SkillQueryService(
-        _ReadmeSkillRepository({"1": {"git_path": "local://x", "bolt_id": "bot"}}),
+        _ReadmeSkillRepository(
+            {"1": {"git_path": "local://x", "bolt_id": "bot", "user_id": "owner"}}
+        ),
         _ReadmeBotRepository(
             {"entity_id": "e", "owner_id": "owner", "active_engine": "x"}
         ),
@@ -690,14 +769,19 @@ async def test_skill_only_readme_returns_string_content():
         _ReadmeFactory(None, "# direct"),
         object(),
         _ReadmeResolver,
+        *_unused_center_dependencies(),
     )
-    assert await service.get_readme_by_skill(skill_id="1", actor_id="owner") == "# direct"
+    assert (
+        await service.get_readme_by_skill(skill_id="1", actor_id="owner") == "# direct"
+    )
 
 
 @pytest.mark.asyncio
 async def test_skill_only_readme_tries_readme_fallback_and_decodes_bytes():
     service = SkillQueryService(
-        _ReadmeSkillRepository({"1": {"git_path": "local://x", "bolt_id": "bot"}}),
+        _ReadmeSkillRepository(
+            {"1": {"git_path": "local://x", "bolt_id": "bot", "user_id": "owner"}}
+        ),
         _ReadmeBotRepository(
             {"entity_id": "e", "owner_id": "owner", "active_engine": "x"}
         ),
@@ -706,14 +790,20 @@ async def test_skill_only_readme_tries_readme_fallback_and_decodes_bytes():
         _ReadmeFactory(None, None, b"# fallback"),
         object(),
         _ReadmeResolver,
+        *_unused_center_dependencies(),
     )
-    assert await service.get_readme_by_skill(skill_id="1", actor_id="owner") == "# fallback"
+    assert (
+        await service.get_readme_by_skill(skill_id="1", actor_id="owner")
+        == "# fallback"
+    )
 
 
 @pytest.mark.asyncio
 async def test_skill_only_readme_masks_empty_local_files():
     service = SkillQueryService(
-        _ReadmeSkillRepository({"1": {"git_path": "local://x", "bolt_id": "bot"}}),
+        _ReadmeSkillRepository(
+            {"1": {"git_path": "local://x", "bolt_id": "bot", "user_id": "owner"}}
+        ),
         _ReadmeBotRepository(
             {"entity_id": "e", "owner_id": "owner", "active_engine": "x"}
         ),
@@ -722,6 +812,7 @@ async def test_skill_only_readme_masks_empty_local_files():
         _ReadmeFactory(None, "", None),
         object(),
         _ReadmeResolver,
+        *_unused_center_dependencies(),
     )
     with pytest.raises(LocalSkillNotFoundError):
         await service.get_readme_by_skill(skill_id="1", actor_id="owner")

--- a/src/backend/tests/community/core/skill_center/test_skill_version_resolver.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_version_resolver.py
@@ -133,6 +133,26 @@ def test_center_assets_use_one_batch_and_preserve_input_order() -> None:
     )
 
 
+def test_single_asset_latest_resolution_returns_the_formal_published_value() -> None:
+    versions = _Versions(
+        (_version(skill_id=10, version_id=102, ordinal=2, number="2.0.0"),)
+    )
+    resolver = SkillVersionResolver(versions)
+
+    resolved = resolver.resolve_latest_published(env="pre", skill_id=10)
+
+    assert resolved.skill_version_id == 102
+    assert resolved.sc_version_number == "2.0.0"
+    assert versions.latest_calls == [{"env": "pre", "skill_ids": (10,)}]
+
+
+def test_single_asset_latest_resolution_fails_without_one_published_row() -> None:
+    resolver = SkillVersionResolver(_Versions())
+
+    with pytest.raises(SkillVersionResolutionError):
+        resolver.resolve_latest_published(env="pre", skill_id=10)
+
+
 @pytest.mark.parametrize(
     ("asset", "rows"),
     [

--- a/src/backend/tests/community/endpoints/test_desktop_center_skill_router.py
+++ b/src/backend/tests/community/endpoints/test_desktop_center_skill_router.py
@@ -1,0 +1,468 @@
+"""Real Router -> DI -> Center query coverage for Desktop Bot Skills."""
+
+from __future__ import annotations
+
+import json
+import time
+from datetime import datetime
+
+import jwt
+from fastapi.testclient import TestClient
+
+from agentclaw.community.adapters.http.openapi_v1.dependencies import (
+    PRINCIPAL_HEADER,
+    require_principal,
+)
+from agentclaw.community.api.bot_app_grant_service import BotAppGrantServiceProtocol
+from agentclaw.community.core.models.skill import Skill
+from agentclaw.community.api.space_service import (
+    SpaceMemberServiceProtocol,
+    SpaceServiceProtocol,
+)
+from agentclaw.community.core.models.space_skill import SkillSpaceBinding, SkillVersion
+from agentclaw.community.core.gateway_principal import (
+    AppPrincipal,
+    GatewayApp,
+    VerifiedCaller,
+)
+from agentclaw.community.core.repository.protocols.center_skill_access import (
+    CenterSkillAccessRepositoryProtocol,
+)
+from agentclaw.community.core.repository.protocols.skill_center import (
+    SkillRepository,
+    SkillVersionRepositoryProtocol,
+)
+from agentclaw.community.core.repository.protocols.bot import BotRepository
+from agentclaw.community.core.skill_center.canonical_center_store import (
+    CanonicalCenterVersion,
+    CanonicalCenterVersionIdentity,
+    CanonicalCenterVersionStore,
+)
+from agentclaw.community.core.skill_center.factories import SkillParameterServiceFactory
+from agentclaw.community.plugin_api.database import DatabasePlugin
+from agentclaw.community.core.spaces.models import SpaceRole
+from agentclaw.community.utils.env_utils import get_current_env
+from agentclaw.community.utils.gateway_principal_config import (
+    init_principal_verifier_config,
+)
+from tests.community.factories.bot_collaborator import (
+    make_bot,
+    make_collaborator_record,
+)
+
+
+_OWNER = "desktop-center-owner"
+_BOT = "desktop-center-bot"
+_SKILL_UUID = "11111111-1111-4111-8111-111111111111"
+_SIGNING_KEY = "desktop-center-router-signing-key-at-least-32-bytes"
+_APP_ID = 2063
+
+
+class _Secret:
+    secret_user = "test"
+    secret_value = _SIGNING_KEY
+
+
+class _SecretResolver:
+    def get_secret(self, _secret_name: str) -> _Secret:
+        return _Secret()
+
+
+def _headers(user_id: str = _OWNER) -> dict[str, str]:
+    now = int(time.time())
+    token = jwt.encode(
+        {
+            "iss": "gateway",
+            "aud": "backend",
+            "iat": now,
+            "exp": now + 3600,
+            "principals": [
+                {
+                    "type": "user",
+                    "tenant": "teamclaw",
+                    "subject": {"id": user_id, "username": f"{user_id}@example.test"},
+                }
+            ],
+        },
+        _SIGNING_KEY,
+        algorithm="HS256",
+    )
+    return {PRINCIPAL_HEADER: token}
+
+
+def _app_caller() -> VerifiedCaller:
+    return VerifiedCaller(
+        principals=(
+            AppPrincipal(
+                tenant="teamclaw",
+                app=GatewayApp(
+                    app_id=_APP_ID,
+                    app_name="desktop-center-client",
+                    owners="desktop-team",
+                    tenant="teamclaw",
+                ),
+            ),
+        )
+    )
+
+
+def _seed_center_skill(
+    world, *, is_public: bool = True, space_id: int | None = None
+) -> int:
+    init_principal_verifier_config(_SecretResolver(), "test-key", strict=False)
+    env = get_current_env()
+    make_bot(
+        world,
+        bot_id=_BOT,
+        owner_id=_OWNER,
+        bot_type="desktop",
+        status="PENDING",
+        active_engine="openclaw",
+    )
+    database = world.get(DatabasePlugin)
+    with database.orm_session() as session:
+        skill = Skill(
+            name="center-report",
+            description="Published Center report",
+            git_path="center://public-center-report",
+            is_public=is_public,
+            is_builtin=False,
+            user_id=None,
+            bolt_id="default",
+            env=env,
+            status="PUBLISHED",
+            version=1,
+            skill_uuid=_SKILL_UUID,
+            source_type="center",
+            avernet_tenant="teamclaw",
+        )
+        session.add(skill)
+        session.flush()
+        session.add(
+            SkillVersion(
+                skill_id=int(skill.id),
+                publication_attempt_id=None,
+                version_ordinal=1,
+                status="PUBLISHED",
+                sc_version_number="1.0.0",
+                sc_skill_id=101,
+                sc_version_id=1001,
+                name="center-report",
+                description="Published Center report",
+                metadata_json=json.dumps({"mcp_dependencies": []}),
+                published_at=datetime(2026, 9, 9),
+                created_by=_OWNER,
+                env=env,
+                avernet_tenant="teamclaw",
+            )
+        )
+        if space_id is not None:
+            session.add(
+                SkillSpaceBinding(
+                    skill_id=int(skill.id),
+                    space_id=space_id,
+                    created_by=_OWNER,
+                    env=env,
+                    avernet_tenant="teamclaw",
+                )
+            )
+        skill_id = int(skill.id)
+        session.commit()
+
+    world.get(CanonicalCenterVersionStore).write_version(
+        CanonicalCenterVersion.from_files(
+            CanonicalCenterVersionIdentity(
+                skill_uuid=_SKILL_UUID,
+                sc_version_number="1.0.0",
+            ),
+            {
+                "SKILL.md": (
+                    b"---\nname: center-report\ndescription: Published Center report\n"
+                    b"config:\n  - name: region\n    required: true\n"
+                    b"---\n# Exact published content\n"
+                )
+            },
+        )
+    )
+    return skill_id
+
+
+def _add_center_version(world, *, skill_id: int, ordinal: int, number: str) -> None:
+    env = get_current_env()
+    with world.get(DatabasePlugin).orm_session() as session:
+        session.add(
+            SkillVersion(
+                skill_id=skill_id,
+                publication_attempt_id=None,
+                version_ordinal=ordinal,
+                status="PUBLISHED",
+                sc_version_number=number,
+                sc_skill_id=101,
+                sc_version_id=1000 + ordinal,
+                name="center-report",
+                description=f"Published Center report v{ordinal}",
+                metadata_json=json.dumps({"mcp_dependencies": []}),
+                published_at=datetime(2026, 9, 9, 0, ordinal),
+                created_by=_OWNER,
+                env=env,
+                avernet_tenant="teamclaw",
+            )
+        )
+        session.commit()
+    world.get(CanonicalCenterVersionStore).write_version(
+        CanonicalCenterVersion.from_files(
+            CanonicalCenterVersionIdentity(
+                skill_uuid=_SKILL_UUID,
+                sc_version_number=number,
+            ),
+            {
+                "SKILL.md": (
+                    b"---\nname: center-report\ndescription: Latest Center report\n"
+                    b"config:\n  - name: region\n    required: true\n"
+                    b"---\n# Exact published content V2\n"
+                )
+            },
+        )
+    )
+
+
+def test_desktop_reads_public_center_exact_content_through_real_router_and_di(
+    app_with_testing_modules,
+    world,
+) -> None:
+    skill_id = _seed_center_skill(world)
+    _add_center_version(world, skill_id=skill_id, ordinal=2, number="2.0.0")
+    client = TestClient(app_with_testing_modules)
+    params = {"owner_id": _OWNER, "user_id": _OWNER}
+
+    detail = client.get(
+        f"/openapi/v1/bots/{_BOT}/skills/{skill_id}",
+        params=params,
+        headers=_headers(),
+    )
+    response = client.get(
+        f"/openapi/v1/bots/{_BOT}/skills/{skill_id}/content",
+        params=params,
+        headers=_headers(),
+    )
+
+    assert detail.status_code == 200, detail.text
+    assert detail.json()["data"]["skill_id"] == str(skill_id)
+    assert response.status_code == 200, response.text
+    assert response.json()["data"]["content"].endswith(
+        "# Exact published content V2\n"
+    )
+    persisted = world.get(SkillRepository).get_by_id(str(skill_id))
+    assert persisted is not None
+    assert persisted["bolt_id"] == "default"
+    assert persisted["user_id"] is None
+
+
+def test_cloud_and_desktop_bots_read_the_same_published_center_content(
+    app_with_testing_modules,
+    world,
+) -> None:
+    skill_id = _seed_center_skill(world)
+    cloud_bot = "center-cloud-bot"
+    make_bot(
+        world,
+        bot_id=cloud_bot,
+        owner_id=_OWNER,
+        bot_type="personal",
+        status="ACTIVE",
+        active_engine="openclaw",
+    )
+    client = TestClient(app_with_testing_modules)
+    params = {"owner_id": _OWNER, "user_id": _OWNER}
+
+    desktop = client.get(
+        f"/openapi/v1/bots/{_BOT}/skills/{skill_id}/content",
+        params=params,
+        headers=_headers(),
+    )
+    cloud = client.get(
+        f"/openapi/v1/bots/{cloud_bot}/skills/{skill_id}/content",
+        params=params,
+        headers=_headers(),
+    )
+
+    assert desktop.status_code == cloud.status_code == 200
+    assert desktop.json()["data"] == cloud.json()["data"]
+
+
+def test_center_access_and_version_protocols_share_one_composition_root_instance(
+    world,
+) -> None:
+    assert world.get(CenterSkillAccessRepositoryProtocol) is world.get(
+        SkillVersionRepositoryProtocol
+    )
+
+
+def test_desktop_center_parameters_use_existing_bot_scoped_json_routes(
+    app_with_testing_modules,
+    world,
+) -> None:
+    skill_id = _seed_center_skill(world)
+
+    class _Parameters:
+        def __init__(self) -> None:
+            self.saved: tuple[str, dict] | None = None
+
+        def get_skill_parameters(self, name: str) -> dict:
+            assert name == "center-report"
+            return {"region": "cn"}
+
+        async def save_skill_parameters(self, name: str, values: dict) -> bool:
+            self.saved = (name, values)
+            return True
+
+    class _Factory:
+        def __init__(self) -> None:
+            self.parameters = _Parameters()
+
+        async def create(self, **kwargs):
+            assert kwargs == {"bot_id": _BOT, "user_id": _OWNER}
+            return self.parameters
+
+    factory = _Factory()
+    world.injector.binder.bind(SkillParameterServiceFactory, to=factory, scope=None)
+    client = TestClient(app_with_testing_modules)
+    path = f"/openapi/v1/bots/{_BOT}/skills/{skill_id}/parameters"
+    params = {"owner_id": _OWNER, "user_id": _OWNER}
+
+    read = client.get(path, params=params, headers=_headers())
+    written = client.put(
+        path,
+        params=params,
+        headers=_headers(),
+        json={"parameters": {"region": "sg"}},
+    )
+
+    assert read.status_code == 200, read.text
+    assert read.json()["data"]["parameters"] == {"region": "cn"}
+    assert written.status_code == 200, written.text
+    assert written.json()["data"]["parameters"] == {"region": "sg"}
+    assert factory.parameters.saved == ("center-report", {"region": "sg"})
+
+
+def test_desktop_can_directly_activate_visible_center_skill_before_installation(
+    app_with_testing_modules,
+    world,
+) -> None:
+    skill_id = _seed_center_skill(world)
+
+    response = TestClient(app_with_testing_modules).post(
+        f"/openapi/v1/bots/{_BOT}/skills/{skill_id}/activate",
+        params={"owner_id": _OWNER, "user_id": _OWNER},
+        headers=_headers(),
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["data"]["skill"]["active"] is True
+    assert response.json()["data"]["runtime_projection"]["status"] == "PENDING"
+
+    deactivated = TestClient(app_with_testing_modules).post(
+        f"/openapi/v1/bots/{_BOT}/skills/{skill_id}/deactivate",
+        params={"owner_id": _OWNER, "user_id": _OWNER},
+        headers=_headers(),
+    )
+    assert deactivated.status_code == 200, deactivated.text
+    assert deactivated.json()["data"]["skill"]["active"] is False
+    assert deactivated.json()["data"]["runtime_projection"]["status"] == "PENDING"
+
+
+def test_shared_center_readme_uses_latest_published_content_without_bot_context(
+    app_with_testing_modules,
+    world,
+) -> None:
+    skill_id = _seed_center_skill(world)
+
+    response = TestClient(app_with_testing_modules).get(
+        f"/openapi/v1/bots/skills/{skill_id}/readme",
+        headers=_headers(),
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["data"]["content"].endswith("# Exact published content\n")
+
+
+def test_private_space_center_content_requires_live_space_membership_after_bot_access(
+    app_with_testing_modules,
+    world,
+) -> None:
+    member = "desktop-center-space-member"
+    outsider = "desktop-center-space-outsider"
+    space = world.get(SpaceServiceProtocol).create_team(
+        name="Center Consumers", creator_id=_OWNER, create_sc_team=False
+    )
+    skill_id = _seed_center_skill(world, is_public=False, space_id=space.id)
+    bot = world.get(BotRepository).get_by_id_and_owner(_BOT, _OWNER)
+    assert bot is not None
+    for actor in (member, outsider):
+        make_collaborator_record(
+            world,
+            bot_pk=int(bot["id"]),
+            bot_id=_BOT,
+            owner_id=_OWNER,
+            user_id=actor,
+            role="member",
+        )
+    world.get(SpaceMemberServiceProtocol).add_member(
+        space_id=space.id,
+        actor_id=_OWNER,
+        user_id=member,
+        role=SpaceRole.MEMBER,
+    )
+    client = TestClient(app_with_testing_modules)
+    path = f"/openapi/v1/bots/{_BOT}/skills/{skill_id}/content"
+    params = {"owner_id": _OWNER}
+
+    allowed = client.get(
+        path,
+        params={**params, "user_id": member},
+        headers=_headers(member),
+    )
+    denied = client.get(
+        path,
+        params={**params, "user_id": outsider},
+        headers=_headers(outsider),
+    )
+
+    assert allowed.status_code == 200, allowed.text
+    assert denied.status_code == 404
+
+
+def test_app_grant_and_bot_collaboration_reach_public_center_content(
+    app_with_testing_modules,
+    world,
+) -> None:
+    collaborator = "desktop-center-app-user"
+    skill_id = _seed_center_skill(world)
+    bot = world.get(BotRepository).get_by_id_and_owner(_BOT, _OWNER)
+    assert bot is not None
+    make_collaborator_record(
+        world,
+        bot_pk=int(bot["id"]),
+        bot_id=_BOT,
+        owner_id=_OWNER,
+        user_id=collaborator,
+        role="member",
+    )
+    world.get(BotAppGrantServiceProtocol).grant(
+        bot_id=_BOT,
+        user_id=collaborator,
+        owner_id=_OWNER,
+        app_id=_APP_ID,
+        app_name="desktop-center-client",
+    )
+    app_with_testing_modules.dependency_overrides[require_principal] = _app_caller
+    try:
+        response = TestClient(app_with_testing_modules).get(
+            f"/openapi/v1/bots/{_BOT}/skills/{skill_id}/content",
+            params={"owner_id": _OWNER, "user_id": collaborator},
+        )
+    finally:
+        app_with_testing_modules.dependency_overrides.pop(require_principal, None)
+
+    assert response.status_code == 200, response.text
+    assert response.json()["data"]["content"].endswith("# Exact published content\n")

--- a/src/backend/tests/community/endpoints/test_openapi_skill_sets.py
+++ b/src/backend/tests/community/endpoints/test_openapi_skill_sets.py
@@ -17,6 +17,7 @@ from agentclaw.community.adapters.http.openapi_v1.dependencies import PRINCIPAL_
 from agentclaw.community.api.direct_activation_service import (
     DirectActivationServiceProtocol,
 )
+from agentclaw.community.api.skill_query_service import SkillQueryServiceProtocol
 from agentclaw.community.api.skill_set_management_service import (
     SkillSetManagementServiceProtocol,
 )
@@ -207,7 +208,7 @@ def _seed(world, *, member: bool = False) -> None:
     direct = DirectActivationService(
         world.get(CapabilityDesiredStateRepositoryProtocol),
         world.get(BotRepository),
-        world.get(SkillRepository),
+        world.get(SkillQueryServiceProtocol),
         runtime,
         world.get(BotCapabilityAuthorizationHookProtocol),
         world.get(BotCollabLogRepositoryProtocol),

--- a/src/backend/tests/community/endpoints/test_openapi_skill_state.py
+++ b/src/backend/tests/community/endpoints/test_openapi_skill_state.py
@@ -10,6 +10,7 @@ from agentclaw.community.adapters.http.openapi_v1.dependencies import PRINCIPAL_
 from agentclaw.community.api.direct_activation_service import (
     DirectActivationServiceProtocol,
 )
+from agentclaw.community.api.skill_query_service import SkillQueryServiceProtocol
 from agentclaw.community.core.repository.protocols.bot import BotRepository
 from agentclaw.community.core.repository.protocols.capability_desired_state import (
     CapabilityDesiredStateRepositoryProtocol,
@@ -176,7 +177,7 @@ def _seed_state(world, *, runtime_success: bool) -> None:
         to=DirectActivationService(
             world.get(CapabilityDesiredStateRepositoryProtocol),
             world.get(BotRepository),
-            world.get(SkillRepository),
+            world.get(SkillQueryServiceProtocol),
             runtime_factory._runtime,
             world.get(BotCapabilityAuthorizationHookProtocol),
             world.get(BotCollabLogRepositoryProtocol),

--- a/src/backend/tests/community/plugins/local/test_local_device_filesystem.py
+++ b/src/backend/tests/community/plugins/local/test_local_device_filesystem.py
@@ -2,6 +2,8 @@
 
 Uses real filesystem via tmp_path — no mocks.
 """
+from pathlib import Path
+
 import pytest
 
 from agentclaw.community.core.devices.services.local_device_filesystem import LocalDeviceFileSystem
@@ -39,6 +41,21 @@ class TestReadFile:
         data = bytes(range(256))
         f.write_bytes(data)
         assert await fs.read_file(str(f)) == data
+
+    @pytest.mark.asyncio
+    async def test_preserve_read_errors_distinguishes_io_failure_from_absence(
+        self, fs, tmp_path, monkeypatch
+    ):
+        target = tmp_path / "unreadable.json"
+        target.write_bytes(b"{}")
+
+        def _denied(_path):
+            raise PermissionError("read denied")
+
+        monkeypatch.setattr(Path, "read_bytes", _denied)
+        assert await fs.read_file(str(target)) is None
+        with pytest.raises(PermissionError, match="read denied"):
+            await fs.read_file(str(target), preserve_read_errors=True)
 
 
 # ── write_file ─────────────────────────────────────────────────────────

--- a/src/backend/tests/community/plugins/prod/test_teclaw_device_filesystem.py
+++ b/src/backend/tests/community/plugins/prod/test_teclaw_device_filesystem.py
@@ -71,6 +71,16 @@ def _fs():
     return fs, baas
 
 
+@pytest.mark.asyncio
+async def test_read_preserve_errors_distinguishes_transport_failure_from_absence():
+    fs, baas = _fs()
+    baas.invoke_http.side_effect = httpx.ConnectError("unavailable")
+
+    assert await fs.read_file(_DEVICE_PATH) is None
+    with pytest.raises(httpx.ConnectError, match="unavailable"):
+        await fs.read_file(_DEVICE_PATH, preserve_read_errors=True)
+
+
 # ── write (per-file upload, no OSS / no redeliver) ────────────────────
 
 @pytest.mark.asyncio

--- a/src/backend/tests/community/repository/skill_center/test_skill_version_repository.py
+++ b/src/backend/tests/community/repository/skill_center/test_skill_version_repository.py
@@ -110,6 +110,77 @@ def _add_version(
         )
 
 
+def _add_center_skill(
+    db: _Database,
+    *,
+    skill_id: int,
+    is_public: bool,
+    tenant: str = "teamclaw",
+    space_id: int | None = None,
+) -> None:
+    with avernet_tenant_scope(tenant), db.orm_session() as session:
+        session.add(
+            Skill(
+                id=skill_id,
+                name=f"center-{skill_id}",
+                git_path=f"center://skill-{skill_id}",
+                skill_uuid=f"00000000-0000-4000-8000-{skill_id:012d}",
+                is_public=is_public,
+                user_id=None,
+                bolt_id="default",
+                env="pre",
+                avernet_tenant=tenant,
+            )
+        )
+        if space_id is not None:
+            session.add(
+                SkillSpaceBinding(
+                    skill_id=skill_id,
+                    space_id=space_id,
+                    created_by="owner",
+                    env="pre",
+                    avernet_tenant=tenant,
+                )
+            )
+
+
+def test_center_access_reports_public_or_space_facts_without_deciding_actor_acl() -> (
+    None
+):
+    db = _Database()
+    _add_center_skill(db, skill_id=10, is_public=True)
+    _add_center_skill(db, skill_id=20, is_public=False, space_id=7)
+    repo = SkillVersionRepository(db)
+
+    with avernet_tenant_scope("teamclaw"):
+        public = repo.get_access(env="pre", skill_id=10)
+        space = repo.get_access(env="pre", skill_id=20)
+
+    assert public == {
+        "skill_id": 10,
+        "skill_uuid": "00000000-0000-4000-8000-000000000010",
+        "visibility": "PUBLIC",
+        "space_id": None,
+        "offline_at": None,
+    }
+    assert space is not None
+    assert space["visibility"] == "SPACE"
+    assert space["space_id"] == 7
+
+
+def test_center_access_fails_closed_for_inconsistent_or_cross_tenant_rows() -> None:
+    db = _Database()
+    _add_center_skill(db, skill_id=10, is_public=False)
+    _add_center_skill(db, skill_id=20, is_public=True, space_id=7)
+    _add_center_skill(db, skill_id=30, is_public=True, tenant="external")
+    repo = SkillVersionRepository(db)
+
+    with avernet_tenant_scope("teamclaw"):
+        assert repo.get_access(env="pre", skill_id=10) is None
+        assert repo.get_access(env="pre", skill_id=20) is None
+        assert repo.get_access(env="pre", skill_id=30) is None
+
+
 def test_latest_query_ignores_materializing_and_is_tenant_scoped() -> None:
     db = _Database()
     repo = SkillVersionRepository(db)


### PR DESCRIPTION
## Problem
Desktop OpenClaw/Hermes bots could reach the existing Skill product routes, but governed `center://` assets stopped at a query placeholder. Center detail/content/parameters/Direct operations and shared README therefore did not share the established Bot, grant, Space visibility, and exact Published-version rules. Parameter read failures could also be mistaken for an empty file and overwrite unrelated configuration.

## Solution
- add a tenant/env-scoped Center access-facts repository seam and keep it identity-shared with the Version repository
- resolve PUBLIC/Space visibility in `SkillQueryService`, select the latest Published version through the formal `SkillVersionResolverProtocol`, and read exact Canonical content without Engine or download I/O
- expose Center assets through existing detail/content/parameters/Direct routes while keeping shared persistence ownership unchanged
- fix shared Local README owner+bot addressing and preserve Repo behavior
- make parameter loading fail closed on corrupt/read errors, preserve other Skill entries/root metadata, and surface write failures
- add an opt-in `preserve_read_errors` filesystem/sandbox contract plus neutral `SandboxFileReadError`; only read-modify-write parameter loading opts in, so legacy unreadable-as-None callers remain unchanged
- admit Hermes through the existing formal Desktop create workflow
- document the frontend distinction between internal `skill_id` Set membership and asynchronous external `skill_codes` Reference

## Validation
- `917 passed` — post-review parameter, device filesystem, service-contract and protocol-contract tests
- `431 passed` — focused Router/service/repository/version-resolver tests plus the complete Community architecture suite before the additive read-error contract revision
- `89 passed` — latest OCB `dev@4a7c6c963` Arca/device/DI tests with this Avernet source overlaid
- explicit OCB `corp_test` resolution: `SkillQueryService SkillVersionRepository True` (access/version Protocols share one instance)
- Standards review: no actionable Avernet findings
- Spec review findings for formal VersionResolver, detail/deactivate/two-version coverage, docs, OCB DI, and scoped parameter read failures were closed
- prior head CI: all 11 checks passed; current head CI is running

## Compatibility and risk
No public Router path or DTO shape changes, so no Gateway schema artifact was regenerated. Upload/delete remain Local-only; Center reads are control-plane expected content and do not prove runtime convergence. `preserve_read_errors` defaults false at both filesystem seams; only Skill parameter read-modify-write opts in. OCB needs a companion adapter change to translate Arca non-404/transport failures to the neutral error, and its PR/gitlink will follow after this public SHA is available in the OCB submodule mirror. Deployment and live Desktop behavior are not claimed by this PR.

## Spec
Implements G1 / D1 / D4 / D10 from the fixed Desktop Skill capability spec at `bba4fe5017e1810e0f4ed0ec397ab2a364abe7c5`.

## Related issues
Refs #2063