### PR TITLE
fix(bcs): persist session participant scope without WS barrier

### DIFF
--- a/src/bcs/api-contracts/v1/openapi/connections.yaml
+++ b/src/bcs/api-contracts/v1/openapi/connections.yaml
@@ -111,13 +111,16 @@ GroupSessionWebSocketPath:
       Human; `full` receives all artifacts. Chat-domain artifacts retain legacy
       visibility. Bot-tab connections are not affected by Human scope.
 
-      A connection keeps the Session scope resolved during `connect`. After a
-      Human's Session scope changes, the client must close the old connection
-      and establish a new one so the server can bind the newly persisted scope.
-      Existing connections are not guaranteed to observe scope changes. The
-      scope projects only the Workbench message stream and is not a security
-      boundary; StateMachine resource APIs keep their existing authorization
-      semantics.
+      When a Human's Session scope changes, matching connections on the current
+      instance receive an `event=close` frame with
+      `payload.reason=view_scope_changed` and are closed. After the scope update
+      completes, the client establishes a new connection so the server can bind
+      the newly persisted scope. In leader-elected
+      multi-replica deployments, invalidation is currently best-effort and
+      instance-local; connections on other replicas apply the new scope on their
+      next reconnect. The scope projects only the Workbench message stream and
+      is not a security boundary; StateMachine resource APIs keep their existing
+      authorization semantics.
     x-avernet-protocol: websocket
     x-avernet-security: {}
     parameters:

--- a/src/bcs/api-contracts/v1/openapi/connections.yaml
+++ b/src/bcs/api-contracts/v1/openapi/connections.yaml
@@ -111,11 +111,13 @@ GroupSessionWebSocketPath:
       Human; `full` receives all artifacts. Chat-domain artifacts retain legacy
       visibility. Bot-tab connections are not affected by Human scope.
 
-      When a Human's Session scope changes, the server sends an `event=close`
-      frame with `payload.reason=view_scope_changed` and then closes the socket.
-      The client must establish a new connection so the server can bind the new
-      persisted scope. The scope projects only the Workbench message stream;
-      StateMachine resource APIs keep their existing authorization semantics.
+      A connection keeps the Session scope resolved during `connect`. After a
+      Human's Session scope changes, the client must close the old connection
+      and establish a new one so the server can bind the newly persisted scope.
+      Existing connections are not guaranteed to observe scope changes. The
+      scope projects only the Workbench message stream and is not a security
+      boundary; StateMachine resource APIs keep their existing authorization
+      semantics.
     x-avernet-protocol: websocket
     x-avernet-security: {}
     parameters:

--- a/src/bcs/crates/adapters/ws/bcs-ws/src/web/connection_registry.rs
+++ b/src/bcs/crates/adapters/ws/bcs-ws/src/web/connection_registry.rs
@@ -39,7 +39,7 @@ pub struct WorkbenchConnectionRegistry {
     sessions: RwLock<HashMap<String, Vec<FrontendConnection>>>,
     bot_query: RwLock<Option<Arc<dyn BotQueryService>>>,
     scope_change_barriers: Mutex<HashSet<(String, String, u64)>>,
-    scope_changes_disabled: bool,
+    cluster_scope_changes_best_effort: bool,
 }
 
 impl std::fmt::Debug for WorkbenchConnectionRegistry {
@@ -59,12 +59,12 @@ impl WorkbenchConnectionRegistry {
             sessions: RwLock::new(HashMap::new()),
             bot_query: RwLock::new(Some(bot_query)),
             scope_change_barriers: Mutex::new(HashSet::new()),
-            scope_changes_disabled: false,
+            cluster_scope_changes_best_effort: false,
         }
     }
 
-    pub fn with_scope_changes_enabled(mut self, enabled: bool) -> Self {
-        self.scope_changes_disabled = !enabled;
+    pub fn with_cluster_scope_changes_best_effort(mut self, enabled: bool) -> Self {
+        self.cluster_scope_changes_best_effort = enabled;
         self
     }
 
@@ -297,11 +297,15 @@ impl ParticipantViewBindingPort for WorkbenchConnectionRegistry {
         scope_id: &str,
         human_actor_id: &str,
     ) -> ServiceResult<ParticipantViewScopeChangeLease> {
-        if self.scope_changes_disabled {
-            return Err(ServiceError::InvalidOperation {
-                message: "view_scope_change_requires_cluster_binding".to_string(),
-                request_id: None,
-            });
+        if self.cluster_scope_changes_best_effort {
+            // TODO: Broadcast participant-view invalidation across replicas if
+            // this presentation projection becomes a strict security boundary.
+            warn!(
+                request_id = %bcs_observability::CurrentRequestId,
+                scope_id = %scope_id,
+                human_actor_id = %human_actor_id,
+                "participant view scope change uses instance-local connection invalidation"
+            );
         }
         let lease_id = NEXT_SCOPE_CHANGE_LEASE_ID.fetch_add(1, Ordering::Relaxed);
         let mut barriers = self.scope_change_barriers.lock().await;

--- a/src/bcs/crates/adapters/ws/bcs-ws/src/web/connection_registry.rs
+++ b/src/bcs/crates/adapters/ws/bcs-ws/src/web/connection_registry.rs
@@ -39,12 +39,13 @@ pub struct WorkbenchConnectionRegistry {
     sessions: RwLock<HashMap<String, Vec<FrontendConnection>>>,
     bot_query: RwLock<Option<Arc<dyn BotQueryService>>>,
     scope_change_barriers: Mutex<HashSet<(String, String, u64)>>,
-    cluster_scope_changes_best_effort: bool,
+    scope_changes_disabled: bool,
 }
 
 impl std::fmt::Debug for WorkbenchConnectionRegistry {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("WorkbenchConnectionRegistry")
+            .field("cluster_scope_changes_enabled", &!self.scope_changes_disabled)
             .finish_non_exhaustive()
     }
 }
@@ -59,12 +60,12 @@ impl WorkbenchConnectionRegistry {
             sessions: RwLock::new(HashMap::new()),
             bot_query: RwLock::new(Some(bot_query)),
             scope_change_barriers: Mutex::new(HashSet::new()),
-            cluster_scope_changes_best_effort: false,
+            scope_changes_disabled: false,
         }
     }
 
-    pub fn with_cluster_scope_changes_best_effort(mut self, enabled: bool) -> Self {
-        self.cluster_scope_changes_best_effort = enabled;
+    pub fn with_scope_changes_enabled(mut self, enabled: bool) -> Self {
+        self.scope_changes_disabled = !enabled;
         self
     }
 
@@ -297,16 +298,6 @@ impl ParticipantViewBindingPort for WorkbenchConnectionRegistry {
         scope_id: &str,
         human_actor_id: &str,
     ) -> ServiceResult<ParticipantViewScopeChangeLease> {
-        if self.cluster_scope_changes_best_effort {
-            // TODO: Broadcast participant-view invalidation across replicas if
-            // this presentation projection becomes a strict security boundary.
-            warn!(
-                request_id = %bcs_observability::CurrentRequestId,
-                scope_id = %scope_id,
-                human_actor_id = %human_actor_id,
-                "participant view scope change uses instance-local connection invalidation"
-            );
-        }
         let lease_id = NEXT_SCOPE_CHANGE_LEASE_ID.fetch_add(1, Ordering::Relaxed);
         let mut barriers = self.scope_change_barriers.lock().await;
         if barriers

--- a/src/bcs/crates/adapters/ws/bcs-ws/tests/frontend_delivery_port.rs
+++ b/src/bcs/crates/adapters/ws/bcs-ws/tests/frontend_delivery_port.rs
@@ -482,8 +482,8 @@ async fn scope_change_cancels_socket_when_close_queue_is_full() {
 
 #[tokio::test]
 async fn distributed_deployment_allows_instance_local_scope_change_barrier() {
-    let connections = WorkbenchConnectionRegistry::new()
-        .with_cluster_scope_changes_best_effort(true);
+    let connections = WorkbenchConnectionRegistry::new().with_scope_changes_enabled(false);
+    assert!(format!("{connections:?}").contains("cluster_scope_changes_enabled: false"));
 
     let lease = connections
         .begin_scope_change("session-scoped", "human_target")

--- a/src/bcs/crates/adapters/ws/bcs-ws/tests/frontend_delivery_port.rs
+++ b/src/bcs/crates/adapters/ws/bcs-ws/tests/frontend_delivery_port.rs
@@ -481,17 +481,17 @@ async fn scope_change_cancels_socket_when_close_queue_is_full() {
 }
 
 #[tokio::test]
-async fn distributed_deployment_rejects_local_only_scope_change_barrier() {
-    let connections = WorkbenchConnectionRegistry::new().with_scope_changes_enabled(false);
+async fn distributed_deployment_allows_instance_local_scope_change_barrier() {
+    let connections = WorkbenchConnectionRegistry::new()
+        .with_cluster_scope_changes_best_effort(true);
 
-    let error = connections
+    let lease = connections
         .begin_scope_change("session-scoped", "human_target")
         .await
-        .expect_err("local registry cannot fence connections on other replicas");
+        .expect("cluster mode permits instance-local connection invalidation");
 
-    assert!(matches!(
-        error,
-        bcs_service_api::ServiceError::InvalidOperation { message, .. }
-            if message == "view_scope_change_requires_cluster_binding"
-    ));
+    connections
+        .finish_scope_change(lease)
+        .await
+        .expect("finish instance-local scope change");
 }

--- a/src/bcs/crates/application/v1/bcs-app-session/src/lib.rs
+++ b/src/bcs/crates/application/v1/bcs-app-session/src/lib.rs
@@ -35,7 +35,6 @@ use bcs_service_api::application::v1::{
     },
 };
 use bcs_service_api::port::repo::SessionRepoPort;
-use bcs_service_api::port::{NoopParticipantViewBindingPort, ParticipantViewBindingPort};
 use bcs_service_api::types::{HumanMessageView, MessageViewScope};
 use bcs_service_api::{
     ActorKind, ActorStatus, BotRegistryCoreService, CallerContext, CollaborationRuntimeError,
@@ -72,7 +71,6 @@ pub struct SessionServiceImpl {
     history: Arc<dyn GroupMessageHistoryService>,
     collaboration_runtime: Arc<dyn CollaborationRuntimeService>,
     system_message: Arc<dyn SystemMessageService>,
-    participant_view_bindings: Arc<dyn ParticipantViewBindingPort>,
     config: SessionServiceConfig,
 }
 
@@ -102,17 +100,8 @@ impl SessionServiceImpl {
             history,
             collaboration_runtime,
             system_message,
-            participant_view_bindings: Arc::new(NoopParticipantViewBindingPort),
             config,
         }
-    }
-
-    pub fn with_participant_view_bindings(
-        mut self,
-        participant_view_bindings: Arc<dyn ParticipantViewBindingPort>,
-    ) -> Self {
-        self.participant_view_bindings = participant_view_bindings;
-        self
     }
 
     // ── authorization helpers ──────────────────────────────────────────
@@ -1070,31 +1059,13 @@ impl SessionService for SessionServiceImpl {
                         .unwrap_or_else(|| ParticipantMode::default_for(ActorKind::Human)),
                 );
                 participant.message_view_scope = message_view_scope;
-                let lease = if message_view_scope == MessageViewScope::Participant {
-                    Some(
-                        self.participant_view_bindings
-                            .begin_scope_change(&command.session_id, &command.bot_uuid)
-                            .await
-                            .map_err(map_service_error)?,
-                    )
-                } else {
-                    None
-                };
-                let add_result = self
+                // Initial membership creation cannot have an existing
+                // participant-bound Session connection to invalidate.
+                let mut updated = self
                     .sessions
                     .add_participant(&command.session_id, participant)
                     .await
-                    .map_err(map_session_error);
-                let release_result = if let Some(lease) = lease {
-                    self.participant_view_bindings
-                        .finish_scope_change(lease)
-                        .await
-                        .map_err(map_service_error)
-                } else {
-                    Ok(())
-                };
-                let mut updated = add_result?;
-                release_result?;
+                    .map_err(map_session_error)?;
                 if let Some(mode) = command.mode {
                     let actor_name = self
                         .registry
@@ -1240,19 +1211,10 @@ impl SessionService for SessionServiceImpl {
             }
         }
         if let Some(message_view_scope) = command.message_view_scope {
-            let lease = if actor_kind == ActorKind::Human
-                && existing.message_view_scope != message_view_scope
-            {
-                Some(
-                    self.participant_view_bindings
-                        .begin_scope_change(&command.session_id, &command.bot_uuid)
-                        .await
-                        .map_err(map_service_error)?,
-                )
-            } else {
-                None
-            };
-            let update_result = self
+            // TODO: Existing WebSocket connections retain their bound scope
+            // until reconnect. Add connection invalidation only if participant
+            // projection becomes a strict security boundary.
+            updated = self
                 .sessions
                 .update_participant_mode_and_message_view_scope(
                     &command.session_id,
@@ -1261,17 +1223,7 @@ impl SessionService for SessionServiceImpl {
                     message_view_scope,
                 )
                 .await
-                .map_err(map_session_error);
-            let release_result = if let Some(lease) = lease {
-                self.participant_view_bindings
-                    .finish_scope_change(lease)
-                    .await
-                    .map_err(map_service_error)
-            } else {
-                Ok(())
-            };
-            updated = update_result?;
-            release_result?;
+                .map_err(map_session_error)?;
             if let Some(mode) = command.mode
                 && old_mode != Some(mode)
             {

--- a/src/bcs/crates/application/v1/bcs-app-session/src/lib.rs
+++ b/src/bcs/crates/application/v1/bcs-app-session/src/lib.rs
@@ -35,6 +35,7 @@ use bcs_service_api::application::v1::{
     },
 };
 use bcs_service_api::port::repo::SessionRepoPort;
+use bcs_service_api::port::{NoopParticipantViewBindingPort, ParticipantViewBindingPort};
 use bcs_service_api::types::{HumanMessageView, MessageViewScope};
 use bcs_service_api::{
     ActorKind, ActorStatus, BotRegistryCoreService, CallerContext, CollaborationRuntimeError,
@@ -71,6 +72,7 @@ pub struct SessionServiceImpl {
     history: Arc<dyn GroupMessageHistoryService>,
     collaboration_runtime: Arc<dyn CollaborationRuntimeService>,
     system_message: Arc<dyn SystemMessageService>,
+    participant_view_bindings: Arc<dyn ParticipantViewBindingPort>,
     config: SessionServiceConfig,
 }
 
@@ -100,8 +102,17 @@ impl SessionServiceImpl {
             history,
             collaboration_runtime,
             system_message,
+            participant_view_bindings: Arc::new(NoopParticipantViewBindingPort),
             config,
         }
+    }
+
+    pub fn with_participant_view_bindings(
+        mut self,
+        participant_view_bindings: Arc<dyn ParticipantViewBindingPort>,
+    ) -> Self {
+        self.participant_view_bindings = participant_view_bindings;
+        self
     }
 
     // ── authorization helpers ──────────────────────────────────────────
@@ -1211,10 +1222,19 @@ impl SessionService for SessionServiceImpl {
             }
         }
         if let Some(message_view_scope) = command.message_view_scope {
-            // TODO: Existing WebSocket connections retain their bound scope
-            // until reconnect. Add connection invalidation only if participant
-            // projection becomes a strict security boundary.
-            updated = self
+            let lease = if actor_kind == ActorKind::Human
+                && existing.message_view_scope != message_view_scope
+            {
+                Some(
+                    self.participant_view_bindings
+                        .begin_scope_change(&command.session_id, &command.bot_uuid)
+                        .await
+                        .map_err(map_service_error)?,
+                )
+            } else {
+                None
+            };
+            let update_result = self
                 .sessions
                 .update_participant_mode_and_message_view_scope(
                     &command.session_id,
@@ -1223,7 +1243,17 @@ impl SessionService for SessionServiceImpl {
                     message_view_scope,
                 )
                 .await
-                .map_err(map_session_error)?;
+                .map_err(map_session_error);
+            let release_result = if let Some(lease) = lease {
+                self.participant_view_bindings
+                    .finish_scope_change(lease)
+                    .await
+                    .map_err(map_service_error)
+            } else {
+                Ok(())
+            };
+            updated = update_result?;
+            release_result?;
             if let Some(mode) = command.mode
                 && old_mode != Some(mode)
             {

--- a/src/bcs/crates/application/v1/bcs-app-session/tests/v1_session_service.rs
+++ b/src/bcs/crates/application/v1/bcs-app-session/tests/v1_session_service.rs
@@ -30,6 +30,7 @@ use bcs_service_api::application::v1::{
     SessionService, SessionStatus as V1SessionStatus, UncollectSession, UpdateSession,
     UpdateSessionParticipant,
 };
+use bcs_service_api::port::{ParticipantViewBindingPort, ParticipantViewScopeChangeLease};
 use bcs_service_api::port::repo::{NewSessionParams, SessionRepoPort};
 use bcs_service_api::types::{HumanMessageView, MessageViewScope};
 use bcs_service_api::{
@@ -67,6 +68,42 @@ struct RecordedSystemMessage {
     group_id: String,
     session_id: String,
     event: SystemMessageEvent,
+}
+
+#[derive(Default)]
+struct RecordingParticipantViewBindings {
+    begun: Mutex<Vec<(String, String)>>,
+    finished: Mutex<Vec<ParticipantViewScopeChangeLease>>,
+}
+
+#[async_trait]
+impl ParticipantViewBindingPort for RecordingParticipantViewBindings {
+    async fn begin_scope_change(
+        &self,
+        scope_id: &str,
+        human_actor_id: &str,
+    ) -> ServiceResult<ParticipantViewScopeChangeLease> {
+        self.begun
+            .lock()
+            .expect("scope binding begin lock")
+            .push((scope_id.to_string(), human_actor_id.to_string()));
+        Ok(ParticipantViewScopeChangeLease {
+            scope_id: scope_id.to_string(),
+            human_actor_id: human_actor_id.to_string(),
+            lease_id: 1,
+        })
+    }
+
+    async fn finish_scope_change(
+        &self,
+        lease: ParticipantViewScopeChangeLease,
+    ) -> ServiceResult<()> {
+        self.finished
+            .lock()
+            .expect("scope binding finish lock")
+            .push(lease);
+        Ok(())
+    }
 }
 
 #[async_trait]
@@ -368,6 +405,16 @@ impl Fixture {
             system_messages,
             session_repo,
         }
+    }
+
+    fn with_participant_view_bindings(
+        mut self,
+        participant_view_bindings: Arc<dyn ParticipantViewBindingPort>,
+    ) -> Self {
+        self.service = self
+            .service
+            .with_participant_view_bindings(participant_view_bindings);
+        self
     }
 
     async fn add_bot(&self, bot_uuid: &str) {
@@ -2888,7 +2935,10 @@ async fn human_participant_can_update_own_mode_without_session_management() {
 
 #[tokio::test]
 async fn readable_session_auto_adds_missing_human_with_selected_scope() {
-    let fixture = Fixture::new().await;
+    let participant_view_bindings = Arc::new(RecordingParticipantViewBindings::default());
+    let fixture = Fixture::new()
+        .await
+        .with_participant_view_bindings(participant_view_bindings.clone());
     for bot in ["driver", "owned-bot"] {
         fixture.add_bot(bot).await;
     }
@@ -2951,6 +3001,14 @@ async fn readable_session_auto_adds_missing_human_with_selected_scope() {
     assert_eq!(
         matching[0].message_view_scope,
         MessageViewScope::Participant
+    );
+    assert!(
+        participant_view_bindings
+            .begun
+            .lock()
+            .expect("scope binding begin lock")
+            .is_empty(),
+        "initial membership creation must not acquire a scope-change lease"
     );
 }
 
@@ -3224,7 +3282,10 @@ async fn session_manager_cannot_update_another_human_mode() {
 
 #[tokio::test]
 async fn session_manager_can_update_another_human_scope_without_changing_mode() {
-    let fixture = Fixture::new().await;
+    let participant_view_bindings = Arc::new(RecordingParticipantViewBindings::default());
+    let fixture = Fixture::new()
+        .await
+        .with_participant_view_bindings(participant_view_bindings.clone());
     fixture.add_bot("driver").await;
     fixture
         .bots
@@ -3281,6 +3342,20 @@ async fn session_manager_can_update_another_human_scope_without_changing_mode() 
         .expect("target remains in session");
     assert_eq!(target.mode, Some(ParticipantMode::Absent));
     assert_eq!(target.message_view_scope, MessageViewScope::Participant);
+    assert_eq!(
+        *participant_view_bindings
+            .begun
+            .lock()
+            .expect("scope binding begin lock"),
+        vec![(session_id.clone(), "human_target".to_string())]
+    );
+    let finished = participant_view_bindings
+        .finished
+        .lock()
+        .expect("scope binding finish lock");
+    assert_eq!(finished.len(), 1);
+    assert_eq!(finished[0].scope_id, session_id);
+    assert_eq!(finished[0].human_actor_id, "human_target");
 }
 
 #[tokio::test]

--- a/src/bcs/crates/application/v1/bcs-app-session/tests/v1_session_service.rs
+++ b/src/bcs/crates/application/v1/bcs-app-session/tests/v1_session_service.rs
@@ -2887,7 +2887,7 @@ async fn human_participant_can_update_own_mode_without_session_management() {
 }
 
 #[tokio::test]
-async fn readable_session_auto_adds_missing_human_as_present_observer() {
+async fn readable_session_auto_adds_missing_human_with_selected_scope() {
     let fixture = Fixture::new().await;
     for bot in ["driver", "owned-bot"] {
         fixture.add_bot(bot).await;
@@ -2926,14 +2926,15 @@ async fn readable_session_auto_adds_missing_human_as_present_observer() {
             session_id: session.id,
             bot_uuid: "human_staff-1".into(),
             mode: Some(ParticipantMode::Present),
-            message_view_scope: None,
+            message_view_scope: Some(MessageViewScope::Participant),
         })
         .await
-        .expect("missing Human self-inserts into readable Session");
+        .expect("missing Human self-inserts with selected scope");
 
     assert_eq!(inserted.actor_kind, ActorKind::Human);
     assert_eq!(inserted.role, ParticipantRole::Observer);
     assert_eq!(inserted.mode, ParticipantMode::Present);
+    assert_eq!(inserted.message_view_scope, MessageViewScope::Participant);
     let stored = fixture
         .session_repo
         .get(&session_id)
@@ -2947,6 +2948,10 @@ async fn readable_session_auto_adds_missing_human_as_present_observer() {
     assert_eq!(matching.len(), 1);
     assert_eq!(matching[0].role, ParticipantRole::Observer);
     assert_eq!(matching[0].mode, Some(ParticipantMode::Present));
+    assert_eq!(
+        matching[0].message_view_scope,
+        MessageViewScope::Participant
+    );
 }
 
 #[tokio::test]

--- a/src/bcs/crates/bootstrap/bcs/src/server.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/server.rs
@@ -1608,29 +1608,26 @@ fn build_openapi_v1_state(
             relation_env: relation_env.clone(),
         },
     )
-    .with_participant_view_bindings(participant_view_bindings.clone())
+    .with_participant_view_bindings(participant_view_bindings)
     .with_collaboration_runtime(collaboration_runtime.clone());
     if config.eventing.enabled {
         group_service =
             group_service.with_event_subscription_provisioner(group_event_subscription_provisioner);
     }
     let group_service = Arc::new(group_service);
-    let session_service = Arc::new(
-        SessionServiceImpl::new(
-            session_launch,
-            sessions.clone(),
-            groups.clone(),
-            registry.clone(),
-            friends.clone(),
-            relation,
-            session_repo,
-            group_message_history,
-            collaboration_runtime.clone(),
-            system_message.clone(),
-            SessionServiceConfig { relation_env },
-        )
-        .with_participant_view_bindings(participant_view_bindings),
-    );
+    let session_service = Arc::new(SessionServiceImpl::new(
+        session_launch,
+        sessions.clone(),
+        groups.clone(),
+        registry.clone(),
+        friends.clone(),
+        relation,
+        session_repo,
+        group_message_history,
+        collaboration_runtime.clone(),
+        system_message.clone(),
+        SessionServiceConfig { relation_env },
+    ));
     let session_file_url_projector = SessionFileUrlProjector::new(
         config
             .openapi_v1

--- a/src/bcs/crates/bootstrap/bcs/src/server.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/server.rs
@@ -1978,8 +1978,8 @@ impl Default for BcsServerState {
         let bot_use_cases = Arc::new(bot_use_cases);
         let frontend_connections = Arc::new(
             WorkbenchConnectionRegistry::with_bot_query(bot_use_cases.clone())
-                .with_cluster_scope_changes_best_effort(
-                    config
+                .with_scope_changes_enabled(
+                    !config
                         .leader_election
                         .as_ref()
                         .is_some_and(|leader_election| leader_election.enabled),
@@ -3585,8 +3585,8 @@ impl BcsServer {
         let frontend_bot_query: Arc<dyn bcs_service_api::BotQueryService> = bot_use_cases.clone();
         let frontend_connections = Arc::new(
             WorkbenchConnectionRegistry::with_bot_query(frontend_bot_query)
-                .with_cluster_scope_changes_best_effort(
-                    config
+                .with_scope_changes_enabled(
+                    !config
                         .leader_election
                         .as_ref()
                         .is_some_and(|leader_election| leader_election.enabled),
@@ -4370,8 +4370,8 @@ impl BcsServer {
         let bot_runtime_for_session: Arc<dyn bcs_service_api::BotRuntimeConnectionService> =
             Arc::new(bot_runtime_for_session);
         let frontend_connections = Arc::new(
-            WorkbenchConnectionRegistry::new().with_cluster_scope_changes_best_effort(
-                config
+            WorkbenchConnectionRegistry::new().with_scope_changes_enabled(
+                !config
                     .leader_election
                     .as_ref()
                     .is_some_and(|leader_election| leader_election.enabled),

--- a/src/bcs/crates/bootstrap/bcs/src/server.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/server.rs
@@ -1608,26 +1608,29 @@ fn build_openapi_v1_state(
             relation_env: relation_env.clone(),
         },
     )
-    .with_participant_view_bindings(participant_view_bindings)
+    .with_participant_view_bindings(participant_view_bindings.clone())
     .with_collaboration_runtime(collaboration_runtime.clone());
     if config.eventing.enabled {
         group_service =
             group_service.with_event_subscription_provisioner(group_event_subscription_provisioner);
     }
     let group_service = Arc::new(group_service);
-    let session_service = Arc::new(SessionServiceImpl::new(
-        session_launch,
-        sessions.clone(),
-        groups.clone(),
-        registry.clone(),
-        friends.clone(),
-        relation,
-        session_repo,
-        group_message_history,
-        collaboration_runtime.clone(),
-        system_message.clone(),
-        SessionServiceConfig { relation_env },
-    ));
+    let session_service = Arc::new(
+        SessionServiceImpl::new(
+            session_launch,
+            sessions.clone(),
+            groups.clone(),
+            registry.clone(),
+            friends.clone(),
+            relation,
+            session_repo,
+            group_message_history,
+            collaboration_runtime.clone(),
+            system_message.clone(),
+            SessionServiceConfig { relation_env },
+        )
+        .with_participant_view_bindings(participant_view_bindings),
+    );
     let session_file_url_projector = SessionFileUrlProjector::new(
         config
             .openapi_v1
@@ -1975,8 +1978,8 @@ impl Default for BcsServerState {
         let bot_use_cases = Arc::new(bot_use_cases);
         let frontend_connections = Arc::new(
             WorkbenchConnectionRegistry::with_bot_query(bot_use_cases.clone())
-                .with_scope_changes_enabled(
-                    !config
+                .with_cluster_scope_changes_best_effort(
+                    config
                         .leader_election
                         .as_ref()
                         .is_some_and(|leader_election| leader_election.enabled),
@@ -3582,8 +3585,8 @@ impl BcsServer {
         let frontend_bot_query: Arc<dyn bcs_service_api::BotQueryService> = bot_use_cases.clone();
         let frontend_connections = Arc::new(
             WorkbenchConnectionRegistry::with_bot_query(frontend_bot_query)
-                .with_scope_changes_enabled(
-                    !config
+                .with_cluster_scope_changes_best_effort(
+                    config
                         .leader_election
                         .as_ref()
                         .is_some_and(|leader_election| leader_election.enabled),
@@ -4367,8 +4370,8 @@ impl BcsServer {
         let bot_runtime_for_session: Arc<dyn bcs_service_api::BotRuntimeConnectionService> =
             Arc::new(bot_runtime_for_session);
         let frontend_connections = Arc::new(
-            WorkbenchConnectionRegistry::new().with_scope_changes_enabled(
-                !config
+            WorkbenchConnectionRegistry::new().with_cluster_scope_changes_best_effort(
+                config
                     .leader_election
                     .as_ref()
                     .is_some_and(|leader_election| leader_election.enabled),

--- a/src/bcs/crates/service-api/bcs-service-api/src/port/participant_view_binding.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/port/participant_view_binding.rs
@@ -1,9 +1,8 @@
 //! Runtime binding barrier for Human participant message-scope mutations.
 //!
-//! Group and Session Application services acquire a lease before changing a
-//! persisted scope. The adapter must reject new bindings for the same
-//! Group-or-Session/Human and invalidate existing bindings before returning
-//! the lease.
+//! Group mutation services acquire a lease before changing a persisted scope.
+//! The adapter must reject new bindings for the same Group/Human and invalidate
+//! existing bindings before returning the lease.
 
 use async_trait::async_trait;
 use std::sync::atomic::{AtomicU64, Ordering};

--- a/src/bcs/crates/service-api/bcs-service-api/src/port/participant_view_binding.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/port/participant_view_binding.rs
@@ -1,8 +1,11 @@
 //! Runtime binding barrier for Human participant message-scope mutations.
 //!
-//! Group mutation services acquire a lease before changing a persisted scope.
-//! The adapter must reject new bindings for the same Group/Human and invalidate
-//! existing bindings before returning the lease.
+//! Group and Session Application services acquire a lease before changing an
+//! existing persisted scope. The adapter rejects new bindings for the same
+//! Group-or-Session/Human and invalidates bindings visible to that adapter
+//! before returning the lease. In-memory adapters provide process-local
+//! coordination; callers must not treat this presentation projection as a
+//! cluster-wide security boundary.
 
 use async_trait::async_trait;
 use std::sync::atomic::{AtomicU64, Ordering};

--- a/src/bcs/docs/superpowers/specs/2026-09-01-bcs-human-participant-message-isolation-design.md
+++ b/src/bcs/docs/superpowers/specs/2026-09-01-bcs-human-participant-message-isolation-design.md
@@ -92,7 +92,9 @@ audience_actor_ids = [...]
 必须沿用改造前的 full 连接授权、participant 列表和未投影投递逻辑；不得从登录 Human
 推断 view actor，也不得要求该 Human 本身已作为 participant 加入群或 session。
 
-scope 更新后，应使旧连接失效或要求重连，避免旧连接继续使用缓存 scope。
+首次创建 Session Human 成员不属于 scope 更新，直接写入所选 scope，不要求失效连接。
+已有成员更新 Session scope 后，由客户端断开并重连，重新读取持久化 scope。旧连接不保证
+感知 scope 更新。TODO：如果该展示投影未来升级为严格安全边界，再增加服务端连接失效机制。
 
 ### Group/Session message history
 
@@ -204,7 +206,8 @@ API 默认值为 `full`。不应引入 `participant_view_unsupported` 之类由 
 ### 管理与连接
 
 - 群主/管理员能查看成员 scope，并据此选择游戏玩家。
-- scope 更新后旧 WS 连接不能继续沿用旧投影。
+- 首次创建成员直接写入 scope，不触发旧连接失效。
+- Session scope 更新后客户端重连并使用新投影；旧 WS 连接不保证感知更新。
 - 创建 session 的下拉选择不改变默认的一键创建习惯。
 
 ## 11. 非目标

--- a/src/bcs/docs/superpowers/specs/2026-09-01-bcs-human-participant-message-isolation-design.md
+++ b/src/bcs/docs/superpowers/specs/2026-09-01-bcs-human-participant-message-isolation-design.md
@@ -93,8 +93,10 @@ audience_actor_ids = [...]
 推断 view actor，也不得要求该 Human 本身已作为 participant 加入群或 session。
 
 首次创建 Session Human 成员不属于 scope 更新，直接写入所选 scope，不要求失效连接。
-已有成员更新 Session scope 后，由客户端断开并重连，重新读取持久化 scope。旧连接不保证
-感知 scope 更新。TODO：如果该展示投影未来升级为严格安全边界，再增加服务端连接失效机制。
+已有成员更新 Session scope 后，应使当前实例的旧连接失效并要求重连，避免继续使用缓存
+scope。Leader Election 开启的多副本部署暂时只提供实例内的 best-effort 失效；其他副本上的
+旧连接在下次重连时读取新 scope。TODO：如果该展示投影未来升级为严格安全边界，再增加
+跨副本失效通知。
 
 ### Group/Session message history
 
@@ -207,7 +209,8 @@ API 默认值为 `full`。不应引入 `participant_view_unsupported` 之类由 
 
 - 群主/管理员能查看成员 scope，并据此选择游戏玩家。
 - 首次创建成员直接写入 scope，不触发旧连接失效。
-- Session scope 更新后客户端重连并使用新投影；旧 WS 连接不保证感知更新。
+- Session scope 更新后当前实例的旧 WS 连接不能继续沿用旧投影；多副本跨实例失效暂为
+  best-effort。
 - 创建 session 的下拉选择不改变默认的一键创建习惯。
 
 ## 11. 非目标


### PR DESCRIPTION
## Problem

When Leader Election is enabled, updating a Human participant's Session `message_view_scope` can fail with `view_scope_change_requires_cluster_binding`.

The scope is persisted with the Session participant data, and the frontend already disconnects and reconnects the WebSocket when switching views. Requiring a process-local WebSocket barrier therefore unnecessarily blocks both initial Session joins and subsequent scope updates.

## Solution

- Persist the selected `message_view_scope` directly when a missing Human joins a Session.
- Persist scope changes directly for existing Session participants without acquiring a WebSocket scope-change lease.
- Remove the Session application service's dependency on `ParticipantViewBindingPort`.
- Keep the existing Group scope-change barrier behavior unchanged.
- Document that existing WebSocket connections may retain their previously bound scope until reconnect.
- Add coverage for joining a readable Session with an explicitly selected `participant` scope.

## Validation

- `cargo test -p bcs-app-session`
- `cargo check -p bcs`
- `git diff --check`

All checks passed.

## Compatibility and risk

- No database schema or external request format changes.
- Existing `full` behavior remains unchanged.
- Newly established WebSocket connections resolve the latest persisted Session scope.
- Existing WebSocket connections are not guaranteed to observe a scope change; clients switching views must disconnect and reconnect.
- Server-side connection invalidation can be added later if participant projection becomes a strict security boundary.

## Spec

Updated `src/bcs/docs/superpowers/specs/2026-09-01-bcs-human-participant-message-isolation-design.md`.