### PR TITLE
fix(bot-config-manifest): let the deployment declare an internal object store

### DIFF
--- a/src/backend/src/agentclaw/community/di/modules/bot_management_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/bot_management_module.py
@@ -240,13 +240,6 @@ from agentclaw.community.core.repository.implementations.bot.manifest_content im
 from agentclaw.community.core.repository.implementations.bot.source_credential import (
     SourceCredentialRepository,
 )
-from agentclaw.community.api.source_credential_service import (
-    SourceCredentialServiceProtocol,
-)
-from agentclaw.community.core.bot_management.token_vault import TokenVault
-from agentclaw.community.core.bot_config_manifest.credentials.service import (
-    SourceCredentialService,
-)
 
 from agentclaw.community.core.repository.implementations.bot.config_manifest_apply import (
     BotConfigManifestApplyLockRepository,
@@ -973,27 +966,3 @@ class BotManagementModule(Module):
         self, svc: DataInitService
     ) -> DataInitServiceProtocol:
         return svc
-
-    @singleton
-    @provider
-    @inject
-    def _source_credential_service_protocol(
-        self,
-        repository: SourceCredentialRepositoryProtocol,
-        vault: TokenVault,
-    ) -> SourceCredentialServiceProtocol:
-        """W3 (#1471): the profile decides the fail-closed posture.
-
-        Production columns (corp, community) refuse credential writes when
-        the vault has no master key — TokenVault's plaintext passthrough
-        is right for local, catastrophic for tenant tokens at rest. The
-        local/test columns keep the permissive default; corp_test runs the
-        Mist-backed vault anyway and benefits from the same guard.
-        """
-        from agentclaw.community.di.profile import DeployProfile
-
-        fail_closed = DeployProfile.detect() in (
-            DeployProfile.CORP,
-            DeployProfile.COMMUNITY,
-        )
-        return SourceCredentialService(repository, vault, fail_closed=fail_closed)

--- a/src/backend/src/agentclaw/community/di/modules/manifest_fetch_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/manifest_fetch_module.py
@@ -26,6 +26,13 @@ from agentclaw.community.plugin_api.object_store_client import (
 from agentclaw.community.core.bot_config_manifest.apply.entry_fetch import (
     EntryFetcher,
 )
+from agentclaw.community.core.bot_config_manifest.credentials.service import (
+    SourceCredentialService,
+)
+from agentclaw.community.core.bot_management.token_vault import TokenVault
+from agentclaw.community.core.repository.protocols.bot.source_credential import (
+    SourceCredentialRepositoryProtocol,
+)
 from agentclaw.community.core.bot_config_manifest.cli_tools.service import (
     CliToolPurger,
     CliToolService,
@@ -144,6 +151,47 @@ class ManifestFetchModule(Module):
         )
 
     # ── the machine parts ──────────────────────────────────────────────────
+
+    @singleton
+    @provider
+    @inject
+    def source_credential_service(
+        self,
+        repository: SourceCredentialRepositoryProtocol,
+        vault: TokenVault,
+        manifest_config: cfg.BotConfigManifestConfig,
+    ) -> SourceCredentialServiceProtocol:
+        """W3 (#1471): the profile decides the fail-closed posture.
+
+        Production columns (corp, community) refuse credential writes when the
+        vault has no master key — TokenVault's plaintext passthrough is right
+        for local, catastrophic for tenant tokens at rest. The local/test
+        columns keep the permissive default; corp_test runs the Mist-backed
+        vault anyway and benefits from the same guard.
+
+        **It binds here, next to the config it reads.** The service takes the
+        deployment's transport allowlist — the SAME value ``GuardedFetcher``
+        takes, off the same ``user_config.bot_config_manifest`` block — because
+        the endpoint guard refuses a host resolving to a private address, which
+        is exactly what an internal object store endpoint does. That escape
+        hatch existed on the service and nothing passed through it while the
+        provider lived a module away from the config: an internal endpoint was
+        unregistrable by any configuration, and the one place a deployment
+        declares such a host governed the fetch road alone. The repository it
+        reads through still binds with its siblings in ``bot_management_module``.
+        """
+        from agentclaw.community.di.profile import DeployProfile
+
+        fail_closed = DeployProfile.detect() in (
+            DeployProfile.CORP,
+            DeployProfile.COMMUNITY,
+        )
+        return SourceCredentialService(
+            repository,
+            vault,
+            fail_closed=fail_closed,
+            endpoint_allow_hosts=manifest_config.fetch_transport_allowlist,
+        )
 
     @singleton
     @provider

--- a/src/backend/tests/community/di/test_manifest_fetch_module_wiring.py
+++ b/src/backend/tests/community/di/test_manifest_fetch_module_wiring.py
@@ -1,0 +1,38 @@
+"""Wiring regression tests for the manifest fetch composition root."""
+
+from __future__ import annotations
+
+
+def test_credential_service_receives_the_deployment_transport_allowlist(
+    test_injector,
+) -> None:
+    """The endpoint guard's escape hatch has to be reachable from config.
+
+    ``SourceCredentialService`` refuses an ``oss_aksk`` endpoint whose host
+    resolves to a private address — which is exactly what an internal object
+    store endpoint does. Its ``endpoint_allow_hosts`` parameter is how a
+    deployment declares such a host, and it takes the SAME value the guarded
+    fetcher reads, from the same ``user_config.bot_config_manifest`` block, so
+    the fetch road and the credential surface cannot disagree about which
+    internal hosts exist.
+
+    That parameter defaults to ``()``, so a composition root that simply omits
+    it type-checks, resolves, and passes every unit test of the service — while
+    leaving a legitimately internal endpoint unregistrable by ANY
+    configuration. Asserted against the real injector rather than the source
+    text: what matters is the value that arrives, not that a keyword appears.
+    """
+    from agentclaw.community.api.source_credential_service import (
+        SourceCredentialServiceProtocol,
+    )
+    from agentclaw.community.di import config as cfg
+
+    declared = ("store.corp.internal", "objects.corp.internal")
+    test_injector.binder.bind(
+        cfg.BotConfigManifestConfig,
+        to=cfg.BotConfigManifestConfig(fetch_transport_allowlist=declared),
+    )
+
+    service = test_injector.get(SourceCredentialServiceProtocol)
+
+    assert tuple(service._endpoint_allow_hosts) == declared


### PR DESCRIPTION
Backport of #2080 onto `REL20260910`. That PR merged to `dev` as `039d7fbe`; this is the same change on the release branch.

## Problem

`SourceCredentialService` refuses an `oss_aksk` endpoint whose host resolves to a private address. That guard is deliberate — without it `https://169.254.169.254/` is a storable endpoint and the platform connects to it on the next apply.

An **internal** object store endpoint resolves exactly that way, and the service already carried the escape hatch for it: `endpoint_allow_hosts`, whose own comment says it is *"the deployment's transport allowlist — the same value the guarded fetcher takes, so a legitimately internal object store is declared in one place rather than two that can disagree."*

Nothing ever passed through it. The composition root constructed the service with `repository`, `vault` and `fail_closed` only, so the parameter took its `()` default in every profile, and the one place a deployment declares such a host — `user_config.bot_config_manifest.fetch_transport_allowlist` — governed the fetch road alone.

The consequence is not a degraded path but a closed one: a legitimately internal object-store endpoint was **unregistrable by any configuration**, because no yaml key reached the check that refused it. Found while registering a credential against an internal OSS endpoint during end-to-end testing of the manifest feature.

## Solution

Inject `BotConfigManifestConfig` into the credential-service provider and pass `fetch_transport_allowlist` through as `endpoint_allow_hosts` — the value that already existed reaching the consumer that documented needing it, with no new config key and no second list to keep in sync with the fetcher's.

The provider also moves from `bot_management_module.py` to `ManifestFetchModule`. On `dev` that was forced by the R9 file-size guard (the wiring took `bot_management_module.py` from 999 to 1015 lines, past the 1000-line cap, with no headroom to trim into), and it is the move that explains the bug rather than working around it: `SourceCredentialService` lives in `core/bot_config_manifest/credentials/` and reads `BotConfigManifestConfig`, both owned by `ManifestFetchModule`, whose docstring already says the manifest config cluster lives there because `config_module` sits at the cap too. The provider was in the bot-management module because it landed there with W4, and that distance is why the allowlist went unwired for a wave — the config was one module away, so passing it was never the obvious thing to do.

The provider moves whole with the three imports only it used; the repository binding stays with its repository siblings. `bot_management_module.py` lands at 968 lines and `manifest_fetch_module.py` at 682, both under the cap with no allowlist entry.

## Validation

The cherry-pick applied without adaptation — `REL20260910` already carries the service's `endpoint_allow_hosts` parameter and `BotConfigManifestConfig`, and both touched modules were at the same blobs `dev` had before the fix. Everything below was nonetheless re-run **on this base** rather than carried over from the `dev` PR, since the file-size guard and the mutation check are exactly the two results that could differ:

- `tests/community/core/bot_config_manifest/` + source-credential endpoint tests + `tests/community/architecture/` — 1318 passed
- `tests/community/di/` + the file-size guard — 348 passed
- `ruff check` clean on every touched file
- file sizes re-measured here: 968 and 682, both under the cap

The regression test was mutation-checked on this base too: removing the `endpoint_allow_hosts=` argument fails it on `assert () == ('store.corp.internal', 'objects.corp.internal')`, and it passes with the argument restored.

It asserts the value that **arrives** at the resolved service rather than that a keyword appears in the provider's source. That matters twice: the source-text form would not have caught the original defect (an omitted argument with a default type-checks, resolves, and passes every unit test of the service — including the existing one proving the allowlist works when it *is* passed), and it makes the test indifferent to which module binds the provider, which is what let it survive the move unchanged.

## Compatibility and risk

No schema, contract or migration impact. Behaviour is unchanged for every deployment that declares no `fetch_transport_allowlist` (the default stays `()`), and for those that do, the credential surface now honours the same declaration the fetch road already honoured. The provider move changes no binding key — both modules register together unconditionally in `di/container.py` — so resolution is identical. Rollback is reverting the commit; nothing persists differently.

## Related issues

Backport of #2080.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019dzBBLChdsLffbjx71e2zM


---
_Generated by [Claude Code](https://claude.ai/code/session_019dzBBLChdsLffbjx71e2zM)_