### PR TITLE
fix(workflow): align draft saves, releases, and version UI

### DIFF
--- a/src/evolverun/clawweb/public/modules/workflow/server/routes/__tests__/workflow-management-auth.test.ts
+++ b/src/evolverun/clawweb/public/modules/workflow/server/routes/__tests__/workflow-management-auth.test.ts
@@ -43,6 +43,7 @@ async function start() {
   } as unknown as WorkflowSpecRepository;
   const historyRepo = {
     listHistory: vi.fn(async () => []),
+    setActive: vi.fn(async () => true),
   } as unknown as WorkflowDeployHistoryRepository;
 
   const app = express();
@@ -104,5 +105,19 @@ describe("workflow management authorization", () => {
     expect((await fetch(`${baseUrl}/api/workflows/wf-1/bot-permissions`, { headers })).status).toBe(403);
     expect((await fetch(`${baseUrl}/api/workflows/wf-1/history`, { headers })).status).toBe(200);
     expect((await fetch(`${baseUrl}/api/workflows/wf-1`, { method: "DELETE", headers })).status).toBe(403);
+  });
+
+  it("allows only an editor to change the default version", async () => {
+    const baseUrl = await start();
+
+    expect((await fetch(`${baseUrl}/api/workflows/wf-1/versions/2/activate`, {
+      method: "POST",
+      headers: { "X-User-Id": "viewer-1" },
+    })).status).toBe(403);
+
+    expect((await fetch(`${baseUrl}/api/workflows/wf-1/versions/2/activate`, {
+      method: "POST",
+      headers: { "X-User-Id": "editor-1" },
+    })).status).toBe(200);
   });
 });

--- a/src/evolverun/clawweb/public/modules/workflow/server/routes/workflows.ts
+++ b/src/evolverun/clawweb/public/modules/workflow/server/routes/workflows.ts
@@ -558,6 +558,7 @@ export function createWorkflowsRouter(
   router.post("/:workflowId/versions/:v/activate", asyncHandler(async (req: Request, res: Response) => {
     if (!wfdhRepo) { res.status(503).json({ error: "Service Unavailable" }); return; }
     const workflowId = String(req.params.workflowId);
+    if (!await requireWorkflowAccess(req, res, botPermRepo, workflowId, "edit")) return;
     const version = parseInt(String(req.params.v), 10);
     if (isNaN(version)) { res.status(400).json({ error: "Bad Request", message: "Invalid version" }); return; }
     const ok = await wfdhRepo.setActive(workflowId, version);

--- a/src/evolverun/clawweb/public/modules/workflow/web/components/WorkflowHistoryPanel.tsx
+++ b/src/evolverun/clawweb/public/modules/workflow/web/components/WorkflowHistoryPanel.tsx
@@ -164,24 +164,24 @@ export default function WorkflowHistoryPanel({ workflowId, onClose }: WorkflowHi
       ) : (
         <div className="flex flex-1 overflow-hidden">
           {/* History list */}
-          <div className="w-1/2 overflow-auto border-r border-gray-200">
-            <table className="w-full text-xs">
+          <div className="w-[46%] overflow-auto border-r border-gray-200">
+            <table className="min-w-[720px] table-fixed text-xs">
               <thead className="sticky top-0 bg-gray-50 text-gray-500">
                 <tr>
-                  <th className="w-8 px-2 py-1.5 text-left font-medium"></th>
-                  <th className="px-2 py-1.5 text-left font-medium">版本</th>
-                  <th className="px-2 py-1.5 text-left font-medium">部署</th>
-                  <th className="px-2 py-1.5 text-left font-medium">状态</th>
-                  <th className="px-2 py-1.5 text-left font-medium">操作</th>
-                  <th className="px-2 py-1.5 text-left font-medium">时间</th>
-                  <th className="px-2 py-1.5 text-left font-medium">触发者</th>
-                  <th className="w-20 px-2 py-1.5 text-left font-medium">默认版本</th>
+                  <th className="w-10 px-2 py-1.5 text-left font-medium"></th>
+                  <th className="w-14 whitespace-nowrap px-2 py-1.5 text-left font-medium">版本</th>
+                  <th className="w-16 whitespace-nowrap px-2 py-1.5 text-left font-medium">部署</th>
+                  <th className="w-[68px] whitespace-nowrap px-2 py-1.5 text-left font-medium">状态</th>
+                  <th className="w-40 whitespace-nowrap px-2 py-1.5 text-left font-medium">时间</th>
+                  <th className="w-44 whitespace-nowrap px-2 py-1.5 text-left font-medium">触发者</th>
+                  <th className="w-24 whitespace-nowrap px-2 py-1.5 text-left font-medium">默认版本</th>
                 </tr>
               </thead>
               <tbody>
                 {history.map((h) => {
                   const isViewing = viewDeploy === h.deployNumber
                   const isSelected = selected.includes(h.deployNumber)
+                  const actor = h.ownerId || h.botId ? [h.ownerId, h.botId].filter(Boolean).join('/') : '-'
                   return (
                     <tr
                       key={`${h.deployNumber}-${h.version}`}
@@ -198,27 +198,27 @@ export default function WorkflowHistoryPanel({ workflowId, onClose }: WorkflowHi
                           className="cursor-pointer"
                         />
                       </td>
-                      <td className="px-2 py-1.5 font-mono text-gray-800">v{h.version}</td>
-                      <td className="px-2 py-1.5 font-mono text-gray-500">#{h.deployNumber}</td>
-                      <td className="px-2 py-1.5">
+                      <td className="whitespace-nowrap px-2 py-1.5 font-mono text-gray-800">v{h.version}</td>
+                      <td className="whitespace-nowrap px-2 py-1.5 font-mono text-gray-500">#{h.deployNumber}</td>
+                      <td className="whitespace-nowrap px-2 py-1.5">
                         <span className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${actionClass(h.action)}`}>
                           {h.action}
                         </span>
                       </td>
-                      <td className="px-2 py-1.5 text-gray-500">{formatTime(h.gmtCreate)}</td>
+                      <td className="whitespace-nowrap px-2 py-1.5 text-gray-500">{formatTime(h.gmtCreate)}</td>
                       <td className="px-2 py-1.5 text-gray-500">
-                        {h.ownerId || h.botId ? [h.ownerId, h.botId].filter(Boolean).join('/') : '-'}
+                        <span className="block truncate" title={actor}>{actor}</span>
                       </td>
                       <td className="px-2 py-1.5" onClick={(e) => e.stopPropagation()}>
                         {h.isActive ? (
-                          <span className="inline-flex items-center gap-0.5 rounded bg-green-100 px-1.5 py-0.5 text-[10px] font-semibold text-green-700">
+                          <span className="inline-flex whitespace-nowrap items-center gap-0.5 rounded bg-green-100 px-1.5 py-0.5 text-[10px] font-semibold text-green-700">
                             默认
                           </span>
                         ) : h.action === 'deploy' ? (
                           <button
                             onClick={() => void handleActivateVersion(h.deployNumber, h.version)}
                             disabled={activating === h.version}
-                            className="rounded border border-blue-300 bg-white px-1.5 py-0.5 text-[10px] font-medium text-blue-600 hover:bg-blue-50 disabled:opacity-50"
+                            className="whitespace-nowrap rounded border border-blue-300 bg-white px-1.5 py-0.5 text-[10px] font-medium text-blue-600 hover:bg-blue-50 disabled:opacity-50"
                             title={`将 v${h.version} 设为默认版本`}
                           >
                             {activating === h.version ? '设置中…' : '设为默认'}

--- a/src/evolverun/clawweb/public/modules/workflow/web/components/WorkflowHistoryPanel.tsx
+++ b/src/evolverun/clawweb/public/modules/workflow/web/components/WorkflowHistoryPanel.tsx
@@ -6,6 +6,7 @@ import WorkflowVersionDiff from './WorkflowVersionDiff'
 
 interface WorkflowHistoryPanelProps {
   workflowId: string
+  onActiveVersionChange?: () => void
   onClose?: () => void
 }
 
@@ -39,7 +40,7 @@ function specJsonToText(specJson: string): string {
   }
 }
 
-export default function WorkflowHistoryPanel({ workflowId, onClose }: WorkflowHistoryPanelProps) {
+export default function WorkflowHistoryPanel({ workflowId, onActiveVersionChange, onClose }: WorkflowHistoryPanelProps) {
   const [history, setHistory] = useState<DeployHistoryItem[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -55,33 +56,37 @@ export default function WorkflowHistoryPanel({ workflowId, onClose }: WorkflowHi
   const [diffToDeploy, setDiffToDeploy] = useState<number | null>(null)
   const [activating, setActivating] = useState<number | null>(null)
 
-  const loadHistory = useCallback(() => {
+  const loadHistory = useCallback(async () => {
     setLoading(true)
     setError(null)
-    api.workflows
-      .getHistory(workflowId, 50, true)
+    try {
+      const r = await api.workflows.getHistory(workflowId, 50, true)
       // `edit` rows are from the old browser-save flow. They have no Git tag and
       // cannot run as a version, so do not present them as release history.
-      .then((r) => setHistory((r.history ?? []).filter((item) => item.action !== 'edit')))
-      .catch((err) => setError(err instanceof Error ? err.message : '加载历史失败'))
-      .finally(() => setLoading(false))
+      setHistory((r.history ?? []).filter((item) => item.action !== 'edit'))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '加载历史失败')
+    } finally {
+      setLoading(false)
+    }
   }, [workflowId])
 
   useEffect(() => {
-    loadHistory()
+    void loadHistory()
   }, [loadHistory])
 
   const handleActivateVersion = useCallback(async (deployNumber: number, version: number) => {
     setActivating(version)
     try {
       await api.workflows.activateVersion(workflowId, version)
-      loadHistory()
+      await loadHistory()
+      onActiveVersionChange?.()
     } catch (err) {
       setError(err instanceof Error ? err.message : '激活版本失败')
     } finally {
       setActivating(null)
     }
-  }, [workflowId, loadHistory])
+  }, [workflowId, loadHistory, onActiveVersionChange])
 
   // Reset selections on workflow change
   useEffect(() => {

--- a/src/evolverun/clawweb/public/modules/workflow/web/components/WorkflowVersionDiff.tsx
+++ b/src/evolverun/clawweb/public/modules/workflow/web/components/WorkflowVersionDiff.tsx
@@ -11,7 +11,7 @@ interface WorkflowVersionDiffProps {
 
 /** A single line in the unified diff view. */
 interface DiffLine {
-  type: 'add' | 'del' | 'ctx'
+  type: 'add' | 'del' | 'ctx' | 'skip'
   text: string
   // 1-indexed line number on the side that contains this line; 0 for del-only/add-only
   fromLine?: number
@@ -72,6 +72,40 @@ export function unifiedDiff(fromText: string, toText: string): DiffLine[] {
   return lines
 }
 
+/**
+ * Keep the change hunks visible by hiding unchanged lines far away from them.
+ * The full diff remains available in the UI for cases where surrounding context
+ * is needed.
+ */
+export function compactDiff(lines: DiffLine[], contextLines = 3): DiffLine[] {
+  const changedIndexes = lines
+    .map((line, index) => (line.type === 'add' || line.type === 'del' ? index : -1))
+    .filter((index) => index >= 0)
+
+  if (changedIndexes.length === 0) return lines
+
+  const visible = new Set<number>()
+  for (const index of changedIndexes) {
+    for (let nearby = Math.max(0, index - contextLines); nearby <= Math.min(lines.length - 1, index + contextLines); nearby++) {
+      visible.add(nearby)
+    }
+  }
+
+  const compacted: DiffLine[] = []
+  let previousIndex = -1
+  for (const index of [...visible].sort((a, b) => a - b)) {
+    if (index > previousIndex + 1) {
+      compacted.push({ type: 'skip', text: `… ${index - previousIndex - 1} 行未变更 …` })
+    }
+    compacted.push(lines[index])
+    previousIndex = index
+  }
+  if (previousIndex < lines.length - 1) {
+    compacted.push({ type: 'skip', text: `… ${lines.length - previousIndex - 1} 行未变更 …` })
+  }
+  return compacted
+}
+
 /** Turn stored JSON (or the legacy { content: yaml } wrapper) into readable YAML.
  * The history API deliberately returns the original snapshot; formatting it here
  * keeps the raw snapshot lossless while making line-level diff useful. */
@@ -112,12 +146,14 @@ export default function WorkflowVersionDiff({
   const [result, setResult] = useState<VersionDiffResult | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [showFullContext, setShowFullContext] = useState(false)
 
   useEffect(() => {
     let cancelled = false
     setLoading(true)
     setError(null)
     setResult(null)
+    setShowFullContext(false)
     api.workflows
       .diffHistory(workflowId, fromDeploy, toDeploy)
       .then((r) => {
@@ -152,6 +188,7 @@ export default function WorkflowVersionDiff({
   const additions = diffLines.filter((l) => l.type === 'add').length
   const deletions = diffLines.filter((l) => l.type === 'del').length
   const changedFields = topLevelChanges(fromText, toText)
+  const displayedLines = showFullContext ? diffLines : compactDiff(diffLines)
 
   return (
     <div className="flex h-full flex-col">
@@ -171,6 +208,12 @@ export default function WorkflowVersionDiff({
           </span>
         </div>
         <div className="flex items-center gap-2">
+          <button
+            onClick={() => setShowFullContext((value) => !value)}
+            className="rounded border border-gray-300 bg-white px-2 py-0.5 text-[11px] text-gray-600 hover:bg-gray-50"
+          >
+            {showFullContext ? '仅看变更' : '完整内容'}
+          </button>
           <span className="text-green-600">+{additions}</span>
           <span className="text-red-500">-{deletions}</span>
         </div>
@@ -192,7 +235,14 @@ export default function WorkflowVersionDiff({
         {diffLines.length === 0 && (
           <div className="p-4 text-gray-400">两个版本内容完全相同</div>
         )}
-        {diffLines.map((line, idx) => {
+        {displayedLines.map((line, idx) => {
+          if (line.type === 'skip') {
+            return (
+              <div key={`skip-${idx}`} className="border-y border-gray-700 bg-gray-800 px-3 py-1 text-center text-gray-500">
+                {line.text}
+              </div>
+            )
+          }
           const bg =
             line.type === 'add'
               ? 'bg-green-900/30'

--- a/src/evolverun/clawweb/public/modules/workflow/web/components/WorkflowVersionDiff.tsx
+++ b/src/evolverun/clawweb/public/modules/workflow/web/components/WorkflowVersionDiff.tsx
@@ -121,6 +121,28 @@ export function formatSpecForDiff(specJson: string): string {
   }
 }
 
+function sortSpecValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortSpecValue)
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .filter(([, nested]) => nested !== undefined)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([key, nested]) => [key, sortSpecValue(nested)]),
+    )
+  }
+  return value
+}
+
+/** Compare parsed specs so YAML field ordering and formatting do not create a false pending deploy. */
+export function specsEqual(fromText: string, toText: string): boolean {
+  try {
+    return JSON.stringify(sortSpecValue(parseYaml(fromText))) === JSON.stringify(sortSpecValue(parseYaml(toText)))
+  } catch {
+    return fromText === toText
+  }
+}
+
 function topLevelChanges(fromText: string, toText: string): string[] {
   try {
     const from = parseYaml(fromText) as Record<string, unknown>

--- a/src/evolverun/clawweb/public/modules/workflow/web/components/WorkflowVersionDiff.tsx
+++ b/src/evolverun/clawweb/public/modules/workflow/web/components/WorkflowVersionDiff.tsx
@@ -109,16 +109,32 @@ export function compactDiff(lines: DiffLine[], contextLines = 3): DiffLine[] {
 /** Turn stored JSON (or the legacy { content: yaml } wrapper) into readable YAML.
  * The history API deliberately returns the original snapshot; formatting it here
  * keeps the raw snapshot lossless while making line-level diff useful. */
+function stripSyntheticSpecFields(value: unknown): unknown {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return value
+  const { updatedAt: _updatedAt, version: _version, facade: _facade, ...persistedSpec } = value as Record<string, unknown>
+  return persistedSpec
+}
+
+/**
+ * Format a deploy-history snapshot in the same persisted-spec shape used for
+ * editor comparisons. `updatedAt`, `version`, and `facade` are enriched or
+ * synchronized metadata, not deployable workflow content.
+ */
 export function formatSpecForDiff(specJson: string): string {
   try {
     const parsed = JSON.parse(specJson)
     if (parsed && typeof parsed === 'object' && typeof parsed.content === 'string' && !Array.isArray(parsed.nodes)) {
-      return parsed.content
+      return stringifyYaml(stripSyntheticSpecFields(parseYaml(parsed.content)), { lineWidth: 0 })
     }
-    return stringifyYaml(parsed, { lineWidth: 0 })
+    return stringifyYaml(stripSyntheticSpecFields(parsed), { lineWidth: 0 })
   } catch {
     return specJson
   }
+}
+
+/** Format the current editor value using the same persisted-spec shape as a deploy snapshot. */
+export function formatCurrentSpecForDiff(spec: unknown): string {
+  return stringifyYaml(stripSyntheticSpecFields(spec), { lineWidth: 0 })
 }
 
 function sortSpecValue(value: unknown): unknown {

--- a/src/evolverun/clawweb/public/modules/workflow/web/components/__tests__/WorkflowVersionDiff.test.ts
+++ b/src/evolverun/clawweb/public/modules/workflow/web/components/__tests__/WorkflowVersionDiff.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { compactDiff, formatSpecForDiff, unifiedDiff } from '../WorkflowVersionDiff'
+import { compactDiff, formatSpecForDiff, specsEqual, unifiedDiff } from '../WorkflowVersionDiff'
 
 describe('WorkflowVersionDiff', () => {
   it('formats JSON snapshots as multiline YAML before calculating the diff', () => {
@@ -30,5 +30,10 @@ describe('WorkflowVersionDiff', () => {
       expect.objectContaining({ type: 'add', text: '  - id: new' }),
       expect.objectContaining({ type: 'skip' }),
     ]))
+  })
+
+  it('does not flag reordered YAML fields as an undeployed change', () => {
+    expect(specsEqual('id: support\ntitle: 支持\nnodes: []\n', 'nodes: []\ntitle: 支持\nid: support\n')).toBe(true)
+    expect(specsEqual('id: support\ntitle: 支持\n', 'id: support\ntitle: 新支持\n')).toBe(false)
   })
 })

--- a/src/evolverun/clawweb/public/modules/workflow/web/components/__tests__/WorkflowVersionDiff.test.ts
+++ b/src/evolverun/clawweb/public/modules/workflow/web/components/__tests__/WorkflowVersionDiff.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { formatSpecForDiff, unifiedDiff } from '../WorkflowVersionDiff'
+import { compactDiff, formatSpecForDiff, unifiedDiff } from '../WorkflowVersionDiff'
 
 describe('WorkflowVersionDiff', () => {
   it('formats JSON snapshots as multiline YAML before calculating the diff', () => {
@@ -17,5 +17,18 @@ describe('WorkflowVersionDiff', () => {
   it('keeps legacy YAML content snapshots readable', () => {
     const yaml = 'id: support\ntitle: 支持\n'
     expect(formatSpecForDiff(JSON.stringify({ content: yaml }))).toBe(yaml)
+  })
+
+  it('keeps changed hunks visible while hiding unrelated context', () => {
+    const from = 'id: support\ntitle: 支持\nsummary: unchanged\nnodes:\n  - id: old\nfooter: unchanged\nowner: unchanged'
+    const to = 'id: support\ntitle: 支持\nsummary: unchanged\nnodes:\n  - id: new\nfooter: unchanged\nowner: unchanged'
+
+    const compacted = compactDiff(unifiedDiff(from, to), 1)
+
+    expect(compacted).toEqual(expect.arrayContaining([
+      expect.objectContaining({ type: 'del', text: '  - id: old' }),
+      expect.objectContaining({ type: 'add', text: '  - id: new' }),
+      expect.objectContaining({ type: 'skip' }),
+    ]))
   })
 })

--- a/src/evolverun/clawweb/public/modules/workflow/web/components/__tests__/WorkflowVersionDiff.test.ts
+++ b/src/evolverun/clawweb/public/modules/workflow/web/components/__tests__/WorkflowVersionDiff.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { compactDiff, formatSpecForDiff, specsEqual, unifiedDiff } from '../WorkflowVersionDiff'
+import { compactDiff, formatCurrentSpecForDiff, formatSpecForDiff, specsEqual, unifiedDiff } from '../WorkflowVersionDiff'
 
 describe('WorkflowVersionDiff', () => {
   it('formats JSON snapshots as multiline YAML before calculating the diff', () => {
@@ -35,5 +35,13 @@ describe('WorkflowVersionDiff', () => {
   it('does not flag reordered YAML fields as an undeployed change', () => {
     expect(specsEqual('id: support\ntitle: 支持\nnodes: []\n', 'nodes: []\ntitle: 支持\nid: support\n')).toBe(true)
     expect(specsEqual('id: support\ntitle: 支持\n', 'id: support\ntitle: 新支持\n')).toBe(false)
+  })
+
+  it('removes editor-enriched fields before comparing a release with the current spec', () => {
+    const deployed = formatSpecForDiff(JSON.stringify({ id: 'support', title: '支持', nodes: [], version: 2 }))
+    const current = formatCurrentSpecForDiff({ id: 'support', title: '支持', nodes: [], version: 2, updatedAt: 123, facade: { command: 'support' } })
+
+    expect(specsEqual(deployed, current)).toBe(true)
+    expect(unifiedDiff(deployed, current).filter((line) => line.type === 'add' || line.type === 'del')).toEqual([])
   })
 })

--- a/src/evolverun/clawweb/public/modules/workflow/web/pages/Editor.tsx
+++ b/src/evolverun/clawweb/public/modules/workflow/web/pages/Editor.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from 'react'
+import { useState, useCallback, useEffect, useMemo } from 'react'
 import { ReactFlowProvider } from '@xyflow/react'
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml'
 import { useDbWorkflow, useSaveWorkflowToDb, useFacadeBindings } from '../api/hooks'
@@ -11,8 +11,9 @@ import NodePropertyPanel from '../components/NodePropertyPanel'
 import WorkflowConfigPanel from '../components/WorkflowConfigPanel'
 import YamlEditor from '../components/YamlEditor'
 import WorkflowHistoryPanel from '../components/WorkflowHistoryPanel'
+import { compactDiff, formatSpecForDiff, specsEqual, unifiedDiff } from '../components/WorkflowVersionDiff'
 import { api } from '@avernet/clawweb-shared/web/api/client'
-import type { WorkflowSpec, DeployHistoryItem } from '@avernet/clawweb-shared/web/types'
+import type { WorkflowSpec, DeployHistoryItem, VersionSnapshot } from '@avernet/clawweb-shared/web/types'
 
 type ViewMode = 'visual' | 'yaml' | 'split'
 
@@ -43,6 +44,8 @@ export default function Editor({ embedded = false, initialWorkflowId }: EditorPr
   const [showDeployGuide, setShowDeployGuide] = useState(false)
   const [deployCommandCopied, setDeployCommandCopied] = useState(false)
   const [latestDeploy, setLatestDeploy] = useState<DeployHistoryItem | null>(null)
+  const [activeSnapshot, setActiveSnapshot] = useState<VersionSnapshot | null>(null)
+  const [showDeploymentDiff, setShowDeploymentDiff] = useState(false)
 
   const { spec, isDirty, selectedNodeId, validationErrors, loadSpec, createNew, importYaml, selectNode, markClean } = useEditorStore()
 
@@ -87,7 +90,7 @@ export default function Editor({ embedded = false, initialWorkflowId }: EditorPr
     api.workflows
       .getHistory(selectedWorkflowId, 50, true)
       .then((r) => {
-        if (!cancelled) setLatestDeploy(r.history?.find((item) => item.action !== 'edit') ?? null)
+        if (!cancelled) setLatestDeploy(r.history?.find((item) => item.isActive) ?? r.history?.find((item) => item.action !== 'edit') ?? null)
       })
       .catch(() => {
         if (!cancelled) setLatestDeploy(null)
@@ -96,6 +99,33 @@ export default function Editor({ embedded = false, initialWorkflowId }: EditorPr
       cancelled = true
     }
   }, [selectedWorkflowId])
+
+  useEffect(() => {
+    if (!selectedWorkflowId || !latestDeploy) {
+      setActiveSnapshot(null)
+      return
+    }
+    let cancelled = false
+    api.workflows
+      .getDeploySnapshot(selectedWorkflowId, latestDeploy.deployNumber)
+      .then((snapshot) => {
+        if (!cancelled) setActiveSnapshot(snapshot)
+      })
+      .catch(() => {
+        if (!cancelled) setActiveSnapshot(null)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [selectedWorkflowId, latestDeploy])
+
+  const deployedSpecText = activeSnapshot ? formatSpecForDiff(activeSnapshot.specJson) : ''
+  const savedSpecText = workflowSpec ? stringifyYaml(workflowSpec, { lineWidth: 0 }) : ''
+  const hasUndeployedChanges = Boolean(activeSnapshot && workflowSpec && !specsEqual(deployedSpecText, savedSpecText))
+  const deploymentDiffLines = useMemo(
+    () => hasUndeployedChanges ? compactDiff(unifiedDiff(deployedSpecText, savedSpecText)) : [],
+    [deployedSpecText, hasUndeployedChanges, savedSpecText],
+  )
 
   const handleOpenSaveDialog = useCallback(() => {
     if (!spec) return
@@ -259,6 +289,15 @@ export default function Editor({ embedded = false, initialWorkflowId }: EditorPr
             ) : (
               <span className="hidden text-[10px] text-slate-400 2xl:inline">仅本地草稿</span>
             ))}
+          {hasUndeployedChanges && latestDeploy && (
+            <button
+              type="button"
+              onClick={() => setShowDeploymentDiff(true)}
+              className="shrink-0 rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-medium text-amber-800 hover:bg-amber-200"
+            >
+              与生效 v{latestDeploy.version} 有差异 · 待部署
+            </button>
+          )}
         </div>
         <div className="flex shrink-0 items-center gap-2">
           <div className="flex rounded-lg bg-slate-100 p-0.5" aria-label="编辑器视图">
@@ -554,6 +593,41 @@ export default function Editor({ embedded = false, initialWorkflowId }: EditorPr
               workflowId={selectedWorkflowId}
               onClose={() => setShowHistory(false)}
             />
+          </div>
+        </div>
+      )}
+
+      {showDeploymentDiff && activeSnapshot && latestDeploy && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 p-6">
+          <div className="flex h-[80vh] w-full max-w-4xl flex-col overflow-hidden rounded-lg bg-white shadow-xl">
+            <div className="flex items-center justify-between border-b border-gray-200 bg-gray-50 px-4 py-3">
+              <div>
+                <h3 className="text-sm font-semibold text-gray-900">部署前差异</h3>
+                <p className="mt-0.5 text-xs text-gray-500">生效 v{latestDeploy.version} · deploy #{latestDeploy.deployNumber} → 当前已保存内容</p>
+              </div>
+              <button onClick={() => setShowDeploymentDiff(false)} className="rounded border border-gray-300 bg-white px-2 py-0.5 text-xs text-gray-600 hover:bg-gray-50">关闭</button>
+            </div>
+            <div className="flex-1 overflow-auto bg-gray-900 font-mono text-xs leading-relaxed">
+              {deploymentDiffLines.map((line, index) => {
+                if (line.type === 'skip') {
+                  return <div key={`skip-${index}`} className="border-y border-gray-700 bg-gray-800 px-3 py-1 text-center text-gray-500">{line.text}</div>
+                }
+                const isAdded = line.type === 'add'
+                const isDeleted = line.type === 'del'
+                const lineNumber = isDeleted ? line.fromLine : line.toLine
+                return (
+                  <div key={index} className={`flex ${isAdded ? 'bg-green-900/30' : isDeleted ? 'bg-red-900/30' : ''}`}>
+                    <span className="w-10 shrink-0 select-none border-r border-gray-700 px-1 text-right text-gray-500">{lineNumber ?? ''}</span>
+                    <span className={`shrink-0 select-none px-1 ${isAdded ? 'text-green-300' : isDeleted ? 'text-red-300' : 'text-gray-300'}`}>{isAdded ? '+' : isDeleted ? '-' : ' '}</span>
+                    <span className={`whitespace-pre px-1 ${isAdded ? 'text-green-300' : isDeleted ? 'text-red-300' : 'text-gray-300'}`}>{line.text}</span>
+                  </div>
+                )
+              })}
+            </div>
+            <div className="flex justify-end gap-2 border-t border-gray-200 bg-gray-50 px-4 py-2">
+              <button onClick={() => setShowDeploymentDiff(false)} className="rounded border border-gray-300 bg-white px-3 py-1 text-xs text-gray-700 hover:bg-gray-50">稍后部署</button>
+              <button onClick={() => { setShowDeploymentDiff(false); setShowDeployGuide(true) }} className="rounded bg-emerald-600 px-3 py-1 text-xs font-medium text-white hover:bg-emerald-700">部署</button>
+            </div>
           </div>
         </div>
       )}

--- a/src/evolverun/clawweb/public/modules/workflow/web/pages/Editor.tsx
+++ b/src/evolverun/clawweb/public/modules/workflow/web/pages/Editor.tsx
@@ -289,14 +289,6 @@ export default function Editor({ embedded = false, initialWorkflowId }: EditorPr
           >
             版本历史
           </button>
-          <button
-            type="button"
-            onClick={() => setShowDeployGuide(true)}
-            disabled={!selectedWorkflowId}
-            className="rounded-lg border border-emerald-300 bg-emerald-50 px-3 py-1.5 text-xs font-medium text-emerald-700 hover:bg-emerald-100 disabled:text-slate-300"
-          >
-            部署
-          </button>
           {!embedded && <div className="relative">
             <button type="button" aria-label="更多操作" aria-expanded={showMore} onClick={() => setShowMore((open) => !open)} className="rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-600 hover:bg-slate-50">更多 ···</button>
             {showMore && <><button type="button" aria-label="关闭更多操作" className="fixed inset-0 z-40 cursor-default" onClick={() => setShowMore(false)} /><div role="menu" className="absolute right-0 top-full z-50 mt-2 w-44 overflow-hidden rounded-xl border border-slate-200 bg-white p-1.5 shadow-[0_16px_40px_rgba(15,23,42,0.16)]">
@@ -312,6 +304,14 @@ export default function Editor({ embedded = false, initialWorkflowId }: EditorPr
             className="rounded-lg bg-blue-600 px-4 py-1.5 text-xs font-medium text-white transition-colors hover:bg-blue-700 disabled:opacity-40"
           >
             {saveToDbMutation.isPending ? '保存中…' : '保存'}
+          </button>
+          <button
+            type="button"
+            onClick={() => setShowDeployGuide(true)}
+            disabled={!selectedWorkflowId}
+            className="rounded-lg border border-emerald-300 bg-emerald-50 px-3 py-1.5 text-xs font-medium text-emerald-700 hover:bg-emerald-100 disabled:text-slate-300"
+          >
+            部署
           </button>
         </div>
       </div>
@@ -563,16 +563,10 @@ export default function Editor({ embedded = false, initialWorkflowId }: EditorPr
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 p-6">
           <div className="w-full max-w-lg rounded-lg bg-white p-6 shadow-xl">
             <h3 className="text-lg font-semibold text-gray-900">部署工作流</h3>
-            <p className="mt-2 text-sm leading-6 text-gray-600">
-              部署会把最近一次保存的快照打 Git tag，并准备对应的只读 Pack。该操作需要 ClawMind 的 Git 凭据，网页端不会只写数据库来伪造一次发布。
-            </p>
             <div className="mt-4 rounded-md border border-slate-200 bg-slate-50 p-3">
               <div className="text-xs text-slate-500">在对应 Bot 对话中执行</div>
               <code className="mt-1 block select-all font-mono text-sm text-slate-800">/workflow deploy {selectedWorkflowId}</code>
             </div>
-            <p className="mt-3 text-xs leading-5 text-slate-500">
-              如果尚未保存过快照，请先执行 <code>/workflow save {selectedWorkflowId}</code>。
-            </p>
             <div className="mt-5 flex justify-end gap-2">
               <button onClick={() => setShowDeployGuide(false)} className="rounded-md border border-gray-300 px-4 py-1.5 text-sm text-gray-700 hover:bg-gray-50">关闭</button>
               <button onClick={() => void handleCopyDeployCommand()} className="rounded-md bg-emerald-600 px-4 py-1.5 text-sm font-medium text-white hover:bg-emerald-700">

--- a/src/evolverun/clawweb/public/modules/workflow/web/pages/Editor.tsx
+++ b/src/evolverun/clawweb/public/modules/workflow/web/pages/Editor.tsx
@@ -44,6 +44,7 @@ export default function Editor({ embedded = false, initialWorkflowId }: EditorPr
   const [showDeployGuide, setShowDeployGuide] = useState(false)
   const [deployCommandCopied, setDeployCommandCopied] = useState(false)
   const [latestDeploy, setLatestDeploy] = useState<DeployHistoryItem | null>(null)
+  const [baselineIsActive, setBaselineIsActive] = useState(false)
   const [activeSnapshot, setActiveSnapshot] = useState<VersionSnapshot | null>(null)
   const [showDeploymentDiff, setShowDeploymentDiff] = useState(false)
 
@@ -84,16 +85,25 @@ export default function Editor({ embedded = false, initialWorkflowId }: EditorPr
   useEffect(() => {
     if (!selectedWorkflowId) {
       setLatestDeploy(null)
+      setBaselineIsActive(false)
       return
     }
+    setLatestDeploy(null)
+    setBaselineIsActive(false)
     let cancelled = false
     api.workflows
       .getHistory(selectedWorkflowId, 50, true)
       .then((r) => {
-        if (!cancelled) setLatestDeploy(r.history?.find((item) => item.isActive) ?? r.history?.find((item) => item.action !== 'edit') ?? null)
+        if (cancelled) return
+        const active = r.history?.find((item) => item.isActive)
+        setLatestDeploy(active ?? r.history?.find((item) => item.action !== 'edit') ?? null)
+        setBaselineIsActive(Boolean(active))
       })
       .catch(() => {
-        if (!cancelled) setLatestDeploy(null)
+        if (!cancelled) {
+          setLatestDeploy(null)
+          setBaselineIsActive(false)
+        }
       })
     return () => {
       cancelled = true
@@ -122,6 +132,7 @@ export default function Editor({ embedded = false, initialWorkflowId }: EditorPr
   const deployedSpecText = activeSnapshot ? formatSpecForDiff(activeSnapshot.specJson) : ''
   const savedSpecText = workflowSpec ? stringifyYaml(workflowSpec, { lineWidth: 0 }) : ''
   const hasUndeployedChanges = Boolean(activeSnapshot && workflowSpec && !specsEqual(deployedSpecText, savedSpecText))
+  const deploymentBaselineLabel = baselineIsActive ? '生效' : '最新发布'
   const deploymentDiffLines = useMemo(
     () => hasUndeployedChanges ? compactDiff(unifiedDiff(deployedSpecText, savedSpecText)) : [],
     [deployedSpecText, hasUndeployedChanges, savedSpecText],
@@ -284,7 +295,7 @@ export default function Editor({ embedded = false, initialWorkflowId }: EditorPr
           {selectedWorkflowId &&
             (latestDeploy ? (
               <span className="hidden shrink-0 rounded-full bg-slate-100 px-2 py-0.5 text-[10px] text-slate-500 2xl:inline">
-                生效 v{latestDeploy.version} · deploy #{latestDeploy.deployNumber}
+                {deploymentBaselineLabel} v{latestDeploy.version} · deploy #{latestDeploy.deployNumber}
               </span>
             ) : (
               <span className="hidden text-[10px] text-slate-400 2xl:inline">仅本地草稿</span>
@@ -295,7 +306,7 @@ export default function Editor({ embedded = false, initialWorkflowId }: EditorPr
               onClick={() => setShowDeploymentDiff(true)}
               className="shrink-0 rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-medium text-amber-800 hover:bg-amber-200"
             >
-              与生效 v{latestDeploy.version} 有差异 · 待部署
+              与{deploymentBaselineLabel} v{latestDeploy.version} 有差异 · 待部署
             </button>
           )}
         </div>
@@ -603,7 +614,7 @@ export default function Editor({ embedded = false, initialWorkflowId }: EditorPr
             <div className="flex items-center justify-between border-b border-gray-200 bg-gray-50 px-4 py-3">
               <div>
                 <h3 className="text-sm font-semibold text-gray-900">部署前差异</h3>
-                <p className="mt-0.5 text-xs text-gray-500">生效 v{latestDeploy.version} · deploy #{latestDeploy.deployNumber} → 当前已保存内容</p>
+                <p className="mt-0.5 text-xs text-gray-500">{deploymentBaselineLabel} v{latestDeploy.version} · deploy #{latestDeploy.deployNumber} → 当前已保存内容</p>
               </div>
               <button onClick={() => setShowDeploymentDiff(false)} className="rounded border border-gray-300 bg-white px-2 py-0.5 text-xs text-gray-600 hover:bg-gray-50">关闭</button>
             </div>

--- a/src/evolverun/clawweb/public/modules/workflow/web/pages/Editor.tsx
+++ b/src/evolverun/clawweb/public/modules/workflow/web/pages/Editor.tsx
@@ -11,7 +11,7 @@ import NodePropertyPanel from '../components/NodePropertyPanel'
 import WorkflowConfigPanel from '../components/WorkflowConfigPanel'
 import YamlEditor from '../components/YamlEditor'
 import WorkflowHistoryPanel from '../components/WorkflowHistoryPanel'
-import { compactDiff, formatSpecForDiff, specsEqual, unifiedDiff } from '../components/WorkflowVersionDiff'
+import { compactDiff, formatCurrentSpecForDiff, formatSpecForDiff, specsEqual, unifiedDiff } from '../components/WorkflowVersionDiff'
 import { api } from '@avernet/clawweb-shared/web/api/client'
 import type { WorkflowSpec, DeployHistoryItem, VersionSnapshot } from '@avernet/clawweb-shared/web/types'
 
@@ -47,6 +47,7 @@ export default function Editor({ embedded = false, initialWorkflowId }: EditorPr
   const [baselineIsActive, setBaselineIsActive] = useState(false)
   const [activeSnapshot, setActiveSnapshot] = useState<VersionSnapshot | null>(null)
   const [showDeploymentDiff, setShowDeploymentDiff] = useState(false)
+  const [deploymentBaselineRevision, setDeploymentBaselineRevision] = useState(0)
 
   const { spec, isDirty, selectedNodeId, validationErrors, loadSpec, createNew, importYaml, selectNode, markClean } = useEditorStore()
 
@@ -108,7 +109,7 @@ export default function Editor({ embedded = false, initialWorkflowId }: EditorPr
     return () => {
       cancelled = true
     }
-  }, [selectedWorkflowId])
+  }, [selectedWorkflowId, deploymentBaselineRevision])
 
   useEffect(() => {
     if (!selectedWorkflowId || !latestDeploy) {
@@ -130,7 +131,7 @@ export default function Editor({ embedded = false, initialWorkflowId }: EditorPr
   }, [selectedWorkflowId, latestDeploy])
 
   const deployedSpecText = activeSnapshot ? formatSpecForDiff(activeSnapshot.specJson) : ''
-  const savedSpecText = workflowSpec ? stringifyYaml(workflowSpec, { lineWidth: 0 }) : ''
+  const savedSpecText = workflowSpec ? formatCurrentSpecForDiff(workflowSpec) : ''
   const hasUndeployedChanges = Boolean(activeSnapshot && workflowSpec && !specsEqual(deployedSpecText, savedSpecText))
   const deploymentBaselineLabel = baselineIsActive ? '生效' : '最新发布'
   const deploymentDiffLines = useMemo(
@@ -602,6 +603,7 @@ export default function Editor({ embedded = false, initialWorkflowId }: EditorPr
           <div className="flex h-[80vh] w-full max-w-5xl flex-col overflow-hidden rounded-lg bg-white shadow-xl">
             <WorkflowHistoryPanel
               workflowId={selectedWorkflowId}
+              onActiveVersionChange={() => setDeploymentBaselineRevision((revision) => revision + 1)}
               onClose={() => setShowHistory(false)}
             />
           </div>


### PR DESCRIPTION
## Summary

Align workflow lifecycle behavior and UI around four clear states: local workspace, remote snapshot, published release, and active online version.

- Save workflow changes as immutable remote snapshots without creating a release tag.
- Deploy the saved snapshot as a published release and make it the active online version.
- Support running the active release by default, the remote snapshot when no active release exists, a local workspace with `--local`, and a specified release with `--version`.
- Improve release history visibility, pending-deployment guidance, and workflow version diffs.
- Fix release-number allocation and related version contract handling.

## Validation

- TypeScript type check
- Focused workflow server and web tests