### PR TITLE
fix(backend): resolve token targets by device provider

### DIFF
--- a/src/backend/specs/token-target-provider/001-spec-output.md
+++ b/src/backend/specs/token-target-provider/001-spec-output.md
@@ -1,0 +1,18 @@
+# Provider-aware outbound token targets
+
+## Problem
+Caller and token plugins treat every runtime binding device_id as a logical BaaS Bot UUID. Direct ARCA bindings instead store their concrete sandbox target in device_props.sandbox_id.
+
+## Design
+Keep authorized, entity-scoped runtime binding selection unchanged. Share target selection through BaasService.resolve_token_outbound_device_id(binding), avoiding a dependency injection cycle. BaaS bindings retain the unique-device lookup; ARCA bindings use their stored sandbox target without a logical Bot lookup. Preserve the stored template suffix, reject missing/invalid targets and unsupported providers, and never invent a tenant/template. Existing append operations, domain policy, Caller-first ordering, failure isolation and Bot-type/allowlist gates remain unchanged.
+
+Return a validated PaaS target string. Target resolution errors expose a stable non-sensitive reason; Caller maps ambiguity/not-found into its existing credential errors. Diagnostic logs contain provider, binding ID, reason and timing, never credentials or complete device_props. The existing fixed-host HTTP client and append validation remain the outbound security boundary.
+
+## Tests
+Reproduce ARCA lookup regression before changing production code. Cover ARCA direct resolution, BaaS unique/empty/multiple targets, unsupported provider, inactive/missing binding, missing/malformed sandbox ID, template suffix retention and path/control characters. Exercise real Caller and corp plugin adapter paths, preserve scoped default-Bot selection, assert zero logical-Bot lookup for ARCA, and verify sanitized diagnostics. Run focused, affected-module and architecture suites separately from corp tests.
+
+## Delivery
+Commit scoped changes, create a new rebase branch, fetch and rebase onto remote REL20260910 (release is the base). Avernet source goes only to inclusionAI/Avernet on GitHub. OCB consumes a mirror-verified source SHA; if synchronization is unavailable, report the dependency as pending rather than publishing an unverified gitlink. Do not auto-merge or deploy.
+
+## Verified append boundary
+PaaS outbound append resolves the stored template and connects directly to the raw container; no logical Bot/device registration lookup is required. The template must exist and be ONLINE. ARCA suffixes must be numeric BaaS template IDs, not backend tenant indices. Missing suffixes, connection ports and malformed identifiers are rejected rather than silently routed to a default template. Existing BaaS target syntax remains compatible. Runtime template availability and downstream header receipt require post-deployment validation; unit tests do not establish either.

--- a/src/backend/specs/token-target-provider/002-validation.md
+++ b/src/backend/specs/token-target-provider/002-validation.md
@@ -1,0 +1,10 @@
+# Validation
+
+- TDD: Caller ARCA branch, resolver, numeric suffix, logical URL and record schema regression tests observed failing before their implementations.
+- Focused target/Caller suite: 91 passed.
+- Related Caller identity, runtime binding, token exchange, service Bot and architecture suites: 1560 passed (17 existing warnings). Explicit PYTHONPATH is required for subprocess cold-import checks with the reused interpreter.
+- Independent code/security review: PASS; no new blocker found. No authorization, Bot-type or append policy broadened.
+- Ruff and git diff --check: PASS.
+- BaasService has a pre-existing class-level coverage exclusion. A separate coverage run with exclude_lines empty measured 47/48 changed executable lines covered (97.9%); the missing line is a TYPE_CHECKING import. This is local changed-code evidence, not a claim of remote CI or full-repository coverage.
+- Direct PaaS template availability and downstream header receipt require deployment testing. No deployment or merge performed.
+- Remote checks: pending PR creation.

--- a/src/backend/src/agentclaw/community/api/README.md
+++ b/src/backend/src/agentclaw/community/api/README.md
@@ -119,6 +119,7 @@ consumes:
   - "No service impls at import time — Protocols only declare shape, they don't depend on concrete services"
   - "A small number of core dataclass / schema types used to type Protocol method signatures (see internal_dependencies)"
 internal_dependencies:
+  - agentclaw.community.core.devices.repository.record  # DeviceBindingRecord input for provider-aware token target resolution
   - agentclaw.community.core.bot_collaborator.models # Collaborator records, roles and permission levels — typed in collaborator_service.py
   - agentclaw.community.core.access.models            # UserInfoRecord — typed in user_service.py
   - agentclaw.community.core.bot_app_grant.models    # BotAppGrantRecord — typed in bot_app_grant_service.py (real signatures, so the conformance gate can compare them)

--- a/src/backend/src/agentclaw/community/api/baas_service.py
+++ b/src/backend/src/agentclaw/community/api/baas_service.py
@@ -14,7 +14,7 @@ imports them so there's exactly one source of truth.
 """
 from __future__ import annotations
 
-from typing import Any, Dict, Optional, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Dict, Optional, Protocol, runtime_checkable
 
 from agentclaw.community.core.service_bot.services.baas_service import (
     BotWsConnectionInfoResponse,
@@ -27,9 +27,27 @@ from agentclaw.community.core.service_bot.types import PublishStage
 from agentclaw.community.kernel.device_dto import OutBoundOperationRule
 
 
+if TYPE_CHECKING:
+    from agentclaw.community.core.devices.repository.record import DeviceBindingRecord
+
+
 @runtime_checkable
 class BaasServiceProtocol(Protocol):
     """BaaS-layer service: bot publish / restart / destroy / inspection."""
+
+    def resolve_token_outbound_device_id(
+        self, binding: DeviceBindingRecord | None,
+    ) -> str:
+        """Resolve an authorized ACTIVE binding to a validated token append target.
+
+        device_provider=baas uses a unique current device lookup (3s timeout);
+        arca uses device_props.sandbox_id directly, retaining its ASCII numeric
+        @template suffix and requiring ARCA-SANDBOX-. No template lookup occurs.
+        BaasOutboundTargetError.reason is binding_unavailable,
+        unsupported_provider, target_not_found, target_ambiguous or invalid_target.
+        Query transport errors propagate unchanged.
+        """
+        ...
 
     def post_bots_api(
         self,

--- a/src/backend/src/agentclaw/community/core/service_bot/services/baas_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/baas_service.py
@@ -72,6 +72,7 @@ from agentclaw.community.kernel.device_dto import (
 )
 
 if TYPE_CHECKING:
+    from agentclaw.community.core.devices.repository.record import DeviceBindingRecord
     from agentclaw.community.core.bot_startup_script.protocols import (
         StartupScriptReaderProtocol,
     )
@@ -189,6 +190,14 @@ def _redact_payload_for_log(payload: Dict[str, Any]) -> Dict[str, Any]:
         "after_create_cmd_hook": elided,
     }
     return redacted
+
+
+class BaasOutboundTargetError(ValueError):
+    """Token target resolution failure with a stable, non-sensitive reason."""
+
+    def __init__(self, reason: str) -> None:
+        self.reason = reason
+        super().__init__(reason)
 
 
 class BaasServiceError(Exception):
@@ -3155,6 +3164,76 @@ class BaasService:  # pragma: no cover
         logger.info("caller_outbound_append_succeeded")
         return True
 
+    def resolve_token_outbound_device_id(
+        self, binding: DeviceBindingRecord | None,
+    ) -> str:
+        """Resolve an authorized runtime binding to its token append target.
+
+        BaaS requires one current device; ARCA uses the stored sandbox ID
+        with its numeric template suffix intact. No template lookup is made.
+        Domain failures raise BaasOutboundTargetError; query failures propagate.
+        """
+        started_at = time.monotonic()
+        binding_id = getattr(binding, "id", None)
+        provider = getattr(binding, "device_provider", None)
+        # COSEC: unknown provider values may contain secrets or log controls.
+        safe_provider = provider if provider in ("baas", "arca") else "unsupported"
+        logger.info(
+            "token_outbound_target_resolution_started binding_id=%s provider=%s "
+            "reason=pending error_type=none",
+            binding_id, safe_provider,
+        )
+        try:
+            if binding is None or str(getattr(binding, "status", "")).upper() != "ACTIVE":
+                raise BaasOutboundTargetError("binding_unavailable")
+            if provider not in ("baas", "arca"):
+                raise BaasOutboundTargetError("unsupported_provider")
+            if provider == "baas":
+                bot_uuid = getattr(binding, "device_id", None)
+                if not bot_uuid:
+                    raise BaasOutboundTargetError("target_not_found")
+                # COSEC: the logical ID also enters a fixed relative URL.
+                if not isinstance(bot_uuid, str) or not re.fullmatch(
+                    r"[A-Za-z0-9._~-]+", bot_uuid,
+                ):
+                    raise BaasOutboundTargetError("invalid_target")
+                devices = self.list_devices_by_bot_uuid(bot_uuid, timeout=3.0)
+                if not devices:
+                    raise BaasOutboundTargetError("target_not_found")
+                if len(devices) != 1:
+                    raise BaasOutboundTargetError("target_ambiguous")
+                target = devices[0].get("provider_device_id")
+            else:
+                props = getattr(binding, "device_props", None)
+                target = props.get("sandbox_id") if isinstance(props, dict) else None
+                if target is None or target == "":
+                    raise BaasOutboundTargetError("target_not_found")
+            if not self._is_valid_paas_device_id(target):
+                raise BaasOutboundTargetError("invalid_target")
+            assert isinstance(target, str)
+            # COSEC: BaaS parses ARCA's @suffix as an integer template ID.
+            # Reject fallback-to-template-0 inputs, without restricting BaaS IDs.
+            if provider == "arca" and (
+                not target.startswith("ARCA-SANDBOX-")
+                or not all("0" <= char <= "9" for char in target.rpartition("@")[2])
+            ):
+                raise BaasOutboundTargetError("invalid_target")
+        except Exception as exc:
+            reason = exc.reason if isinstance(exc, BaasOutboundTargetError) else "query_failed"
+            logger.warning(
+                "token_outbound_target_resolution_failed binding_id=%s provider=%s "
+                "reason=%s error_type=%s duration_ms=%.1f",
+                binding_id, safe_provider, reason, type(exc).__name__,
+                (time.monotonic() - started_at) * 1000,
+            )
+            raise
+        logger.info(
+            "token_outbound_target_resolution_succeeded binding_id=%s provider=%s "
+            "reason=resolved error_type=none duration_ms=%.1f",
+            binding_id, safe_provider, (time.monotonic() - started_at) * 1000,
+        )
+        return target
+
     def update_caller_identity(
         self,
         *,
@@ -3211,21 +3290,15 @@ class BaasService:  # pragma: no cover
             )
         )
         binding = self._device_binding_repo.get_by_id(resolved_binding_id)
-        if (
-            binding is None
-            or str(getattr(binding, "status", "")).upper() != "ACTIVE"
-            or not str(getattr(binding, "device_id", ""))
-        ):
-            raise CallerCredentialError(CALLER_TARGET_NOT_FOUND)
-
-        devices = self.list_devices_by_bot_uuid(str(binding.device_id), timeout=3.0)
-        if not devices:
-            raise CallerCredentialError(CALLER_TARGET_NOT_FOUND)
-        if len(devices) != 1:
-            raise CallerCredentialError(CALLER_TARGET_AMBIGUOUS)
-        paas_device_id = devices[0].get("provider_device_id")
-        if not self._is_valid_paas_device_id(paas_device_id):
-            raise CallerCredentialError(CALLER_TARGET_NOT_FOUND)
+        try:
+            paas_device_id = self.resolve_token_outbound_device_id(binding)
+        except BaasOutboundTargetError as exc:
+            code = (
+                CALLER_TARGET_AMBIGUOUS
+                if exc.reason == "target_ambiguous"
+                else CALLER_TARGET_NOT_FOUND
+            )
+            raise CallerCredentialError(code) from exc
 
         caller_rule = self._outbound_rule_provider.build_caller_rule(
             caller_token=caller_token.access_token,

--- a/src/backend/tests/community/core/service_bot/services/test_baas_service_token_outbound_target.py
+++ b/src/backend/tests/community/core/service_bot/services/test_baas_service_token_outbound_target.py
@@ -1,0 +1,395 @@
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from agentclaw.community.core.caller_identity.credential import (
+    CALLER_CREDENTIAL_REQUEST_INVALID,
+    CALLER_OUTBOUND_INVALID,
+    CALLER_OUTBOUND_UPDATE_FAILED,
+    CALLER_TARGET_AMBIGUOUS,
+    CALLER_TARGET_NOT_FOUND,
+    CallerCredentialError,
+    CallerToken,
+)
+from agentclaw.community.core.devices.repository.record import DeviceBindingRecord
+from agentclaw.community.core.service_bot.services import baas_service as module
+from agentclaw.community.kernel.device_dto import (
+    HeaderOperationRule,
+    OutBoundOperationRule,
+)
+
+
+TARGET = "ARCA-SANDBOX-direct@001"
+
+
+def binding(**kwargs):
+    return DeviceBindingRecord(
+        **{
+            "entity_id": "ENTITY-1",
+            "entity_type": "staff",
+            "env": "dev",
+            "apply_reason": None,
+            "applied_by": "owner-1",
+            "release_reason": None,
+            "released_by": None,
+            "released_at": None,
+            "last_alive_at": None,
+            "gmt_create": None,
+            "gmt_modified": None,
+            "id": 9,
+            "status": "ACTIVE",
+            "device_provider": "arca",
+            "device_id": "logical-bot",
+            "device_props": {"sandbox_id": TARGET, "token": "private-props-token"},
+            **kwargs,
+        }
+    )
+
+
+@pytest.fixture
+def service():
+    result = object.__new__(module.BaasService)
+    result.list_devices_by_bot_uuid = MagicMock(
+        return_value=[{"provider_device_id": "generic-device@template-2"}]
+    )
+    return result
+
+
+@pytest.mark.parametrize(
+    "provider,expected",
+    [
+        ("arca", TARGET),
+        ("baas", "generic-device@template-2"),
+    ],
+)
+def test_resolves_provider_target_without_rewriting_template(
+    service, provider, expected
+):
+    assert (
+        service.resolve_token_outbound_device_id(binding(device_provider=provider))
+        == expected
+    )
+    if provider == "arca":
+        service.list_devices_by_bot_uuid.assert_not_called()
+    else:
+        service.list_devices_by_bot_uuid.assert_called_once_with(
+            "logical-bot", timeout=3.0
+        )
+
+
+@pytest.mark.parametrize("unavailable", [None, binding(status="INACTIVE")])
+def test_rejects_unavailable_binding_before_query(service, unavailable):
+    with pytest.raises(ValueError) as error:
+        service.resolve_token_outbound_device_id(unavailable)
+    assert isinstance(error.value, module.BaasOutboundTargetError)
+    assert error.value.reason == "binding_unavailable"
+    service.list_devices_by_bot_uuid.assert_not_called()
+
+
+@pytest.mark.parametrize("provider", [None, "", "unknown-private-provider\nsecret", 42])
+def test_rejects_unknown_or_missing_provider_without_query(service, provider):
+    target_binding = binding(device_provider=provider)
+    if provider is None:
+        del target_binding.device_provider
+    with pytest.raises(ValueError) as error:
+        service.resolve_token_outbound_device_id(target_binding)
+    assert error.value.reason == "unsupported_provider"
+    service.list_devices_by_bot_uuid.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "devices,reason",
+    [
+        ([], "target_not_found"),
+        ([{"provider_device_id": TARGET}] * 2, "target_ambiguous"),
+        ([{}], "invalid_target"),
+    ],
+)
+def test_baas_requires_one_valid_device(service, devices, reason):
+    service.list_devices_by_bot_uuid.return_value = devices
+    with pytest.raises(ValueError) as error:
+        service.resolve_token_outbound_device_id(binding(device_provider="baas"))
+    assert error.value.reason == reason
+
+
+@pytest.mark.parametrize("device_id", [None, ""])
+def test_missing_baas_logical_id_does_not_query(service, device_id):
+    with pytest.raises(ValueError) as error:
+        service.resolve_token_outbound_device_id(
+            binding(device_provider="baas", device_id=device_id)
+        )
+    assert error.value.reason == "target_not_found"
+    service.list_devices_by_bot_uuid.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "props", [None, {}, "private-props-token", {"sandbox_id": None}]
+)
+def test_arca_missing_target_does_not_query(service, props):
+    with pytest.raises(ValueError) as error:
+        service.resolve_token_outbound_device_id(binding(device_props=props))
+    assert error.value.reason == "target_not_found"
+    service.list_devices_by_bot_uuid.assert_not_called()
+
+
+@pytest.mark.parametrize("provider", ["arca", "baas"])
+@pytest.mark.parametrize(
+    "target",
+    [
+        "",
+        42,
+        "ARCA-SANDBOX-direct",
+        "ARCA-SANDBOX-direct@",
+        "@template",
+        "ARCA-SANDBOX-direct@a@b",
+        "ARCA-SANDBOX-direct/secret@template",
+        "ARCA-SANDBOX-direct@../secret",
+        "ARCA-SANDBOX-direct@a\nsecret",
+        "ARCA-SANDBOX-direct@a\x00secret",
+        "ARCA-SANDBOX-direct@a?secret",
+        "ARCA-SANDBOX-direct@a%2fsecret",
+        "ARCA-SANDBOX-" + "a" * 256 + "@t",
+    ],
+)
+def test_rejects_invalid_targets(service, provider, target):
+    service.list_devices_by_bot_uuid.return_value = [{"provider_device_id": target}]
+    with pytest.raises(ValueError) as error:
+        service.resolve_token_outbound_device_id(
+            binding(device_provider=provider, device_props={"sandbox_id": target})
+        )
+    assert error.value.reason == (
+        "target_not_found" if provider == "arca" and target == "" else "invalid_target"
+    )
+    if provider == "arca":
+        service.list_devices_by_bot_uuid.assert_not_called()
+
+
+def test_arca_rejects_generic_paas_id(service):
+    with pytest.raises(ValueError) as error:
+        service.resolve_token_outbound_device_id(
+            binding(device_props={"sandbox_id": "generic@t"})
+        )
+    assert error.value.reason == "invalid_target"
+
+
+def test_arca_does_not_require_logical_baas_id(service):
+    assert service.resolve_token_outbound_device_id(binding(device_id=None)) == TARGET
+
+
+@pytest.mark.parametrize(
+    "mode,reason,error_type",
+    [
+        ("success", "resolved", "none"),
+        ("provider", "unsupported_provider", "BaasOutboundTargetError"),
+        ("target", "invalid_target", "BaasOutboundTargetError"),
+        ("transport", "query_failed", "RuntimeError"),
+    ],
+)
+def test_safe_resolution_logs_and_transport_error_identity(
+    service, monkeypatch, mode, reason, error_type
+):
+    log = MagicMock()
+    monkeypatch.setattr(module, "logger", log)
+    target_binding = binding()
+    if mode == "provider":
+        target_binding.device_provider = "private-provider\nsecret"
+    elif mode == "target":
+        target_binding.device_props["sandbox_id"] = "private-target/secret@t"
+    elif mode == "transport":
+        target_binding.device_provider = "baas"
+        failure = RuntimeError("private-transport-token")
+        service.list_devices_by_bot_uuid.side_effect = failure
+    if mode == "success":
+        assert service.resolve_token_outbound_device_id(target_binding) == TARGET
+    else:
+        with pytest.raises(Exception) as error:
+            service.resolve_token_outbound_device_id(target_binding)
+        if mode == "transport":
+            assert error.value is failure
+    rendered = "\n".join(call.args[0] % call.args[1:] for call in log.method_calls)
+    assert "token_outbound_target_resolution_started" in rendered
+    assert (
+        "token_outbound_target_resolution_succeeded"
+        if mode == "success"
+        else "token_outbound_target_resolution_failed"
+    ) in rendered
+    assert "binding_id=9" in rendered
+    assert "provider=" in rendered
+    assert f"reason={reason}" in rendered
+    assert f"error_type={error_type}" in rendered
+    for secret in ("private-", TARGET, "logical-bot", "sandbox_id"):
+        assert secret not in rendered
+
+
+@pytest.fixture
+def caller(service):
+    service._bot_repo = MagicMock()
+    service._bot_repo.get_by_id_and_entity.return_value = {
+        "bot_type": "service",
+        "status": "ACTIVE",
+        "owner_id": "owner-1",
+    }
+    service._device_binding_repo = MagicMock()
+    service._device_binding_repo.get_by_id.return_value = binding()
+    service._outbound_rule_provider = MagicMock()
+    service._outbound_rule_provider.build_caller_rule.return_value = (
+        OutBoundOperationRule(
+            header_operation_rules=[
+                HeaderOperationRule(
+                    domains=["https://mcp.example"],
+                    action="set",
+                    header_name="x-caller-token",
+                    value="caller-token",
+                )
+            ]
+        )
+    )
+    service.append_caller_outbound_rule = MagicMock(return_value=True)
+    kwargs = dict(
+        bot_id="default",
+        owner_user_id="owner-1",
+        caller_user_id="caller-1",
+        caller_token=CallerToken(
+            access_token="caller-token",
+            subject_user_id="caller-1",
+            expires_at=datetime.now(),
+            fingerprint="ignored",
+        ),
+        stage="draft",
+        publish_id=None,
+        entity_id="ENTITY-1",
+        binding_id=9,
+    )
+    return service, kwargs
+
+
+@pytest.mark.parametrize(
+    "target_binding,devices,expected",
+    [
+        (None, [], CALLER_TARGET_NOT_FOUND),
+        (binding(status="INACTIVE"), [], CALLER_TARGET_NOT_FOUND),
+        (binding(device_provider=None), [], CALLER_TARGET_NOT_FOUND),
+        (binding(device_provider="unknown"), [], CALLER_TARGET_NOT_FOUND),
+        (binding(device_props={}), [], CALLER_TARGET_NOT_FOUND),
+        (
+            binding(device_props={"sandbox_id": "bad/target@t"}),
+            [],
+            CALLER_TARGET_NOT_FOUND,
+        ),
+        (binding(device_provider="baas"), [], CALLER_TARGET_NOT_FOUND),
+        (binding(device_provider="baas"), [{}], CALLER_TARGET_NOT_FOUND),
+        (binding(device_provider="baas"), [{}, {}], CALLER_TARGET_AMBIGUOUS),
+    ],
+)
+def test_caller_preserves_target_error_contract(
+    caller, target_binding, devices, expected
+):
+    service, kwargs = caller
+    service._device_binding_repo.get_by_id.return_value = target_binding
+    service.list_devices_by_bot_uuid.return_value = devices
+    with pytest.raises(CallerCredentialError) as error:
+        service.update_caller_identity(**kwargs)
+    assert error.value.code == expected
+    service.append_caller_outbound_rule.assert_not_called()
+
+
+@pytest.mark.parametrize("gate", ["auth", "type", "status", "owner", "missing"])
+def test_caller_keeps_gates_before_target_resolution(caller, gate):
+    service, kwargs = caller
+    bot = service._bot_repo.get_by_id_and_entity.return_value
+    if gate == "auth":
+        kwargs["caller_user_id"] = "other-caller"
+    elif gate == "missing":
+        service._bot_repo.get_by_id_and_entity.return_value = None
+    else:
+        bot[{"type": "bot_type", "status": "status", "owner": "owner_id"}[gate]] = (
+            "other"
+        )
+    with pytest.raises(CallerCredentialError) as error:
+        service.update_caller_identity(**kwargs)
+    assert error.value.code == (
+        CALLER_CREDENTIAL_REQUEST_INVALID if gate == "auth" else CALLER_TARGET_NOT_FOUND
+    )
+    service._device_binding_repo.get_by_id.assert_not_called()
+    service.list_devices_by_bot_uuid.assert_not_called()
+    service.append_caller_outbound_rule.assert_not_called()
+    if gate != "auth":
+        service._bot_repo.get_by_id_and_entity.assert_called_once_with(
+            "default", "ENTITY-1"
+        )
+
+
+@pytest.mark.parametrize(
+    "failure", ["rule", "append_false", "append_exception", "transport"]
+)
+def test_caller_retains_rule_append_and_transport_failures(caller, failure):
+    service, kwargs = caller
+    if failure == "rule":
+        service._outbound_rule_provider.build_caller_rule.return_value = None
+    elif failure == "append_false":
+        service.append_caller_outbound_rule.return_value = False
+    elif failure == "append_exception":
+        service.append_caller_outbound_rule.side_effect = RuntimeError("private-append")
+    else:
+        service._device_binding_repo.get_by_id.return_value.device_provider = "baas"
+        original = RuntimeError("private-transport")
+        service.list_devices_by_bot_uuid.side_effect = original
+    with pytest.raises(Exception) as error:
+        service.update_caller_identity(**kwargs)
+    if failure == "transport":
+        assert error.value is original
+    else:
+        assert isinstance(error.value, CallerCredentialError)
+        assert error.value.code == (
+            CALLER_OUTBOUND_INVALID
+            if failure == "rule"
+            else CALLER_OUTBOUND_UPDATE_FAILED
+        )
+
+
+@pytest.mark.parametrize(
+    "target",
+    [
+        "ARCA-SANDBOX-direct@template",
+        "ARCA-SANDBOX-direct@１２",
+        "ARCA-SANDBOX-direct@١٢",
+        "ARCA-SANDBOX-direct@1:8080",
+        "ARCA-SANDBOX-direct:8080@1",
+        "ARCA-SANDBOX-direct@-1",
+        "ARCA-SANDBOX-direct@1.2",
+        "ARCA-SANDBOX-direct@+1",
+    ],
+)
+def test_arca_requires_ascii_numeric_template(service, target):
+    with pytest.raises(ValueError) as error:
+        service.resolve_token_outbound_device_id(
+            binding(device_props={"sandbox_id": target})
+        )
+    assert error.value.reason == "invalid_target"
+    service.list_devices_by_bot_uuid.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "logical_id",
+    [
+        "bot/path",
+        "../bot",
+        "bot\nsecret",
+        "bot\x00secret",
+        "bot#fragment",
+        "bot?query",
+        "bot%2fpath",
+        "bot@template",
+        "bot:8080",
+        "bot with space",
+        42,
+    ],
+)
+def test_baas_rejects_unsafe_logical_id_before_query(service, logical_id):
+    with pytest.raises(ValueError) as error:
+        service.resolve_token_outbound_device_id(
+            binding(device_provider="baas", device_id=logical_id)
+        )
+    assert error.value.reason == "invalid_target"
+    service.list_devices_by_bot_uuid.assert_not_called()

--- a/src/backend/tests/community/core/service_bot/services/test_caller_identity_outbound.py
+++ b/src/backend/tests/community/core/service_bot/services/test_caller_identity_outbound.py
@@ -23,7 +23,8 @@ def _bare_baas_service() -> BaasService:
     return object.__new__(BaasService)
 
 
-def test_caller_identity_uses_supplied_binding_or_falls_back_to_resolution() -> None:
+@pytest.mark.parametrize("provider", ["arca", "baas"])
+def test_caller_identity_uses_supplied_binding_or_falls_back_to_resolution(provider) -> None:
     service = _bare_baas_service()
     service._bot_repo = MagicMock()
     service._bot_repo.get_by_id_and_entity.return_value = {
@@ -35,9 +36,14 @@ def test_caller_identity_uses_supplied_binding_or_falls_back_to_resolution() -> 
     }
     service._device_binding_repo = MagicMock()
     service._device_binding_repo.get_by_id.return_value = SimpleNamespace(
+        id=9,
+        device_provider="baas",
         status="ACTIVE",
         device_id="baas-bot-1",
     )
+    binding = service._device_binding_repo.get_by_id.return_value
+    binding.device_provider = provider
+    binding.device_props = {"sandbox_id": "ARCA-SANDBOX-direct@002"}
     service._outbound_rule_provider = MagicMock()
     service._outbound_rule_provider.build_caller_rule.return_value = (
         OutBoundOperationRule(
@@ -91,7 +97,13 @@ def test_caller_identity_uses_supplied_binding_or_falls_back_to_resolution() -> 
         caller_token="caller-token"
     )
     paas_device_id, outbound_rule = service.append_caller_outbound_rule.call_args.args
-    assert paas_device_id == "device-1@template-1"
+    if provider == "arca":
+        assert paas_device_id == "ARCA-SANDBOX-direct@002"
+        service.list_devices_by_bot_uuid.assert_not_called()
+    else:
+        assert paas_device_id == "device-1@template-1"
+        assert service.list_devices_by_bot_uuid.call_count == 2
+        service.list_devices_by_bot_uuid.assert_called_with("baas-bot-1", timeout=3.0)
     assert outbound_rule.header_operation_rules[0].header_name == "x-caller-token"
     assert outbound_rule.header_operation_rules[0].action == "set"
     assert outbound_rule.header_operation_rules[0].value == "caller-token"
@@ -165,6 +177,8 @@ def test_caller_identity_test_exchange_allows_active_personal_bot() -> None:
     }
     service._device_binding_repo = MagicMock()
     service._device_binding_repo.get_by_id.return_value = SimpleNamespace(
+        id=9,
+        device_provider="baas",
         status="ACTIVE",
         device_id="baas-bot-1",
     )


### PR DESCRIPTION
## Problem

Caller token refresh treats every runtime binding's device_id as a logical BaaS Bot UUID. Direct ARCA bindings instead store their concrete target in device_props.sandbox_id, so the lookup fails before token installation. Outbound token plugins need the same provider-aware target contract.

## Solution

- Add a shared, documented target resolver: BaaS bindings retain a unique-device lookup; ARCA bindings use the stored sandbox target without querying a logical Bot.
- Preserve numeric ARCA template suffixes and reject unsupported providers, inactive bindings and malformed URL identifiers rather than guessing a template.
- Reuse the resolver for Caller while preserving owner/entity checks, eligibility, error codes and append semantics.
- Add non-sensitive target-resolution diagnostics and regression tests using the actual device_provider field.

## Validation

- Target/Caller regression suite: 91 passed; regressions were observed failing before implementation.
- Related Caller, runtime-binding, token-exchange, service-Bot and architecture suites: 1560 passed.
- Ruff and git diff --check passed; independent code/security review passed.
- With pre-existing coverage exclusions disabled for a separate local measurement, changed executable lines: 47/48 covered (97.9%). The remaining line is a TYPE_CHECKING import. This is not a full-repository or remote CI coverage claim.

## Compatibility and risk

Direct append still requires an online, correctly configured BaaS template and accessible ARCA sandbox. Missing suffixes are rejected rather than defaulted. No deployment or downstream header-receipt verification was performed. The enterprise adapter must consume a mirror-verified source revision before release.

## Spec

src/backend/specs/token-target-provider/001-spec-output.md
