### PR TITLE
fix(backend): stop publish pollers before test teardown

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -178,6 +178,7 @@ jobs:
   backend:
     name: Backend unit tests
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     env:
       # PR: compare against the checked-out merge commit's exact base tree.
       # push/dispatch: compare against dev (repo default branch) instead.

--- a/scripts/ci/tests/test_unit_test_workflow_diff.py
+++ b/scripts/ci/tests/test_unit_test_workflow_diff.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 WORKFLOW_PATH = REPO_ROOT / ".github/workflows/unit-tests.yml"
+BACKEND_CI_PATH = REPO_ROOT / "src/backend/scripts/ci_test.sh"
 PR_MERGE_PARENT_EXPRESSION = (
     "${{ github.event_name == 'pull_request' && 'HEAD^1' || 'origin/dev' }}"
 )
@@ -38,6 +39,16 @@ def _write(repository: Path, relative_path: str, content: str) -> None:
 
 
 class UnitTestWorkflowDiffTest(unittest.TestCase):
+    def test_backend_worker_crashes_fail_fast(self) -> None:
+        workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+        backend_job = workflow.split("\n  backend:\n", 1)[1].split(
+            "\n  engine:\n", 1
+        )[0]
+        backend_ci = BACKEND_CI_PATH.read_text(encoding="utf-8")
+
+        self.assertIn("    timeout-minutes: 25\n", backend_job)
+        self.assertIn("--max-worker-restart=0", backend_ci)
+
     def test_pr_module_diffs_use_the_checked_out_merge_parent(self) -> None:
         workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
         for env_name, module_path in MODULE_JOBS.values():

--- a/src/backend/scripts/ci_test.sh
+++ b/src/backend/scripts/ci_test.sh
@@ -83,7 +83,7 @@ fi
 pytest_workers="${BACKEND_CI_PYTEST_WORKERS:-auto}"
 xdist_args=()
 if [[ "$pytest_workers" != "0" ]]; then
-  xdist_args=(-n "$pytest_workers" --dist loadfile)
+  xdist_args=(-n "$pytest_workers" --dist loadfile --max-worker-restart=0)
 fi
 
 # Coverage measurement core. ``sysmon`` is coverage.py's PEP 669 (sys.monitoring)

--- a/src/backend/src/agentclaw/community/core/devices/services/baas_publish_poller.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/baas_publish_poller.py
@@ -50,16 +50,52 @@ class BaasPublishPoller:
             if poll_timeout_seconds is not None
             else self.DEFAULT_POLL_TIMEOUT_SECONDS
         )
+        self._stop_event = threading.Event()
+        self._threads_lock = threading.Lock()
+        self._threads: set[threading.Thread] = set()
 
     def start(self, *, publish_id: str, device_id: str, binding_id: int) -> None:
         """启动后台 thread 轮询，daemon=True 不阻塞进程退出。"""
         thread = threading.Thread(
-            target=bind_current_avernet_tenant(self._poll),
+            target=bind_current_avernet_tenant(self._run_tracked),
             args=(publish_id, device_id, binding_id),
             daemon=True,
             name=f"baas-poll-{publish_id}",
         )
-        thread.start()
+        with self._threads_lock:
+            if self._stop_event.is_set():
+                raise RuntimeError("BaasPublishPoller is shut down")
+            self._threads.add(thread)
+            thread.start()
+
+    def shutdown(self, *, timeout_seconds: float | None = None) -> bool:
+        """Stop accepting work and wait for every active poller thread."""
+        self._stop_event.set()
+        deadline = (
+            time.monotonic() + timeout_seconds
+            if timeout_seconds is not None
+            else None
+        )
+        with self._threads_lock:
+            threads = tuple(self._threads)
+        for thread in threads:
+            remaining = (
+                max(0.0, deadline - time.monotonic())
+                if deadline is not None
+                else None
+            )
+            thread.join(remaining)
+        with self._threads_lock:
+            return not self._threads
+
+    def _run_tracked(
+        self, publish_id: str, device_id: str, binding_id: int
+    ) -> None:
+        try:
+            self._poll(publish_id, device_id, binding_id)
+        finally:
+            with self._threads_lock:
+                self._threads.discard(threading.current_thread())
 
     def _poll(self, publish_id: str, device_id: str, binding_id: int) -> None:
         try:
@@ -67,7 +103,8 @@ class BaasPublishPoller:
             device_service = self._device_service_provider()
 
             while (time.monotonic() - start) < self._poll_timeout:
-                time.sleep(self._poll_interval)
+                if self._stop_event.wait(self._poll_interval):
+                    return
                 try:
                     progress = self._baas_service.get_publish_progress(publish_id)
                     status = (progress or {}).get("status", "")
@@ -78,6 +115,8 @@ class BaasPublishPoller:
                     )
                     continue
 
+                if self._stop_event.is_set():
+                    return
                 if status == "SUCCESS":
                     try:
                         device_service.report_device_alive(
@@ -101,8 +140,9 @@ class BaasPublishPoller:
                                 )
                         else:
                             logger.warning(
-                                f"[BaasPublishPoller] device_service has no _mark_alive_active_fallback "
-                                f"helper; device may remain PENDING"
+                                "[BaasPublishPoller] device_service has no "
+                                "_mark_alive_active_fallback helper; device may "
+                                "remain PENDING"
                             )
                     return
 
@@ -113,6 +153,8 @@ class BaasPublishPoller:
                     )
                     return
 
+            if self._stop_event.is_set():
+                return
             # 循环退出 = 超时
             device_service._mark_service_start_failed(
                 binding_id=binding_id,

--- a/src/backend/tests/community/core/devices/services/test_baas_publish_poller.py
+++ b/src/backend/tests/community/core/devices/services/test_baas_publish_poller.py
@@ -1,6 +1,9 @@
 """Tests for BaasPublishPoller — 轮询 BaaS publish 状态、触发 PENDING→ACTIVE."""
-from unittest.mock import MagicMock
+
+import threading
 import time
+from unittest.mock import MagicMock
+
 import pytest
 
 from agentclaw.community.core.devices.services.baas_publish_poller import BaasPublishPoller
@@ -157,3 +160,76 @@ def test_poll_multiple_pending_then_success_calls_alive_once(fake_baas, fake_dev
 
     assert fake_device_service.report_device_alive.call_count == 1
     assert fake_baas.get_publish_progress.call_count == 3
+
+
+def test_shutdown_interrupts_sleep_and_waits_for_the_poller_thread(
+    fake_baas, fake_device_service
+):
+    provider_called = threading.Event()
+
+    def device_service_provider():
+        provider_called.set()
+        return fake_device_service
+
+    fake_baas.get_publish_progress.return_value = {"status": "PENDING"}
+    poller = BaasPublishPoller(
+        baas_service=fake_baas,
+        device_service_provider=device_service_provider,
+        poll_interval_seconds=60,
+        poll_timeout_seconds=180,
+    )
+
+    poller.start(publish_id="pub-shutdown", device_id="dev-shutdown", binding_id=48)
+    assert provider_called.wait(timeout=1)
+
+    assert poller.shutdown(timeout_seconds=1) is True
+    fake_baas.get_publish_progress.assert_not_called()
+    fake_device_service.report_device_alive.assert_not_called()
+    fake_device_service._mark_service_start_failed.assert_not_called()
+
+
+def test_shutdown_during_progress_check_skips_device_database_work(
+    fake_baas, fake_device_service
+):
+    progress_started = threading.Event()
+    release_progress = threading.Event()
+
+    def get_publish_progress(_publish_id):
+        progress_started.set()
+        assert release_progress.wait(timeout=1)
+        return {"status": "SUCCESS"}
+
+    fake_baas.get_publish_progress.side_effect = get_publish_progress
+    poller = BaasPublishPoller(
+        baas_service=fake_baas,
+        device_service_provider=lambda: fake_device_service,
+        poll_interval_seconds=0,
+        poll_timeout_seconds=1.0,
+    )
+    poller.start(publish_id="pub-in-flight", device_id="dev-in-flight", binding_id=49)
+    assert progress_started.wait(timeout=1)
+
+    shutdown_result = []
+    shutdown_thread = threading.Thread(
+        target=lambda: shutdown_result.append(poller.shutdown(timeout_seconds=1))
+    )
+    shutdown_thread.start()
+    release_progress.set()
+    shutdown_thread.join(timeout=1)
+
+    assert shutdown_result == [True]
+    fake_device_service.report_device_alive.assert_not_called()
+    fake_device_service._mark_service_start_failed.assert_not_called()
+
+
+def test_start_rejects_work_after_shutdown(fake_baas, fake_device_service):
+    poller = BaasPublishPoller(
+        baas_service=fake_baas,
+        device_service_provider=lambda: fake_device_service,
+        poll_interval_seconds=0.01,
+        poll_timeout_seconds=1.0,
+    )
+    assert poller.shutdown(timeout_seconds=1) is True
+
+    with pytest.raises(RuntimeError, match="shut down"):
+        poller.start(publish_id="pub-late", device_id="dev-late", binding_id=50)

--- a/src/backend/tests/community/framework/fixtures.py
+++ b/src/backend/tests/community/framework/fixtures.py
@@ -104,6 +104,12 @@ def app_with_testing_modules(request) -> FastAPI:
     try:
         yield app
     finally:
+        from agentclaw.community.core.devices.services.baas_publish_poller import (
+            BaasPublishPoller,
+        )
+
+        poller = injector.get(BaasPublishPoller)
+        poller_stopped = poller.shutdown(timeout_seconds=5)
         _CURRENT_TEST_INJECTOR.pop(id(request.node), None)
         if prev_app is not None:
             attach_injector(app, prev_app)
@@ -113,6 +119,10 @@ def app_with_testing_modules(request) -> FastAPI:
         # Dispose the per-test engine deterministically; ``reset_for_tests``
         # on the NEXT injector build would do this anyway, but explicit
         # disposal here keeps connection lifecycle observable.
+        if not poller_stopped:
+            raise RuntimeError(
+                "BaasPublishPoller threads did not stop before test database disposal"
+            )
         engine.dispose()
 
 


### PR DESCRIPTION
## Problem
Backend unit-test runs on PRs #2036 and #2079 exceeded one hour after an xdist worker crashed near the end of the suite. The failing worker was still running `BaasPublishPoller` threads while the function-scoped SQLite engine was being disposed, allowing a native SQLite/SQLAlchemy race. Xdist then replaced the crashed worker and left the workflow waiting instead of failing promptly.

## Solution
- Track active BaaS publish-poller threads and provide deterministic shutdown with interruptible waits.
- Stop and join pollers before the per-test SQLite engine is disposed, and skip device database work once shutdown starts.
- Disable xdist worker replacement so a native worker crash fails the Backend job immediately.
- Cap the Backend job at 25 minutes to bound any future infrastructure hang.
- Add lifecycle regression tests and CI configuration contract coverage.

## Validation
- Backend full gate: `18218 passed, 60 skipped` in 279.07s; 88.93% line coverage; 96.55% changed-line coverage.
- Original failing owner-name test file: 5 consecutive xdist runs with `-n 4 --dist loadfile --max-worker-restart=0`; all 18 tests passed in every run.
- Poller and CI contract tests: 11 passed.
- Fixture and architecture narrow tests: 24 passed.
- Matching OCB `REL20260910@6eda649135` with this Avernet source: 9 Corp device tests passed.
- Python SAST, Ruff, shell syntax, and `git diff --check`: passed.
- Standards/Spec dual-axis review: PASS, no P0/P1/P2 findings.

## Compatibility and risk
The publish SUCCESS, FAILED, and timeout semantics are unchanged. `shutdown()` is additive and is used by the test fixture to establish a deterministic lifecycle boundary. OCB Corp tests reuse the community fixture and passed against the matching release checkout. Rollback is a single commit revert.

## Related issues
- Related to #2036
- Related to #2079