### PR TITLE
fix(frontend): allow users to change their message view and inherit g…

### DIFF
--- a/src/frontend/src/pages/GroupChat/components/CreateSessionControl.tsx
+++ b/src/frontend/src/pages/GroupChat/components/CreateSessionControl.tsx
@@ -4,8 +4,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@/components/ui/popover';
-import { cn } from '@/utils/utils';
-import { Check, ChevronDown, Plus } from 'lucide-react';
+import { ChevronDown, Plus } from 'lucide-react';
 import React, { useState } from 'react';
 import type { MessageViewScope } from '../types';
 
@@ -61,11 +60,11 @@ const CreateSessionControl: React.FC<CreateSessionControlProps> = ({
         variant="secondary"
         soft
         size="sm"
-        onClick={() => onCreateSession('full')}
+        onClick={() => onCreateSession()}
         loading={isCreating}
         leftIcon={<Plus className="h-3.5 w-3.5" />}
         className="h-7 gap-1 rounded-r-none pr-2 text-xs"
-        title="以完整视角新建会话"
+        title="按群中您的消息视角新建会话"
       >
         新建会话
       </Button>
@@ -99,14 +98,6 @@ const CreateSessionControl: React.FC<CreateSessionControlProps> = ({
                 }}
                 className="h-auto items-start justify-start gap-2 rounded-md px-2.5 py-2 text-left hover:bg-lavender-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lavender-400"
               >
-                <Check
-                  className={cn(
-                    'mt-0.5 h-3.5 w-3.5 flex-shrink-0',
-                    option.value === 'full'
-                      ? 'text-lavender-500'
-                      : 'text-transparent',
-                  )}
-                />
                 <span className="min-w-0">
                   <span className="block text-xs font-medium text-slate-700">
                     {option.label}

--- a/src/frontend/src/pages/GroupChat/components/GroupSettings/GroupMembersSection.tsx
+++ b/src/frontend/src/pages/GroupChat/components/GroupSettings/GroupMembersSection.tsx
@@ -26,6 +26,7 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 import { useGroupMembers } from '@/pages/GroupChat/hooks/useGroupMembers';
+import { useUserStore } from '@/stores/userStore';
 import { cn } from '@/utils/utils';
 import { EyeOff, Plus, X } from 'lucide-react';
 import React, { useState } from 'react';
@@ -71,6 +72,7 @@ const GroupMembersSection: React.FC<GroupMembersSectionProps> = ({
   isOwner,
   onClickAddMember,
 }) => {
+  const userId = useUserStore((state) => state.userId);
   const {
     removeGroupMember,
     updateGroupMemberScope,
@@ -134,7 +136,10 @@ const GroupMembersSection: React.FC<GroupMembersSectionProps> = ({
                 >
                   {member.actorKind === 'human' ? '用户' : 'Bot'}
                 </span>
-                {member.actorKind === 'human' && isOwner ? (
+                {member.actorKind === 'human' &&
+                (isOwner ||
+                  (!!userId &&
+                    (member.botUuid || member.id) === `human_${userId}`)) ? (
                   <select
                     aria-label={`设置 ${member.name} 的群级消息视角`}
                     value={member.messageViewScope || 'full'}

--- a/src/frontend/src/pages/GroupChat/components/SessionSettings/SessionMembersSection.tsx
+++ b/src/frontend/src/pages/GroupChat/components/SessionSettings/SessionMembersSection.tsx
@@ -27,6 +27,7 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 import { useSessionMembers } from '@/pages/GroupChat/hooks/useSessionMembers';
+import { useUserStore } from '@/stores/userStore';
 import { cn } from '@/utils/utils';
 import { EyeOff, Mic, MicOff, Plus, User, X } from 'lucide-react';
 import React, { useMemo, useState } from 'react';
@@ -87,6 +88,7 @@ const SessionMembersSection: React.FC<SessionMembersSectionProps> = ({
   isOwner,
   onClickAddMember,
 }) => {
+  const userId = useUserStore((state) => state.userId);
   const {
     removeSessionMember,
     updateSessionMemberScope,
@@ -204,7 +206,8 @@ const SessionMembersSection: React.FC<SessionMembersSectionProps> = ({
                     主节点
                   </span>
                 )}
-                {m.actorKind === 'human' && isOwner ? (
+                {m.actorKind === 'human' &&
+                (isOwner || (!!userId && m.actorId === `human_${userId}`)) ? (
                   <select
                     aria-label={`设置 ${m.name} 的会话消息视角`}
                     value={m.messageViewScope || 'full'}

--- a/src/frontend/src/pages/GroupChat/components/__tests__/createSessionControl.test.ts
+++ b/src/frontend/src/pages/GroupChat/components/__tests__/createSessionControl.test.ts
@@ -1,0 +1,39 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import CreateSessionControl from '../CreateSessionControl';
+
+const mockButtons: any[] = [];
+jest.mock('@/components', () => ({
+  Button: (props: any) => {
+    mockButtons.push(props);
+    return null;
+  },
+}));
+jest.mock('@/components/ui/popover', () => ({
+  Popover: ({ children }: any) => children,
+  PopoverContent: ({ children }: any) => children,
+  PopoverTrigger: ({ children }: any) => children,
+}));
+
+describe('new session scope selection', () => {
+  beforeEach(() => { mockButtons.length = 0; });
+
+  it.each([true, false])('inherits group scope on the main button (menu=%s)', (showScopeMenu) => {
+    const onCreateSession = jest.fn();
+    renderToStaticMarkup(React.createElement(CreateSessionControl, {
+      isCreating: false, showScopeMenu, onCreateSession,
+    }));
+    mockButtons[0].onClick();
+    expect(onCreateSession).toHaveBeenCalledWith();
+  });
+
+  it.each(['full', 'participant'])('allows an explicit %s override from the menu', (scope) => {
+    const onCreateSession = jest.fn();
+    renderToStaticMarkup(React.createElement(CreateSessionControl, {
+      isCreating: false, showScopeMenu: true, onCreateSession,
+    }));
+    const options = mockButtons.filter((button) => button.role === 'menuitem');
+    options[scope === 'full' ? 0 : 1].onClick();
+    expect(onCreateSession).toHaveBeenCalledWith(scope);
+  });
+});

--- a/src/frontend/src/pages/GroupChat/components/__tests__/memberScopeControls.test.ts
+++ b/src/frontend/src/pages/GroupChat/components/__tests__/memberScopeControls.test.ts
@@ -1,0 +1,60 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import GroupMembersSection from '../GroupSettings/GroupMembersSection';
+import SessionMembersSection from '../SessionSettings/SessionMembersSection';
+
+let mockUserId = 'alice';
+jest.mock('@/stores/userStore', () => ({
+  useUserStore: (selector: any) => selector({ userId: mockUserId }),
+}));
+jest.mock('@/pages/GroupChat/hooks/useGroupMembers', () => ({
+  useGroupMembers: () => ({}),
+}));
+jest.mock('@/pages/GroupChat/hooks/useSessionMembers', () => ({
+  useSessionMembers: () => ({}),
+}));
+jest.mock('@/components/BotAvatar', () => () => null);
+
+const participants = [
+  { id: 'human_alice', name: 'Alice', actorKind: 'human' },
+  { id: 'human_bob', name: 'Bob', actorKind: 'human' },
+  { id: 'bot_1', name: 'Bot', actorKind: 'bot' },
+];
+
+describe.each(['group', 'session'])('%s member scope controls', (level) => {
+  function render(isOwner = false) {
+    const group = { id: 'group_1', participants };
+    const props = { group, isOwner, onClickAddMember: jest.fn() };
+    return renderToStaticMarkup(
+      level === 'group'
+        ? React.createElement(GroupMembersSection, props as any)
+        : React.createElement(SessionMembersSection, {
+            ...props,
+            session: {
+              sessionId: 'session_1',
+              members: participants.map((p) => ({ ...p, actorId: p.id })),
+            },
+          } as any),
+    );
+  }
+
+  beforeEach(() => { mockUserId = 'alice'; });
+
+  it('lets a non-owner change only their own human scope', () => {
+    const html = render();
+    expect(html.match(/<select /g)).toHaveLength(1);
+    expect(html).toContain('aria-label="设置 Alice');
+    expect(html).not.toContain('aria-label="设置 Bob');
+    expect(html).toContain('value="participant"');
+    expect(html).not.toContain('添加成员');
+  });
+
+  it('keeps owner controls for human members only', () => {
+    expect(render(true).match(/<select /g)).toHaveLength(2);
+  });
+
+  it('does not expose self controls without a logged-in user', () => {
+    mockUserId = '';
+    expect(render()).not.toContain('<select ');
+  });
+});

--- a/src/frontend/src/pages/GroupChat/index.tsx
+++ b/src/frontend/src/pages/GroupChat/index.tsx
@@ -317,7 +317,7 @@ const GroupChat: React.FC<GroupChatProps> = ({
     setShowServiceInvocationSessionModal,
   ] = useState(false);
   const [pendingSessionMessageViewScope, setPendingSessionMessageViewScope] =
-    useState<MessageViewScope>('full');
+    useState<MessageViewScope>();
   const [groupListCollapsed, setGroupListCollapsed] = useState(false);
   const [sessionListCollapsed, setSessionListCollapsed] = useState(false);
   const [showSessionDrawer, setShowSessionDrawer] = useState(false);
@@ -681,7 +681,7 @@ const GroupChat: React.FC<GroupChatProps> = ({
   );
 
   const handleCreateSession = useCallback(
-    async (messageViewScope: MessageViewScope = 'full') => {
+    async (messageViewScope?: MessageViewScope) => {
       if (!groupId) return;
       if (currentGroup?.groupStrategy === 'state_machine') {
         setPendingSessionMessageViewScope(messageViewScope);


### PR DESCRIPTION
## Problem

Users could not change their own message view in Group or Session management unless they were viewing as the group owner. Creating a session with the main button also forced `full`, overriding the user's group-level setting.

## Solution

- Allow users to switch their own Human member view between `full` and `participant` in both management panels.
- Preserve existing group-owner controls.
- Make the main New Session button inherit the user's group-level view.
- Keep explicit view selection available in the dropdown.
- Apply inheritance to both chat and service-invocation sessions.

## Validation

- Passed 10 regression tests covering self-service controls, owner controls, default inheritance, and explicit overrides.
- Passed ESLint for changed files.
- Passed `git diff --check`.
- Re-ran all 10 regression tests after rebase.
- Browser save and creation flows were not manually verified.

## Compatibility and risk

No API or database schema changes. Existing sessions retain their current view settings. New sessions use the existing backend inheritance behavior when no explicit view is supplied.