### PR TITLE
feat(workflow): add configurable approval cards and elapsed time

### DIFF
--- a/src/evolverun/clawweb/public/modules/workflow/server/repositories/approval-card-repository.ts
+++ b/src/evolverun/clawweb/public/modules/workflow/server/repositories/approval-card-repository.ts
@@ -1,0 +1,296 @@
+/**
+ * Approval card repository — DB-backed CRUD for card-web approval cards.
+ *
+ * Table: approval_cards
+ *   - id: auto-increment primary key (used in URLs: /approval/:id)
+ *   - flow_id, node_id, workflow_id: link back to workflow runtime workflow
+ *   - card_fields_json: JSON array of {label, value} for display
+ *   - approver_ids: comma-separated empIds
+ *   - approved_by / rejected_by: comma-separated empIds (appended on action)
+ *   - status: pending | approved | rejected
+ */
+
+import type { IDatabase } from "@avernet/clawweb-shared/server/db";
+
+function logDbError(context: string, err: unknown): void {
+  const e = err as Record<string, unknown>;
+  console.error(`[approval-card] ${context} failed:`, {
+    message: e?.message ?? String(err),
+    code: (e as any)?.code,
+    sql: (e as any)?.sql,
+    sqlMessage: (e as any)?.sqlMessage,
+    stack: (err instanceof Error ? err.stack : undefined),
+  });
+}
+
+// ── Types ──────────────────────────────────────────────────────────────
+
+export type ApprovalCardRow = {
+  id: number;
+  flow_id: string;
+  node_id: string;
+  workflow_id: string;
+  workflow_title: string | null;
+  approval_type: string | null;
+  message: string | null;
+  card_fields_json: string | null;
+  approver_ids: string;
+  approver_names: string | null;
+  approval_policy: string;
+  approved_by: string;
+  rejected_by: string;
+  status: string;
+  delivery_mode: string;
+  created_at: number;
+  resolved_at: number | null;
+  /** Structured or plain-text comment from the approver. */
+  comment: string | null;
+};
+
+export type ApprovalCardCreate = {
+  flowId: string;
+  nodeId: string;
+  workflowId: string;
+  workflowTitle?: string;
+  approvalType?: string;
+  message?: string;
+  /** Legacy shape: Array<{label, value}> or unified shape: {fields, sections}. */
+  cardFields?: unknown;
+  approverIds: string[];
+  approverNames?: string[];
+  approvalPolicy?: string;
+  deliveryMode?: string;
+};
+
+export type ApprovalActionResult = {
+  ok: boolean;
+  status: "pending" | "approved" | "rejected";
+  approvedBy: string[];
+  rejectedBy: string[];
+  error?: string;
+};
+
+// ── Repository ─────────────────────────────────────────────────────────
+
+export class ApprovalCardRepository {
+  constructor(private db: IDatabase) {}
+
+  /** Create a new approval card. Returns the inserted row ID. */
+  async create(card: ApprovalCardCreate): Promise<number> {
+    try {
+    // created_at is BIGINT (unix timestamp) in MySQL / INTEGER in SQLite — always use integer.
+    // Do NOT use nowForDb() which returns datetime strings for MySQL TIMESTAMP columns.
+    const now = Math.floor(Date.now() / 1000);
+    const sql = `
+      INSERT INTO approval_cards
+        (flow_id, node_id, workflow_id, workflow_title, approval_type, message,
+         card_fields_json, approver_ids, approver_names, approval_policy,
+         approved_by, rejected_by, status, delivery_mode, created_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, '', '', 'pending', ?, ?)
+    `;
+    const result = await this.db.exec(sql, [
+      card.flowId,
+      card.nodeId,
+      card.workflowId,
+      card.workflowTitle ?? null,
+      card.approvalType ?? null,
+      card.message ?? null,
+      card.cardFields ? JSON.stringify(card.cardFields) : null,
+      card.approverIds.join(","),
+      card.approverNames?.join(",") ?? null,
+      card.approvalPolicy ?? "any",
+      card.deliveryMode ?? "card-web",
+      now,
+    ]);
+    return result.insertId ?? 0;
+    } catch (err) {
+      logDbError("create", err);
+      throw err;
+    }
+  }
+
+  /** Find an approval card by its ID. */
+  async findById(id: number): Promise<ApprovalCardRow | null> {
+    const rows = await this.db.query<ApprovalCardRow>(
+      "SELECT * FROM approval_cards WHERE id = ?",
+      [id],
+    );
+    return rows[0] ?? null;
+  }
+
+  /** Find approval cards by flowId + nodeId. */
+  async findByFlowNode(flowId: string, nodeId: string): Promise<ApprovalCardRow[]> {
+    return this.db.query<ApprovalCardRow>(
+      "SELECT * FROM approval_cards WHERE flow_id = ? AND node_id = ? ORDER BY created_at DESC",
+      [flowId, nodeId],
+    );
+  }
+
+  /** Check if an empId is in the approver list for a card. */
+  isApprover(card: ApprovalCardRow, empId: string): boolean {
+    const ids = card.approver_ids.split(",").map((s) => s.trim());
+    return ids.includes(empId);
+  }
+
+  /** Parse approved_by / rejected_by comma-separated strings into arrays. */
+  parseList(csv: string | null): string[] {
+    if (!csv) return [];
+    return csv.split(",").map((s) => s.trim()).filter(Boolean);
+  }
+
+  /**
+   * Record an approval/rejection action by an approver.
+   *
+   * - Validates the approver is authorized
+   * - Idempotent: no-op if the user already performed this action
+   * - Evaluates approval policy after the action
+   * - Updates status to "approved" or "rejected" if policy is met
+   *
+   * Returns the result including the updated status.
+   */
+  async recordAction(
+    cardId: number,
+    empId: string,
+    action: "approve" | "reject",
+    comment?: string,
+  ): Promise<ApprovalActionResult> {
+    const card = await this.findById(cardId);
+    if (!card) {
+      return { ok: false, status: "pending", approvedBy: [], rejectedBy: [], error: "审批记录未找到" };
+    }
+
+    if (!this.isApprover(card, empId)) {
+      return { ok: false, status: "pending" as const, approvedBy: [], rejectedBy: [], error: "您不是此审批的授权审批人" };
+    }
+
+    if (card.status !== "pending") {
+      const approvedBy = this.parseList(card.approved_by);
+      const rejectedBy = this.parseList(card.rejected_by);
+      return { ok: false, status: card.status as "approved" | "rejected", approvedBy, rejectedBy, error: "审批已处理" };
+    }
+
+    const approvedBy = this.parseList(card.approved_by);
+    const rejectedBy = this.parseList(card.rejected_by);
+    const approverIds = this.parseList(card.approver_ids);
+
+    // Idempotent: already performed this exact action
+    if (action === "approve" && approvedBy.includes(empId)) {
+      return this.evaluatePolicy(approverIds, approvedBy, rejectedBy, card.approval_policy);
+    }
+    if (action === "reject" && rejectedBy.includes(empId)) {
+      return this.evaluatePolicy(approverIds, approvedBy, rejectedBy, card.approval_policy);
+    }
+
+    // Apply action
+    if (action === "approve") {
+      approvedBy.push(empId);
+      // Remove from rejectedBy if switching
+      const idx = rejectedBy.indexOf(empId);
+      if (idx >= 0) rejectedBy.splice(idx, 1);
+    } else {
+      rejectedBy.push(empId);
+      // Remove from approvedBy if switching
+      const idx = approvedBy.indexOf(empId);
+      if (idx >= 0) approvedBy.splice(idx, 1);
+    }
+
+    // Evaluate policy
+    const policyResult = this.evaluatePolicy(approverIds, approvedBy, rejectedBy, card.approval_policy);
+
+    // Update database
+    const newStatus = policyResult.status;
+    // resolved_at is BIGINT (unix timestamp) in MySQL / INTEGER in SQLite — always use integer.
+    const resolvedAt = newStatus !== "pending" ? Math.floor(Date.now() / 1000) : null;
+
+    await this.db.exec(
+      `UPDATE approval_cards
+       SET approved_by = ?, rejected_by = ?, status = ?, resolved_at = COALESCE(?, resolved_at),
+           comment = COALESCE(?, comment)
+       WHERE id = ?`,
+      [
+        approvedBy.join(","),
+        rejectedBy.join(","),
+        newStatus,
+        resolvedAt,
+        comment ?? null,
+        cardId,
+      ],
+    ).catch((err) => {
+      logDbError("recordAction", err);
+      throw err;
+    });
+
+    return policyResult;
+  }
+
+  /**
+   * Evaluate the approval policy given the current state.
+   */
+  evaluatePolicy(
+    approverIds: string[],
+    approvedBy: string[],
+    rejectedBy: string[],
+    policy: string,
+  ): ApprovalActionResult {
+    const total = approverIds.length;
+
+    switch (policy) {
+      case "any": {
+        // First action wins
+        if (approvedBy.length > 0) {
+          return { ok: true, status: "approved", approvedBy, rejectedBy };
+        }
+        if (rejectedBy.length > 0) {
+          return { ok: true, status: "rejected", approvedBy, rejectedBy };
+        }
+        return { ok: true, status: "pending", approvedBy, rejectedBy };
+      }
+
+      case "all": {
+        // Any rejection → rejected; all approve → approved
+        if (rejectedBy.length > 0) {
+          return { ok: true, status: "rejected", approvedBy, rejectedBy };
+        }
+        if (approvedBy.length >= total) {
+          return { ok: true, status: "approved", approvedBy, rejectedBy };
+        }
+        return { ok: true, status: "pending", approvedBy, rejectedBy };
+      }
+
+      case "majority": {
+        // >50% approve → approved; any rejection when can't reach majority → rejected
+        const threshold = Math.floor(total / 2) + 1;
+        if (approvedBy.length >= threshold) {
+          return { ok: true, status: "approved", approvedBy, rejectedBy };
+        }
+        if (rejectedBy.length > 0) {
+          return { ok: true, status: "rejected", approvedBy, rejectedBy };
+        }
+        return { ok: true, status: "pending", approvedBy, rejectedBy };
+      }
+
+      default:
+        return { ok: true, status: "pending", approvedBy, rejectedBy };
+    }
+  }
+
+  /** Find resolved (non-pending) card-web cards that workflow runtime should process. */
+  async findResolvedCardWeb(limit = 50): Promise<ApprovalCardRow[]> {
+    return this.db.query<ApprovalCardRow>(
+      `SELECT * FROM approval_cards
+       WHERE status != 'pending' AND delivery_mode = 'card-web'
+       ORDER BY resolved_at DESC LIMIT ?`,
+      [limit],
+    );
+  }
+
+  /** Mark a card as processed by workflow runtime (set resolved_at or a processed flag). */
+  async markProcessed(cardId: number): Promise<void> {
+    // We use a soft approach: if resolved_at is set, workflow runtime has the data.
+    // No extra column needed — workflow runtime uses (flowId, nodeId, status) to resume.
+    await this.db.exec(
+      "UPDATE approval_cards SET gmt_modified = ? WHERE id = ?",
+      [this.db.dialect.now(), cardId],
+    );
+  }
+}

--- a/src/evolverun/clawweb/public/modules/workflow/server/routes/__tests__/approval.test.ts
+++ b/src/evolverun/clawweb/public/modules/workflow/server/routes/__tests__/approval.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, expect, it } from 'vitest';
+import express from 'express';
+import type { Server } from 'node:http';
+import { createApprovalRouter } from '../approval';
+import type { ApprovalCardRow } from '../../repositories/approval-card-repository';
+const servers: Server[]=[];
+afterEach(async()=>{await Promise.all(servers.splice(0).map(s=>new Promise<void>((resolve,reject)=>s.close(err=>err?reject(err):resolve()))));});
+async function fixture(content: unknown) {
+ const row: ApprovalCardRow={id:1,flow_id:'flow-1',node_id:'review',workflow_id:'test',workflow_title:'流程',approval_type:'HUMAN_CONFIRM',message:'确认',card_fields_json:JSON.stringify(content),approver_ids:'reviewer',approver_names:'审核人',approval_policy:'any',approved_by:'',rejected_by:'',status:'pending',delivery_mode:'card-web',created_at:100,resolved_at:null,comment:null};
+ const db={query:async(_sql:string,p:unknown[])=>p?.[0]===1?[{...row}]:[],exec:async(_sql:string,p:unknown[])=>{[row.approved_by,row.rejected_by,row.status,row.resolved_at,row.comment]=p as any;return {affectedRows:1};}};
+ const app=express();app.use(express.json());app.use('/approval',createApprovalRouter(db as any));
+ const server=app.listen(0,'127.0.0.1');servers.push(server);await new Promise<void>(resolve=>server.once('listening',resolve));
+ const base=`http://127.0.0.1:${(server.address() as any).port}/approval/1`;
+ return {row,base};
+}
+it('serves legacy fields and configured display envelopes through the migrated API',async()=>{
+ for(const content of [[{label:'任务',value:'T-1'}],{fields:[{label:'任务',value:'T-1'}],display:{title:'复核',confirmLabel:'执行处置',footer:''}}]){
+  const {base}=await fixture(content);const data=await(await fetch(`${base}?empId=reviewer`)).json();
+  expect(data.cardFields).toEqual([{label:'任务',value:'T-1'}]);expect(data.isApprover).toBe(true);
+  if(!Array.isArray(content))expect(data.display).toEqual(content.display);else expect(data.display).toBeUndefined();
+ }
+});
+it('retains action authorization, resolution time and duplicate protection',async()=>{
+ const {base}=await fixture([]);
+ const submit=(empId:string)=>fetch(`${base}/resolve`,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({empId,action:'approve',comment:'checked'})});
+ expect((await submit('stranger')).status).toBe(403);
+ expect((await submit('reviewer')).status).toBe(200);
+ const status=await(await fetch(`${base}/status`)).json();expect(status.status).toBe('approved');expect(status.resolvedAt).toBeGreaterThan(100);expect(status.approvedBy).toEqual(['reviewer']);
+ expect((await submit('reviewer')).status).toBe(409);
+});
+
+
+it('retains missing and invalid approval responses', async () => {
+  const {base}=await fixture([]);
+  expect((await fetch(base.replace(/\/1$/, '/999'))).status).toBe(404);
+  expect((await fetch(base.replace(/\/1$/, '/invalid'))).status).toBe(400);
+});
+
+it('keeps data resource section decisions in detail across resolve and detail reads', async () => {
+ const sections=[{id:'assetSelection',title:'资产确认',items:[{id:'authAsset',label:'确认确权资产',expected:'recommended.table',customizable:true,actions:[{key:'accept',label:'使用推荐'},{key:'customize',label:'自定义'}]}]}];
+ const {base,row}=await fixture({fields:[{label:'申请',value:'data resource'}],sections,display:{confirmLabel:'确认资产'}});
+ const before=await(await fetch(`${base}?empId=reviewer`)).json();expect(before.sections).toEqual(sections);
+ const detail={assetSelection:{authAsset:{action:'customize',value:'project.table'}}};
+ const response=await fetch(`${base}/resolve`,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({empId:'reviewer',action:'approve',comment:'已核对',detail})});
+ expect(response.status).toBe(200);expect(row.delivery_mode).toBe('card-web');
+ expect(JSON.parse(row.comment!)).toEqual({note:'已核对',detail});
+ const after=await(await fetch(`${base}?empId=reviewer`)).json();expect(after.detail).toEqual(detail);expect(after.sections).toEqual(sections);
+});

--- a/src/evolverun/clawweb/public/modules/workflow/server/routes/approval.ts
+++ b/src/evolverun/clawweb/public/modules/workflow/server/routes/approval.ts
@@ -1,0 +1,221 @@
+/**
+ * Approval API routes — card-web delivery endpoints.
+ *
+ * Shared approval endpoints; the host supplies platform-specific identity exchange.
+ *   GET  /api/approval/:id         — get approval details
+ *   POST /api/approval/:id/resolve — execute an authorized approval action
+ *   GET  /api/approval/:id/status  — poll approval status
+ *
+ * All data is read from/written to the approval_cards database table.
+ * workflow runtime creates the row when sending the approval; clawweb serves the UI
+ * and records the action; workflow runtime polls the DB to detect resolution.
+ */
+
+import { Router, type Request, type Response } from "express";
+import type { IDatabase } from "@avernet/clawweb-shared/server/db";
+import { ApprovalCardRepository } from "../repositories/approval-card-repository.js";
+import { asyncHandler } from "@avernet/clawweb-shared/server/middleware/async-handler";
+import { parseApprovalCardContent } from "../../shared/approval-display.js";
+import { invalidateResolvedCache } from "./internal/approval-cards.js";
+
+// ── Route factory ──────────────────────────────────────────────────────
+
+export function createApprovalRouter(db: IDatabase): Router {
+  const router = Router();
+  const repo = new ApprovalCardRepository(db);
+
+  /**
+   * GET /api/approval/:id — get approval details
+   *
+   * Query param: empId (optional) — if provided, checks if this person is an approver
+   *
+   * Returns the approval card data including card fields, approvers, and status.
+   * empId is not required to view the card — it's only needed for action authorization.
+   *
+   * card_fields_json supports two shapes:
+   *   - Legacy: Array<{label, value}> → rendered as traditional card
+   *   - Section mode: {fields: [...], sections: [...]} → rendered as interactive section card
+   */
+  router.get("/:id", asyncHandler(async (req: Request, res: Response) => {
+    const id = parseInt(String(req.params.id), 10);
+    if (Number.isNaN(id)) {
+      res.status(400).json({ error: "Bad Request", message: "无效的审批 ID" });
+      return;
+    }
+
+    const card = await repo.findById(id);
+    if (!card) {
+      res.status(404).json({ error: "Not Found", message: "审批记录未找到" });
+      return;
+    }
+
+    const empId = String(req.query.empId ?? "");
+    const isApprover = empId ? repo.isApprover(card, empId) : false;
+
+    const approvedBy = repo.parseList(card.approved_by);
+    const rejectedBy = repo.parseList(card.rejected_by);
+    const approverIds = repo.parseList(card.approver_ids);
+    const approverNames = card.approver_names
+      ? card.approver_names.split(",").map((s) => s.trim())
+      : approverIds;
+
+    const { fields: cardFields, sections, display } = parseApprovalCardContent(card.card_fields_json);
+
+    // Parse structured comment (detail + note) for resolved cards
+    let comment: string | undefined = card.comment ?? undefined;
+    let note: string | undefined;
+    let detail: unknown | undefined;
+    if (comment && comment.trim().startsWith("{")) {
+      try {
+        const parsed = JSON.parse(comment);
+        if (parsed && typeof parsed === "object" && parsed.detail) {
+          note = parsed.note ?? undefined;
+          detail = parsed.detail;
+        }
+      } catch {
+        // Not structured, keep raw comment
+      }
+    }
+
+    const response: Record<string, unknown> = {
+      id: card.id,
+      flowId: card.flow_id,
+      nodeId: card.node_id,
+      workflowId: card.workflow_id,
+      workflowTitle: card.workflow_title,
+      approvalType: card.approval_type,
+      message: card.message,
+      cardFields,
+      ...(display ? { display } : {}),
+      approverIds,
+      approverNames,
+      approvalPolicy: card.approval_policy,
+      approvedBy,
+      rejectedBy,
+      status: card.status,
+      deliveryMode: card.delivery_mode,
+      createdAt: card.created_at,
+      resolvedAt: card.resolved_at,
+      isApprover,
+      empId: empId || undefined,
+    };
+    if (sections) response.sections = sections;
+    if (comment) response.comment = comment;
+    if (note) response.note = note;
+    if (detail) response.detail = detail;
+
+    res.json(response);
+  }));
+
+  /**
+   * POST /api/approval/:id/resolve — execute approval action
+   *
+   * Body: { empId: string, action: "approve" | "reject", comment?: string }
+   *
+   * 1. Verify empId is an authorized approver
+   * 2. Record the action in the DB
+   * 3. Evaluate approval policy
+   * 4. Update status if policy is met
+   * No external callback — workflow runtime polls the DB.
+   */
+  router.post("/:id/resolve", asyncHandler(async (req: Request, res: Response) => {
+    const id = parseInt(String(req.params.id), 10);
+    if (Number.isNaN(id)) {
+      res.status(400).json({ error: "Bad Request", message: "无效的审批 ID" });
+      return;
+    }
+
+    const { empId, action, comment, detail } = req.body as {
+      empId?: string;
+      action?: string;
+      comment?: string;
+      detail?: Record<string, unknown>;
+    };
+
+    if (!empId) {
+      res.status(400).json({ error: "Bad Request", message: "缺少 empId" });
+      return;
+    }
+
+    if (!action || (action !== "approve" && action !== "reject")) {
+      res.status(400).json({ error: "Bad Request", message: "action 必须是 'approve' 或 'reject'" });
+      return;
+    }
+
+    // Build comment: if detail is provided, store as structured JSON; otherwise plain text
+    const commentToStore = (detail && typeof detail === "object" && Object.keys(detail).length > 0)
+      ? JSON.stringify({ note: comment ?? "", detail })
+      : (comment ?? undefined);
+
+    const result = await repo.recordAction(id, empId, action as "approve" | "reject", commentToStore);
+
+    // Invalidate resolved-cards cache — status may have changed from pending to approved/rejected
+    invalidateResolvedCache();
+
+    if (!result.ok && result.error) {
+      // Determine status code based on error type
+      if (result.error === "审批记录未找到") {
+        res.status(404).json({ error: "Not Found", message: result.error });
+        return;
+      }
+      if (result.error === "您不是此审批的授权审批人") {
+        res.status(403).json({ error: "Forbidden", message: result.error });
+        return;
+      }
+      if (result.error === "审批已处理") {
+        res.status(409).json({
+          error: "Conflict",
+          message: result.error,
+          status: result.status,
+          approvedBy: result.approvedBy,
+          rejectedBy: result.rejectedBy,
+        });
+        return;
+      }
+      res.status(500).json({ error: "Internal Error", message: result.error });
+      return;
+    }
+
+    res.json({
+      ok: true,
+      action,
+      status: result.status,
+      approvedBy: result.approvedBy,
+      rejectedBy: result.rejectedBy,
+      comment: comment ?? null,
+    });
+  }));
+
+  /**
+   * GET /api/approval/:id/status — poll approval status
+   *
+   * Lightweight endpoint for status polling (no card data, just status).
+   * Query param: empId (optional, for approver check)
+   */
+  router.get("/:id/status", asyncHandler(async (req: Request, res: Response) => {
+    const id = parseInt(String(req.params.id), 10);
+    if (Number.isNaN(id)) {
+      res.status(400).json({ error: "Bad Request", message: "无效的审批 ID" });
+      return;
+    }
+
+    const card = await repo.findById(id);
+    if (!card) {
+      res.status(404).json({ error: "Not Found", message: "审批记录未找到" });
+      return;
+    }
+
+    res.json({
+      id: card.id,
+      flowId: card.flow_id,
+      nodeId: card.node_id,
+      status: card.status,
+      approvalPolicy: card.approval_policy,
+      approvedBy: repo.parseList(card.approved_by),
+      rejectedBy: repo.parseList(card.rejected_by),
+      resolvedAt: card.resolved_at,
+    });
+  }));
+
+  return router;
+}

--- a/src/evolverun/clawweb/public/modules/workflow/server/routes/internal/approval-cards.ts
+++ b/src/evolverun/clawweb/public/modules/workflow/server/routes/internal/approval-cards.ts
@@ -1,0 +1,163 @@
+/**
+ * Internal API routes for approval_cards — write operations for workflow runtime.
+ *
+ * Endpoints:
+ *   POST /             — insert a new approval card
+ *   GET  /resolved     — find resolved card-web cards for workflow runtime to process
+ *   POST  /:id/processed — mark a card as processed
+ */
+import { Router, type Request, type Response } from "express";
+import { ApprovalCardRepository } from "../../repositories/approval-card-repository.js";
+import { apiLog, apiLogBody } from "../internal-logger.js";
+import { asyncHandler } from "@avernet/clawweb-shared/server/middleware/async-handler";
+
+// ── Resolved-cards cache ───────────────────────────────────────────────
+// workflow runtime's card-web-poller hits GET /resolved at high frequency.
+// Since the result set changes infrequently (only when an approver acts),
+// a short TTL cache dramatically reduces DB load without meaningful
+// latency impact — the poller already runs on 60s+ intervals.
+
+const RESOLVED_CACHE_TTL_MS = 30_000; // 30 seconds
+
+type CachedResult = { data: unknown; timestamp: number };
+
+let _resolvedCache: CachedResult | null = null;
+
+/** Invalidate the resolved-cards cache (call on writes that change the set). */
+export function invalidateResolvedCache(): void {
+  _resolvedCache = null;
+}
+
+/** Return cached data if fresh, otherwise null. */
+function getResolvedCache(): unknown | null {
+  if (!_resolvedCache) return null;
+  if (Date.now() - _resolvedCache.timestamp > RESOLVED_CACHE_TTL_MS) {
+    _resolvedCache = null;
+    return null;
+  }
+  return _resolvedCache.data;
+}
+
+export function createInternalApprovalCardsRouter(approvalCardRepo: ApprovalCardRepository | null): Router {
+  const router = Router();
+
+  /** POST / — insert a new approval card */
+  router.post("/", asyncHandler(async (req: Request, res: Response) => {
+    apiLogBody("WRITE", "/approval-cards", req.body);
+    if (!approvalCardRepo) {
+      apiLog("WRITE", "/approval-cards", { status: 503, error: "Database not configured" });
+      res.status(503).json({ success: false, error: "Service Unavailable", message: "Database not configured" });
+      return;
+    }
+
+    const {
+        flow_id,
+        node_id,
+        workflow_id,
+        workflow_title,
+        approval_type,
+        message,
+        card_fields_json,
+        approver_ids,
+        approver_names,
+        approval_policy,
+        delivery_mode,
+      } = req.body as {
+        flow_id?: string;
+        node_id?: string;
+        workflow_id?: string;
+        workflow_title?: string;
+        approval_type?: string;
+        message?: string;
+        card_fields_json?: string;
+        approver_ids?: string;
+        approver_names?: string;
+        approval_policy?: string;
+        delivery_mode?: string;
+        [key: string]: unknown;
+      };
+
+    try {
+      if (!flow_id || !node_id || !workflow_id || !approver_ids) {
+        apiLog("WRITE", "/approval-cards", { httpStatus: 400, error: "Missing required fields" });
+        res.status(400).json({ success: false, error: "Bad Request", message: "Missing required fields: flow_id, node_id, workflow_id, approver_ids" });
+        return;
+      }
+
+      const id = await approvalCardRepo.create({
+        flowId: flow_id,
+        nodeId: node_id,
+        workflowId: workflow_id,
+        workflowTitle: workflow_title,
+        approvalType: approval_type,
+        message,
+        cardFields: card_fields_json ? JSON.parse(card_fields_json) : undefined,
+        approverIds: approver_ids.split(",").map((s: string) => s.trim()).filter(Boolean),
+        approverNames: approver_names ? approver_names.split(",").map((s: string) => s.trim()).filter(Boolean) : undefined,
+        approvalPolicy: approval_policy ?? "any",
+        deliveryMode: delivery_mode ?? "card-web",
+      });
+
+      apiLog("WRITE", "/approval-cards", { httpStatus: 201, id });
+      // New card may be resolved soon — invalidate cache so poller picks it up
+      invalidateResolvedCache();
+      res.status(201).json({ success: true, data: { id } });
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      const code = (error as any)?.code;
+      const sqlMessage = (error as any)?.sqlMessage;
+      apiLog("WRITE", "/approval-cards", { httpStatus: 500, error: msg, code, sqlMessage });
+      console.error(`[approval-cards] insert failed: ${msg}`, { code, sqlMessage, flow_id, node_id, workflow_id });
+      res.status(500).json({ success: false, error: "Internal Server Error", message: msg, code, detail: sqlMessage });
+    }
+  }));
+
+  /** GET /resolved — find resolved card-web cards for workflow runtime polling */
+  router.get("/resolved", asyncHandler(async (_req: Request, res: Response) => {
+    if (!approvalCardRepo) {
+      res.status(503).json({ success: false, error: "Service Unavailable", message: "Database not configured" });
+      return;
+    }
+
+    try {
+      // Serve from TTL cache if fresh — avoids hitting DB on every poll
+      const cached = getResolvedCache();
+      if (cached) {
+        res.json(cached);
+        return;
+      }
+
+      const limit = parseInt(_req.query.limit as string, 10) || 50;
+      const cards = await approvalCardRepo.findResolvedCardWeb(limit);
+      const body = { success: true, data: cards };
+      _resolvedCache = { data: body, timestamp: Date.now() };
+      res.json(body);
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      res.status(500).json({ success: false, error: "Internal Server Error", message: msg });
+    }
+  }));
+
+  /** POST /:id/processed — mark a card as processed */
+  router.post("/:id/processed", asyncHandler(async (req: Request, res: Response) => {
+    if (!approvalCardRepo) {
+      res.status(503).json({ success: false, error: "Service Unavailable", message: "Database not configured" });
+      return;
+    }
+
+    try {
+      const id = parseInt(String(req.params.id), 10);
+      if (isNaN(id)) {
+        res.status(400).json({ success: false, error: "Bad Request", message: "Invalid id" });
+        return;
+      }
+      await approvalCardRepo.markProcessed(id);
+      res.json({ success: true });
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      res.status(500).json({ success: false, error: "Internal Server Error", message: msg });
+    }
+  }));
+
+  return router;
+}

--- a/src/evolverun/clawweb/public/modules/workflow/shared/__tests__/approval-display.test.ts
+++ b/src/evolverun/clawweb/public/modules/workflow/shared/__tests__/approval-display.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { parseApprovalCardContent, approvalDisplay } from '../approval-display.js';
+
+describe('approval card content compatibility', () => {
+  it('preserves old field arrays and section envelopes', () => {
+    const fields = [{ label: '任务', value: 'T-1' }];
+    expect(parseApprovalCardContent(JSON.stringify(fields)).fields).toEqual(fields);
+    expect(parseApprovalCardContent(JSON.stringify({ fields, sections: [{ id: 'review', fields: [] }] })).sections).toHaveLength(1);
+  });
+  it('reads display-only envelopes without requiring sections', () => {
+    const result = parseApprovalCardContent(JSON.stringify({ fields: [{ label: '任务', value: 'T-1' }], display: { confirmLabel: '执行处置', footer: '' } }));
+    expect(result.fields).toHaveLength(1);
+    expect(approvalDisplay('HUMAN_CONFIRM', result.display)).toMatchObject({ confirmLabel: '执行处置', rejectLabel: '拒绝', footer: '' });
+  });
+  it('retains defaults for absent or malformed data', () => {
+    expect(parseApprovalCardContent('{invalid')).toEqual({ fields: [] });
+    expect(approvalDisplay('HUMAN_CONFIRM')).toMatchObject({ confirmLabel: '确认执行', notePlaceholder: '备注（可选）' });
+    expect(approvalDisplay('HUMAN_CONFIRM', { confirmLabel: 12 } as any).confirmLabel).toBe('确认执行');
+  });
+});
+
+
+it('distinguishes zero duration from missing timing', async () => {
+  const { formatDuration } = await import('../../web/utils/time');
+  expect(formatDuration(0)).toBe('0ms');
+  expect(formatDuration(null)).toBe('—');
+  expect(formatDuration(120000)).toBe('2m');
+});
+
+
+it('retains scalar values in historical field arrays', () => {
+  expect(parseApprovalCardContent(JSON.stringify([{label:'数量',value:3},{label:'通过',value:true}])).fields)
+    .toEqual([{label:'数量',value:'3'},{label:'通过',value:'true'}]);
+});

--- a/src/evolverun/clawweb/public/modules/workflow/shared/approval-display.ts
+++ b/src/evolverun/clawweb/public/modules/workflow/shared/approval-display.ts
@@ -1,0 +1,45 @@
+export type ApprovalDisplay = Partial<Record<'title' | 'subtitle' | 'confirmLabel' | 'rejectLabel' | 'notePlaceholder' | 'pendingText' | 'approvedText' | 'rejectedText' | 'footer', string>>;
+const keys = ['title', 'subtitle', 'confirmLabel', 'rejectLabel', 'notePlaceholder', 'pendingText', 'approvedText', 'rejectedText', 'footer'] as const;
+
+function safeDisplay(value: unknown): ApprovalDisplay {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
+  const result: ApprovalDisplay = {};
+  for (const key of keys) {
+    const text = (value as Record<string, unknown>)[key];
+    if (typeof text === 'string' && text.length <= 1000) result[key] = text;
+  }
+  return result;
+}
+
+export function parseApprovalCardContent(json: string | null | undefined): { fields: Array<{ label: string; value: string }>; sections?: unknown[]; display?: ApprovalDisplay } {
+  try {
+    const value: unknown = JSON.parse(json ?? 'null');
+    const envelope = value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : undefined;
+    const fields = Array.isArray(value) ? value : Array.isArray(envelope?.fields) ? envelope.fields : [];
+    return {
+      fields: fields
+        .filter((field) => field && typeof field.label === 'string' && ['string', 'number', 'boolean'].includes(typeof field.value))
+        .map((field) => ({ label: field.label, value: String(field.value) })),
+      ...(Array.isArray(envelope?.sections) ? { sections: envelope.sections } : {}),
+      ...(envelope?.display ? { display: safeDisplay(envelope.display) } : {}),
+    };
+  } catch {
+    return { fields: [] };
+  }
+}
+
+export function approvalDisplay(type: string | null, custom?: ApprovalDisplay): Required<Omit<ApprovalDisplay, 'title'>> & { title?: string } {
+  const supplement = type === 'SUPPLEMENT_COMPLETE';
+  const human = type === 'HUMAN_CONFIRM';
+  return {
+    subtitle: supplement ? '工单申请信息补充' : human ? '审批决策确认' : type === 'BUDGET_APPROVE' ? '预算审批' : type ?? '审批',
+    confirmLabel: supplement ? '确认补充' : human ? '确认执行' : '同意',
+    rejectLabel: '拒绝',
+    notePlaceholder: supplement ? '补充说明（可选）' : '备注（可选）',
+    pendingText: supplement ? '待补充' : human ? '待确认' : '待审批',
+    approvedText: supplement ? '补充已提交' : human ? '决策已确认' : '审批已通过',
+    rejectedText: '审批已拒绝',
+    footer: '工作流审批',
+    ...safeDisplay(custom),
+  };
+}

--- a/src/evolverun/clawweb/public/modules/workflow/web/pages/Approval.tsx
+++ b/src/evolverun/clawweb/public/modules/workflow/web/pages/Approval.tsx
@@ -1,0 +1,1111 @@
+import { useState, useEffect, useCallback } from 'react'
+import { approvalDisplay, type ApprovalDisplay } from '../../shared/approval-display'
+import { formatDuration } from '../utils/time'
+import { useParams, useSearchParams } from 'react-router-dom'
+
+// ── Types ──────────────────────────────────────────────────────────────
+
+type ApprovalStatus = 'pending' | 'approved' | 'rejected'
+
+type CardField = { label: string; value: string }
+
+type SectionFieldAction = {
+  key: string
+  label: string
+  type?: 'primary' | 'default' | 'danger'
+  autoFill?: string
+}
+
+type SectionField = {
+  id: string
+  label: string
+  expected?: string
+  expectedLabel?: string
+  actual?: string
+  actualLabel?: string
+  actions?: SectionFieldAction[]
+  customizable?: boolean
+  placeholder?: string
+}
+
+type CardSection = {
+  id: string
+  title: string
+  description?: string
+  style?: 'default' | 'warning' | 'info' | 'danger' | 'success'
+  icon?: string
+  fields: SectionField[]
+}
+
+type FieldSelection = {
+  action: string
+  value?: string
+}
+
+type ApprovalData = {
+  id: number
+  flowId: string
+  nodeId: string
+  workflowId: string
+  workflowTitle: string | null
+  approvalType: string | null
+  message: string | null
+  cardFields: CardField[]
+  display?: ApprovalDisplay
+  sections?: CardSection[]
+  approverIds: string[]
+  approverNames: string[]
+  approvalPolicy: 'any' | 'all' | 'majority'
+  approvedBy: string[]
+  rejectedBy: string[]
+  status: ApprovalStatus
+  deliveryMode: string
+  createdAt: number
+  resolvedAt: number | null
+  comment?: string | null
+  note?: string | null
+  detail?: Record<string, unknown>
+  isApprover?: boolean
+  empId?: string
+}
+
+type ResolveResult = {
+  ok?: boolean
+  action?: string
+  status?: ApprovalStatus
+  approvedBy?: string[]
+  rejectedBy?: string[]
+  comment?: string | null
+  error?: string
+  message?: string
+}
+
+type StatusResult = {
+  id: number
+  flowId: string
+  nodeId: string
+  status: ApprovalStatus
+  approvalPolicy: 'any' | 'all' | 'majority'
+  approvedBy: string[]
+  rejectedBy: string[]
+  resolvedAt: number | null
+}
+
+type DingTalkAuthResult = {
+  ok: boolean
+  userId?: string
+  error?: string
+}
+
+// ── DingTalk JSAPI ─────────────────────────────────────────────────────
+
+declare global {
+  interface Window {
+    dd?: {
+      ready: (callback: () => void) => void
+      runtime: {
+        permission: {
+          requestAuthCode: (params: {
+            corpId: string
+            onSuccess: (result: { code: string }) => void
+            onFail: (err: unknown) => void
+          }) => void
+        }
+      }
+    }
+  }
+}
+
+function getDingTalkUserId(corpId: string): Promise<DingTalkAuthResult> {
+  return new Promise((resolve) => {
+    if (!window.dd?.ready) {
+      resolve({ ok: false, error: '非钉钉环境' })
+      return
+    }
+
+    window.dd.ready(() => {
+      if (!window.dd?.runtime?.permission?.requestAuthCode) {
+        resolve({ ok: false, error: '钉钉 JSAPI 不可用' })
+        return
+      }
+
+      window.dd.runtime.permission.requestAuthCode({
+        corpId,
+        onSuccess: async (result: { code: string }) => {
+          try {
+            const res = await fetch('/api/approval/auth/dingtalk', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ authCode: result.code }),
+            })
+            const data: DingTalkAuthResult = await res.json()
+            resolve(data)
+          } catch {
+            resolve({ ok: false, error: '钉钉认证请求失败' })
+          }
+        },
+        onFail: (err: unknown) => {
+          const msg = err instanceof Error ? err.message : '获取授权码失败'
+          resolve({ ok: false, error: msg })
+        },
+      })
+    })
+
+    setTimeout(() => {
+      resolve({ ok: false, error: '钉钉环境检测超时' })
+    }, 3000)
+  })
+}
+
+// ── API helpers ────────────────────────────────────────────────────────
+
+async function resolveApproval(
+  id: number,
+  empId: string,
+  action: 'approve' | 'reject',
+  comment?: string,
+  detail?: Record<string, unknown>,
+): Promise<ResolveResult> {
+  const res = await fetch(`/api/approval/${id}/resolve`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ empId, action, comment, detail }),
+  })
+  return res.json()
+}
+
+async function pollStatus(id: number): Promise<StatusResult> {
+  const res = await fetch(`/api/approval/${id}/status`)
+  if (!res.ok) throw new Error(`HTTP ${res.status}`)
+  return res.json()
+}
+
+// ── Format helper ──────────────────────────────────────────────────────
+
+function formatTime(ts: number | null): string {
+  if (!ts) return ''
+  const ms = typeof ts === 'number'
+    ? (ts > 1e12 ? ts : ts * 1000)
+    : new Date(ts).getTime()
+  return new Date(ms).toLocaleString('zh-CN', {
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+// ── Section Card Component ───────────────────────────────────────────────
+
+type SectionState = Record<string, FieldSelection>
+
+type SectionCardProps = {
+  sections: CardSection[]
+  selection: Record<string, SectionState>
+  setSelection: React.Dispatch<React.SetStateAction<Record<string, SectionState>>>
+  disabled: boolean
+}
+
+const sectionStyleMap: Record<string, { borderLeft: string; icon: string }> = {
+  default: { borderLeft: '4px solid #1677ff', icon: '📋' },
+  success: { borderLeft: '4px solid #52c41a', icon: '🎉' },
+  info: { borderLeft: '4px solid #13c2c2', icon: 'ℹ️' },
+  warning: { borderLeft: '4px solid #fa8c16', icon: '⚠️' },
+  danger: { borderLeft: '4px solid #ff4d4f', icon: '🚨' },
+}
+
+function SectionCard({ sections, selection, setSelection, disabled }: SectionCardProps) {
+  const handleActionClick = (sectionId: string, fieldId: string, actionKey: string) => {
+    if (disabled) return
+    setSelection((prev) => {
+      const next = { ...prev }
+      if (!next[sectionId]) next[sectionId] = {}
+      // If clicking the same action, deselect
+      if (next[sectionId][fieldId]?.action === actionKey) {
+        const sNext = { ...next[sectionId] }
+        delete sNext[fieldId]
+        next[sectionId] = sNext
+      } else {
+        next[sectionId] = {
+          ...next[sectionId],
+          [fieldId]: {
+            action: actionKey,
+            value: actionKey === 'customize'
+              ? (prev[sectionId]?.[fieldId]?.value ?? '')
+              : undefined,
+          },
+        }
+      }
+      return next
+    })
+  }
+
+  const handleCustomChange = (sectionId: string, fieldId: string, value: string) => {
+    if (disabled) return
+    setSelection((prev) => {
+      const next = { ...prev }
+      if (!next[sectionId]) next[sectionId] = {}
+      next[sectionId] = {
+        ...next[sectionId],
+        [fieldId]: {
+          action: 'customize',
+          value,
+        },
+      }
+      return next
+    })
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+      {sections.map((section) => {
+        const style = sectionStyleMap[section.style ?? 'default']
+        return (
+          <div
+            key={section.id}
+            style={{
+              background: '#fff',
+              borderRadius: 12,
+              border: '1px solid #e4e9f0', boxShadow: '0 3px 12px rgba(24,39,61,0.035)',
+              overflow: 'hidden',
+              borderLeft: style.borderLeft,
+            }}
+          >
+            {/* Section header */}
+            <div style={{ padding: '12px 16px', borderBottom: '1px solid #f0f0f0' }}>
+              <div style={{ fontSize: 15, fontWeight: 600, color: '#1a1a1a', display: 'flex', alignItems: 'center', gap: 6, lineHeight: 1.4 }}>
+                <span style={{ fontSize: 18 }}>{section.icon ?? style.icon}</span>
+                {section.title}
+              </div>
+              {section.description && (
+                <div style={{ fontSize: 12, color: '#999', marginTop: 4, lineHeight: 1.5 }}>
+                  {section.description}
+                </div>
+              )}
+            </div>
+
+            {/* Fields */}
+            <div style={{ padding: '2px 16px' }}>
+              {section.fields.map((field, fieldIdx) => {
+                const fieldSel = selection[section.id]?.[field.id]
+                const isCustomActive = fieldSel?.action === 'customize'
+                const isLastField = fieldIdx === section.fields.length - 1
+
+                return (
+                  <div
+                    key={field.id}
+                    style={{
+                      padding: '8px 0',
+                      borderBottom: isLastField ? 'none' : '1px solid #f6f6f6',
+                    }}
+                  >
+                    <div style={{ fontSize: 13, fontWeight: 500, color: '#1a1a1a', marginBottom: 8 }}>
+                      {field.label}
+                    </div>
+
+                    {/* Adaptive value rendering: compare / reference / display */}
+                    {(() => {
+                      const hasActions = field.actions && field.actions.length > 0
+                      const hasCustomizable = field.customizable === true
+                      const isInteractive = hasActions || hasCustomizable
+                      const hasExpected = field.expected !== undefined
+                      const hasActual = field.actual !== undefined
+
+                      // ── Mode 1: DISPLAY (read-only) ──
+                      if (!isInteractive && (hasExpected || hasActual)) {
+                        return (
+                          <div style={{
+                            padding: '6px 8px',
+                            background: '#fafafa',
+                            borderRadius: 6,
+                            marginBottom: 0,
+                            fontSize: 13,
+                            color: '#262626',
+                            lineHeight: 1.5,
+                            whiteSpace: 'pre-wrap',
+                            wordBreak: 'break-word',
+                          }}>
+                            {hasExpected && (
+                              <div style={{ marginBottom: hasActual ? 6 : 0 }}>
+                                {field.expectedLabel && field.actual && (
+                                  <div style={{ fontSize: 11, color: '#8c8c8c', marginBottom: 2 }}>{field.expectedLabel}</div>
+                                )}
+                                <div>{field.expected || '—'}</div>
+                              </div>
+                            )}
+                            {hasActual && (
+                              <div>
+                                {field.actualLabel && field.expected && (
+                                  <div style={{ fontSize: 11, color: '#8c8c8c', marginBottom: 2 }}>{field.actualLabel}</div>
+                                )}
+                                <div>{field.actual || '—'}</div>
+                              </div>
+                            )}
+                          </div>
+                        )
+                      }
+
+                      // ── Mode 2: COMPARE (dual-column, green-blue) ──
+                      if (isInteractive && hasExpected && hasActual) {
+                        return (
+                          <div style={{
+                            display: 'grid',
+                            gridTemplateColumns: '1fr 1fr',
+                            gap: 10,
+                            marginBottom: 10,
+                          }}>
+                            {hasExpected && (
+                              <div style={{ background: '#f6ffed', borderRadius: 6, padding: '6px 8px' }}>
+                                <div style={{ fontSize: 11, color: '#87d068', marginBottom: 2 }}>{field.expectedLabel ?? 'AI推荐'}</div>
+                                <div style={{ fontSize: 12, color: '#1a1a1a', lineHeight: 1.5, wordBreak: 'break-word', whiteSpace: 'pre-wrap' }}>
+                                  {field.expected || '—'}
+                                </div>
+                              </div>
+                            )}
+                            {hasActual && (
+                              <div style={{ background: '#e6f7ff', borderRadius: 6, padding: '6px 8px' }}>
+                                <div style={{ fontSize: 11, color: '#1677ff', marginBottom: 2 }}>{field.actualLabel ?? '当前'}</div>
+                                <div style={{ fontSize: 12, color: '#1a1a1a', lineHeight: 1.5, wordBreak: 'break-word', whiteSpace: 'pre-wrap' }}>
+                                  {field.actual || '—'}
+                                </div>
+                              </div>
+                            )}
+                          </div>
+                        )
+                      }
+
+                      // ── Mode 3: REFERENCE (full-width grey block + actions) ──
+                      if (isInteractive && hasExpected && !hasActual) {
+                        return (
+                          <div style={{ marginBottom: 10 }}>
+                            <div style={{
+                              padding: '10px 12px',
+                              background: '#fafafa',
+                              borderRadius: 6,
+                              marginBottom: 10,
+                              fontSize: 13,
+                              color: '#262626',
+                              lineHeight: 1.6,
+                              whiteSpace: 'pre-wrap',
+                              wordBreak: 'break-word',
+                            }}>
+                              {field.expectedLabel && (
+                                <div style={{ fontSize: 11, color: '#8c8c8c', marginBottom: 4 }}>{field.expectedLabel}</div>
+                              )}
+                              <div>{field.expected || '—'}</div>
+                            </div>
+                          </div>
+                        )
+                      }
+
+                      return null
+                    })()}
+
+                    {/* Action buttons */}
+                    {field.actions && field.actions.length > 0 && (
+                      <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+                        {field.actions.map((action) => {
+                          const isSelected = fieldSel?.action === action.key
+                          const colorMap: Record<string, { bg: string; text: string; border: string }> = {
+                            primary: { bg: '#1677ff', text: '#fff', border: '#1677ff' },
+                            danger: { bg: '#fff', text: '#ff4d4f', border: '#ff4d4f' },
+                            default: { bg: '#f5f5f5', text: '#595959', border: '#d9d9d9' },
+                          }
+                          const c = colorMap[action.type ?? 'default'] ?? colorMap.default
+                          return (
+                            <button
+                              key={action.key}
+                              onClick={() => handleActionClick(section.id, field.id, action.key)}
+                              disabled={disabled}
+                              style={{
+                                padding: '5px 12px',
+                                borderRadius: 6,
+                                border: `1px solid ${isSelected ? c.border : '#d9d9d9'}`,
+                                background: isSelected ? c.bg : '#fff',
+                                color: isSelected ? c.text : '#595959',
+                                fontSize: 13,
+                                cursor: disabled ? 'not-allowed' : 'pointer',
+                                opacity: disabled ? 0.5 : 1,
+                                fontWeight: isSelected ? 500 : 400,
+                                transition: 'all 0.15s',
+                              }}
+                            >
+                              {isSelected && '✓ '}
+                              {action.label}
+                            </button>
+                          )
+                        })}
+                      </div>
+                    )}
+
+                    {/* Custom input */}
+                    {(isCustomActive || (!field.actions && field.customizable)) && (
+                      <textarea
+                        value={fieldSel?.value ?? ''}
+                        onChange={(e) => handleCustomChange(section.id, field.id, e.target.value)}
+                        placeholder={field.placeholder ?? '请输入自定义内容'}
+                        rows={2}
+                        disabled={disabled || (!isCustomActive && !!field.actions)}
+                        style={{
+                          width: '100%',
+                          marginTop: 8,
+                          border: '1px solid #e8e8e8',
+                          borderRadius: 6,
+                          padding: '8px 10px',
+                          fontSize: 13,
+                          color: '#1a1a1a',
+                          resize: 'none',
+                          outline: 'none',
+                          boxSizing: 'border-box',
+                          ...(isCustomActive ? { borderColor: '#1677ff' } : { background: '#fafafa' }),
+                          cursor: disabled || (!isCustomActive && !!field.actions) ? 'not-allowed' : 'text',
+                        }}
+                      />
+                    )}
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+// ── Validation helper ──────────────────────────────────────────────────
+
+function validateSections(sections: CardSection[], selection: Record<string, SectionState>): string | null {
+  for (const section of sections) {
+    for (const field of section.fields) {
+      // Skip fields with no actions and not customizable
+      if (!field.actions?.length && !field.customizable) continue
+      // Fields with actions that must be selected
+      if (field.actions?.length && !selection[section.id]?.[field.id]?.action) {
+        return `「${section.title}」中「${field.label}」请选择处理意见`
+      }
+      // Customizable fields in customize mode must have value
+      if (
+        field.customizable &&
+        selection[section.id]?.[field.id]?.action === 'customize' &&
+        !selection[section.id][field.id]?.value?.trim()
+      ) {
+        return `「${section.title}」中「${field.label}」请填写自定义内容`
+      }
+    }
+  }
+  return null
+}
+
+function buildDetailPayload(
+  sections: CardSection[],
+  selection: Record<string, SectionState>,
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = {}
+  for (const section of sections) {
+    const sectionData: Record<string, unknown> = {}
+    for (const field of section.fields) {
+      const sel = selection[section.id]?.[field.id]
+      if (sel) {
+        const actionDef = field.actions?.find((a) => a.key === sel.action)
+        // For accept/keep actions, derive value from expected/actual so that
+        // downstream saveAs templates (e.g. workflowData.gdg_confirmed_asset)
+        // receive a concrete string instead of null.
+        let derivedValue = sel.value ?? actionDef?.autoFill ?? (
+          sel.action === 'accept' ? field.expected
+          : sel.action === 'keep' ? field.actual
+          : null
+        )
+        // Defensive: customize with empty/whitespace input should fall back to
+        // autoFill or expected so that saveAs never writes "", which breaks
+        // downstream default-filter fallbacks ("" does not trigger default).
+        if (sel.action === 'customize' && typeof derivedValue === 'string') {
+          const trimmed = derivedValue.trim()
+          if (!trimmed) {
+            derivedValue = actionDef?.autoFill || field.expected || null
+          }
+        }
+        sectionData[field.id] = {
+          action: sel.action,
+          actionLabel: actionDef?.label ?? sel.action,
+          value: derivedValue,
+          expected: field.expected ?? null,
+          actual: field.actual ?? null,
+        }
+      }
+    }
+    if (Object.keys(sectionData).length > 0) {
+      payload[section.id] = sectionData
+    }
+  }
+  return payload
+}
+
+// ── Approval page ──────────────────────────────────────────────────────
+
+export default function Approval() {
+  const { id: idStr } = useParams<{ id: string }>()
+  const [searchParams] = useSearchParams()
+
+  const [data, setData] = useState<ApprovalData | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [actionLoading, setActionLoading] = useState(false)
+  const [comment, setComment] = useState('')
+  const [result, setResult] = useState<ResolveResult | null>(null)
+  const [sectionSelection, setSectionSelection] = useState<Record<string, SectionState>>({})
+  const [validationError, setValidationError] = useState<string | null>(null)
+
+  const [empId, setEmpId] = useState<string>('')
+  const [identitySource, setIdentitySource] = useState<'dingtalk' | 'url' | 'unknown'>('unknown')
+
+  const approvalId = idStr ? parseInt(idStr, 10) : NaN
+
+  const isSectionMode = !!data?.sections && data.sections.length > 0
+
+  // ── Identity resolution ──────────────────────────────────────────────
+  useEffect(() => {
+    if (Number.isNaN(approvalId)) {
+      setError('无效的审批 ID')
+      setLoading(false)
+      return
+    }
+
+    let cancelled = false
+
+    async function resolveIdentity() {
+      const corpId = searchParams.get('corpId') ?? ''
+      if (corpId) {
+        const dtResult = await getDingTalkUserId(corpId)
+        if (!cancelled && dtResult.ok && dtResult.userId) {
+          setEmpId(dtResult.userId)
+          setIdentitySource('dingtalk')
+          return
+        }
+      }
+
+      const urlEmpId = searchParams.get('empId') ?? ''
+      if (urlEmpId) {
+        setEmpId(urlEmpId)
+        setIdentitySource('url')
+        return
+      }
+
+      if (!cancelled) {
+        setIdentitySource('unknown')
+      }
+    }
+
+    resolveIdentity()
+    return () => { cancelled = true }
+  }, [approvalId, searchParams])
+
+  // ── Load approval data ───────────────────────────────────────────────
+  useEffect(() => {
+    if (Number.isNaN(approvalId)) return
+
+    let cancelled = false
+    const url = empId
+      ? `/api/approval/${approvalId}?empId=${encodeURIComponent(empId)}`
+      : `/api/approval/${approvalId}`
+
+    fetch(url)
+      .then((res) => {
+        if (!res.ok) {
+          return res.json().catch(() => ({})).then((body) => {
+            throw new Error(body.message || `HTTP ${res.status}`)
+          })
+        }
+        return res.json()
+      })
+      .then((d: ApprovalData) => {
+        if (!cancelled) {
+          setData(d)
+          setLoading(false)
+          // If resolved with detail already, hydrate selection state for display
+          if (d.detail && d.sections && d.status !== 'pending') {
+            const initial: Record<string, SectionState> = {}
+            for (const section of d.sections) {
+              const secDetail = d.detail[section.id] as Record<string, unknown> | undefined
+              if (secDetail) {
+                initial[section.id] = {}
+                for (const field of section.fields) {
+                  const fd = secDetail[field.id] as Record<string, unknown> | undefined
+                  if (fd && typeof fd.action === 'string') {
+                    initial[section.id][field.id] = {
+                      action: fd.action,
+                      value: typeof fd.value === 'string' ? fd.value : undefined,
+                    }
+                  }
+                }
+              }
+            }
+            if (Object.keys(initial).length > 0) {
+              setSectionSelection(initial)
+            }
+          }
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : '加载审批数据失败')
+          setLoading(false)
+        }
+      })
+    return () => { cancelled = true }
+  }, [approvalId, empId])
+
+  // Poll status every 3s when pending
+  useEffect(() => {
+    if (Number.isNaN(approvalId) || !data || data.status !== 'pending') return
+    const interval = setInterval(() => {
+      pollStatus(approvalId)
+        .then((s) => {
+          setData((prev) =>
+            prev
+              ? { ...prev, status: s.status, approvedBy: s.approvedBy, rejectedBy: s.rejectedBy, resolvedAt: s.resolvedAt }
+              : prev,
+          )
+        })
+        .catch(() => { /* ignore */ })
+    }, 3000)
+    return () => clearInterval(interval)
+  }, [approvalId, data?.status])
+
+  const handleAction = useCallback(
+    async (action: 'approve' | 'reject') => {
+      if (Number.isNaN(approvalId)) return
+
+      // Section mode validation
+      if (isSectionMode && data?.sections) {
+        const err = validateSections(data.sections, sectionSelection)
+        if (err) {
+          setValidationError(err)
+          return
+        }
+        setValidationError(null)
+      }
+
+      if (!empId) {
+        const corpId = searchParams.get('corpId') ?? ''
+        if (corpId && window.dd?.ready) {
+          setActionLoading(true)
+          const dtResult = await getDingTalkUserId(corpId)
+          if (dtResult.ok && dtResult.userId) {
+            setEmpId(dtResult.userId)
+            setIdentitySource('dingtalk')
+            try {
+              const detail = isSectionMode && data?.sections
+                ? buildDetailPayload(data.sections, sectionSelection)
+                : undefined
+              const res = await resolveApproval(approvalId, dtResult.userId, action, comment || undefined, detail)
+              setResult(res)
+              if (res.ok) {
+                const freshUrl = `/api/approval/${approvalId}?empId=${encodeURIComponent(dtResult.userId)}`
+                const fresh = await (await fetch(freshUrl)).json()
+                setData(fresh)
+              }
+            } catch (err) {
+              setResult({ error: err instanceof Error ? err.message : '操作失败' })
+            } finally {
+              setActionLoading(false)
+            }
+            return
+          }
+        }
+        setResult({ error: '无法获取用户身份，请在钉钉中打开此页面' })
+        return
+      }
+
+      setActionLoading(true)
+      try {
+        const detail = isSectionMode && data?.sections
+          ? buildDetailPayload(data.sections, sectionSelection)
+          : undefined
+        const res = await resolveApproval(approvalId, empId, action, comment || undefined, detail)
+        setResult(res)
+        if (res.ok) {
+          const freshUrl = `/api/approval/${approvalId}?empId=${encodeURIComponent(empId)}`
+          const fresh = await (await fetch(freshUrl)).json()
+          setData(fresh)
+        }
+      } catch (err) {
+        setResult({ error: err instanceof Error ? err.message : '操作失败' })
+      } finally {
+        setActionLoading(false)
+      }
+    },
+    [approvalId, empId, comment, searchParams, isSectionMode, data?.sections, sectionSelection],
+  )
+
+  // ── Loading ──────────────────────────────────────────────────────────
+  if (loading) {
+    return (
+      <div style={{ display: 'flex', minHeight: '100vh', alignItems: 'center', justifyContent: 'center', background: '#f5f5f5' }}>
+        <div style={{ textAlign: 'center' }}>
+          <div style={{ width: 32, height: 32, border: '3px solid #1677ff', borderTopColor: 'transparent', borderRadius: '50%', animation: 'spin 1s linear infinite', margin: '0 auto 12px' }} />
+          <p style={{ color: '#999', fontSize: 14 }}>加载审批信息...</p>
+          <style>{`@keyframes spin { to { transform: rotate(360deg) } }`}</style>
+        </div>
+      </div>
+    )
+  }
+
+  // ── Error ────────────────────────────────────────────────────────────
+  if (error) {
+    return (
+      <div style={{ display: 'flex', minHeight: '100vh', alignItems: 'center', justifyContent: 'center', background: '#f5f5f5' }}>
+        <div style={{ background: '#fff', borderRadius: 12, padding: 24, textAlign: 'center', maxWidth: 320, width: '100%', border: '1px solid #e4e9f0', boxShadow: '0 3px 12px rgba(24,39,61,0.035)' }}>
+          <div style={{ fontSize: 40, marginBottom: 12 }}>🔒</div>
+          <h2 style={{ fontSize: 16, fontWeight: 600, color: '#1a1a1a', marginBottom: 8 }}>无法访问审批</h2>
+          <p style={{ fontSize: 13, color: '#999', margin: 0 }}>{error}</p>
+          <p style={{ fontSize: 12, color: '#ccc', marginTop: 12 }}>该链接可能已过期或无效</p>
+        </div>
+      </div>
+    )
+  }
+
+  if (!data) return null
+
+  const isResolved = data.status === 'approved' || data.status === 'rejected'
+  const canAct = data.status === 'pending'
+
+  // Approver display
+  const approverList = data.approverIds.map((id, i) => ({
+    id,
+    name: data.approverNames[i] || id,
+    approved: data.approvedBy.includes(id),
+    rejected: data.rejectedBy.includes(id),
+    isCurrent: id === empId,
+  }))
+
+  const policyLabel: Record<string, string> = {
+    any: '任一审批人通过即可',
+    all: '需全部审批人通过',
+    majority: '多数审批人通过即可',
+  }
+
+  const statusIcon: Record<ApprovalStatus, string> = { pending: '⏳', approved: '✅', rejected: '❌' }
+  const copy = approvalDisplay(data.approvalType, data.display)
+  const statusCopy = data.status === 'pending' ? copy.pendingText : data.status === 'approved' ? copy.approvedText : copy.rejectedText
+  const elapsedEnd = data.status === 'pending' ? Math.floor(Date.now() / 1000) : data.resolvedAt
+  const elapsedMs = data.createdAt > 0 && elapsedEnd != null && elapsedEnd >= data.createdAt
+    ? (elapsedEnd - data.createdAt) * 1000
+    : null
+
+  function renderCardFieldValue(field: CardField): any {
+    if (field.label === '申请单' && field.value) {
+      return (
+        <a
+          href={field.value}
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{ color: '#1677ff', fontSize: 14, textDecoration: 'none' }}
+          onClick={(e) => e.stopPropagation()}
+        >
+          点击打开申请单 →
+        </a>
+      )
+    }
+    if (field.value.length > 400) {
+      return <details><summary style={{ cursor: 'pointer', color: '#486384', fontWeight: 400 }}>
+        {field.value.slice(0, 160)}… <span style={{ color: '#2563a6' }}>展开完整内容</span>
+      </summary><div style={{ marginTop: 12, maxHeight: 360, overflow: 'auto', fontWeight: 400 }}>{field.value}</div></details>
+    }
+    return field.value || '—'
+  }
+
+  return (
+    <div style={{ minHeight: '100vh', background: '#f7f8fa', padding: '20px 12px', color: '#243247' }}>
+      <div style={{ maxWidth: 560, margin: '0 auto', overflowWrap: 'anywhere' }}>
+        {/* ── Title Card ─────────────────────────────────────────────── */}
+        <div style={{
+          background: '#fff',
+          borderRadius: 12,
+          border: '1px solid #e4e9f0', boxShadow: '0 3px 12px rgba(24,39,61,0.035)',
+          marginBottom: 12,
+          overflow: 'hidden',
+        }}>
+          {/* Header bar */}
+          <div style={{
+            background: '#edf4ff', borderTop: '3px solid #356fc4', borderBottom: '1px solid #dce7f7',
+            padding: '20px',
+            color: '#243b60',
+          }}>
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 8 }}>
+              <span style={{ fontSize: 13, opacity: 0.85 }}>{copy.subtitle}</span>
+              <span style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 4,
+                background: '#fff', color: '#315a8f', border: '1px solid #d5e3f4',
+                borderRadius: 12,
+                padding: '2px 10px',
+                fontSize: 12,
+              }}>
+                {statusIcon[data.status]} {statusCopy}
+              </span>
+            </div>
+            <h1 style={{ fontSize: 17, fontWeight: 600, margin: 0, lineHeight: 1.4 }}>
+              {copy.title ?? (data.message || data.workflowTitle || '审批请求')}
+            </h1>
+          </div>
+
+          {/* Section mode — interactive section cards */}
+          {isSectionMode && data.sections && (
+            <div style={{ padding: '12px 16px' }}>
+              <SectionCard
+                sections={data.sections}
+                selection={sectionSelection}
+                setSelection={setSectionSelection}
+                disabled={!canAct}
+              />
+            </div>
+          )}
+
+          {/* Traditional mode — stacked card fields */}
+          <div style={{ padding: '12px 16px', background: '#fafbfd', borderBottom: '1px solid #edf0f5', fontSize: 12, color: '#65758b' }}>
+            {data.status === 'pending' ? '等待确认' : '确认耗时'} · {elapsedMs === null ? '—' : elapsedMs === 0 ? '0s' : formatDuration(elapsedMs)}
+          </div>
+          {!isSectionMode && data.cardFields.length > 0 && (
+            <div style={{ padding: '12px 16px' }}>
+              {data.cardFields.map((field, i) => (
+                <div key={i} style={{
+                  padding: '10px 0',
+                  borderBottom: i < data.cardFields.length - 1 ? '1px solid #f0f0f0' : 'none',
+                }}>
+                  <div style={{ fontSize: 13, color: '#999', marginBottom: 4 }}>{field.label}</div>
+                  <div style={{ fontSize: 14, color: '#1a1a1a', fontWeight: 500, lineHeight: 1.6, wordBreak: 'break-word', whiteSpace: 'pre-wrap' }}>
+                    {renderCardFieldValue(field)}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* ── Detail Card ────────────────────────────────────────────── */}
+        {!['SUPPLEMENT_COMPLETE', 'HUMAN_CONFIRM'].includes(data.approvalType ?? '') && (
+          <div style={{
+            background: '#fff',
+            borderRadius: 12,
+            border: '1px solid #e4e9f0', boxShadow: '0 3px 12px rgba(24,39,61,0.035)',
+            marginBottom: 12,
+          }}>
+            {/* Approver section */}
+            <div style={{ padding: '14px 16px', borderBottom: '1px solid #f0f0f0' }}>
+              <div style={{ fontSize: 13, color: '#999', marginBottom: 8 }}>审批人</div>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+                {approverList.map((a) => (
+                  <span key={a.id} style={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: 4,
+                    padding: '4px 10px',
+                    borderRadius: 14,
+                    fontSize: 13,
+                    background: a.approved
+                      ? '#f6ffed'
+                      : a.rejected
+                        ? '#fff2f0'
+                        : '#f5f5f5',
+                    color: a.approved
+                      ? '#52c41a'
+                      : a.rejected
+                        ? '#ff4d4f'
+                        : '#595959',
+                    border: a.isCurrent ? '2px solid #1677ff' : '1px solid transparent',
+                  }}>
+                    {a.approved && '✓ '}
+                    {a.rejected && '✗ '}
+                    {a.name}
+                    {a.isCurrent && <span style={{ fontSize: 11, color: '#1677ff' }}>(我)</span>}
+                  </span>
+                ))}
+              </div>
+            </div>
+
+            {/* Policy */}
+            <div style={{ padding: '10px 16px', borderBottom: '1px solid #f0f0f0', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+              <span style={{ fontSize: 13, color: '#999' }}>审批策略</span>
+              <span style={{ fontSize: 13, color: '#595959' }}>{policyLabel[data.approvalPolicy] ?? data.approvalPolicy}</span>
+            </div>
+
+            {/* Workflow info */}
+            <div style={{ padding: '10px 16px', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+              <span style={{ fontSize: 13, color: '#999' }}>发起时间</span>
+              <span style={{ fontSize: 13, color: '#595959' }}>{formatTime(data.createdAt)}</span>
+            </div>
+
+            {data.resolvedAt && (
+              <div style={{ padding: '10px 16px', borderTop: '1px solid #f0f0f0', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                <span style={{ fontSize: 13, color: '#999' }}>
+                  {data.status === 'approved' ? '通过时间' : '拒绝时间'}
+                </span>
+                <span style={{ fontSize: 13, color: '#595959' }}>{formatTime(data.resolvedAt)}</span>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* ── Action Card ────────────────────────────────────────────── */}
+        {canAct && (
+          <div style={{
+            background: '#fff',
+            borderRadius: 12,
+            border: '1px solid #e4e9f0', boxShadow: '0 3px 12px rgba(24,39,61,0.035)',
+            marginBottom: 12,
+            padding: 16,
+          }}>
+            {/* Validation error */}
+            {validationError && isSectionMode && (
+              <div style={{
+                background: '#fff2f0',
+                border: '1px solid #ffccc7',
+                borderRadius: 8,
+                padding: '8px 12px',
+                marginBottom: 12,
+                fontSize: 13,
+                color: '#ff4d4f',
+              }}>
+                {validationError}
+              </div>
+            )}
+
+            {/* Comment */}
+            <textarea
+              value={comment}
+              onChange={(e) => setComment(e.target.value)}
+              placeholder={copy.notePlaceholder}
+              aria-label={copy.notePlaceholder}
+              rows={isSectionMode ? 2 : 2}
+              style={{
+                width: '100%',
+                border: '1px solid #e8e8e8',
+                borderRadius: 8,
+                padding: '8px 12px',
+                fontSize: 14,
+                color: '#1a1a1a',
+                resize: 'none',
+                outline: 'none',
+                marginBottom: 12,
+                boxSizing: 'border-box',
+              }}
+              onFocus={(e) => { e.target.style.borderColor = '#1677ff' }}
+              onBlur={(e) => { e.target.style.borderColor = '#e8e8e8' }}
+            />
+
+            {/* Buttons */}
+            <div style={{ display: 'flex', gap: 12 }}>
+              <button
+                onClick={() => handleAction('reject')}
+                disabled={actionLoading}
+                style={{
+                  flex: 1,
+                  minHeight: 44, padding: '8px 12px',
+                  borderRadius: 8,
+                  border: '1px solid #ff4d4f',
+                  background: '#fff',
+                  color: '#ff4d4f',
+                  fontSize: 15,
+                  fontWeight: 500,
+                  cursor: actionLoading ? 'not-allowed' : 'pointer',
+                  opacity: actionLoading ? 0.5 : 1,
+                }}
+              >
+                {copy.rejectLabel}
+              </button>
+              <button
+                onClick={() => handleAction('approve')}
+                disabled={actionLoading}
+                style={{
+                  flex: 1,
+                  minHeight: 44, padding: '8px 12px',
+                  borderRadius: 8,
+                  border: 'none',
+                  background: '#1677ff',
+                  color: '#fff',
+                  fontSize: 15,
+                  fontWeight: 500,
+                  cursor: actionLoading ? 'not-allowed' : 'pointer',
+                  opacity: actionLoading ? 0.5 : 1,
+                }}
+              >
+                {actionLoading ? '处理中...' : copy.confirmLabel}
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* ── Resolved status ────────────────────────────────────────── */}
+        {isResolved && (
+          <div style={{
+            background: '#fff',
+            borderRadius: 12,
+            border: '1px solid #e4e9f0', boxShadow: '0 3px 12px rgba(24,39,61,0.035)',
+            marginBottom: 12,
+            padding: '20px 16px',
+            textAlign: 'center',
+          }}>
+            <div style={{ fontSize: 32, marginBottom: 8 }}>
+              {data.status === 'approved' ? '✅' : '❌'}
+            </div>
+            <div style={{ fontSize: 15, fontWeight: 500, color: data.status === 'approved' ? '#52c41a' : '#ff4d4f' }}>
+              {data.status === 'approved'
+                ? copy.approvedText
+                : copy.rejectedText}
+            </div>
+            {isSectionMode && data.detail && (
+              <div style={{ marginTop: 12, textAlign: 'left' }}>
+                {data.sections?.map((section) => {
+                  const secDetail = data.detail?.[section.id] as Record<string, { actionLabel?: string; value?: string | null }> | undefined
+                  if (!secDetail) return null
+                  return (
+                    <div key={section.id} style={{ marginBottom: 8 }}>
+                      <div style={{ fontSize: 13, fontWeight: 500, color: '#595959' }}>{section.title}</div>
+                      {section.fields.map((field) => {
+                        const fd = secDetail[field.id]
+                        if (!fd) return null
+                        return (
+                          <div key={field.id} style={{ fontSize: 12, color: '#999', paddingLeft: 12, marginTop: 2 }}>
+                            {field.label}: {fd.actionLabel}
+                            {fd.value ? ` → ${fd.value}` : ''}
+                          </div>
+                        )
+                      })}
+                    </div>
+                  )
+                })}
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* ── Result message ─────────────────────────────────────────── */}
+        {result && (
+          <div style={{
+            borderRadius: 8,
+            padding: '10px 14px',
+            fontSize: 13,
+            background: result.error ? '#fff2f0' : '#f6ffed',
+            color: result.error ? '#ff4d4f' : '#52c41a',
+            marginBottom: 12,
+          }}>
+            {result.error
+              ? `操作失败: ${result.error}`
+              : result.status === 'approved'
+                ? copy.approvedText
+                : result.status === 'rejected'
+                  ? copy.rejectedText
+                  : '操作成功，等待其他审批人...'}
+          </div>
+        )}
+
+        {/* ── Footer ─────────────────────────────────────────────────── */}
+        <div style={{ textAlign: 'center', padding: '8px 0', fontSize: 11, color: '#ccc' }}>
+          {copy.footer}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/evolverun/clawweb/public/modules/workflow/web/pages/__tests__/ApprovalDisplay.test.tsx
+++ b/src/evolverun/clawweb/public/modules/workflow/web/pages/__tests__/ApprovalDisplay.test.tsx
@@ -1,0 +1,33 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import Approval from '../Approval';
+
+const card = {
+  id: 1, flowId: 'flow-1', nodeId: 'review', workflowId: 'test', workflowTitle: '审核流程',
+  approvalType: 'HUMAN_CONFIRM', message: '人工确认', cardFields: [{ label: '任务', value: 'T-1' }],
+  approverIds: ['reviewer'], approverNames: ['审核人'], approvalPolicy: 'any', approvedBy: [], rejectedBy: [],
+  status: 'pending', deliveryMode: 'card-web', createdAt: 100, resolvedAt: null,
+};
+afterEach(() => { cleanup(); vi.unstubAllGlobals(); });
+function show(data: Record<string, unknown>) {
+  vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => data })));
+  return render(<MemoryRouter initialEntries={['/approval/1?empId=reviewer']}><Routes><Route path='/approval/:id' element={<Approval />} /></Routes></MemoryRouter>);
+}
+describe('approval display configuration', () => {
+  it('renders configured title, buttons and accessible note without default footer', async () => {
+    show({ ...card, display: { title: '处置复核', confirmLabel: '执行处置', rejectLabel: '暂不执行', notePlaceholder: '填写复核说明', footer: '' } });
+    expect(await screen.findByText('处置复核')).toBeTruthy();
+    expect(screen.getByRole('button', { name: '执行处置' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: '暂不执行' })).toBeTruthy();
+    expect(screen.getByRole('textbox', { name: '填写复核说明' })).toBeTruthy();
+    expect(screen.queryByText('工作流审批')).toBeNull();
+  });
+  it('shows configured resolved text and removes action buttons', async () => {
+    show({ ...card, status: 'approved', approvedBy: ['reviewer'], resolvedAt: 145, display: { approvedText: '已完成处置复核' } });
+    expect((await screen.findAllByText('已完成处置复核')).length).toBeGreaterThan(0);
+    expect(screen.queryByRole('button', { name: '确认执行' })).toBeNull();
+  });
+});

--- a/src/evolverun/clawweb/public/modules/workflow/web/utils/time.ts
+++ b/src/evolverun/clawweb/public/modules/workflow/web/utils/time.ts
@@ -37,7 +37,7 @@ export function formatTimeShort(value: string | number | null): string {
 
 /**
  * Format a duration in milliseconds as a human-readable string.
- * Supports hours, minutes, and seconds. Returns '—' for null/zero.
+ * Supports hours, minutes, and seconds. Returns '—' when duration is unknown or invalid.
  *
  * Examples:
  *   500        → '500ms'
@@ -47,7 +47,7 @@ export function formatTimeShort(value: string | number | null): string {
  *   86400000   → '1d 0h'
  */
 export function formatDuration(ms: number | null): string {
-  if (ms === null || ms === 0) return '—'
+  if (ms == null || !Number.isFinite(ms) || ms < 0) return '—'
   if (ms < 1000) return `${ms}ms`
 
   const totalSeconds = Math.floor(ms / 1000)


### PR DESCRIPTION
Approval cards now support configurable page copy and elapsed time while preserving existing URLs, legacy field arrays, section-based decisions, and result detail payloads. The workflow package provides reusable approval routes, persistence, and UI; host-specific identity integration remains with the host.

Validation: 11 focused route, display, and page tests pass. Package-boundary checks pass. The full package build currently reports API signature/type errors in unchanged WorkflowHistoryPanel.tsx and Editor.tsx; these errors are outside this change. End-to-end host validation remains pending.

This draft contains generic approval functionality and synthetic test data only. No database-column migration or automatic change to existing approval delivery is introduced.