### PR TITLE
feat(frontend): support message view scope

### DIFF
--- a/src/frontend-nextgen/OPEN_CORE_MANIFEST.json
+++ b/src/frontend-nextgen/OPEN_CORE_MANIFEST.json
@@ -1,6 +1,6 @@
 {
   "sourceRepository": "teamclaw",
-  "sourceCommit": "989456f8d10a752d5f08c5c93790ad9bffff1099",
+  "sourceCommit": "3414cb6b39ea6780e76fb79926e58be3a2c99ae9",
   "sourceDirty": false,
   "exportSchemaVersion": 1,
   "target": "src/frontend-nextgen",

--- a/src/frontend-nextgen/src/assets/TaskPanel/TaskPanelFetcher.tsx
+++ b/src/frontend-nextgen/src/assets/TaskPanel/TaskPanelFetcher.tsx
@@ -2,7 +2,7 @@
 /**
  * TaskPanelFetcher —— 任务副屏轮询内核（路 A 自管）。
  * - 数据流：由上层 wrapper 透传 {apiBaseUrl(host), taskApiBase(路径前缀), taskId}，组件内 raw fetch，不自读 config / 不依赖 taskService / 不反查 capability。
- * - apiBaseUrl 为 '' 时走相对路径，由当前环境代理转发；taskApiBase 缺省回退内面 /api/v1。
+ * - apiBaseUrl 为 '' 时走相对路径，由当前环境代理转发；taskApiBase 缺省回退 /openapi/v1 读公开面（gateway spanner 鉴权）。
  * - 轮询：图级 status 非终态时 setTimeout 重排（默认 1000ms）；产品态 DONE/FAILED/REVIEWING/CANCELLED 停，兼容旧 HUNG。
  * - 取消：AbortController，切 taskId / 卸载时 abort。
  * - 日志：include_action_log 默认 false（日志抽屉打开时由上层单独请求，P0 常规轮询不携带）。
@@ -29,7 +29,7 @@ function joinUrl(baseUrl: string, path: string): string {
 export interface TaskPanelFetcherProps {
   apiBaseUrl: string;
   // task API 路径前缀（不含 host）：Open Core /openapi/v1/collaboration/tasks、内部 /api/v1/collaboration/tasks。
-  // 由 app-level 经 capability 解析透传，缺省回退内面路径（向后兼容纯 assets 渲染）。
+  // 由 app-level 透传读公开面 /openapi/v1（gateway spanner 鉴权）；缺省回退同一公开面（向后兼容纯 assets 渲染）。
   taskApiBase?: string;
   taskId: string;
   userId?: string;
@@ -45,7 +45,7 @@ export interface TaskPanelFetcherProps {
 
 export const TaskPanelFetcher: React.FC<TaskPanelFetcherProps> = ({
   apiBaseUrl,
-  taskApiBase = '/api/v1/collaboration/tasks',
+  taskApiBase = '/openapi/v1/collaboration/tasks',
   taskId,
   userId,
   includeActionLog = false,

--- a/src/frontend-nextgen/src/capabilities/defaultCapabilities.ts
+++ b/src/frontend-nextgen/src/capabilities/defaultCapabilities.ts
@@ -198,7 +198,7 @@ export const defaultCapabilities: AppCapabilities = {
     status: 'available',
     value: { adminEntry: true, spaceSwitcher: false, notificationBell: true },
   }),
-  // Open Core（阿里云部署）管理后台页内分区：隐藏【空间管理】Tab、仅保留【工单中心】
+  // Open Core（阿里云部署）管理后台页内分区：隐藏【空间管理】Tab、仅保留【通知中心】
   // （管理后台入口已开放，空间管理收敛在页内完成；空间数据链路不受影响）。
   // internal overlay 覆盖为 { spaces:true, workOrders:true }（extensions/internal.ts），内部形态两 Tab 均在。
   getAdminSections: (): CapabilityResult<AdminSections> => ({

--- a/src/frontend-nextgen/src/capabilities/types.ts
+++ b/src/frontend-nextgen/src/capabilities/types.ts
@@ -204,9 +204,9 @@ export interface ShellVisibility {
 /**
  * 管理后台页内分区（Tab）形态级可见性（见 `getAdminSections` capability）。
  * - `spaces`：【空间管理】Tab（空间卡片/创建/成员管理视图）
- * - `workOrders`：【工单中心】Tab
+ * - `workOrders`：【通知中心】Tab（标识符沿用 `workOrders`，与后端 work-orders 端点对齐）
  * Open Core（阿里云部署）默认 `{ spaces:false, workOrders:true }`——管理后台入口开放后，
- * 仅暴露工单中心，空间管理 Tab 收敛（空间数据链路不受影响）；internal overlay 覆盖为全 true。
+ * 仅暴露通知中心，空间管理 Tab 收敛（空间数据链路不受影响）；internal overlay 覆盖为全 true。
  * 消费方（`src/pages/Admin`）按本结果过滤 Tab 与默认/深链回退，MUST NOT 以 `if (isInternal)` 替代。
  */
 export interface AdminSections {
@@ -371,8 +371,8 @@ export interface AppCapabilities {
    */
   getShellVisibility: () => CapabilityResult<ShellVisibility>;
   /**
-   * 管理后台页内分区（Tab）可见性（空间管理 / 工单中心，见 `AdminSections`）。
-   * Open Core（阿里云部署）默认 `{ spaces:false, workOrders:true }`——管理后台入口开放后仅暴露工单中心，
+   * 管理后台页内分区（Tab）可见性（空间管理 / 通知中心，见 `AdminSections`）。
+   * Open Core（阿里云部署）默认 `{ spaces:false, workOrders:true }`——管理后台入口开放后仅暴露通知中心，
    * 空间管理 Tab 收敛；internal overlay 经 `src/extensions/internal.ts` 覆盖为 `{ spaces:true, workOrders:true }`，
    * 内部形态两 Tab 均在（与改造前一致）。同步签名，不发请求。
    * 消费方（`src/pages/Admin/index.tsx`）按本结果过滤 Tab、选择默认 Tab 并对隐藏/非法 `?tab=` 深链回落首项。

--- a/src/frontend-nextgen/src/components/Admin/NotificationBell/index.tsx
+++ b/src/frontend-nextgen/src/components/Admin/NotificationBell/index.tsx
@@ -1,4 +1,5 @@
-// 通知铃铛：红点未读数 + Popover（最近3条 / 全部已读 / 查看全部通知）。
+// 通知铃铛：通知中心的快速预览入口。红点未读数 + Popover（最近3条 / 全部已读 / 查看全部）。
+// 与通知中心完整视图（/admin?tab=work-orders）同数据源：list 端点、未读 badge_count、WorkOrderDto 均共用。
 // 视觉规格：docs/specs/2026-08-17-admin-module/prd-visual-spec.md §4（Popover 约 360 宽）。
 import { Button, Empty, IconButton, Popover, PopoverContent, PopoverTrigger, Skeleton } from '@/components/ui';
 import type { NotificationSummary, WorkOrderCategory } from '@/domain/admin/models';
@@ -52,7 +53,7 @@ export function NotificationBell() {
       </PopoverTrigger>
       <PopoverContent align="end" sideOffset={8} className="w-[360px] max-w-[calc(100vw-1rem)] p-0">
         <div className="flex items-center justify-between px-4 pt-3 pb-2">
-          <p className="m-0 text-sm font-semibold text-foreground">通知中心</p>
+          <p className="m-0 text-sm font-semibold text-foreground">最近通知</p>
           {unreadCount > 0 && (
             <Button variant="ghost" size="sm" onClick={() => void markAllRead()}>
               全部已读
@@ -86,7 +87,7 @@ export function NotificationBell() {
         </div>
         <div className="border-t border-border px-4 py-2">
           <Button variant="ghost" size="sm" className="w-full" onClick={() => goWorkOrders()}>
-            查看全部通知
+            查看全部
           </Button>
         </div>
       </PopoverContent>

--- a/src/frontend-nextgen/src/components/Admin/NotificationItem/index.tsx
+++ b/src/frontend-nextgen/src/components/Admin/NotificationItem/index.tsx
@@ -1,4 +1,4 @@
-// 通知下拉单条。未读浅蓝底 + 未读 dot；已读透明无 dot。点击跳工单中心对应分类。
+// 通知下拉单条。未读浅蓝底 + 未读 dot；已读透明无 dot。点击跳通知中心对应分类。
 import { Button } from '@/components/ui';
 import type { NotificationSummary } from '@/domain/admin/models';
 import { cn } from '@/utils/cn';

--- a/src/frontend-nextgen/src/components/Admin/SpaceJoinForm/index.tsx
+++ b/src/frontend-nextgen/src/components/Admin/SpaceJoinForm/index.tsx
@@ -56,7 +56,7 @@ export function SpaceJoinForm({ space, open, onOpenChange, onSubmit }: SpaceJoin
             />
           </div>
           <CaptionText className="m-0">
-            提交后需等待该团队管理员审批，审批结果可在「工单中心 - 我发起的」中查看。
+            提交后需等待该团队管理员审批，审批结果可在管理后台「通知中心 - 我发起的」中查看。
           </CaptionText>
         </div>
         <ModalFooter>

--- a/src/frontend-nextgen/src/components/Admin/Tabs.tsx
+++ b/src/frontend-nextgen/src/components/Admin/Tabs.tsx
@@ -1,5 +1,5 @@
 // Admin 专用轻量 tab 组件（对齐 PRD ant-tabs 视觉，不引入 antd）。
-// - UnderlineTabs：主 tab（空间管理/工单中心），下划线指示器，54px 高，ink-bar 3px 主色。
+// - UnderlineTabs：主 tab（空间管理/通知中心），下划线指示器，54px 高，ink-bar 3px 主色。
 // - CardTabs：工单视图 tab（待我处理/我发起的/已处理），卡片式，40px 高，激活态白底主色字，独立于下方内容面板（间距由调用方给）。
 import { Button } from '@/components/ui';
 import { cn } from '@/utils/cn';

--- a/src/frontend-nextgen/src/components/Admin/WorkOrderCard/index.tsx
+++ b/src/frontend-nextgen/src/components/Admin/WorkOrderCard/index.tsx
@@ -18,7 +18,7 @@ export interface WorkOrderCardProps {
   onApprove?: (workOrderId: number | string) => void;
   onReject?: (workOrderId: number | string, remark: string) => void | Promise<void>;
   onView?: (workOrder: WorkOrder) => void;
-  canAct?: boolean; // 工单中心容器决定是否可操作（缺 identity 时只读）
+  canAct?: boolean; // 通知中心容器决定是否可操作（缺 identity 时只读）
 }
 
 export function WorkOrderCard({ workOrder: wo, onApprove, onReject, onView, canAct = true }: WorkOrderCardProps) {

--- a/src/frontend-nextgen/src/components/Admin/WorkOrderTabs/index.tsx
+++ b/src/frontend-nextgen/src/components/Admin/WorkOrderTabs/index.tsx
@@ -1,4 +1,4 @@
-// 工单中心：card 视图 tab + 分类 Segmented + 全部已读 + 列表（骨架/空态/错误）+ 分页 + 工单/通知详情 Drawer。
+// 通知中心完整视图：card 视图 tab + 分类 Segmented + 全部已读 + 列表（骨架/空态/错误）+ 分页 + 审批/通知详情 Drawer。
 // 视觉对齐 admin 视觉交互指南 §7.2/§7.4/§8。切视图/分类回第 1 页；详情用 typeLabel/statusLabel 本地化。
 import { Button, Card, Empty, Pagination, Skeleton } from '@/components/ui';
 import type { WorkOrder, WorkOrderCategory, WorkOrderView } from '@/domain/admin/models';

--- a/src/frontend-nextgen/src/components/BotWorkshop/Editor/CapabilityPickerModal.tsx
+++ b/src/frontend-nextgen/src/components/BotWorkshop/Editor/CapabilityPickerModal.tsx
@@ -61,7 +61,9 @@ export function CapabilityPickerModal({
   const remoteMcpSearch = kind === 'mcp';
   const skillCenter = useSkillCenterPicker(open && remoteSearch, keyword);
   const items =
-    source === 'mine'
+    kind === 'mcp'
+      ? marketItems
+      : source === 'mine'
       ? myItems
       : source === 'market'
       ? marketSource === 'skillcenter-market'

--- a/src/frontend-nextgen/src/components/CollaborationPrivacy/FriendApprovalEditor/index.tsx
+++ b/src/frontend-nextgen/src/components/CollaborationPrivacy/FriendApprovalEditor/index.tsx
@@ -13,9 +13,9 @@ import { ChoiceGroup } from '../ChoiceGroup';
 import { OrganizationScopeSearch } from '../OrganizationScopeSearch';
 
 const modes: Array<{ value: FriendApprovalMode; label: string; description: string }> = [
-  { value: 'none', label: '无需审批', description: '符合 Bot 可见性限制的新申请直接建立好友关系' },
-  { value: 'all', label: '全部审批', description: '所有新好友申请都需要确认' },
-  { value: 'partial_exempt', label: '部分组织免审批', description: '指定组织范围直接通过，其余申请需审批' },
+  { value: 'none', label: '无需审批', description: '新好友申请无需用户审批，直接通过' },
+  { value: 'all', label: '全部审批', description: '新好友申请都需要用户审批后方可通过' },
+  { value: 'partial_exempt', label: '部分组织免审批', description: '限定组织的用户申请可直接通过；其余组织的用户申请仍需当前用户审批' },
 ];
 
 interface FriendApprovalEditorProps {
@@ -89,6 +89,7 @@ export function FriendApprovalEditor({
             options={availableModes}
             ariaLabel="好友审批策略"
             onChange={setMode}
+            className={partialExemptEnabled ? 'sm:grid-cols-3' : 'sm:grid-cols-2'}
           />
           {!partialExemptEnabled && initialConfig.mode === 'partial_exempt' && mode === null && (
             <p className="text-xs text-warning">当前策略“部分组织免审批”已下线，请重新选择“无需审批”或“全部审批”。</p>

--- a/src/frontend-nextgen/src/components/CollaborationPrivacy/HelpTooltip/index.tsx
+++ b/src/frontend-nextgen/src/components/CollaborationPrivacy/HelpTooltip/index.tsx
@@ -1,0 +1,44 @@
+import { Button } from '@/components/ui/Button';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/Tooltip';
+import { CircleAlert, Info } from 'lucide-react';
+import type { ReactNode } from 'react';
+import { collaborationPrivacyTooltipDelayMs } from '../interaction';
+
+interface HelpTooltipProps {
+  label: string;
+  content: ReactNode;
+}
+
+export function LabelHelpTooltip({ label, content }: HelpTooltipProps) {
+  return (
+    <TooltipProvider delayDuration={collaborationPrivacyTooltipDelayMs}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button variant="ghost" size="icon" className="h-5 w-5 text-muted-foreground" aria-label={`${label}功能说明`}>
+            <Info className="h-3.5 w-3.5" aria-hidden />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>{content}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+interface ControlStateTooltipProps extends HelpTooltipProps {
+  status: string;
+}
+
+export function ControlStateTooltip({ label, status, content }: ControlStateTooltipProps) {
+  return (
+    <TooltipProvider delayDuration={collaborationPrivacyTooltipDelayMs}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button variant="ghost" size="icon" className="h-5 w-5 text-warning" aria-label={`${label}${status}原因`}>
+            <CircleAlert className="h-3.5 w-3.5" aria-hidden />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>{content}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/src/frontend-nextgen/src/components/CollaborationPrivacy/PermissionCard/index.tsx
+++ b/src/frontend-nextgen/src/components/CollaborationPrivacy/PermissionCard/index.tsx
@@ -1,14 +1,12 @@
 import { Badge } from '@/components/ui/Badge';
-import { Button } from '@/components/ui/Button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card';
 import { IconButton } from '@/components/ui/IconButton';
 import { Switch } from '@/components/ui/Switch';
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/Tooltip';
 import type { CollaborationBot, PublicAudience } from '@/domain/collaborationPrivacy/types';
 import type { DirectSetting } from '@/services/collaborationPrivacy';
-import { Copy, Info, RefreshCw } from 'lucide-react';
+import { Copy, RefreshCw } from 'lucide-react';
 import { botFriendApprovalSection, botVisibilitySection } from '../botVisibilityCopy';
-import { collaborationPrivacyTooltipDelayMs } from '../interaction';
+import { ControlStateTooltip, LabelHelpTooltip } from '../HelpTooltip';
 import { RelationCard } from '../RelationCard';
 import { RequestList } from '../RequestList';
 
@@ -39,35 +37,19 @@ function SettingRow({ label, description, checked, disabled, busy, status, statu
   return (
     <div className="flex items-start justify-between gap-4 py-3 first:pt-0 last:pb-0">
       <div className="min-w-0 flex-1">
-        <div className="flex flex-wrap items-center gap-2">
-          <p className="m-0 text-sm font-medium text-foreground">{label}</p>
-          {status && (
-            <TooltipProvider delayDuration={collaborationPrivacyTooltipDelayMs}>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="h-6 gap-1 px-1 text-muted-foreground"
-                    aria-label={`${label}${status}说明`}
-                  >
-                    <Badge tone="neutral">{status}</Badge>
-                    <Info className="h-3.5 w-3.5" aria-hidden />
-                  </Button>
-                </TooltipTrigger>
-                {statusReason && <TooltipContent>{statusReason}</TooltipContent>}
-              </Tooltip>
-            </TooltipProvider>
-          )}
-        </div>
+        <p className="m-0 text-sm font-medium text-foreground">{label}</p>
         <p className="mt-1 text-xs leading-5 text-muted-foreground">{description}</p>
       </div>
-      <Switch
-        checked={checked}
-        disabled={disabled || busy}
-        aria-label={`${checked ? '关闭' : '开启'}${label}`}
-        onCheckedChange={onChange}
-      />
+      <div className="flex shrink-0 items-center gap-2">
+        {status && <Badge tone="neutral">{status}</Badge>}
+        {status && statusReason && <ControlStateTooltip label={label} status={status} content={statusReason} />}
+        <Switch
+          checked={checked}
+          disabled={disabled || busy}
+          aria-label={`${checked ? '关闭' : '开启'}${label}`}
+          onCheckedChange={onChange}
+        />
+      </div>
     </div>
   );
 }
@@ -181,21 +163,7 @@ export function PermissionCard({
                 <h4 className="m-0 text-xs font-semibold tracking-wide text-muted-foreground">
                   {botVisibilitySection.title}
                 </h4>
-                <TooltipProvider delayDuration={collaborationPrivacyTooltipDelayMs}>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        className="h-5 w-5 text-muted-foreground"
-                        aria-label="Bot 可见性说明"
-                      >
-                        <Info className="h-3.5 w-3.5" aria-hidden />
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent>{botVisibilitySection.description}</TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
+                <LabelHelpTooltip label={botVisibilitySection.title} content={botVisibilitySection.description} />
               </div>
               <div className="divide-y divide-border">
                 <RelationCard
@@ -221,21 +189,21 @@ export function PermissionCard({
                 <h4 className="text-xs font-semibold tracking-wide text-muted-foreground">
                   {botFriendApprovalSection.title}
                 </h4>
-                <TooltipProvider delayDuration={collaborationPrivacyTooltipDelayMs}>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        className="h-5 w-5 text-muted-foreground"
-                        aria-label="Bot 好友审批说明"
+                <LabelHelpTooltip
+                  label={botFriendApprovalSection.title}
+                  content={
+                    <>
+                      {botFriendApprovalSection.descriptionLeading}
+                      <a
+                        href={botFriendApprovalSection.approvalEntryPath}
+                        className="font-medium text-primary hover:opacity-80"
                       >
-                        <Info className="h-3.5 w-3.5" aria-hidden />
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent>{botFriendApprovalSection.description}</TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
+                        {botFriendApprovalSection.approvalEntryLabel}
+                      </a>
+                      {botFriendApprovalSection.descriptionTrailing}
+                    </>
+                  }
+                />
               </div>
               <RequestList
                 config={bot.friendApproval}

--- a/src/frontend-nextgen/src/components/CollaborationPrivacy/PublicationEditor/index.tsx
+++ b/src/frontend-nextgen/src/components/CollaborationPrivacy/PublicationEditor/index.tsx
@@ -27,14 +27,14 @@ const audienceTitles: Record<PublicAudience, string> = {
 const collaborationSquareBotsPath = '/collaboration-square/bots';
 const scopeDescriptions: Record<PublicAudience, Record<PublicScope, string>> = {
   user: {
-    none: '其他用户以个人身份，无法在协作广场看到当前 Bot，也不能发起申请。',
-    all: '其他用户以个人身份，在协作广场可见当前 Bot 并申请好友。',
-    restricted: '其他用户以个人身份，在协作广场可见当前 Bot，但仅选中组织范围的用户可申请好友。',
+    none: '其他用户无法发现该 Bot',
+    all: '其他用户可见，也可申请好友',
+    restricted: '其他用户可见，仅选中组织范围内的用户可申请好友',
   },
   bot: {
-    none: '其他 Bot 以 Bot 工作身份，无法在协作广场看到当前 Bot，也不能发起申请。',
-    all: '其他 Bot 以 Bot 工作身份，在协作广场可见当前 Bot 并申请好友。',
-    restricted: '其他 Bot 以 Bot 工作身份，在协作广场可见当前 Bot，但仅选中组织范围的 Bot 可申请好友。',
+    none: '其他 Bot 无法发现该 Bot',
+    all: '其他 Bot 可见，也可申请好友',
+    restricted: '其他 Bot 可见，仅选中组织范围内的用户的 Bot 可申请好友',
   },
 };
 
@@ -126,7 +126,7 @@ export function PublicationEditor({
         <ModalHeader>
           <ModalTitle>{audienceTitles[audience]}</ModalTitle>
           <ModalDescription>
-            {visibilityEditorDescription}
+            {visibilityEditorDescription.leading}
             <a
               href={collaborationSquareBotsPath}
               className="font-medium text-primary hover:opacity-80"
@@ -134,6 +134,7 @@ export function PublicationEditor({
             >
               [协作广场/公开Bot]
             </a>
+            {visibilityEditorDescription.trailing}
           </ModalDescription>
         </ModalHeader>
         <div className="space-y-5">

--- a/src/frontend-nextgen/src/components/CollaborationPrivacy/RelationCard/index.tsx
+++ b/src/frontend-nextgen/src/components/CollaborationPrivacy/RelationCard/index.tsx
@@ -1,20 +1,12 @@
 import { Badge } from '@/components/ui/Badge';
 import { Button } from '@/components/ui/Button';
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/Tooltip';
 import type { PendingPublication, PublicAudience, PublicConfig } from '@/domain/collaborationPrivacy/types';
-import { Info } from 'lucide-react';
 import { visibilityAudience, visibilityScopeLabels } from '../botVisibilityCopy';
-import { collaborationPrivacyTooltipDelayMs } from '../interaction';
 
 const audienceLabels: Record<PublicAudience, string> = {
   user: visibilityAudience.user.label,
   bot: visibilityAudience.bot.label,
 };
-const audienceDescriptions: Record<PublicAudience, string> = {
-  user: visibilityAudience.user.description,
-  bot: visibilityAudience.bot.description,
-};
-
 interface RelationCardProps {
   audience: PublicAudience;
   config: PublicConfig;
@@ -29,24 +21,7 @@ export function RelationCard({ audience, config, pending, disabled, onEdit, onVi
     <div className="flex flex-wrap items-start justify-between gap-3 py-4 first:pt-0 last:pb-0">
       <div className="min-w-0 flex-1">
         <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-          <div className="flex items-center gap-1.5">
-            <p className="m-0 text-sm font-medium text-foreground">{audienceLabels[audience]}</p>
-            <TooltipProvider delayDuration={collaborationPrivacyTooltipDelayMs}>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="h-5 w-5 text-muted-foreground"
-                    aria-label={`${audienceLabels[audience]}说明`}
-                  >
-                    <Info className="h-3.5 w-3.5" aria-hidden />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>{audienceDescriptions[audience]}</TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-          </div>
+          <p className="m-0 text-sm font-medium text-foreground">{audienceLabels[audience]}</p>
           {pending && <Badge tone="warning">待审批</Badge>}
           {pending?.approvalUrl && (
             <Button asChild variant="ghost" size="sm" className="h-auto p-0 text-primary">

--- a/src/frontend-nextgen/src/components/CollaborationPrivacy/RequestList/index.tsx
+++ b/src/frontend-nextgen/src/components/CollaborationPrivacy/RequestList/index.tsx
@@ -1,9 +1,5 @@
 import { Button } from '@/components/ui/Button';
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/Tooltip';
 import type { FriendApprovalConfig } from '@/domain/collaborationPrivacy/types';
-import { Info } from 'lucide-react';
-import { botFriendApprovalSection } from '../botVisibilityCopy';
-import { collaborationPrivacyTooltipDelayMs } from '../interaction';
 
 const modeLabels = { none: '无需审批', all: '全部审批', partial_exempt: '部分组织免审批（历史配置）' } as const;
 
@@ -21,24 +17,7 @@ export function RequestList({ config, disabled, disabledReason, onEdit, onViewSc
     <section className="flex flex-wrap items-start justify-between gap-3">
       <div className="min-w-0 flex-1">
         <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
-          <div className="flex items-center gap-1.5">
-            <p className="m-0 text-sm font-medium text-foreground">好友审批策略</p>
-            <TooltipProvider delayDuration={collaborationPrivacyTooltipDelayMs}>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="h-5 w-5 text-muted-foreground"
-                    aria-label="好友审批策略说明"
-                  >
-                    <Info className="h-3.5 w-3.5" aria-hidden />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>{botFriendApprovalSection.policyDescription}</TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-          </div>
+          <p className="m-0 text-sm font-medium text-foreground">好友审批策略</p>
           {disabledReason && <span className="text-xs leading-5 text-warning">{disabledReason}</span>}
         </div>
         <p className="mt-1 text-xs text-muted-foreground">

--- a/src/frontend-nextgen/src/components/CollaborationPrivacy/botVisibilityCopy.ts
+++ b/src/frontend-nextgen/src/components/CollaborationPrivacy/botVisibilityCopy.ts
@@ -2,7 +2,8 @@ import type { PublicAudience, PublicScope } from '@/domain/collaborationPrivacy/
 
 export const botVisibilitySection = {
   title: 'Bot 可见性',
-  description: '控制其他用户和 Bot 是否可发现并申请当前 Bot 为好友。',
+  description:
+    '分别控制其他用户和其他 Bot 能否在协作广场看到当前 Bot，并决定其是否可以发起好友申请。两个对象的可见性可单独设置。',
   disabledFriendApprovalReason: '至少开启一种 Bot 可见性后，才能修改好友审批策略',
 } as const;
 
@@ -35,8 +36,10 @@ export const visibilityScopeLabels: Record<PublicScope, string> = {
   restricted: '限定组织可申请',
 } as const;
 
-export const visibilityEditorDescription =
-  '选择当前 Bot 在协作广场中的可见性，以及其他用户或 Bot 能否申请当前 Bot 为好友。';
+export const visibilityEditorDescription = {
+  leading: '选择当前 Bot 在',
+  trailing: '中的可见性，以及其他用户或 Bot 能否申请当前 Bot 为好友。',
+} as const;
 
 export const organizationScopeCopy = {
   editorTitle: '选择组织范围',
@@ -49,7 +52,8 @@ export const organizationScopeCopy = {
 
 export const botFriendApprovalSection = {
   title: 'Bot 好友审批',
-  description: '统一控制其他用户和其他 Bot 申请添加当前 Bot 为好友时的审批方式。',
-  policyDescription:
-    '统一控制其他用户和其他 Bot 申请添加当前 Bot 为好友时的审批方式。审批入口见「工单中心 - 待我处理」，也可通过顶栏铃铛「通知中心」查看。',
+  descriptionLeading: '在其他用户或其他 Bot 发起好友申请后，统一控制是否需要审批。待审批的申请可前往「',
+  approvalEntryLabel: '管理后台 / 通知中心 / 待我处理',
+  approvalEntryPath: '/admin?tab=work-orders',
+  descriptionTrailing: '」处理。',
 } as const;

--- a/src/frontend-nextgen/src/components/CollaborationSquare/CreateGroupSessionModal/index.tsx
+++ b/src/frontend-nextgen/src/components/CollaborationSquare/CreateGroupSessionModal/index.tsx
@@ -1,16 +1,20 @@
+import { MessageViewScopeField } from '@/components/MessageViewScope';
 import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
 import { Modal, ModalContent, ModalHeader, ModalTitle } from '@/components/ui/Modal';
 import { Textarea } from '@/components/ui/Textarea';
+import { DEFAULT_MESSAGE_VIEW_SCOPE } from '@/domain/collaboration/messageViewScope';
+import type { MessageViewScope } from '@/domain/collaboration/types';
 import type { PublicGroup } from '@/domain/collaborationSquare/types';
 import { MessagesSquare } from 'lucide-react';
 import type { FormEvent } from 'react';
 import { useEffect, useState } from 'react';
 
-/** 创建公开协作群会话的表单值（对应接口 body：title + input.query）。 */
+/** 创建公开协作群会话的表单值（对应接口 body：title + input.query + message_view_scope）。 */
 export interface CreateGroupSessionFormValues {
   title: string;
   query: string;
+  messageViewScope: MessageViewScope;
 }
 
 export interface CreateGroupSessionModalProps {
@@ -32,12 +36,14 @@ export interface CreateGroupSessionModalProps {
 export function CreateGroupSessionModal({ open, group, loading, onClose, onSubmit }: CreateGroupSessionModalProps) {
   const [title, setTitle] = useState('');
   const [query, setQuery] = useState('');
+  const [viewScope, setViewScope] = useState<MessageViewScope>(DEFAULT_MESSAGE_VIEW_SCOPE);
 
   // 弹窗打开/切换目标群时重置表单，避免上一群残留输入。
   useEffect(() => {
     if (open) {
       setTitle('');
       setQuery('');
+      setViewScope(DEFAULT_MESSAGE_VIEW_SCOPE);
     }
   }, [open, group?.id]);
 
@@ -48,7 +54,7 @@ export function CreateGroupSessionModal({ open, group, loading, onClose, onSubmi
   const handleSubmit = (event: FormEvent) => {
     event.preventDefault();
     if (!canSubmit) return;
-    onSubmit({ title: trimmedTitle, query: trimmedQuery });
+    onSubmit({ title: trimmedTitle, query: trimmedQuery, messageViewScope: viewScope });
   };
 
   return (
@@ -99,6 +105,7 @@ export function CreateGroupSessionModal({ open, group, loading, onClose, onSubmi
               onChange={(event) => setQuery(event.target.value)}
             />
           </label>
+          <MessageViewScopeField value={viewScope} onChange={setViewScope} disabled={loading} />
           <div className="flex items-center justify-end gap-2">
             <Button type="button" variant="secondary" disabled={loading} onClick={onClose}>
               取消

--- a/src/frontend-nextgen/src/components/MessageViewScope/MessageViewScopeBadge.tsx
+++ b/src/frontend-nextgen/src/components/MessageViewScope/MessageViewScopeBadge.tsx
@@ -1,0 +1,8 @@
+import { Badge } from '@/components/ui';
+import { MESSAGE_VIEW_SCOPE_LABEL } from '@/domain/collaboration/messageViewScope';
+import type { MessageViewScope } from '@/domain/collaboration/types';
+
+/** 消息可见域标签：full 主色蓝（primary），participant 灰（neutral）。 */
+export function MessageViewScopeBadge({ scope }: { scope: MessageViewScope }) {
+  return <Badge tone={scope === 'full' ? 'primary' : 'neutral'}>{MESSAGE_VIEW_SCOPE_LABEL[scope]}</Badge>;
+}

--- a/src/frontend-nextgen/src/components/MessageViewScope/MessageViewScopeCheckbox.tsx
+++ b/src/frontend-nextgen/src/components/MessageViewScope/MessageViewScopeCheckbox.tsx
@@ -1,0 +1,37 @@
+import { Checkbox } from '@/components/ui';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/Tooltip';
+import { PARTICIPANT_ONLY_CHECKBOX } from '@/domain/collaboration/messageViewScope';
+import { HelpCircle } from 'lucide-react';
+
+export interface MessageViewScopeCheckboxProps {
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+  disabled?: boolean;
+}
+
+/** 「加入当前会话」弹窗的参与者视角 checkbox 卡片（视觉稿：加入当前会话按钮效果.png）。 */
+export function MessageViewScopeCheckbox({ checked, onCheckedChange, disabled }: MessageViewScopeCheckboxProps) {
+  return (
+    <div className="rounded-lg bg-muted/60 px-3 py-2.5 text-left">
+      <label className="flex items-center gap-2">
+        <Checkbox checked={checked} disabled={disabled} onCheckedChange={onCheckedChange} />
+        <span className="text-sm font-medium text-foreground">{PARTICIPANT_ONLY_CHECKBOX.label}</span>
+        <TooltipProvider delayDuration={0}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span
+                tabIndex={0}
+                aria-label={PARTICIPANT_ONLY_CHECKBOX.tooltip}
+                className="flex items-center outline-none"
+              >
+                <HelpCircle className="h-3.5 w-3.5 text-muted-foreground" aria-hidden="true" />
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>{PARTICIPANT_ONLY_CHECKBOX.tooltip}</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      </label>
+      <p className="mt-1 pl-6 text-xs text-muted-foreground">{PARTICIPANT_ONLY_CHECKBOX.hint}</p>
+    </div>
+  );
+}

--- a/src/frontend-nextgen/src/components/MessageViewScope/MessageViewScopeField.tsx
+++ b/src/frontend-nextgen/src/components/MessageViewScope/MessageViewScopeField.tsx
@@ -1,0 +1,41 @@
+import { MESSAGE_VIEW_SCOPE_OPTIONS } from '@/domain/collaboration/messageViewScope';
+import type { MessageViewScope } from '@/domain/collaboration/types';
+import { useId } from 'react';
+
+export interface MessageViewScopeFieldProps {
+  value: MessageViewScope;
+  onChange: (scope: MessageViewScope) => void;
+  disabled?: boolean;
+  label?: string;
+}
+
+/** 消息视角两选项 radio（表单 / 确认页场景；默认值由调用方给 full）。 */
+export function MessageViewScopeField({ value, onChange, disabled, label = '消息视角' }: MessageViewScopeFieldProps) {
+  const name = useId();
+  return (
+    <fieldset className="space-y-2 text-left" disabled={disabled}>
+      <legend className="mb-2 text-xs font-medium text-foreground">{label}</legend>
+      <div className="space-y-2" role="radiogroup" aria-label={label}>
+        {MESSAGE_VIEW_SCOPE_OPTIONS.map((option) => (
+          <label
+            key={option.value}
+            className="flex cursor-pointer items-start gap-2 rounded-lg border border-border px-3 py-2 has-[:checked]:border-primary has-[:checked]:bg-primary/5"
+          >
+            <input
+              type="radio"
+              name={name}
+              className="mt-0.5 size-4 accent-primary"
+              checked={value === option.value}
+              disabled={disabled}
+              onChange={() => onChange(option.value)}
+            />
+            <span className="min-w-0">
+              <span className="block text-sm text-foreground">{option.label}</span>
+              <span className="mt-0.5 block text-xs text-muted-foreground">{option.description}</span>
+            </span>
+          </label>
+        ))}
+      </div>
+    </fieldset>
+  );
+}

--- a/src/frontend-nextgen/src/components/MessageViewScope/MessageViewScopeMenuButton.tsx
+++ b/src/frontend-nextgen/src/components/MessageViewScope/MessageViewScopeMenuButton.tsx
@@ -1,0 +1,63 @@
+import { Button, IconButton } from '@/components/ui';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/Popover';
+import { DEFAULT_MESSAGE_VIEW_SCOPE, MESSAGE_VIEW_SCOPE_OPTIONS } from '@/domain/collaboration/messageViewScope';
+import type { MessageViewScope } from '@/domain/collaboration/types';
+import { cn } from '@/utils/cn';
+import { Check, Plus } from 'lucide-react';
+import { useState } from 'react';
+
+export interface MessageViewScopeMenuButtonProps {
+  /** 点选项即以此 scope 执行动作（如创建会话）。 */
+  onSelect: (scope: MessageViewScope) => void;
+  /** 勾选态（默认 full）。 */
+  selected?: MessageViewScope;
+  disabled?: boolean;
+}
+
+/**
+ * 「+」图标形态的新建会话入口：点击打开视角菜单，点选项即以该视角执行 onSelect。
+ * 仅 human 身份使用；bot 身份直接创建会话，不经过本组件。
+ */
+export function MessageViewScopeMenuButton({ onSelect, selected, disabled }: MessageViewScopeMenuButtonProps) {
+  const [open, setOpen] = useState(false);
+  const current = selected ?? DEFAULT_MESSAGE_VIEW_SCOPE;
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <IconButton
+          label="新建会话"
+          size="sm"
+          icon={<Plus className="h-4 w-4" />}
+          disabled={disabled}
+          onClick={(event) => event.stopPropagation()}
+          className="rounded-md text-muted-foreground hover:bg-primary/10 hover:text-primary"
+        />
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-64 p-1">
+        {MESSAGE_VIEW_SCOPE_OPTIONS.map((option) => (
+          <Button
+            key={option.value}
+            variant="ghost"
+            className={cn(
+              'h-auto w-full items-start justify-start gap-2 px-2.5 py-2 text-left',
+              current === option.value && 'border border-primary bg-primary/5',
+            )}
+            onClick={() => {
+              setOpen(false);
+              onSelect(option.value);
+            }}
+          >
+            <Check
+              className={cn('mt-0.5 h-4 w-4 shrink-0', current === option.value ? 'text-primary' : 'text-transparent')}
+              aria-hidden="true"
+            />
+            <span className="min-w-0">
+              <span className="block text-sm font-medium text-foreground">{option.label}</span>
+              <span className="mt-0.5 block text-xs text-muted-foreground">{option.description}</span>
+            </span>
+          </Button>
+        ))}
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/frontend-nextgen/src/components/MessageViewScope/index.ts
+++ b/src/frontend-nextgen/src/components/MessageViewScope/index.ts
@@ -1,0 +1,4 @@
+export { MessageViewScopeBadge } from './MessageViewScopeBadge';
+export { MessageViewScopeCheckbox } from './MessageViewScopeCheckbox';
+export { MessageViewScopeField } from './MessageViewScopeField';
+export { MessageViewScopeMenuButton } from './MessageViewScopeMenuButton';

--- a/src/frontend-nextgen/src/components/TaskCards/TaskCardControls.tsx
+++ b/src/frontend-nextgen/src/components/TaskCards/TaskCardControls.tsx
@@ -24,13 +24,13 @@ export const taskCardTextareaClass =
   'min-h-0 w-full p-1.5 rounded-lg border-blue-200 px-1.5 text-[11px] text-gray-700 resize-none focus-visible:border-blue-300 focus-visible:ring-2 focus-visible:ring-blue-300/50';
 
 export const taskCardDiscardBtnClass =
-  'flex-1 inline-flex items-center justify-center gap-0.5 h-auto px-1.5 py-1 rounded-lg border border-red-200 text-red-500 text-[11px] font-medium hover:bg-red-50 hover:scale-105 active:scale-95 transition-all duration-300 leading-none';
+  'flex-1 inline-flex items-center justify-center gap-0.5 h-7 px-1.5 py-1 rounded-lg border border-red-200 text-red-500 text-[11px] font-medium hover:bg-red-50 hover:scale-105 active:scale-95 transition-all duration-300 leading-none';
 
 export const taskCardSaveBtnClass =
-  'flex-1 inline-flex items-center justify-center gap-0.5 h-auto px-1.5 py-1 rounded-lg border border-gray-200 text-gray-500 text-[11px] font-medium hover:bg-muted/50 hover:scale-105 active:scale-95 transition-all duration-300 leading-none';
+  'flex-1 inline-flex items-center justify-center gap-0.5 h-7 px-1.5 py-1 rounded-lg border border-gray-200 text-gray-500 text-[11px] font-medium hover:bg-muted/50 hover:scale-105 active:scale-95 transition-all duration-300 leading-none';
 
 export const taskCardExecuteBtnClass =
-  'flex-1 inline-flex items-center justify-center gap-0.5 h-auto px-1.5 py-1 rounded-lg bg-blue-500 text-white text-[11px] font-medium hover:bg-blue-600 hover:scale-105 active:scale-95 transition-all duration-300 shadow-sm leading-none border-transparent';
+  'flex-1 inline-flex items-center justify-center gap-0.5 h-7 px-1.5 py-1 rounded-lg bg-blue-500 text-white text-[11px] font-medium hover:bg-blue-600 hover:scale-105 active:scale-95 transition-all duration-300 shadow-sm leading-none border-transparent';
 
 /** 编辑态「确认 / 取消」二按组合。 */
 export function EditFieldControls({ onConfirm, onCancel }: { onConfirm: () => void; onCancel: () => void }) {

--- a/src/frontend-nextgen/src/components/TaskCards/TaskClarifyCard.tsx
+++ b/src/frontend-nextgen/src/components/TaskCards/TaskClarifyCard.tsx
@@ -68,7 +68,7 @@ export function TaskClarifyCard({ data }: { data: TaskCardData }) {
 
   return (
     <div className="p-1 w-full flex justify-start task-loop-card-root">
-      <div className="w-full max-w-[360px] bg-white border border-gray-100 shadow-md rounded-2xl overflow-hidden transition-all duration-500">
+      <div className="w-full max-w-[420px] bg-white border border-gray-100 shadow-md rounded-2xl overflow-hidden transition-all duration-500">
         {/* Header */}
         <div className="px-3.5 pt-3.5 pb-2 border-b border-gray-50">
           <div className="flex items-center gap-1">

--- a/src/frontend-nextgen/src/components/TaskCards/TaskLoopCard.tsx
+++ b/src/frontend-nextgen/src/components/TaskCards/TaskLoopCard.tsx
@@ -22,7 +22,7 @@ export function TaskLoopCard(props: PanelContentProps) {
     default:
       return (
         <div className="p-1 w-full flex justify-start task-loop-card-root">
-          <div className="w-full max-w-[360px] bg-white border border-gray-100 shadow-md rounded-2xl p-4 text-center">
+          <div className="w-full max-w-[420px] bg-white border border-gray-100 shadow-md rounded-2xl p-4 text-center">
             <AlertCircle className="block mx-auto mb-1.5 h-4 w-4 text-gray-300" aria-hidden />
             <p className="text-[11px] text-gray-400">暂无数据</p>
           </div>

--- a/src/frontend-nextgen/src/components/TaskCards/TaskMultiSelectCard.tsx
+++ b/src/frontend-nextgen/src/components/TaskCards/TaskMultiSelectCard.tsx
@@ -23,7 +23,7 @@ export function TaskMultiSelectCard({ data }: { data: TaskCardData }) {
 
   return (
     <div className="p-1 w-full flex justify-start task-loop-card-root">
-      <div className="w-full max-w-[360px] bg-white border border-gray-100 shadow-md rounded-2xl overflow-hidden transition-all duration-500">
+      <div className="w-full max-w-[420px] bg-white border border-gray-100 shadow-md rounded-2xl overflow-hidden transition-all duration-500">
         {/* Header */}
         <div className="px-3.5 pt-3.5 pb-2 border-b border-gray-50">
           <div className="flex items-center gap-1">

--- a/src/frontend-nextgen/src/components/TaskCards/TaskReadyCard.tsx
+++ b/src/frontend-nextgen/src/components/TaskCards/TaskReadyCard.tsx
@@ -181,7 +181,7 @@ export function TaskReadyCard({ data }: { data: TaskCardData }) {
 
   return (
     <div className="p-1 w-full flex justify-start task-loop-card-root">
-      <div className="w-full max-w-[360px] bg-white border border-gray-100 shadow-md rounded-2xl overflow-hidden transition-all duration-500">
+      <div className="w-full max-w-[420px] bg-white border border-gray-100 shadow-md rounded-2xl overflow-hidden transition-all duration-500">
         {/* Header */}
         <div className="px-3.5 pt-3.5 pb-2 border-b border-gray-50">
           <div className="flex items-center gap-1">

--- a/src/frontend-nextgen/src/components/Workspace/IdentitySelector/BotRegistrationDialog.tsx
+++ b/src/frontend-nextgen/src/components/Workspace/IdentitySelector/BotRegistrationDialog.tsx
@@ -1,5 +1,4 @@
 import {
-  Badge,
   Button,
   Empty,
   Modal,
@@ -68,12 +67,9 @@ export function BotRegistrationDialog({ open, onClose }: BotRegistrationDialogPr
     <Modal open={open} onOpenChange={(next) => !next && onClose()}>
       <ModalContent size="lg" className="min-w-0 p-5">
         <ModalHeader>
-          <Badge tone="primary" className="w-fit">
-            Bot 接入
-          </Badge>
-          <ModalTitle className="text-lg">接入新 Bot</ModalTitle>
+          <ModalTitle className="text-lg">接入外部 Bot</ModalTitle>
           <ModalDescription className="leading-5">
-            选择接入方式，复制命令后在对应环境中执行，即可完成新 Bot 的初始化接入。
+            选择接入方式，复制命令后在对应环境中执行，即可完成外部 Bot 的初始化接入。
           </ModalDescription>
         </ModalHeader>
 

--- a/src/frontend-nextgen/src/components/Workspace/IdentitySelector/index.tsx
+++ b/src/frontend-nextgen/src/components/Workspace/IdentitySelector/index.tsx
@@ -1,9 +1,10 @@
 import { getCapabilities } from '@/capabilities';
 import { Button, Popover, PopoverContent, PopoverTrigger } from '@/components/ui';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/Tooltip';
+import type { HumanIdentityStatus } from '@/hooks/useHumanIdentity';
 import type { Identity } from '@/services/workspace/workspaceModel';
 import { cn } from '@/utils/cn';
-import { ChevronDown, Info, Plus, ShieldCheck } from 'lucide-react';
+import { ChevronDown, Info, Loader2, Plus, ShieldCheck } from 'lucide-react';
 import { useState } from 'react';
 import { BotRegistrationDialog } from './BotRegistrationDialog';
 import { IdentityAvatar, IdentityDetails, IdentitySection } from './IdentitySelectorParts';
@@ -16,6 +17,9 @@ interface WorkspaceIdentitySelectorProps {
   /** 顶栏右侧当前用户头像；所有用户身份复用该头像，Bot 仍使用自身头像。 */
   userAvatarUrl?: string;
   layout?: 'default' | 'sidebar';
+  identityStatus?: HumanIdentityStatus;
+  identityError?: string;
+  identityListLoading?: boolean;
 }
 
 /** Workspace 业务层身份选择器：只消费已映射的 Identity，不直接读取 Store 或调用接口。 */
@@ -26,6 +30,9 @@ export function WorkspaceIdentitySelector({
   onOpenPermissions,
   userAvatarUrl,
   layout = 'default',
+  identityStatus,
+  identityError,
+  identityListLoading,
 }: WorkspaceIdentitySelectorProps) {
   const [open, setOpen] = useState(false);
   const activeIdentity = identities.find((identity) => identity.id === activeId) ?? identities[0] ?? null;
@@ -34,6 +41,8 @@ export function WorkspaceIdentitySelector({
   const sidebarLayout = layout === 'sidebar';
   const botRegistrationEnabled = getCapabilities().getBotRegistrationEnabled().value;
   const [botRegistrationOpen, setBotRegistrationOpen] = useState(false);
+  const showListLoading = identityListLoading || (identities.length === 0 && identityStatus === 'loading');
+  const emptyIdentityLabel = identityStatus === 'error' ? '暂无可协作身份，请刷新重试' : '暂无可协作身份';
 
   return (
     <div className="space-y-1">
@@ -52,7 +61,9 @@ export function WorkspaceIdentitySelector({
                   <Info className="h-3 w-3" aria-hidden />
                 </span>
               </TooltipTrigger>
-              <TooltipContent>当前工作身份决定你以个人或指定 Bot 身份使用工作区各项功能，并影响各菜单中可查看的数据和可执行的操作。</TooltipContent>
+              <TooltipContent>
+                当前工作身份决定你以个人或指定 Bot 身份使用工作区各项功能，并影响各菜单中可查看的数据和可执行的操作。
+              </TooltipContent>
             </Tooltip>
           </div>
         </TooltipProvider>
@@ -74,7 +85,9 @@ export function WorkspaceIdentitySelector({
                   <Info className="h-3.5 w-3.5" aria-hidden />
                 </span>
               </TooltipTrigger>
-              <TooltipContent>当前工作身份决定你以个人或指定 Bot 身份使用工作区各项功能，并影响各菜单中可查看的数据和可执行的操作。</TooltipContent>
+              <TooltipContent>
+                当前工作身份决定你以个人或指定 Bot 身份使用工作区各项功能，并影响各菜单中可查看的数据和可执行的操作。
+              </TooltipContent>
             </Tooltip>
           </div>
         </TooltipProvider>
@@ -120,7 +133,7 @@ export function WorkspaceIdentitySelector({
             >
               <div className="mb-2 flex items-center justify-between gap-2 border-b border-border px-2.5 pb-2">
                 <div className="flex min-w-0 items-center gap-1">
-                  <p className="text-xs font-medium text-foreground">切换协作身份</p>
+                  <p className="text-xs font-medium text-foreground">切换工作身份</p>
                   {!sidebarLayout ? (
                     <TooltipProvider delayDuration={300}>
                       <Tooltip>
@@ -135,7 +148,8 @@ export function WorkspaceIdentitySelector({
                           </span>
                         </TooltipTrigger>
                         <TooltipContent>
-                          当前工作身份决定你以个人或指定 Bot 身份使用工作区各项功能，并影响各菜单中可查看的数据和可执行的操作。
+                          当前工作身份决定你以个人或指定 Bot
+                          身份使用工作区各项功能，并影响各菜单中可查看的数据和可执行的操作。
                         </TooltipContent>
                       </Tooltip>
                     </TooltipProvider>
@@ -179,22 +193,39 @@ export function WorkspaceIdentitySelector({
                   userAvatarUrl={userAvatarUrl}
                 />
                 {identities.length === 0 ? (
-                  <p className="px-2.5 py-4 text-center text-xs text-muted-foreground">暂无可协作身份</p>
+                  <p className="px-2.5 py-4 text-center text-xs text-muted-foreground">{emptyIdentityLabel}</p>
                 ) : null}
               </div>
               {botRegistrationEnabled ? (
-                <div className="mt-2 border-t border-border pt-2">
+                <div className="mt-2 flex items-center gap-1 border-t border-border pt-2">
                   <Button
                     variant="ghost"
-                    className="h-auto w-full justify-start gap-2 rounded-lg px-2.5 py-2 text-left text-xs text-primary hover:bg-accent hover:text-primary"
+                    className="h-auto min-w-0 flex-1 justify-start gap-2 rounded-lg px-2.5 py-2 text-left text-xs text-primary hover:bg-accent hover:text-primary"
                     onClick={() => {
                       setOpen(false);
                       setBotRegistrationOpen(true);
                     }}
                   >
                     <Plus aria-hidden className="h-3.5 w-3.5" />
-                    接入新的 Bot
+                    接入外部 Bot
                   </Button>
+                  <TooltipProvider delayDuration={300}>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span
+                          role="img"
+                          aria-label="接入外部 Bot 说明"
+                          tabIndex={0}
+                          className="inline-flex shrink-0 cursor-help items-center rounded-sm p-1 text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                        >
+                          <Info aria-hidden className="h-3.5 w-3.5" />
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent className="max-w-72">
+                        获取接入指令，将当前平台之外创建的 Bot 接入当前协作网络。
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
                 </div>
               ) : null}
             </PopoverContent>
@@ -203,14 +234,31 @@ export function WorkspaceIdentitySelector({
             <BotRegistrationDialog open={botRegistrationOpen} onClose={() => setBotRegistrationOpen(false)} />
           ) : null}
         </>
+      ) : showListLoading ? (
+        <Button
+          type="button"
+          variant="ghost"
+          disabled
+          aria-live="polite"
+          aria-label="协作身份加载中"
+          className="h-auto min-h-9 w-full justify-between gap-2 rounded-lg border border-border bg-muted/60 px-2.5 py-1.5 text-left text-foreground"
+        >
+          <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-primary/10">
+            <Loader2 className="h-3.5 w-3.5 animate-spin text-primary" aria-hidden />
+          </span>
+          <span className="min-w-0 flex-1 truncate text-left text-xs font-medium">加载中…</span>
+          <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform" aria-hidden />
+        </Button>
       ) : (
         <div
+          role="status"
           className={cn(
             'px-3 py-3 text-center text-xs text-muted-foreground',
             !sidebarLayout && 'rounded-lg border border-dashed border-border',
           )}
         >
-          暂无可协作身份
+          {emptyIdentityLabel}
+          {identityStatus === 'error' && identityError ? <span className="sr-only">{identityError}</span> : null}
         </div>
       )}
     </div>

--- a/src/frontend-nextgen/src/domain/admin/models.ts
+++ b/src/frontend-nextgen/src/domain/admin/models.ts
@@ -9,9 +9,9 @@ export type SpaceType = 'TEAM' | 'PERSONAL' | 'UNKNOWN';
 export type SpaceRole = 'ADMIN' | 'MEMBER' | 'UNKNOWN';
 export type WorkOrderStatus = 'PENDING' | 'APPROVED' | 'REJECTED' | 'UNKNOWN';
 export type WorkOrderItemType = 'APPROVAL' | 'NOTIFICATION' | 'UNKNOWN';
-/** 工单中心三视图（对应顶部分组 tab） */
+/** 通知中心三视图（对应顶部分组 tab） */
 export type WorkOrderView = 'pending_mine' | 'initiated_mine' | 'processed';
-/** 工单中心分类筛选（Segmented 全部/审批类/通知类） */
+/** 通知中心分类筛选（Segmented 全部/审批类/通知类） */
 export type WorkOrderCategory = 'ALL' | 'APPROVAL' | 'NOTIFICATION';
 
 /** 空间加入态（后端 join_status：JOINED/APPLYING/NOT_JOINED） */

--- a/src/frontend-nextgen/src/domain/collaboration/messageViewScope.ts
+++ b/src/frontend-nextgen/src/domain/collaboration/messageViewScope.ts
@@ -1,0 +1,29 @@
+import type { MessageViewScope } from './types';
+
+export interface MessageViewScopeOption {
+  value: MessageViewScope;
+  label: string;
+  description: string;
+}
+
+/** 各入口控件固定默认值（不做本地记忆）。 */
+export const DEFAULT_MESSAGE_VIEW_SCOPE: MessageViewScope = 'full';
+
+/** 两选项控件（下拉菜单 / radio）共用文案。 */
+export const MESSAGE_VIEW_SCOPE_OPTIONS: MessageViewScopeOption[] = [
+  { value: 'full', label: '完整视角', description: '显示本会话内的全部协作消息' },
+  { value: 'participant', label: '参与者视角', description: '仅显示公共及与您相关的消息' },
+];
+
+/** 成员卡标签文案（full → 完整视角；participant → 参与者视角）。 */
+export const MESSAGE_VIEW_SCOPE_LABEL: Record<MessageViewScope, string> = {
+  full: '完整视角',
+  participant: '参与者视角',
+};
+
+/** 「加入当前会话」checkbox 形态文案（视觉稿：加入当前会话按钮效果.png）。 */
+export const PARTICIPANT_ONLY_CHECKBOX = {
+  label: '只看公开及与我相关的消息',
+  hint: '未勾选时，可看到会话内的全部消息。',
+  tooltip: '勾选后将以参与者视角加入：仅接收公共消息、明确发送给你的消息与你自己的消息。',
+} as const;

--- a/src/frontend-nextgen/src/domain/collaboration/types.ts
+++ b/src/frontend-nextgen/src/domain/collaboration/types.ts
@@ -22,6 +22,8 @@ export type SessionStatus = 'running' | 'completed';
 export type SenderKind = 'human' | 'bot' | 'system';
 export type ParticipantRole = 'owner' | 'driver' | 'manager' | 'worker' | 'member';
 export type ParticipantMode = 'auto' | 'muted' | 'present' | 'absent';
+/** 消息可见域：full=完整视角；participant=参与者视角（仅公共/与自己相关/自己的消息）。 */
+export type MessageViewScope = 'full' | 'participant';
 export type DeliveryPolicy = 'send_to_driver' | 'inject_observers';
 
 export interface ParticipantView {
@@ -32,6 +34,8 @@ export interface ParticipantView {
   role: ParticipantRole;
   mode: ParticipantMode;
   online?: boolean;
+  /** 消息可见域回显（只读；bot 恒为 full）。 */
+  messageViewScope?: MessageViewScope;
 }
 export interface SidePanelConfig {
   initializeSidePanel?: boolean;

--- a/src/frontend-nextgen/src/domain/collaborationPrivacy/loadScope.ts
+++ b/src/frontend-nextgen/src/domain/collaborationPrivacy/loadScope.ts
@@ -14,7 +14,7 @@ export type CollaborationPrivacyLoadScope =
    */
   | { target: 'allBots' };
 
-/** Work 区 Bot 身份 ID 可能携带 `:` 后缀（如 `bot-real-1:447147`），比较前归一到 Bot UUID 部分。 */
+/** Work 区 Bot 身份 ID 可能携带 `:` 后缀（如 `bot-real-1:900004`），比较前归一到 Bot UUID 部分。 */
 export function normalizeBotIdentityId(id: string): string {
   const separator = id.indexOf(':');
   return separator >= 0 ? id.slice(0, separator) : id;

--- a/src/frontend-nextgen/src/domain/collaborationSquare/taskMapper.ts
+++ b/src/frontend-nextgen/src/domain/collaborationSquare/taskMapper.ts
@@ -141,7 +141,7 @@ function toTaskOutputText(raw: unknown): string | undefined {
 }
 
 /**
- * 将 BBS 任务列表项（{@link BbsTaskItem}，GET /api/v1/collaboration/tasks/bbs/list 的 data 元素）
+ * 将 BBS 任务列表项（{@link BbsTaskItem}，GET /openapi/v1/collaboration/tasks/bbs/list 的 data 元素）
  * 映射为只读 {@link PublicTask}。
  *
  * 字段映射（确定的）：

--- a/src/frontend-nextgen/src/domain/collaborationSquare/types.ts
+++ b/src/frontend-nextgen/src/domain/collaborationSquare/types.ts
@@ -199,9 +199,9 @@ export interface PublicGroupMember {
 }
 
 export interface HumanBotActionContext {
-  /** Collaboration actor path parameter, for example human_327325. */
+  /** Collaboration actor path parameter, for example human_900003. */
   actorId: string;
-  /** Normalized OpenAPI user_id, for example 327325. */
+  /** Normalized OpenAPI user_id, for example 900003. */
   userId: string;
 }
 

--- a/src/frontend-nextgen/src/domain/tasks/models.ts
+++ b/src/frontend-nextgen/src/domain/tasks/models.ts
@@ -63,7 +63,7 @@ export interface TaskRecord {
   finish_time: string | null;
 }
 
-/** list 接口返回的任务行项（顶层字段 + task_spec，后端 /api/v1/collaboration/tasks/list）。 */
+/** list 接口返回的任务行项（顶层字段 + task_spec，后端 /openapi/v1/collaboration/tasks/list）。 */
 export interface TaskListItem {
   id: number;
   task_id: string;

--- a/src/frontend-nextgen/src/extensions/empty.ts
+++ b/src/frontend-nextgen/src/extensions/empty.ts
@@ -2,7 +2,7 @@ import { registerTaskPanel, TaskPanelAdapter } from '@/assets/TaskPanel';
 import { defaultCapabilities, getCapabilities } from '@/capabilities';
 import { TaskLoopCard } from '@/components/TaskCards';
 import { registerUmdPanelHandler } from '@/services/bcs/UmdPanel';
-import { resolveTaskApiBase } from '@/services/tasks/taskConfig';
+import { TASK_READ_API_BASE } from '@/services/tasks/taskConfig';
 import { ensureReactGlobal } from '@/services/workspace';
 import '@/services/workspace/chatBridge';
 import { useWorkspaceStore } from '@/stores/workspaceStore';
@@ -22,9 +22,9 @@ type SidePanelConfigureFn = (opts: { maxTabLabelLength?: number }) => void;
  *
  * assets 守卫禁止 TaskPanelAdapter 反查 teamclaw 业务层（stores/capabilities/services），故在此 wrapper 注入：
  * - userId：从登录态 human identity 取纯工号塞入 params.userId；params 已带（发起方/后端注入）优先沿用，缺省才回填登录人工号。
- * - taskApiBase：task API 路径前缀由 capability getTaskApiBase 解析（Open Core → /openapi/v1/collaboration/tasks、
- *   内部 overlay → /api/v1/collaboration/tasks），渲染期注入而不落库到持久 params——部署路由随环境变化，
- *   渲染期取当前 capability 最准，旧副屏消息切环境后仍命中正确路由。
+ * - taskApiBase：副屏的 dashboard/list 读接口统一走 /openapi/v1/collaboration/tasks 读公开面
+ *   （前端经 gateway spanner 鉴权），不随 capability 切到内面 /api/v1——对齐后端安全收敛（删除非 openapi 接口，
+ *   仅保留公开面，杜绝公网出口上内部 /api/v1 裸奔）。渲染期注入而不落库到持久 params，旧副屏消息仍命中正确路由。
  *
  * 用 getHumanIdentity 而非 getCurrentOpenApiUserId：后者依赖 activeIdentityId，群聊副屏以 bot 身份
  * 渲染时取不到工号；前者直接从 workspaceStore.identities 取 kind=user 的登录人，不受当前身份影响。
@@ -35,11 +35,11 @@ const TaskPanelAdapterWithUser: ComponentType<PanelContentProps> = (props) => {
   const human = getCapabilities().getHumanIdentity();
   const loginUserId = human.status === 'available' ? human.value?.userId?.trim() || undefined : undefined;
   const incoming = props.params ?? {};
-  // userId：已带沿用，缺省回填登录人工号；taskApiBase：capability 渲染期注入（部署路由随环境取最准）。
+  // userId：已带沿用，缺省回填登录人工号；taskApiBase：读公开面 /openapi/v1（gateway 鉴权），不随 capability 切内面。
   const params = {
     ...incoming,
     userId: incoming.userId ?? loginUserId,
-    taskApiBase: resolveTaskApiBase(),
+    taskApiBase: TASK_READ_API_BASE,
   };
   return React.createElement(TaskPanelAdapter, { ...props, params } as PanelContentProps);
 };

--- a/src/frontend-nextgen/src/hooks/useCreateGroupSessionFlow.ts
+++ b/src/frontend-nextgen/src/hooks/useCreateGroupSessionFlow.ts
@@ -36,7 +36,7 @@ export function useCreateGroupSessionFlow(
         const result = await collaborationSquareGroupService.createGroupSession(
           group.id,
           humanBotContext ?? undefined,
-          { title: values.title, query: values.query },
+          { title: values.title, query: values.query, messageViewScope: values.messageViewScope },
         );
         notifySuccess('会话创建成功');
         setTarget(null);

--- a/src/frontend-nextgen/src/hooks/useHumanIdentity.ts
+++ b/src/frontend-nextgen/src/hooks/useHumanIdentity.ts
@@ -11,6 +11,7 @@
 import type { HumanIdentity } from '@/capabilities';
 import { getCapabilities } from '@/capabilities';
 import { identityService } from '@/services/workspace/identityService';
+import { applyIdentityLoadResult } from '@/services/workspace/identityStore';
 import { useExternalAuthStore } from '@/stores/externalAuthStore';
 import { useWorkspaceStore } from '@/stores/workspaceStore';
 import { useEffect, useState } from 'react';
@@ -77,7 +78,7 @@ export function useHumanIdentity(): UseHumanIdentityResult {
     void identityService.loadIdentities().then((res) => {
       if (cancelled) return;
       if (res.ok) {
-        useWorkspaceStore.getState().setIdentities(res.data.identities, res.data.defaultActiveId);
+        applyIdentityLoadResult(res.data);
       } else {
         setResult({ identity: null, status: 'error', error: res.error.friendlyMessage });
       }

--- a/src/frontend-nextgen/src/hooks/useWorkOrders.ts
+++ b/src/frontend-nextgen/src/hooks/useWorkOrders.ts
@@ -1,4 +1,4 @@
-// useWorkOrders：工单中心三视图 / 分类 / 分页 / 审批 / 通知已读编排。
+// useWorkOrders：通知中心三视图 / 分类 / 分页 / 审批 / 通知已读编排。
 // view/category/pageNo 变化 -> 拉列表；审批后移除并 toast；错误回填 store + toast。
 // user_id 由 workOrderService 内部经 resolveUserId(activeIdentityId) 注入，hook 不再透传 currentUserId。
 

--- a/src/frontend-nextgen/src/pages/Admin/WorkOrders/index.tsx
+++ b/src/frontend-nextgen/src/pages/Admin/WorkOrders/index.tsx
@@ -1,4 +1,4 @@
-// 工单中心视图。容器宽度由 WorkOrderTabs 自带 max-w-[1200px]，此处不再重复包一层（§5）。
+// 通知中心完整视图。容器宽度由 WorkOrderTabs 自带 max-w-[1200px]，此处不再重复包一层（§5）。
 import { WorkOrderTabs } from '@/components/Admin/WorkOrderTabs';
 
 export function AdminWorkOrdersView() {

--- a/src/frontend-nextgen/src/pages/Admin/index.tsx
+++ b/src/frontend-nextgen/src/pages/Admin/index.tsx
@@ -1,8 +1,8 @@
-// 管理后台入口（单页 `/admin` + 顶部下划线 tab：空间管理 / 工单中心）。
+// 管理后台入口（单页 `/admin` + 顶部下划线 tab：空间管理 / 通知中心）。
 // 消费 `?tab=spaces|work-orders` query 切主 tab（PRD 单页意图，视觉规格 §1）。
 // 视觉对齐 PRD：主 tab 为下划线式，位于白色 header 条上；内容区灰底带内边距。
 // 形态级 Tab 可见性经 `getAdminSections` capability 解析：Open Core（阿里云部署）隐藏【空间管理】、
-// 仅留【工单中心】；internal overlay 两 Tab 均在。隐藏 Tab 的深链（?tab=spaces）回落首个可见 Tab。
+// 仅留【通知中心】；internal overlay 两 Tab 均在。隐藏 Tab 的深链（?tab=spaces）回落首个可见 Tab。
 import { getCapabilities } from '@/capabilities';
 import { UnderlineTabs } from '@/components/Admin/Tabs';
 import { useSearchParams } from '@umijs/max';
@@ -14,7 +14,7 @@ type AdminTab = 'spaces' | 'work-orders';
 
 const TAB_OPTIONS: { value: AdminTab; label: string }[] = [
   { value: 'spaces', label: '空间管理' },
-  { value: 'work-orders', label: '工单中心' },
+  { value: 'work-orders', label: '通知中心' },
 ];
 
 const AdminPage: React.FC = () => {

--- a/src/frontend-nextgen/src/pages/BotWorkshop/index.tsx
+++ b/src/frontend-nextgen/src/pages/BotWorkshop/index.tsx
@@ -20,7 +20,7 @@ const BotWorkshopPage: React.FC = () => {
   return (
     <main className="app-scrollbar h-full overflow-y-auto">
       <div className="mx-auto w-full max-w-[1600px] space-y-5 p-4 sm:p-6 2xl:p-8">
-        <PageHeader title="Bot 工坊" description="创建、配置和运维当前空间内的 Bot。" />
+        <PageHeader title="Bot 工坊" description="创建、配置和运维当前空间内的 Bot" />
         <div className="py-3">
           <BotWorkshopToolbar
             keyword={workshop.keyword}

--- a/src/frontend-nextgen/src/pages/CollaborationPrivacy/index.tsx
+++ b/src/frontend-nextgen/src/pages/CollaborationPrivacy/index.tsx
@@ -43,7 +43,7 @@ export default function CollaborationPrivacyPage() {
       <div className="mx-auto max-w-7xl space-y-5 p-4 sm:p-6 lg:p-8">
         <PageHeader
           title="协作权限"
-          description="管理用户信息，以及归属于当前用户的所有 Bot 在 BCN 网络中的各类协作状态及好友审批策略。"
+          description="管理用户信息，以及归属于当前用户的所有 Bot 在 BCN 网络中的各类协作状态及好友审批策略"
         />
         {privacy.loading && <LoadingState />}
         {!privacy.loading && privacy.error && (

--- a/src/frontend-nextgen/src/pages/MyTask/components/MyTaskDrawers.tsx
+++ b/src/frontend-nextgen/src/pages/MyTask/components/MyTaskDrawers.tsx
@@ -3,7 +3,7 @@ import { Drawer, DrawerContent } from '@/components/ui/Drawer';
 import { Empty } from '@/components/ui/Empty';
 import type { TaskListItem } from '@/domain/tasks/models';
 import type { ScheduledRoutineRecord, ScheduledRoutineRunRecord } from '@/services/scheduledTasks';
-import { TASK_API_BASE, resolveTaskApiBase } from '@/services/tasks/taskConfig';
+import { TASK_API_BASE, TASK_READ_API_BASE } from '@/services/tasks/taskConfig';
 import { getBotDisplayName, getUserTaskSourceLabel, getUserTaskTypeLabel } from '../userTaskUtils';
 import { MyTaskRoutineDrawer } from './MyTaskRoutineDrawer';
 import { MyTaskRoutineHistoryDrawer } from './MyTaskRoutineHistoryDrawer';
@@ -82,7 +82,7 @@ export function MyTaskDrawers({
             {selectedTaskId ? (
               <TaskPanel
                 apiBaseUrl={TASK_API_BASE}
-                taskApiBase={resolveTaskApiBase()}
+                taskApiBase={TASK_READ_API_BASE}
                 bcsBaseUrl=""
                 userId={ownerUserId}
                 taskId={selectedTaskId}

--- a/src/frontend-nextgen/src/pages/Workspace/GroupWorkspaceArea.tsx
+++ b/src/frontend-nextgen/src/pages/Workspace/GroupWorkspaceArea.tsx
@@ -1,6 +1,7 @@
 import { getCapabilities } from '@/capabilities';
 import { Drawer, DrawerContent, DrawerTitle } from '@/components/ui';
 import type { WorkspaceView } from '@/domain/collaboration/availableViews';
+import type { MessageViewScope } from '@/domain/collaboration/types';
 import type { GroupPanelKind } from '@/pages/Workspace/components/GroupHeader';
 import { sessionService } from '@/services/workspace/sessionService';
 import { useWorkspaceStore } from '@/stores/workspaceStore';
@@ -62,8 +63,7 @@ export function GroupWorkspaceArea({
   const sessionTabsByGroup = useWorkspaceStore((s) => s.sessionTabsByGroup);
   const setSessionTabForGroup = useWorkspaceStore((s) => s.setSessionTabForGroup);
 
-  const selectedGroup = ws.selectedGroup;
-  const canManage = ws.canManageGroup;
+  const { selectedGroup, canManageGroup: canManage } = ws;
 
   // 管理面板打开期间跟随选中群补拉详情：打开面板（齿轮/「…」菜单）或面板保持打开时切群，
   // 都会为新选中群拉取 participants 等详情；否则列表项 participants 为空且 participantCount>0，
@@ -114,7 +114,8 @@ export function GroupWorkspaceArea({
           error: { code: 'GROUP_MISSING', friendlyMessage: '未选择协作群', canRetry: false },
         });
   const handleShareSession = () => sessionManage.createShare();
-  const handleCreateSession = (groupId: string) => void sessions.createSessionIn(groupId);
+  const handleCreateSession = (groupId: string, scope?: MessageViewScope) =>
+    void sessions.createSessionIn(groupId, undefined, undefined, scope);
   const handleCreateGroup = () => createGroupDialog.openModal();
   // 侧栏「…」菜单：群管理（选中该群并打开管理面板；详情由上方 effect 按需补拉）。
   const handleManageGroup = (groupId: string) => {
@@ -122,9 +123,7 @@ export function GroupWorkspaceArea({
     setActivePanel('manage');
   };
   // 头部齿轮切面板：打开群管理时详情由上方 effect 按需补拉。
-  const handleTogglePanel = (panel: GroupPanelKind) => {
-    setActivePanel(panel);
-  };
+  const handleTogglePanel = (panel: GroupPanelKind) => setActivePanel(panel);
   const handleManageSession = (groupId: string, sessionId: string) => {
     void ws.onSelectGroup(groupId);
     sessions.openSession(groupId, sessionId);
@@ -143,6 +142,8 @@ export function GroupWorkspaceArea({
   const groupSidebarProps: GroupSidebarProps = {
     view,
     onViewChange,
+    // 身份未加载完成（null）时按 human 兜底展示视角菜单。
+    viewerKind: ws.activeIdentity?.kind === 'bot' ? 'bot' : 'user',
     availableViews,
     groups: ws.groups,
     isLoading: ws.isLoadingGroups,
@@ -210,6 +211,7 @@ export function GroupWorkspaceArea({
         session={sessions.selectedSession}
         activeIdentity={ws.activeIdentity}
         updateMemberMode={sessions.updateMemberMode}
+        updateMemberScope={sessions.updateMemberScope}
         panelRef={chat.panelRef}
         chatBridge={chat.chatBridge}
         chat={chat.chat}

--- a/src/frontend-nextgen/src/pages/Workspace/InviteAcceptPanel.tsx
+++ b/src/frontend-nextgen/src/pages/Workspace/InviteAcceptPanel.tsx
@@ -1,4 +1,7 @@
+import { MessageViewScopeField } from '@/components/MessageViewScope';
 import { Button, Empty, Spin } from '@/components/ui';
+import { DEFAULT_MESSAGE_VIEW_SCOPE } from '@/domain/collaboration/messageViewScope';
+import type { MessageViewScope } from '@/domain/collaboration/types';
 import { useInviteAccept } from '@/pages/Workspace/hooks/useInviteAccept';
 import { Sparkles } from 'lucide-react';
 import { useEffect, useState } from 'react';
@@ -21,6 +24,8 @@ export function InviteAcceptPanel() {
   const { status, friendlyMessage, targetType, targetId, groupId, alreadyJoined, accept, resetToConfirm } =
     useInviteAccept(token);
   const targetLabel = inviteType === 'session' ? '该会话' : '该协作群';
+  // 确认页可选消息视角，accept 时透传给邀请接受接口。
+  const [viewScope, setViewScope] = useState<MessageViewScope>(DEFAULT_MESSAGE_VIEW_SCOPE);
 
   // accepted 状态下做一次导航副作用（写在 effect 里避免渲染中途触发路由跳转）。
   const [navigated, setNavigated] = useState(false);
@@ -113,10 +118,13 @@ export function InviteAcceptPanel() {
           ? '加入后将作为成员参与该会话的对话与资源协作，可随时退出。'
           : '加入后将作为成员参与该协作群的对话与资源协作，可随时退出。'}
       </p>
+      <div className="w-full">
+        <MessageViewScopeField value={viewScope} onChange={setViewScope} />
+      </div>
       <Button
         size="lg"
         onClick={() => {
-          void accept();
+          void accept(viewScope);
         }}
       >
         确认加入

--- a/src/frontend-nextgen/src/pages/Workspace/components/GroupChatPane/CollabPanel.tsx
+++ b/src/frontend-nextgen/src/pages/Workspace/components/GroupChatPane/CollabPanel.tsx
@@ -1,3 +1,4 @@
+import { MessageViewScopeCheckbox } from '@/components/MessageViewScope';
 import { Button, Segmented } from '@/components/ui';
 import {
   AlertDialog,
@@ -9,9 +10,10 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/AlertDialog';
+import type { MessageViewScope } from '@/domain/collaboration/types';
 import type { CollabPanelState } from '@/pages/Workspace/hooks/useCollabPanel';
 import { Loader2, UserPlus } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { BotControlRow } from './BotControlRow';
 import { LeaveBar } from './LeaveBar';
 
@@ -67,7 +69,7 @@ function HumanJoinedRow({
   );
 }
 
-/** 加入会话二次确认（与群内解散群等破坏性/身份变更操作一致的确认规范）。 */
+/** 加入会话二次确认（含消息可见域选择，视觉稿：加入当前会话按钮效果.png）。 */
 function JoinConfirmDialog({
   open,
   onOpenChange,
@@ -78,19 +80,32 @@ function JoinConfirmDialog({
   open: boolean;
   onOpenChange: (v: boolean) => void;
   joining: boolean;
-  onConfirm: () => void;
+  onConfirm: (scope: MessageViewScope) => void;
   humanName: string;
 }) {
+  const [participantOnly, setParticipantOnly] = useState(false);
+  // 每次打开重置为未勾选（默认完整视角，不做记忆）。
+  useEffect(() => {
+    if (open) setParticipantOnly(false);
+  }, [open]);
   return (
     <AlertDialog open={open} onOpenChange={onOpenChange}>
       <AlertDialogContent>
         <AlertDialogHeader>
           <AlertDialogTitle>加入当前会话</AlertDialogTitle>
-          <AlertDialogDescription>加入后，{humanName}将参与本会话协作，可以直接发言。</AlertDialogDescription>
+          <AlertDialogDescription>确认后：您的所有发言将以用户身份（{humanName}）发送。</AlertDialogDescription>
         </AlertDialogHeader>
+        <div className="space-y-3">
+          <MessageViewScopeCheckbox checked={participantOnly} onCheckedChange={setParticipantOnly} disabled={joining} />
+          <div className="rounded-lg bg-muted px-3 py-2.5 text-xs leading-5 text-muted-foreground">
+            <p className="font-medium text-foreground">其他须知：</p>
+            <p className="mt-1">· 您可与主节点Bot进行对话，由主节点Bot负责任务分发、状态推进、质量核验</p>
+            <p className="mt-1">· 勾选参与者视角后将过滤协作内部消息；切换到您拥有的 Bot 视角不受影响</p>
+          </div>
+        </div>
         <AlertDialogFooter>
           <AlertDialogCancel>取消</AlertDialogCancel>
-          <AlertDialogAction onClick={onConfirm} disabled={joining}>
+          <AlertDialogAction onClick={() => onConfirm(participantOnly ? 'participant' : 'full')} disabled={joining}>
             {joining ? '加入中…' : '确认加入'}
           </AlertDialogAction>
         </AlertDialogFooter>
@@ -124,7 +139,14 @@ export function CollabPanel({ panel }: CollabPanelProps) {
     };
     return (
       <div className="border-t border-border bg-background px-3 pb-2 pt-2 sm:px-6">
-        <LeaveBar humanName={panel.humanName} onLeave={handleLeave} leaving={leaving} />
+        <LeaveBar
+          humanName={panel.humanName}
+          onLeave={handleLeave}
+          leaving={leaving}
+          viewScope={panel.humanViewScope}
+          switchingViewScope={panel.switchingViewScope}
+          onViewScopeChange={(scope) => void panel.setViewScope(scope)}
+        />
       </div>
     );
   }
@@ -138,8 +160,8 @@ export function CollabPanel({ panel }: CollabPanelProps) {
           open={confirmJoin}
           onOpenChange={setConfirmJoin}
           joining={panel.joining}
-          onConfirm={() => {
-            void panel.joinSession().then((ok) => {
+          onConfirm={(scope) => {
+            void panel.joinSession(scope).then((ok) => {
               if (ok) setConfirmJoin(false);
             });
           }}
@@ -149,8 +171,8 @@ export function CollabPanel({ panel }: CollabPanelProps) {
     );
   }
 
-  const join = () => {
-    void panel.joinSession().then((ok) => {
+  const join = (scope: MessageViewScope) => {
+    void panel.joinSession(scope).then((ok) => {
       if (ok) setConfirmJoin(false);
     });
   };

--- a/src/frontend-nextgen/src/pages/Workspace/components/GroupChatPane/GroupChatPane.types.ts
+++ b/src/frontend-nextgen/src/pages/Workspace/components/GroupChatPane/GroupChatPane.types.ts
@@ -1,4 +1,5 @@
 import type { GroupView, IdentityView, ParticipantMode, SessionView } from '@/domain/collaboration';
+import type { MessageViewScope } from '@/domain/collaboration/types';
 import type { SessionMessageAttachment } from '@/services/workspace/groupChatAttachmentService';
 import type { GroupChatState } from '@/services/workspace/groupChatProvider';
 import type { PolicyResult } from '@/services/workspace/groupService';
@@ -16,6 +17,8 @@ export interface GroupChatPaneProps {
   activeIdentity?: IdentityView | null;
   /** 会话成员 mode 更新出口（PATCH participants/{actor}），经由会话 Hook 注入。 */
   updateMemberMode?: (sessionId: string, actorId: string, mode: ParticipantMode) => Promise<boolean>;
+  /** 会话成员消息可见域更新出口（PATCH participants/{actor} 仅带 scope），经由会话 Hook 注入。 */
+  updateMemberScope?: (sessionId: string, actorId: string, scope: MessageViewScope) => Promise<boolean>;
   chat: UseChatResult<unknown>;
   /** 建群后 Driver/Manager 尚未产生第一条消息时的瞬态处理状态。 */
   groupBootstrapProcessing?: boolean;

--- a/src/frontend-nextgen/src/pages/Workspace/components/GroupChatPane/LeaveBar.tsx
+++ b/src/frontend-nextgen/src/pages/Workspace/components/GroupChatPane/LeaveBar.tsx
@@ -1,15 +1,26 @@
+import { MessageViewScopeBadge } from '@/components/MessageViewScope';
 import { Badge, Button } from '@/components/ui';
-import { Loader2, LogOut, Volume2 } from 'lucide-react';
+import type { MessageViewScope } from '@/domain/collaboration/types';
+import { Eye, EyeOff, Loader2, LogOut, Volume2 } from 'lucide-react';
 
 /** 「在会话中隐身」条（human 视角 present 态，显示在聊天输入框上方）。 */
 export function LeaveBar({
   humanName,
   onLeave,
   leaving,
+  viewScope,
+  switchingViewScope,
+  onViewScopeChange,
 }: {
   humanName: string;
   onLeave: () => void;
   leaving: boolean;
+  /** human 成员消息可见域回显；缺失（null/undefined）时不渲染视角切换按钮与视角 Badge。 */
+  viewScope?: MessageViewScope | null;
+  /** 视角切换请求进行中（禁用切换按钮）。 */
+  switchingViewScope?: boolean;
+  /** 切换消息可见域（参与者视角 ↔ 完整视角），参数为目标 scope。 */
+  onViewScopeChange?: (scope: MessageViewScope) => void;
 }) {
   return (
     <div className="flex items-center justify-between py-1.5">
@@ -21,20 +32,45 @@ export function LeaveBar({
             <Badge tone="success" className="ml-1 align-middle">
               用户发言模式
             </Badge>
+            {viewScope ? (
+              <span className="ml-1 align-middle">
+                <MessageViewScopeBadge scope={viewScope} />
+              </span>
+            ) : null}
           </p>
           <p className="mt-0.5 text-xs leading-tight text-muted-foreground">以用户身份发言中，可随时隐身退出。</p>
         </div>
       </div>
-      <Button
-        size="sm"
-        variant="ghost"
-        disabled={leaving}
-        onClick={onLeave}
-        className="shrink-0 border border-border text-muted-foreground hover:border-destructive/30 hover:text-destructive"
-      >
-        {leaving ? <Loader2 className="h-4 w-4 animate-spin" /> : <LogOut className="h-4 w-4" />}
-        在会话中隐身
-      </Button>
+      <div className="flex shrink-0 items-center gap-3">
+        <Button
+          size="sm"
+          variant="ghost"
+          disabled={leaving}
+          onClick={onLeave}
+          className="shrink-0 border border-border text-muted-foreground hover:border-destructive/30 hover:text-destructive"
+        >
+          {leaving ? <Loader2 className="h-4 w-4 animate-spin" /> : <LogOut className="h-4 w-4" />}
+          在会话中隐身
+        </Button>
+        {viewScope && onViewScopeChange ? (
+          <Button
+            size="sm"
+            variant="ghost"
+            disabled={switchingViewScope}
+            onClick={() => onViewScopeChange(viewScope === 'full' ? 'participant' : 'full')}
+            className="shrink-0 border border-border text-muted-foreground hover:border-primary/30 hover:text-primary"
+          >
+            {switchingViewScope ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : viewScope === 'full' ? (
+              <EyeOff className="h-4 w-4" />
+            ) : (
+              <Eye className="h-4 w-4" />
+            )}
+            {viewScope === 'full' ? '切换到参与者视角' : '切换到完整视角'}
+          </Button>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/src/frontend-nextgen/src/pages/Workspace/components/GroupChatPane/index.tsx
+++ b/src/frontend-nextgen/src/pages/Workspace/components/GroupChatPane/index.tsx
@@ -30,6 +30,7 @@ export function GroupChatPane(props: GroupChatPaneProps) {
     session,
     activeIdentity,
     updateMemberMode,
+    updateMemberScope,
     chat,
     supportState,
     connectionStatus,
@@ -64,6 +65,7 @@ export function GroupChatPane(props: GroupChatPaneProps) {
     updateMemberMode ?? (() => Promise.resolve(false)),
     userIdentityId,
     userIdentityName,
+    updateMemberScope,
   );
 
   const messages = (chat.messages ?? []).filter(

--- a/src/frontend-nextgen/src/pages/Workspace/components/GroupSidebar/GroupItem.tsx
+++ b/src/frontend-nextgen/src/pages/Workspace/components/GroupSidebar/GroupItem.tsx
@@ -1,3 +1,4 @@
+import { MessageViewScopeMenuButton } from '@/components/MessageViewScope';
 import { Button, IconButton } from '@/components/ui';
 import {
   AlertDialog,
@@ -25,6 +26,7 @@ export type { SessionTab } from './GroupItem.types';
 
 export const GroupItem = React.memo(function GroupItem({
   group,
+  viewerKind,
   expanded,
   sessions,
   sessionTab,
@@ -149,16 +151,20 @@ export const GroupItem = React.memo(function GroupItem({
             </TooltipProvider>
           </div>
         </Button>
-        <IconButton
-          label="新建会话"
-          size="sm"
-          icon={<Plus className="h-4 w-4" />}
-          className="rounded-md text-muted-foreground hover:bg-primary/10 hover:text-primary"
-          onClick={(event) => {
-            event.stopPropagation();
-            onCreateSession(group.groupId);
-          }}
-        />
+        {viewerKind === 'user' ? (
+          <MessageViewScopeMenuButton onSelect={(scope) => onCreateSession(group.groupId, scope)} />
+        ) : (
+          <IconButton
+            label="新建会话"
+            size="sm"
+            icon={<Plus className="h-4 w-4" />}
+            className="rounded-md text-muted-foreground hover:bg-primary/10 hover:text-primary"
+            onClick={(event) => {
+              event.stopPropagation();
+              onCreateSession(group.groupId);
+            }}
+          />
+        )}
         <SessionScopeFilter
           value={sessionTab}
           onChange={handleSessionScopeChange}

--- a/src/frontend-nextgen/src/pages/Workspace/components/GroupSidebar/GroupItem.types.ts
+++ b/src/frontend-nextgen/src/pages/Workspace/components/GroupSidebar/GroupItem.types.ts
@@ -1,4 +1,4 @@
-import type { GroupView, SessionView } from '@/domain/collaboration/types';
+import type { GroupView, MessageViewScope, SessionView } from '@/domain/collaboration/types';
 import type { DomainResult } from '@/services/workspace/identityService';
 
 export type SessionTab = 'all' | 'favorite';
@@ -16,7 +16,9 @@ export interface GroupItemProps {
   onToggleGroupExpanded: (groupId: string) => void;
   onSelectSession: (groupId: string, sessionId: string) => void;
   onToggleFavorite: (sessionId: string) => void;
-  onCreateSession: (groupId: string) => void;
+  onCreateSession: (groupId: string, scope?: MessageViewScope) => void;
+  /** 当前登录身份类型：human 点「+」弹视角菜单，bot 直接创建会话。 */
+  viewerKind: 'user' | 'bot';
   onManageGroup: (groupId: string) => void;
   onManageSession: (groupId: string, sessionId: string) => void;
   onShareGroup: (groupId: string) => Promise<DomainResult<{ invitationUrl: string }>>;

--- a/src/frontend-nextgen/src/pages/Workspace/components/GroupSidebar/index.tsx
+++ b/src/frontend-nextgen/src/pages/Workspace/components/GroupSidebar/index.tsx
@@ -1,6 +1,6 @@
 import { Button, Empty, Input, Skeleton } from '@/components/ui';
 import type { WorkspaceView } from '@/domain/collaboration/availableViews';
-import type { GroupView, SessionView } from '@/domain/collaboration/types';
+import type { GroupView, MessageViewScope, SessionView } from '@/domain/collaboration/types';
 import type { DomainResult } from '@/services/workspace/identityService';
 import { Search } from 'lucide-react';
 import { ListErrorState } from '../ListErrorState';
@@ -16,6 +16,8 @@ export type SessionTab = 'all' | 'favorite';
 export interface GroupSidebarProps {
   view: 'chat' | 'group';
   onViewChange: (v: 'chat' | 'group') => void;
+  /** 当前登录身份类型：human 点「+」弹视角菜单，bot 直接创建会话。 */
+  viewerKind: 'user' | 'bot';
   /** 当前身份可见视图；Bot 仅协作群时不再渲染「会话」切换项。 */
   availableViews?: WorkspaceView[];
   groups: GroupView[];
@@ -49,7 +51,7 @@ export interface GroupSidebarProps {
   selectedGroupId: string | null;
   selectedSessionId: string | null;
   onSelectSession: (groupId: string, sessionId: string) => void;
-  onCreateSession: (groupId: string) => void;
+  onCreateSession: (groupId: string, scope?: MessageViewScope) => void;
   onToggleFavorite: (sessionId: string) => void;
   onClearSessionFilter: () => void;
   onCreateGroup: () => void;
@@ -68,6 +70,7 @@ export function GroupSidebarList(props: GroupSidebarProps) {
   const {
     view,
     onViewChange,
+    viewerKind,
     availableViews: availableViewsProp,
     groups,
     isLoading,
@@ -176,45 +179,41 @@ export function GroupSidebarList(props: GroupSidebarProps) {
             />
           )
         ) : (
-          <>
-            <div className="flex min-h-9 items-center border-b border-border/70 bg-muted/10 px-[18px] py-2 text-xs font-medium text-foreground">
-              协作群 ({groups.length})
-            </div>
-            <div className="divide-y divide-border/70 overflow-hidden border-b border-border bg-muted/10">
-              {groups.map((group) => {
-                const sessions = sessionsByGroupId[group.groupId];
-                return (
-                  <GroupItem
-                    key={group.groupId}
-                    group={group}
-                    expanded={!!expandedGroupIds[group.groupId]}
-                    sessions={sessions}
-                    sessionTab={sessionTabsByGroup[group.groupId] ?? 'all'}
-                    onSessionTabChange={(t) => onSessionTabForGroup(group.groupId, t)}
-                    favoriteSessionIds={favoriteSessionIds}
-                    selectedGroupId={selectedGroupId}
-                    selectedSessionId={selectedSessionId}
-                    onSelectGroup={onSelectGroup}
-                    onToggleGroupExpanded={onToggleGroupExpanded}
-                    onSelectSession={onSelectSession}
-                    onToggleFavorite={onToggleFavorite}
-                    onCreateSession={onCreateSession}
-                    onManageGroup={onManageGroup}
-                    onManageSession={onManageSession}
-                    onShareGroup={onShareGroup}
-                    onDissolveGroup={onDissolveGroup}
-                    totalSessionCount={totalSessionsByGroupId[group.groupId]}
-                    hasMoreSessions={hasMoreSessionsByGroupId[group.groupId] ?? false}
-                    isLoadingMoreSessions={isLoadingMoreSessionsByGroupId[group.groupId] ?? false}
-                    error={errorByGroupId[group.groupId]}
-                    loadMoreError={loadMoreErrorByGroupId[group.groupId]}
-                    onRetrySessions={() => onReloadSession?.(group.groupId) ?? Promise.resolve()}
-                    onLoadMoreSessions={() => onLoadMoreSessions(group.groupId)}
-                  />
-                );
-              })}
-            </div>
-          </>
+          <div className="divide-y divide-border/70 overflow-hidden border-b border-border bg-muted/10">
+            {groups.map((group) => {
+              const sessions = sessionsByGroupId[group.groupId];
+              return (
+                <GroupItem
+                  key={group.groupId}
+                  group={group}
+                  viewerKind={viewerKind}
+                  expanded={!!expandedGroupIds[group.groupId]}
+                  sessions={sessions}
+                  sessionTab={sessionTabsByGroup[group.groupId] ?? 'all'}
+                  onSessionTabChange={(t) => onSessionTabForGroup(group.groupId, t)}
+                  favoriteSessionIds={favoriteSessionIds}
+                  selectedGroupId={selectedGroupId}
+                  selectedSessionId={selectedSessionId}
+                  onSelectGroup={onSelectGroup}
+                  onToggleGroupExpanded={onToggleGroupExpanded}
+                  onSelectSession={onSelectSession}
+                  onToggleFavorite={onToggleFavorite}
+                  onCreateSession={onCreateSession}
+                  onManageGroup={onManageGroup}
+                  onManageSession={onManageSession}
+                  onShareGroup={onShareGroup}
+                  onDissolveGroup={onDissolveGroup}
+                  totalSessionCount={totalSessionsByGroupId[group.groupId]}
+                  hasMoreSessions={hasMoreSessionsByGroupId[group.groupId] ?? false}
+                  isLoadingMoreSessions={isLoadingMoreSessionsByGroupId[group.groupId] ?? false}
+                  error={errorByGroupId[group.groupId]}
+                  loadMoreError={loadMoreErrorByGroupId[group.groupId]}
+                  onRetrySessions={() => onReloadSession?.(group.groupId) ?? Promise.resolve()}
+                  onLoadMoreSessions={() => onLoadMoreSessions(group.groupId)}
+                />
+              );
+            })}
+          </div>
         )}
       </div>
     </div>

--- a/src/frontend-nextgen/src/pages/Workspace/components/ManagePanel/MemberList.tsx
+++ b/src/frontend-nextgen/src/pages/Workspace/components/ManagePanel/MemberList.tsx
@@ -1,3 +1,4 @@
+import { MessageViewScopeBadge } from '@/components/MessageViewScope';
 import { Badge, Button, IconButton, Skeleton } from '@/components/ui';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import type { GroupView, IdentityView, ParticipantView } from '@/domain/collaboration';
@@ -150,6 +151,9 @@ export function MemberList({
                     <Badge tone={getRoleTone(participant, groupKind)}>{getRoleLabel(participant, groupKind)}</Badge>
                     {showMode && getModeLabel(participant) ? (
                       <Badge tone={getModeTone(participant)}>{getModeLabel(participant)}</Badge>
+                    ) : null}
+                    {participant.kind === 'human' && participant.messageViewScope ? (
+                      <MessageViewScopeBadge scope={participant.messageViewScope} />
                     ) : null}
                   </div>
                 </div>

--- a/src/frontend-nextgen/src/pages/Workspace/components/Modals/CreateGroupModal.tsx
+++ b/src/frontend-nextgen/src/pages/Workspace/components/Modals/CreateGroupModal.tsx
@@ -13,6 +13,7 @@ import { BindingSlot, YamlValidateButton } from './BindingSlot';
 import { CollaborationFlowAside } from './CollaborationFlowAside';
 import { CollaborationTemplatePicker } from './CollaborationTemplatePicker';
 import { CreateGroupHeader } from './CreateGroupHeader';
+import { CreateGroupViewScope, useCreateGroupViewScope } from './CreateGroupViewScope';
 import { GroupConfigFields, type GroupStrategyKind } from './GroupConfigFields';
 import type { GroupLeaderOption } from './GroupLeaderSelect';
 import { formatAutoGroupName } from './groupNaming';
@@ -39,6 +40,7 @@ export function CreateGroupModal({
   onCreated,
 }: CreateGroupModalProps) {
   const { run, friendlyError, creating, clearError } = useCreateGroup();
+  const { viewScope, changeViewScope, applyViewScope } = useCreateGroupViewScope(open, clearError);
   const picker = useGroupCollaborationPicker(activeIdentity?.id, open, activeIdentity?.kind === 'user');
   const [kind, setKind] = useState<GroupStrategyKind>('free_chat');
   const [name, setName] = useState('');
@@ -184,9 +186,7 @@ export function CreateGroupModal({
       memberIds = [currentHuman, effectiveLeader, ...botUuids].filter((id): id is string => Boolean(id));
     }
     const participantIds = Array.from(new Set(memberIds));
-    const participants = participantIds.map((id) => ({ actor_id: id }));
-    const participantName = (id: string) =>
-      id === activeIdentity?.id ? activeIdentityDisplayName : allBotName(id);
+    const participantName = (id: string) => (id === activeIdentity?.id ? activeIdentityDisplayName : allBotName(id));
     const participantBindingsArr = Object.entries(binding.participantBindings)
       .filter(([, botId]) => Boolean(botId))
       .map(([binding, botId]) => ({ binding, actor_ids: [botId] }));
@@ -198,7 +198,7 @@ export function CreateGroupModal({
         definitionYaml,
         driverBotUuid: effectiveLeader,
         originator: activeIdentity?.id ?? '',
-        participants,
+        participants: applyViewScope(participantIds, currentHuman),
         context: context.trim() || undefined,
         participantBindings: kind === 'task_dag' ? participantBindingsArr : undefined,
       },
@@ -258,6 +258,7 @@ export function CreateGroupModal({
                 binding.yamlValidation.invalidate();
               }}
             />
+            <CreateGroupViewScope activeIdentity={activeIdentity} value={viewScope} onChange={changeViewScope} />
 
             {(kind !== 'task_dag' || binding.yamlValidation.isValidated) && (
               <GroupParticipantPicker

--- a/src/frontend-nextgen/src/pages/Workspace/components/Modals/CreateGroupViewScope.tsx
+++ b/src/frontend-nextgen/src/pages/Workspace/components/Modals/CreateGroupViewScope.tsx
@@ -1,0 +1,65 @@
+import { MessageViewScopeField } from '@/components/MessageViewScope';
+import type { IdentityView } from '@/domain/collaboration';
+import { DEFAULT_MESSAGE_VIEW_SCOPE } from '@/domain/collaboration/messageViewScope';
+import type { MessageViewScope } from '@/domain/collaboration/types';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export interface CreateGroupViewScopeProps {
+  activeIdentity?: IdentityView | null;
+  value: MessageViewScope;
+  onChange: (scope: MessageViewScope) => void;
+}
+
+/**
+ * 建群面板的「消息视角」radio —— 仅 human（kind==='user'）身份展示。
+ * bot 身份建群不显示；后端默认会话视角仅对 human 建群链路生效。
+ */
+export function CreateGroupViewScope({ activeIdentity, value, onChange }: CreateGroupViewScopeProps) {
+  if (activeIdentity?.kind !== 'user') return null;
+  return <MessageViewScopeField value={value} onChange={onChange} />;
+}
+
+export interface UseCreateGroupViewScopeResult {
+  /** 当前选择的默认会话消息视角（human 建群时挂到 participants 的 human 条目）。 */
+  viewScope: MessageViewScope;
+  /** radio 变更入口：清空 Modal inline 错误后更新视角。 */
+  changeViewScope: (scope: MessageViewScope) => void;
+  /** 提交组装：为 human（currentHuman）参与者条目附加 message_view_scope，其余条目原样。 */
+  applyViewScope: (
+    participantIds: string[],
+    currentHuman: string | null,
+  ) => Array<{ actor_id: string; message_view_scope?: MessageViewScope }>;
+}
+
+/**
+ * 建群面板视角选择的状态管理：弹窗打开时重置为默认值（full，与其他入口一致，不做本地记忆）。
+ * 从 CreateGroupModal 抽出以遵守 Component ≤300 行的文件体积门禁。
+ */
+export function useCreateGroupViewScope(open: boolean, clearError: () => void): UseCreateGroupViewScopeResult {
+  const [viewScope, setViewScope] = useState<MessageViewScope>(DEFAULT_MESSAGE_VIEW_SCOPE);
+  const wasOpenRef = useRef(false);
+
+  useEffect(() => {
+    const opening = open && !wasOpenRef.current;
+    wasOpenRef.current = open;
+    if (opening) setViewScope(DEFAULT_MESSAGE_VIEW_SCOPE);
+  }, [open]);
+
+  const changeViewScope = useCallback(
+    (scope: MessageViewScope) => {
+      clearError();
+      setViewScope(scope);
+    },
+    [clearError],
+  );
+
+  const applyViewScope = useCallback(
+    (participantIds: string[], currentHuman: string | null) =>
+      participantIds.map((id) =>
+        id === currentHuman ? { actor_id: id, message_view_scope: viewScope } : { actor_id: id },
+      ),
+    [viewScope],
+  );
+
+  return { viewScope, changeViewScope, applyViewScope };
+}

--- a/src/frontend-nextgen/src/pages/Workspace/hooks/useCollabPanel.ts
+++ b/src/frontend-nextgen/src/pages/Workspace/hooks/useCollabPanel.ts
@@ -1,4 +1,5 @@
 import type { IdentityView, ParticipantMode, ParticipantView, SessionView } from '@/domain/collaboration';
+import type { MessageViewScope } from '@/domain/collaboration/types';
 import { isSameHumanIdentity } from '@/domain/userIdentity';
 import { useWorkspaceStore } from '@/stores/workspaceStore';
 import { useCallback, useMemo, useRef, useState } from 'react';
@@ -22,12 +23,18 @@ export interface CollabPanelState {
   canSwitchToHuman: boolean;
   switchingBotMode: boolean;
   joining: boolean;
+  /** human 成员的消息可见域回显（后端未返回时为 null，UI 不渲染切换控件）。 */
+  humanViewScope: MessageViewScope | null;
+  /** 消息视角切换请求进行中（禁用 Switch）。 */
+  switchingViewScope: boolean;
   setBotMode: (mode: 'auto' | 'muted') => Promise<void>;
-  joinSession: () => Promise<boolean>;
+  joinSession: (scope?: MessageViewScope) => Promise<boolean>;
   /** 退出当前会话（将 human mode 置为 absent）。 */
   leaveSession: () => Promise<boolean>;
   /** 切换到用户视角继续发言（对齐 open-claw「去发言」）。 */
   switchToHuman: () => void;
+  /** 仅切换 human 成员消息可见域；成功后触发 ws 整体重连（重拉一次性 token）。 */
+  setViewScope: (scope: MessageViewScope) => Promise<boolean>;
 }
 
 /**
@@ -42,12 +49,19 @@ export interface CollabPanelState {
 export function useCollabPanel(
   session: SessionView | null,
   activeIdentity: IdentityView | null,
-  updateMemberMode: (sessionId: string, actorId: string, mode: ParticipantMode) => Promise<boolean>,
+  updateMemberMode: (
+    sessionId: string,
+    actorId: string,
+    mode: ParticipantMode,
+    messageViewScope?: MessageViewScope,
+  ) => Promise<boolean>,
   authenticatedUserId?: string | null,
   authenticatedUserName?: string | null,
+  updateMemberScope?: (sessionId: string, actorId: string, scope: MessageViewScope) => Promise<boolean>,
 ): CollabPanelState {
   const [switchingBotMode, setSwitchingBotMode] = useState(false);
   const [joining, setJoining] = useState(false);
+  const [switchingViewScope, setSwitchingViewScope] = useState(false);
 
   const isBotViewer = activeIdentity?.kind === 'bot';
   const botActorId = isBotViewer ? activeIdentity?.id ?? null : null;
@@ -146,25 +160,28 @@ export function useCollabPanel(
     [session, botActorId, botMode, updateMemberMode],
   );
 
-  const joinSession = useCallback(async (): Promise<boolean> => {
-    if (!session) return false;
-    const actorId = human?.actorId ?? humanActorId;
-    if (!actorId) {
-      toast.error('未找到用户身份，请稍后重试');
-      return false;
-    }
-    setJoining(true);
-    try {
-      const ok = await updateMemberMode(session.sessionId, actorId, 'present');
-      if (ok) {
-        if (humanActorId) setActiveIdentity(humanActorId);
-        openGroupSessionAsHuman(session);
+  const joinSession = useCallback(
+    async (scope?: MessageViewScope): Promise<boolean> => {
+      if (!session) return false;
+      const actorId = human?.actorId ?? humanActorId;
+      if (!actorId) {
+        toast.error('未找到用户身份，请稍后重试');
+        return false;
       }
-      return ok;
-    } finally {
-      setJoining(false);
-    }
-  }, [human, humanActorId, openGroupSessionAsHuman, session, setActiveIdentity, updateMemberMode]);
+      setJoining(true);
+      try {
+        const ok = await updateMemberMode(session.sessionId, actorId, 'present', scope);
+        if (ok) {
+          if (humanActorId) setActiveIdentity(humanActorId);
+          openGroupSessionAsHuman(session);
+        }
+        return ok;
+      } finally {
+        setJoining(false);
+      }
+    },
+    [human, humanActorId, openGroupSessionAsHuman, session, setActiveIdentity, updateMemberMode],
+  );
 
   const leaveSession = useCallback(async (): Promise<boolean> => {
     if (!session) return false;
@@ -172,6 +189,27 @@ export function useCollabPanel(
     if (!actorId) return false;
     return updateMemberMode(session.sessionId, actorId, 'absent');
   }, [human, humanActorId, session, updateMemberMode]);
+
+  // 仅切换消息可见域（不带 mode）：成功后 bump wsReconnectNonce 触发 ws 整体重连（重拉一次性 token）。
+  const setViewScope = useCallback(
+    async (scope: MessageViewScope): Promise<boolean> => {
+      if (!session || !updateMemberScope) return false;
+      const actorId = human?.actorId ?? humanActorId;
+      if (!actorId) return false;
+      setSwitchingViewScope(true);
+      try {
+        const ok = await updateMemberScope(session.sessionId, actorId, scope);
+        if (ok) {
+          useWorkspaceStore.getState().bumpWsReconnect();
+          toast.success(scope === 'participant' ? '已切换到参与者视角，正在重连' : '已切换到完整视角，正在重连');
+        }
+        return ok;
+      } finally {
+        setSwitchingViewScope(false);
+      }
+    },
+    [human, humanActorId, session, updateMemberScope],
+  );
 
   // bot 视角恒显;human 视角 absent 时显示加入条;human 视角 present 时显示「在会话中隐身」条。
   const humanAbsentOnly = !isBotViewer && !!session && humanAbsent;
@@ -190,9 +228,12 @@ export function useCollabPanel(
     canSwitchToHuman: !!humanActorId,
     switchingBotMode,
     joining,
+    humanViewScope: human?.messageViewScope ?? null,
+    switchingViewScope,
     setBotMode,
     joinSession,
     leaveSession,
     switchToHuman,
+    setViewScope,
   };
 }

--- a/src/frontend-nextgen/src/pages/Workspace/hooks/useCreateGroup.ts
+++ b/src/frontend-nextgen/src/pages/Workspace/hooks/useCreateGroup.ts
@@ -1,4 +1,5 @@
 import type { GroupView } from '@/domain/collaboration';
+import type { MessageViewScope } from '@/domain/collaboration/types';
 import { resolveUserId } from '@/services/workspace/botSessionService';
 import { GROUP_CREATE_VIA_EXECUTE } from '@/services/workspace/groupCreateConfig';
 import { groupService } from '@/services/workspace/groupService';
@@ -13,7 +14,7 @@ export interface CreateGroupInput {
   definitionYaml?: string;
   driverBotUuid: string;
   originator: string;
-  participants: Array<{ actor_id: string }>;
+  participants: Array<{ actor_id: string; message_view_scope?: MessageViewScope }>;
   context?: string;
   participantBindings?: Array<{ binding: string; actor_ids: string[] }>;
 }

--- a/src/frontend-nextgen/src/pages/Workspace/hooks/useGroupChat.ts
+++ b/src/frontend-nextgen/src/pages/Workspace/hooks/useGroupChat.ts
@@ -20,6 +20,9 @@ import { useConnectionStatusSmoothing } from './useConnectionStatusSmoothing';
 import { useGroupBootstrapProcessing } from './useGroupBootstrapProcessing';
 import { useHumanOnlyChatRequests } from './useHumanOnlyChatRequests';
 import { useManifestHistoryLoader } from './useManifestHistoryLoader';
+import { useProviderStateSubscriptions } from './useProviderStateSubscriptions';
+import { useViewScopeChangedNotice } from './useViewScopeChangedNotice';
+import { useWsReconnectNonce } from './useWsReconnectNonce';
 
 /**
  * useGroupChat —— 协作群对话 Hook。
@@ -99,18 +102,8 @@ export function useGroupChat(session: SessionView | null) {
       }),
   });
 
-  // 订阅 Provider 阶段状态 + WebSocket 连接状态。
-  useEffect(() => {
-    if (!provider) return;
-    const offState = provider.subscribeToSupportState(setSupportState);
-    const offStatus = provider.subscribeToConnectionStatus((event: { status: ProviderConnectionStatus }) =>
-      setConnectionStatus(event.status),
-    );
-    return () => {
-      offState();
-      offStatus();
-    };
-  }, [provider]);
+  // 订阅 Provider 阶段状态 + WebSocket 连接状态（拆至 useProviderStateSubscriptions，行为不变）。
+  useProviderStateSubscriptions(provider, setSupportState, setConnectionStatus);
 
   // 切换会话时清理旧会话副屏；连接、history hydration 与 WS 暂存由
   // useManifestHistoryLoader 作为同一个可取消初始化流程统一管理。
@@ -189,6 +182,10 @@ export function useGroupChat(session: SessionView | null) {
       toast.error(error instanceof Error ? error.message : '加载历史消息失败');
     }
   };
+
+  // 视角切换成功重连后 / 服务端 view_scope_changed 推送后，以不变参数刷新历史消息（两路径回调重叠可接受）。
+  useWsReconnectNonce(provider, () => void reloadHistory());
+  useViewScopeChangedNotice(provider, () => void reloadHistory());
 
   // 向上翻页加载更早的历史消息：provider 以当前最旧时间戳为 before 游标拉取上一页，
   // 这里按 id 去重后前置拼接到 SDK chat.messages（旧→新升序），并由 BubbleList

--- a/src/frontend-nextgen/src/pages/Workspace/hooks/useGroupSessions.ts
+++ b/src/frontend-nextgen/src/pages/Workspace/hooks/useGroupSessions.ts
@@ -1,4 +1,5 @@
 import type { SessionView } from '@/domain/collaboration';
+import type { MessageViewScope } from '@/domain/collaboration/types';
 import type { DomainError, DomainResult } from '@/services/workspace/identityService';
 import { sessionService } from '@/services/workspace/sessionService';
 import { useWorkspaceStore } from '@/stores/workspaceStore';
@@ -114,7 +115,7 @@ export function useGroupSessions(groupId: string | null, expandedGroupIds: strin
     [sessionViews, selectedSessionId],
   );
 
-  const { updateMemberMode, applySessionUpdate } = useSessionMemberSync(
+  const { updateMemberMode, updateMemberScope, applySessionUpdate } = useSessionMemberSync(
     selectedSessionId,
     applyMapUpdate,
     selectedSession?.participants.length ?? 0,
@@ -125,8 +126,18 @@ export function useGroupSessions(groupId: string | null, expandedGroupIds: strin
   useStaleSessionFallback(groupId, isLoading, rawByGroupId, applyMapUpdate, selectSession, identityEpochRef);
 
   const createSessionIn = useCallback(
-    async (gid: string, title?: string, contextQuery?: string): Promise<SessionView | null> => {
-      const res: DomainResult<SessionView> = await sessionService.createNewSession(gid, title, contextQuery);
+    async (
+      gid: string,
+      title?: string,
+      contextQuery?: string,
+      messageViewScope?: MessageViewScope,
+    ): Promise<SessionView | null> => {
+      const res: DomainResult<SessionView> = await sessionService.createNewSession(
+        gid,
+        title,
+        contextQuery,
+        messageViewScope,
+      );
       if (!res.ok) {
         notifyError(errOf(res));
         return null;
@@ -144,9 +155,9 @@ export function useGroupSessions(groupId: string | null, expandedGroupIds: strin
   );
 
   const createSession = useCallback(
-    (title?: string, contextQuery?: string): Promise<SessionView | null> => {
+    (title?: string, contextQuery?: string, messageViewScope?: MessageViewScope): Promise<SessionView | null> => {
       if (!groupId) return Promise.resolve(null);
-      return createSessionIn(groupId, title, contextQuery);
+      return createSessionIn(groupId, title, contextQuery, messageViewScope);
     },
     [groupId, createSessionIn],
   );
@@ -227,6 +238,7 @@ export function useGroupSessions(groupId: string | null, expandedGroupIds: strin
     leaveSession,
     toggleFavorite,
     updateMemberMode,
+    updateMemberScope,
     applySessionUpdate,
     reloadSessions,
     reloadGroup,

--- a/src/frontend-nextgen/src/pages/Workspace/hooks/useGroupSessions.types.ts
+++ b/src/frontend-nextgen/src/pages/Workspace/hooks/useGroupSessions.types.ts
@@ -1,4 +1,5 @@
 import type { ParticipantMode, SessionView } from '@/domain/collaboration';
+import type { MessageViewScope } from '@/domain/collaboration/types';
 
 export interface UseGroupSessionsResult {
   sessions: SessionView[];
@@ -19,9 +20,18 @@ export interface UseGroupSessionsResult {
   selectSession: (sessionId: string | null) => void;
   /** 打开某群下的会话：必要时先切换选中群（chat pane 跟随），再选中会话。 */
   openSession: (groupId: string, sessionId: string) => void;
-  createSession: (title?: string, contextQuery?: string) => Promise<SessionView | null>;
+  createSession: (
+    title?: string,
+    contextQuery?: string,
+    messageViewScope?: MessageViewScope,
+  ) => Promise<SessionView | null>;
   /** 在指定群内创建会话（侧栏每个群的「新建会话」入口）；创建后选中该群与这条新会话。 */
-  createSessionIn: (groupId: string, title?: string, contextQuery?: string) => Promise<SessionView | null>;
+  createSessionIn: (
+    groupId: string,
+    title?: string,
+    contextQuery?: string,
+    messageViewScope?: MessageViewScope,
+  ) => Promise<SessionView | null>;
   renameSession: (sessionId: string, title: string) => Promise<boolean>;
   deleteSession: (sessionId: string) => Promise<boolean>;
   /** 退出会话（移除自己）：从侧边栏移除该会话并清空选中。 */
@@ -29,6 +39,8 @@ export interface UseGroupSessionsResult {
   toggleFavorite: (sessionId: string) => Promise<void>;
   /** 更新会话成员姿态/发言模式（参考 open-claw 我的协作：bot auto↔muted、human present↔absent）。 */
   updateMemberMode: (sessionId: string, actorId: string, mode: ParticipantMode) => Promise<boolean>;
+  /** 仅更新成员消息可见域（隐身条参与者视角 Switch），成功后就地刷新会话。 */
+  updateMemberScope: (sessionId: string, actorId: string, scope: MessageViewScope) => Promise<boolean>;
   /** 用后端返回的会话详情就地替换指定会话数据（成员增删后就地刷新）。 */
   applySessionUpdate: (sessionId: string, session: SessionView) => void;
   reloadSessions: () => Promise<void>;

--- a/src/frontend-nextgen/src/pages/Workspace/hooks/useInviteAccept.ts
+++ b/src/frontend-nextgen/src/pages/Workspace/hooks/useInviteAccept.ts
@@ -1,3 +1,4 @@
+import type { MessageViewScope } from '@/domain/collaboration/types';
 import { invitationService } from '@/services/workspace/invitationService';
 import { sessionService } from '@/services/workspace/sessionService';
 import { useCallback, useEffect, useState } from 'react';
@@ -28,13 +29,14 @@ export interface InviteAcceptState {
  * - mount → loading（调 getAcceptPageState 校验 token）
  * - 校验通过 → confirm
  * - 校验失败 → invalid（friendlyMessage 来自 service error）
- * - accept() → accepting → accepted（携带 targetType/targetId/groupId/sessionId） 或 error
+ * - accept(scope?) → accepting → accepted（携带 targetType/targetId/groupId/sessionId） 或 error；
+ *   scope 为消息视角（message_view_scope），透传给 acceptInvitation
  *
  * 不含导航副作用——把 `accepted` 状态与 groupId/alreadyJoined 交给组件决定跳转目标，
  * 让组件保持纯 view。
  */
 export function useInviteAccept(token: string): InviteAcceptState & {
-  accept: () => Promise<void>;
+  accept: (scope?: MessageViewScope) => Promise<void>;
   resetToConfirm: () => void;
 } {
   const [state, setState] = useState<InviteAcceptState>({ status: 'loading' });
@@ -60,37 +62,40 @@ export function useInviteAccept(token: string): InviteAcceptState & {
     };
   }, [token]);
 
-  const accept = useCallback(async () => {
-    setState({ status: 'accepting' });
-    const res = await invitationService.acceptInvitation(token);
-    if (!res.ok) {
-      setState({ status: 'error', friendlyMessage: res.error.friendlyMessage });
-      return;
-    }
-    const { targetType, targetId, alreadyJoined } = res.data;
-    if (targetType === 'session' && targetId) {
-      const session = await sessionService.getSessionDetail(targetId);
-      if (session.ok) {
-        setState({
-          status: 'accepted',
-          targetType,
-          targetId,
-          groupId: session.data.groupId,
-          sessionId: targetId,
-          alreadyJoined,
-        });
+  const accept = useCallback(
+    async (scope?: MessageViewScope) => {
+      setState({ status: 'accepting' });
+      const res = await invitationService.acceptInvitation(token, scope);
+      if (!res.ok) {
+        setState({ status: 'error', friendlyMessage: res.error.friendlyMessage });
         return;
       }
-    }
-    setState({
-      status: 'accepted',
-      targetType,
-      targetId,
-      groupId: targetType === 'group' ? targetId : undefined,
-      sessionId: targetType === 'session' ? targetId : undefined,
-      alreadyJoined,
-    });
-  }, [token]);
+      const { targetType, targetId, alreadyJoined } = res.data;
+      if (targetType === 'session' && targetId) {
+        const session = await sessionService.getSessionDetail(targetId);
+        if (session.ok) {
+          setState({
+            status: 'accepted',
+            targetType,
+            targetId,
+            groupId: session.data.groupId,
+            sessionId: targetId,
+            alreadyJoined,
+          });
+          return;
+        }
+      }
+      setState({
+        status: 'accepted',
+        targetType,
+        targetId,
+        groupId: targetType === 'group' ? targetId : undefined,
+        sessionId: targetType === 'session' ? targetId : undefined,
+        alreadyJoined,
+      });
+    },
+    [token],
+  );
 
   const resetToConfirm = useCallback(() => {
     setState({ status: 'confirm' });

--- a/src/frontend-nextgen/src/pages/Workspace/hooks/useProviderStateSubscriptions.ts
+++ b/src/frontend-nextgen/src/pages/Workspace/hooks/useProviderStateSubscriptions.ts
@@ -1,0 +1,24 @@
+import type { GroupChatProvider, GroupChatState } from '@/services/workspace/groupChatProvider';
+import type { ProviderConnectionStatus } from '@tc-chat/adapters';
+import { useEffect } from 'react';
+
+/**
+ * 订阅 Provider 阶段状态 + WebSocket 连接状态（从 useGroupChat 拆出以控制文件体积，行为不变）。
+ */
+export function useProviderStateSubscriptions(
+  provider: GroupChatProvider | null,
+  setSupportState: (state: GroupChatState) => void,
+  setConnectionStatus: (status: ProviderConnectionStatus) => void,
+): void {
+  useEffect(() => {
+    if (!provider) return;
+    const offState = provider.subscribeToSupportState(setSupportState);
+    const offStatus = provider.subscribeToConnectionStatus((event: { status: ProviderConnectionStatus }) =>
+      setConnectionStatus(event.status),
+    );
+    return () => {
+      offState();
+      offStatus();
+    };
+  }, [provider, setSupportState, setConnectionStatus]);
+}

--- a/src/frontend-nextgen/src/pages/Workspace/hooks/useSessionMemberSync.ts
+++ b/src/frontend-nextgen/src/pages/Workspace/hooks/useSessionMemberSync.ts
@@ -1,4 +1,5 @@
 import type { ParticipantMode, SessionView } from '@/domain/collaboration';
+import type { MessageViewScope } from '@/domain/collaboration/types';
 import type { DomainError } from '@/services/workspace/identityService';
 import { sessionService } from '@/services/workspace/sessionService';
 import { useCallback, useEffect, useRef } from 'react';
@@ -16,7 +17,14 @@ function errOf(res: { ok: false; error: DomainError }): DomainError {
 
 export interface UseSessionMemberSyncResult {
   /** 更新会话成员姿态/发言模式（Bot auto↔muted；Human present↔absent），成功后就地刷新会话参与者。 */
-  updateMemberMode: (sessionId: string, actorId: string, mode: ParticipantMode) => Promise<boolean>;
+  updateMemberMode: (
+    sessionId: string,
+    actorId: string,
+    mode: ParticipantMode,
+    messageViewScope?: MessageViewScope,
+  ) => Promise<boolean>;
+  /** 仅更新成员消息可见域（不带 mode），成功后就地刷新会话参与者。 */
+  updateMemberScope: (sessionId: string, actorId: string, scope: MessageViewScope) => Promise<boolean>;
   /** 用后端返回的会话详情就地替换指定会话（成员增删后就地刷新）。 */
   applySessionUpdate: (sessionId: string, session: SessionView) => void;
 }
@@ -93,8 +101,13 @@ export function useSessionMemberSync(
   }, [applyDetail, selectedSessionId, sessionMap]);
 
   const updateMemberMode = useCallback(
-    async (sessionId: string, actorId: string, mode: ParticipantMode): Promise<boolean> => {
-      const res = await sessionService.updateMemberMode(sessionId, actorId, mode);
+    async (
+      sessionId: string,
+      actorId: string,
+      mode: ParticipantMode,
+      messageViewScope?: MessageViewScope,
+    ): Promise<boolean> => {
+      const res = await sessionService.updateMemberMode(sessionId, actorId, mode, messageViewScope);
       if (!res.ok) {
         notifyError(errOf(res));
         return false;
@@ -107,6 +120,20 @@ export function useSessionMemberSync(
     [applyMapUpdate],
   );
 
+  const updateMemberScope = useCallback(
+    async (sessionId: string, actorId: string, scope: MessageViewScope): Promise<boolean> => {
+      const res = await sessionService.updateMemberScope(sessionId, actorId, scope);
+      if (!res.ok) {
+        notifyError(errOf(res));
+        return false;
+      }
+      const refreshed = res.data;
+      applyMapUpdate((cur) => replaceSessionInMap(cur, sessionId, refreshed));
+      return true;
+    },
+    [applyMapUpdate],
+  );
+
   const applySessionUpdate = useCallback(
     (sessionId: string, session: SessionView) => {
       applyMapUpdate((current) => replaceSessionInMap(current, sessionId, session));
@@ -114,5 +141,5 @@ export function useSessionMemberSync(
     [applyMapUpdate],
   );
 
-  return { updateMemberMode, applySessionUpdate };
+  return { updateMemberMode, updateMemberScope, applySessionUpdate };
 }

--- a/src/frontend-nextgen/src/pages/Workspace/hooks/useViewScopeChangedNotice.ts
+++ b/src/frontend-nextgen/src/pages/Workspace/hooks/useViewScopeChangedNotice.ts
@@ -1,0 +1,18 @@
+import type { GroupChatProvider } from '@/services/workspace/groupChatProvider';
+import { useEffect } from 'react';
+import { toast } from 'sonner';
+
+/**
+ * 服务端在线修改 message_view_scope 后会以 view_scope_changed 关闭 ws：
+ * provider 内部自动整体重连，本 Hook 负责用户可见提示，并同步调用
+ * onViewScopeChanged（如以不变参数刷新历史消息，与切换按钮路径保持一致）。
+ */
+export function useViewScopeChangedNotice(provider: GroupChatProvider | null, onViewScopeChanged?: () => void): void {
+  useEffect(() => {
+    if (!provider) return;
+    return provider.subscribeToViewScopeChanged(() => {
+      toast.info('消息视角已更新，正在重连');
+      onViewScopeChanged?.();
+    });
+  }, [provider, onViewScopeChanged]);
+}

--- a/src/frontend-nextgen/src/pages/Workspace/hooks/useWsReconnectNonce.ts
+++ b/src/frontend-nextgen/src/pages/Workspace/hooks/useWsReconnectNonce.ts
@@ -1,0 +1,37 @@
+import type { GroupChatProvider } from '@/services/workspace/groupChatProvider';
+import { useWorkspaceStore } from '@/stores/workspaceStore';
+import { useEffect, useRef } from 'react';
+import { toast } from 'sonner';
+
+/**
+ * 监听 wsReconnectNonce：消息视角切换成功后 store 递增该值，
+ * 这里对当前 provider 触发整体重连（reconnect 内部重拉一次性 token）；
+ * 重连成功后调用 onReconnected（如以不变参数刷新历史消息），失败仅 toast 不回调。
+ *
+ * 注意回调重叠：视角切换按钮路径会同时触发本 Hook 的 onReconnected 与
+ * 服务端 view_scope_changed 推送路径（useViewScopeChangedNotice）的回调，
+ * 历史刷新可能执行两次——REST 拉取幂等、setMessages 后者覆盖前者，可接受。
+ *
+ * 从 useGroupChat 拆出以守住 Hook ≤250 行门禁（useGroupChat 已 243 行）；
+ * mount 首跳忽略（以 ref 记录最近一次已消费的 nonce，仅响应后续变化）。
+ */
+export function useWsReconnectNonce(provider: GroupChatProvider | null, onReconnected?: () => void): void {
+  const wsReconnectNonce = useWorkspaceStore((s) => s.wsReconnectNonce);
+  const lastNonceRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (lastNonceRef.current === null) {
+      lastNonceRef.current = wsReconnectNonce;
+      return;
+    }
+    if (wsReconnectNonce === lastNonceRef.current) return;
+    lastNonceRef.current = wsReconnectNonce;
+    if (!provider) return;
+    void provider
+      .reconnect()
+      .then(() => onReconnected?.())
+      .catch((error: unknown) => {
+        toast.error(error instanceof Error ? error.message : '重连失败');
+      });
+  }, [wsReconnectNonce, provider, onReconnected]);
+}

--- a/src/frontend-nextgen/src/services/admin/notificationService.ts
+++ b/src/frontend-nextgen/src/services/admin/notificationService.ts
@@ -30,7 +30,7 @@ function toServiceError(e: unknown): ServiceError {
 }
 
 export const notificationService = {
-  /** 红点总数（铃铛 + 工单中心「待我处理」徽标共用）。
+  /** 红点总数（铃铛 + 通知中心「待我处理」徽标共用）。
    * 后端 UnreadCountResponse 同时返回 unread_count / pending_approval_count / unread_notice_count / badge_count，
    * 铃铛红点语义是「需要我处理的总数」(待审批 + 未读通知)，因此读 badge_count。
    * 单读 unread_count 会漏掉待审批工单的提醒。 */

--- a/src/frontend-nextgen/src/services/admin/userIdentity.ts
+++ b/src/frontend-nextgen/src/services/admin/userIdentity.ts
@@ -12,7 +12,7 @@
 import { getCapabilities } from '@/capabilities';
 import { resolveUserId } from '@/services/workspace/botSessionService';
 import { identityService } from '@/services/workspace/identityService';
-import { useWorkspaceStore } from '@/stores/workspaceStore';
+import { applyIdentityLoadResult } from '@/services/workspace/identityStore';
 
 /** 同步读当前已就绪操作者 user_id（经 canonical getHumanIdentity 能力），剥前缀兜底；未就绪返回 null（不主动拉取）。 */
 export function readUserId(): string | null {
@@ -29,7 +29,7 @@ export async function ensureUserId(): Promise<string | null> {
   if (cached) return cached;
   const res = await identityService.loadIdentities();
   if (!res.ok) return null;
-  useWorkspaceStore.getState().setIdentities(res.data.identities, res.data.defaultActiveId);
+  applyIdentityLoadResult(res.data);
   return readUserId();
 }
 
@@ -54,6 +54,6 @@ export async function ensureUserName(): Promise<string | null> {
   if (cached) return cached;
   const res = await identityService.loadIdentities();
   if (!res.ok) return null;
-  useWorkspaceStore.getState().setIdentities(res.data.identities, res.data.defaultActiveId);
+  applyIdentityLoadResult(res.data);
   return readUserName();
 }

--- a/src/frontend-nextgen/src/services/admin/workOrderService.ts
+++ b/src/frontend-nextgen/src/services/admin/workOrderService.ts
@@ -1,4 +1,4 @@
-// 工单中心 Service：三视图查询 / 分类筛选 / 详情 / 审批 / 通知已读。
+// 通知中心 Service：三视图查询 / 分类筛选 / 详情 / 审批 / 通知已读。
 // 契约对齐 clawweb=Avernet：user_id query 必填（Service 经 resolveUserId 注入）；分页 page_no；
 // query_type=INITIATED_BY_ME、item_type=NOTICE；审批走统一 /approval 入口（decision=APPROVED/REJECTED，reject 非空）。
 // 错误标准化（catch -> {message,apiPath}），不 throw 到 Component。

--- a/src/frontend-nextgen/src/services/backendApi/admin/notificationController.ts
+++ b/src/frontend-nextgen/src/services/backendApi/admin/notificationController.ts
@@ -1,6 +1,6 @@
 // 消息通知协议层 Controller。铃铛未读数 / 最近 N 条 / 全部已读 / 单条已读。
 // 契约对齐 clawweb=Avernet（/openapi/v1/bots/work-order-notifications）：user_id query 必填。
-// 「通知列表」复用 work-orders 端点（与工单中心同源，靠 query 参数区分），仅复用路径常量与 DTO 类型。
+// 「通知列表」复用 work-orders 端点（与通知中心完整视图同源，靠 query 参数区分），仅复用路径常量与 DTO 类型。
 
 import { backendRequest } from '../httpClient';
 import type { BackendApiEnvelope, BackendApiPage } from '../types';

--- a/src/frontend-nextgen/src/services/backendApi/admin/workOrderController.ts
+++ b/src/frontend-nextgen/src/services/backendApi/admin/workOrderController.ts
@@ -1,4 +1,4 @@
-// 工单中心协议层 Controller。
+// 通知中心协议层 Controller（模块 UI 名为「通知中心」，后端端点仍为 work-orders）。
 // 契约对齐 clawweb=Avernet（/openapi/v1/bots/work-orders）：user_id query 必填；
 // 审批统一入口 POST .../{id}/approval（decision=APPROVED/REJECTED，reject 时 review_remark 必填）。分页 page_no。
 // DTO=BackendUnknownRecord，由 domain/admin/mappers 读字段映射。
@@ -36,7 +36,7 @@ export interface WorkOrderApprovalBody {
   review_remark?: string | null;
 }
 
-// 查询我的工单列表（消息通知铃铛与工单中心共用，靠参数区分）。
+// 查询我的消息列表（铃铛预览与通知中心完整视图共用，靠参数区分）。
 export function listWorkOrders(params: WorkOrderListParams) {
   return backendRequest<BackendApiEnvelope<BackendApiPage<WorkOrderDto>>>(WORK_ORDER_ENDPOINTS.list, {
     method: 'GET',

--- a/src/frontend-nextgen/src/services/backendApi/collaboration/bbsTaskController.ts
+++ b/src/frontend-nextgen/src/services/backendApi/collaboration/bbsTaskController.ts
@@ -1,11 +1,6 @@
-import { getCapabilities } from '@/capabilities';
+import { TASK_READ_API_BASE } from '@/services/tasks/taskConfig';
 import { backendRequest } from '../httpClient';
 import type { BackendApiEnvelope } from '../types';
-
-/** 解析 task API 路径前缀；capability 缺省回退内面 /api/v1。 */
-function taskApiBase(): string {
-  return getCapabilities().getTaskApiBase().value ?? '/api/v1/collaboration/tasks';
-}
 
 /**
  * BBS 接力公开任务列表项（GET {taskApiBase}/bbs/list 的 data 数组元素）。
@@ -99,7 +94,7 @@ export async function listBbsTasks(
   params: ListBbsTasksParams = {},
   signal?: AbortSignal,
 ): Promise<BbsTaskListResponse> {
-  const response = await backendRequest<unknown>(`${taskApiBase()}/${BBS_TASK_ENDPOINTS.list}`, {
+  const response = await backendRequest<unknown>(`${TASK_READ_API_BASE}/${BBS_TASK_ENDPOINTS.list}`, {
     method: 'GET',
     params: params as Record<string, unknown>,
     injectUserId: false,

--- a/src/frontend-nextgen/src/services/backendApi/collaboration/collaborationGroupController.ts
+++ b/src/frontend-nextgen/src/services/backendApi/collaboration/collaborationGroupController.ts
@@ -1,3 +1,4 @@
+import type { MessageViewScope } from '@/domain/collaboration/types';
 import { isAceLoginResponse } from '../aceLoginBody';
 import { backendRequest } from '../httpClient';
 import type { BackendApiEnvelope, BackendApiPage } from '../types';
@@ -13,6 +14,8 @@ export interface GroupParticipantDto {
   name?: string;
   role: 'driver' | 'consultant' | 'manager' | 'worker' | 'observer';
   mode: 'auto' | 'muted' | 'absent' | 'present';
+  /** 该成员的消息可见域（human 参与者专属；bot 不下发）。 */
+  message_view_scope?: MessageViewScope;
 }
 export interface GroupCollaborationChat {
   strategy: 'chat';
@@ -40,6 +43,8 @@ export type GroupCollaboration =
 export interface GroupParticipantInput {
   actor_id: string;
   role: GroupParticipantDto['role'];
+  /** 创建群时为指定 human 参与者设置消息可见域；不传时由后端默认规则决定。 */
+  message_view_scope?: MessageViewScope;
 }
 
 export interface GroupDetailData {

--- a/src/frontend-nextgen/src/services/backendApi/collaboration/collaborationInvitationController.ts
+++ b/src/frontend-nextgen/src/services/backendApi/collaboration/collaborationInvitationController.ts
@@ -1,3 +1,4 @@
+import type { MessageViewScope } from '@/domain/collaboration/types';
 import { backendRequest } from '../httpClient';
 import type { BackendApiEnvelope } from '../types';
 
@@ -35,10 +36,10 @@ export async function createSessionInvitation(session_id: string, body: CreateIn
   );
 }
 
-// 接受邀请。
-export async function acceptInvitation(token: string) {
+// 接受邀请。body 可选携带 human 加入后的消息可见域。
+export async function acceptInvitation(token: string, body?: { message_view_scope?: MessageViewScope }) {
   return backendRequest<BackendApiEnvelope<AcceptInvitationData>>(
     `/openapi/v1/collaboration/invitations/${token}/accept`,
-    { method: 'POST', data: {}, injectUserId: false },
+    { method: 'POST', data: body ?? {}, injectUserId: false },
   );
 }

--- a/src/frontend-nextgen/src/services/backendApi/collaboration/sessionController.ts
+++ b/src/frontend-nextgen/src/services/backendApi/collaboration/sessionController.ts
@@ -1,3 +1,4 @@
+import type { MessageViewScope } from '@/domain/collaboration/types';
 import { backendRequest } from '../httpClient';
 import type { BackendApiEnvelope } from '../types';
 
@@ -11,6 +12,8 @@ export interface SessionParticipantDto {
   role: 'driver' | 'consultant' | 'manager' | 'worker' | 'observer';
   mode: SessionParticipantMode;
   joined_at?: number;
+  /** 该成员的消息可见域（human 参与者专属；bot 不下发）。 */
+  message_view_scope?: MessageViewScope;
 }
 export interface SessionDetailData {
   session_id: string;
@@ -123,11 +126,11 @@ export async function listSessionMessages(
   );
 }
 
-// 更新会话成员模式。
+// 更新会话成员模式；body 可选携带 human 成员的消息可见域（mode 与 scope 至少传一个）。
 export async function updateSessionMemberMode(
   session_id: string,
   actor_id: string,
-  body: { mode: SessionParticipantMode },
+  body: { mode?: SessionParticipantMode; message_view_scope?: MessageViewScope },
 ) {
   return backendRequest<BackendApiEnvelope<SessionParticipantDto>>(
     `/openapi/v1/collaboration/sessions/${session_id}/participants/${actor_id}`,
@@ -179,6 +182,8 @@ export interface CreateSessionRequest {
   acting_bot_id?: string;
   creator_role?: Exclude<SessionParticipantDto['role'], 'driver'>;
   input?: { query?: string; [key: string]: unknown };
+  /** 创建者（human）在会话中的消息可见域；不传时由后端继承/默认规则决定。 */
+  message_view_scope?: MessageViewScope;
 }
 
 export async function createSession(group_id: string, body: CreateSessionRequest, signal?: AbortSignal) {

--- a/src/frontend-nextgen/src/services/backendApi/tasks/taskController.ts
+++ b/src/frontend-nextgen/src/services/backendApi/tasks/taskController.ts
@@ -7,6 +7,7 @@
  * 测试场景可通过 baseUrl 直连本地 singlebox（localhost:8888），绕过 proxy。
  */
 import { getCapabilities } from '@/capabilities';
+import { TASK_READ_API_BASE } from '@/services/tasks/taskConfig';
 import type { Envelope, ExecuteTaskRequest, ExecuteTaskResponse, TaskListItem } from '@/services/tasks/taskModel';
 import { backendRequest } from '../httpClient';
 import type { BackendApiPage } from '../types';
@@ -34,7 +35,7 @@ export async function dashboardTask(
   includeActionLog = false,
   baseUrl: string = DEFAULT_BASE,
 ): Promise<Envelope<unknown>> {
-  const path = `${taskApiBase()}/dashboard`;
+  const path = `${TASK_READ_API_BASE}/dashboard`;
   const url = baseUrl ? `${baseUrl.replace(/\/+$/, '')}${path}` : path;
   return backendRequest<Envelope<unknown>>(url, {
     method: 'GET',
@@ -62,7 +63,7 @@ export async function listTasks(
   params: ListTasksParams,
   baseUrl: string = DEFAULT_BASE,
 ): Promise<Envelope<BackendApiPage<TaskListItem> | TaskListItem[]>> {
-  const path = `${taskApiBase()}/list`;
+  const path = `${TASK_READ_API_BASE}/list`;
   const url = baseUrl ? `${baseUrl.replace(/\/+$/, '')}${path}` : path;
   return backendRequest<Envelope<BackendApiPage<TaskListItem> | TaskListItem[]>>(url, {
     method: 'GET',

--- a/src/frontend-nextgen/src/services/collaborationSquare/collaborationSquareApiAdapter.ts
+++ b/src/frontend-nextgen/src/services/collaborationSquare/collaborationSquareApiAdapter.ts
@@ -1,3 +1,4 @@
+import type { MessageViewScope } from '@/domain/collaboration/types';
 import { mapPublicBotCatalogDto, mapPublicGroupCatalogDto } from '@/domain/collaborationSquare/mapper';
 import { mapBbsTaskItemDto, mapPlazaStatusToBbsStatus } from '@/domain/collaborationSquare/taskMapper';
 import type {
@@ -282,7 +283,7 @@ export class CollaborationSquareApiAdapter implements CollaborationSquareGateway
   async createGroupSession(
     groupId: string,
     context?: HumanBotActionContext,
-    options?: { title?: string; query?: string },
+    options?: { title?: string; query?: string; messageViewScope?: MessageViewScope },
   ): Promise<CreateSessionResult> {
     try {
       const response = await createGroupSessionRequest(groupId, {
@@ -290,6 +291,7 @@ export class CollaborationSquareApiAdapter implements CollaborationSquareGateway
         ...(context?.actorId ? { acting_bot_id: context.actorId } : {}),
         ...(options?.title ? { title: options.title } : {}),
         ...(options?.query ? { input: { query: options.query } } : {}),
+        ...(options?.messageViewScope ? { message_view_scope: options.messageViewScope } : {}),
       });
       if (isAceLoginResponse(response))
         throw new CollaborationSquareError('unauthenticated', '登录状态已失效，请重新登录后重试');
@@ -314,7 +316,7 @@ export class CollaborationSquareApiAdapter implements CollaborationSquareGateway
     }
   }
 
-  // 任务广场：接入真实 BBS 接力公开任务端点 GET /api/v1/collaboration/tasks/bbs/list（1-based 分页 +
+  // 任务广场：接入真实 BBS 接力公开任务端点 GET /openapi/v1/collaboration/tasks/bbs/list（1-based 分页 +
   // 可选 status / search_word 过滤，`total` 为过滤后行数）。分页 / 过滤 / 排序均在服务端，adapter 只做参数
   // 换算与展示名反查：offset/limit→page/page_size、search→search_word、广场态 status→BBS 原始态；publisher 与
   // assignee 经 bots/query 反查为展示名（复合 bot_id:owner 由 resolveBotNames 拆 realBotId 下发，按原始 id 回填）。

--- a/src/frontend-nextgen/src/services/collaborationSquare/collaborationSquareGateway.ts
+++ b/src/frontend-nextgen/src/services/collaborationSquare/collaborationSquareGateway.ts
@@ -1,3 +1,4 @@
+import type { MessageViewScope } from '@/domain/collaboration/types';
 import type {
   CollaborationSquarePage,
   CreateSessionResult,
@@ -48,7 +49,7 @@ export interface CollaborationSquareGateway {
   createGroupSession(
     groupId: string,
     context?: HumanBotActionContext,
-    options?: { title?: string; query?: string },
+    options?: { title?: string; query?: string; messageViewScope?: MessageViewScope },
   ): Promise<CreateSessionResult>;
   /** 浏览/搜索公开任务广场（跨用户公开，本期仅 Mock/Unsupported，真实端点待后端建设）。 */
   listPublicTasks(query?: PublicTaskSearchQuery, signal?: AbortSignal): Promise<PublicTaskPage>;

--- a/src/frontend-nextgen/src/services/collaborationSquare/collaborationSquareService.ts
+++ b/src/frontend-nextgen/src/services/collaborationSquare/collaborationSquareService.ts
@@ -1,3 +1,4 @@
+import type { MessageViewScope } from '@/domain/collaboration/types';
 import type {
   BotCatalogViewer,
   FriendRequestActor,
@@ -125,7 +126,11 @@ export class CollaborationSquareService {
     );
   }
 
-  createGroupSession(groupId: string, context?: HumanBotActionContext, options?: { title?: string; query?: string }) {
+  createGroupSession(
+    groupId: string,
+    context?: HumanBotActionContext,
+    options?: { title?: string; query?: string; messageViewScope?: MessageViewScope },
+  ) {
     return this.runTargetAction(`session:${groupId}`, () => this.gateway.createGroupSession(groupId, context, options));
   }
 }
@@ -133,6 +138,6 @@ export class CollaborationSquareService {
 export const collaborationSquareService = new CollaborationSquareService(new MockCollaborationSquareAdapter());
 export const collaborationSquareBotService = new CollaborationSquareService(new CollaborationSquareApiAdapter());
 export const collaborationSquareGroupService = new CollaborationSquareService(new CollaborationSquareApiAdapter());
-// 任务广场：接入真实 BBS 任务列表端点 GET /api/v1/collaboration/tasks/bbs/list，与 bot/group 一致走 ApiAdapter。
+// 任务广场：接入真实 BBS 任务列表端点 GET /openapi/v1/collaboration/tasks/bbs/list，与 bot/group 一致走 ApiAdapter。
 // Mock 的 task 方法/fixture 保留（不再被 wired service 使用，留作 dev/测试兜底，不删）。
 export const collaborationSquareTaskService = new CollaborationSquareService(new CollaborationSquareApiAdapter());

--- a/src/frontend-nextgen/src/services/myTask.ts
+++ b/src/frontend-nextgen/src/services/myTask.ts
@@ -6,7 +6,7 @@ import type { BackendApiPage } from '@/services/backendApi/types';
 // @/services/backendApi/types，由 service 层转出，保持全库判定逻辑单一收口(见 types.ts isEnvelopeFailure)。
 export { isEnvelopeFailure } from '@/services/backendApi/types';
 
-/** 我的任务列表查询参数（对齐 GET /api/v1/collaboration/tasks/list）。 */
+/** 我的任务列表查询参数（对齐 GET /openapi/v1/collaboration/tasks/list）。 */
 export interface ListMyTaskParams {
   user_id: string;
   status?: string;
@@ -20,7 +20,7 @@ export type ListMyTaskData = TaskListItem[] | BackendApiPage<TaskListItem>;
 
 /**
  * 我的任务列表「状态 Tab」是产品态(DRAFTING/DEFINED/EXECUTING/REVIEWING/DONE/FAILED/CANCELLED);
- * 后端 GET /api/v1/collaboration/tasks/list 的 status 入参是运行时态枚举
+ * 后端 GET /openapi/v1/collaboration/tasks/list 的 status 入参是运行时态枚举
  * (PENDING/PLANNING/RUNNING/DONE/FAILED/HUNG/CANCELLED),支持逗号分隔多值做 IN 过滤。
  * 这里把前端 Tab 的产品态反查为运行时态集合(对齐后端 runtime_status_to_product_status 逆映射;
  * DRAFTING 为作者态,运行时不产生 → 空集合,由上层短路返回空)。

--- a/src/frontend-nextgen/src/services/tasks/taskConfig.ts
+++ b/src/frontend-nextgen/src/services/tasks/taskConfig.ts
@@ -23,3 +23,14 @@ export const TASK_API_BASE = '';
 export function resolveTaskApiBase(): string {
   return getCapabilities().getTaskApiBase().value ?? '/api/v1/collaboration/tasks';
 }
+
+/**
+ * 任务「读公开面」路径前缀（dashboard / list / bbs-list）：所有环境统一走
+ * /openapi/v1/collaboration/tasks 公开面（前端经 gateway spanner 鉴权），不随 internal
+ * overlay 切到内面 /api/v1 —— 对齐后端安全收敛：后续将删除后端非 openapi 接口，仅保留
+ * /openapi/v1 公开面，杜绝公网出口（如 avernet 阿里云部署）上内部 /api/v1 未经鉴权裸奔。
+ *
+ * 仅用于前端发起的「读」接口（dashboard/list/bbs-list）；execute/grant/revoke 等写口
+ * 仍由 resolveTaskApiBase() 按 capability 决定（Open Core /openapi、内部 overlay /api/v1）。
+ */
+export const TASK_READ_API_BASE = '/openapi/v1/collaboration/tasks';

--- a/src/frontend-nextgen/src/services/workspace/botSessionService.ts
+++ b/src/frontend-nextgen/src/services/workspace/botSessionService.ts
@@ -77,7 +77,7 @@ export function splitBotId(botId: string): { realBotId: string; ownerId?: string
 }
 
 /** user_id 规则:human 身份 id 含冒号取尾段,否则原值。 */
-/** mine 返回的 human 身份 bot_id 形如 "human_327325",工号取 "human_" 之后的部分;
+/** mine 返回的 human 身份 bot_id 形如 "human_900003",工号取 "human_" 之后的部分;
  *  兼容旧的 "{head}:{staffNo}" 复合写法(取首个冒号之后)。结果只保留工号本身。
  *  导出供 botChatProvider 等同样调用 /openapi/v1/bots/* 的地方复用,避免漏归一化。 */
 export function resolveUserId(userId: string): string {

--- a/src/frontend-nextgen/src/services/workspace/groupChatProvider.ts
+++ b/src/frontend-nextgen/src/services/workspace/groupChatProvider.ts
@@ -9,7 +9,7 @@ import {
 } from '@tc-chat/adapters';
 import type { AixContext, ChatMessage, ChatProvider } from '@tc-chat/core';
 import { GroupChatHistoryPaginator } from './groupChatHistoryPaginator';
-import { buildGroupChatPayload, buildGroupWsUrl } from './groupChatProviderHelpers';
+import { buildGroupChatPayload, buildGroupWsUrl, isViewScopeChangedFrame } from './groupChatProviderHelpers';
 
 /** 透出 WS URL 构造器，保持既有 import 路径稳定（历史分页等纯函数已下沉到独立模块）。 */
 export { buildGroupWsUrl } from './groupChatProviderHelpers';
@@ -86,8 +86,11 @@ export class GroupChatProvider implements ChatProvider<GroupChatRequest> {
   private readonly options: GroupChatProviderOptions;
   private inner: SdkGroupChatProvider | null = null;
   private initializePromise: Promise<SdkGroupChatProvider> | null = null;
+  /** reconnect in-flight 守卫：并发重连共享同一 promise（只重拉一次 token）。 */
+  private reconnectPromise: Promise<void> | null = null;
   private connectionListeners = new Set<(event: ConnectionStatusEvent) => void>();
   private stateListeners = new Set<(state: GroupChatState) => void>();
+  private viewScopeListeners = new Set<() => void>();
   private unsubscribeInnerConnection?: () => void;
   private state: GroupChatState = { phase: 'idle', error: null };
   private bufferLiveEvents = true;
@@ -139,6 +142,18 @@ export class GroupChatProvider implements ChatProvider<GroupChatRequest> {
     };
   }
 
+  /** 订阅服务端 view_scope_changed 关闭事件（scope 在线变更，前端需重连）。 */
+  subscribeToViewScopeChanged(listener: () => void): () => void {
+    this.viewScopeListeners.add(listener);
+    return () => {
+      this.viewScopeListeners.delete(listener);
+    };
+  }
+
+  private emitViewScopeChanged(): void {
+    this.viewScopeListeners.forEach((listener) => listener());
+  }
+
   /**
    * 拉取一次性 session token；失败直接抛出——不降级为 owner 匿名请求（详见 brief 行为要求 2）。
    */
@@ -184,6 +199,7 @@ export class GroupChatProvider implements ChatProvider<GroupChatRequest> {
     // 当前已安装 SDK 的 GroupChatProvider 类型和运行时只处理 group_id，
     // 传入的 sessionId 会被忽略；在包装层保留会话级帧适配，避免重连后落到默认 main 会话。
     this.patchSessionFrames(inner);
+    this.patchIncomingFrames(inner);
 
     if (this.historyHydrationActive) {
       (inner as HydrationCapableGroupChatProvider).beginHistoryHydration?.();
@@ -225,8 +241,28 @@ export class GroupChatProvider implements ChatProvider<GroupChatRequest> {
       if (target.method !== 'connect' && target.method !== 'chat.send') return originalSend(frame);
 
       const params: Record<string, unknown> = { ...target.params, session_id: sessionId };
+      if (target.method === 'connect') params.view_actor_id = this.options.identityId;
       if (target.method === 'chat.send') params.sessionKey = sessionId;
       return originalSend({ ...target, params });
+    };
+  }
+
+  /**
+   * 拦截入站帧识别 view_scope_changed 关闭事件：通知订阅者并整体重连
+   * （重连会重拉一次性 token；旧 inner 被 disconnect 后其内部重连尝试自然失效）。
+   * 事件帧不透传给 SDK parser。
+   */
+  private patchIncomingFrames(inner: SdkGroupChatProvider): void {
+    const transport = (inner as unknown as { transport?: { onMessage?: (msg: unknown) => void } }).transport;
+    if (!transport || typeof transport.onMessage !== 'function') return;
+    const originalOnMessage = transport.onMessage.bind(transport);
+    transport.onMessage = (msg: unknown) => {
+      if (isViewScopeChangedFrame(msg)) {
+        this.emitViewScopeChanged();
+        void this.reconnect();
+        return;
+      }
+      return originalOnMessage(msg);
     };
   }
 
@@ -312,8 +348,20 @@ export class GroupChatProvider implements ChatProvider<GroupChatRequest> {
     return typeof hydrateRun === 'function' ? hydrateRun.call(inner, message) : message;
   }
 
-  /** 重置初始化状态并重新连接——供业务层在断线恢复时主动调用。 */
+  /**
+   * 重置初始化状态并重新连接——供业务层在断线恢复时主动调用。
+   * in-flight 守卫：并发调用（视角切换 bump + view_scope_changed 帧 + 手动重连）
+   * 共享同一 promise，只重拉一次 token / 只重建一次 SDK Provider。
+   */
   async reconnect(): Promise<void> {
+    if (this.reconnectPromise) return this.reconnectPromise;
+    this.reconnectPromise = this.reconnectInner().finally(() => {
+      this.reconnectPromise = null;
+    });
+    return this.reconnectPromise;
+  }
+
+  private async reconnectInner(): Promise<void> {
     this.unsubscribeInnerConnection?.();
     this.unsubscribeInnerConnection = undefined;
     this.inner?.disconnect();

--- a/src/frontend-nextgen/src/services/workspace/groupChatProviderHelpers.ts
+++ b/src/frontend-nextgen/src/services/workspace/groupChatProviderHelpers.ts
@@ -93,3 +93,15 @@ export function resolveGroupGatewayOrigin(hostname?: string): string | undefined
 export function resolveGroupWsOrigin(hostname?: string): string | undefined {
   return resolveGroupGatewayOrigin(hostname)?.replace(/^https/, 'wss');
 }
+
+/**
+ * 匹配服务端「在线修改 scope 后关闭连接」的 view_scope_changed 事件帧。
+ * 兼容 method / type / event 三种载体（具体帧形以联调为准，匹配从宽）。
+ */
+export function isViewScopeChangedFrame(message: unknown): boolean {
+  if (!message || typeof message !== 'object') return false;
+  const frame = message as Record<string, unknown>;
+  return (
+    frame.method === 'view_scope_changed' || frame.type === 'view_scope_changed' || frame.event === 'view_scope_changed'
+  );
+}

--- a/src/frontend-nextgen/src/services/workspace/groupCreateRequest.ts
+++ b/src/frontend-nextgen/src/services/workspace/groupCreateRequest.ts
@@ -1,3 +1,4 @@
+import type { MessageViewScope } from '@/domain/collaboration/types';
 import type { CreateGroupBody } from '@/services/backendApi/collaboration/collaborationGroupController';
 
 export interface CreateGroupInput {
@@ -7,7 +8,7 @@ export interface CreateGroupInput {
   definitionYaml?: string;
   driverBotUuid: string;
   originator: string;
-  participants: Array<{ actor_id: string }>;
+  participants: Array<{ actor_id: string; message_view_scope?: MessageViewScope }>;
   context?: string;
   participantBindings?: Array<{ binding: string; actor_ids: string[] }>;
 }
@@ -24,6 +25,7 @@ export function buildCreateGroupBody(input: CreateGroupInput): CreateGroupBody {
         : input.strategy === 'chat'
         ? ('consultant' as const)
         : ('worker' as const),
+    ...(participant.message_view_scope ? { message_view_scope: participant.message_view_scope } : {}),
   }));
   const base = {
     group_kind: 'normal' as const,

--- a/src/frontend-nextgen/src/services/workspace/groupService.ts
+++ b/src/frontend-nextgen/src/services/workspace/groupService.ts
@@ -149,6 +149,7 @@ export const groupService = {
           name: p.name ?? p.actor_id,
           role: ROLE_NATIVE_TO_DOMAIN[p.role] ?? 'member',
           mode: p.mode,
+          ...(p.message_view_scope ? { messageViewScope: p.message_view_scope } : {}),
         })),
         sessions: (sessions.data?.items ?? []).map((s) => mapSessionListItem(s)),
         lastMessageAt: d.updated_at,

--- a/src/frontend-nextgen/src/services/workspace/identityStore.ts
+++ b/src/frontend-nextgen/src/services/workspace/identityStore.ts
@@ -1,0 +1,24 @@
+import type { IdentityView } from '@/domain/collaboration';
+import { useWorkspaceStore } from '@/stores/workspaceStore';
+
+export interface IdentityLoadResult {
+  identities: IdentityView[];
+  defaultActiveId: string | null;
+}
+
+/**
+ * 将 identityService 结果统一写回 Store：保留仍在列表内的 active，列表未变化时不写新引用。
+ * 该函数与 loadIdentities 解耦，供 AppShell、useHumanIdentity 和 admin 身份兜底共同使用。
+ */
+export function applyIdentityLoadResult(result: IdentityLoadResult): void {
+  const store = useWorkspaceStore.getState();
+  const activeId =
+    store.activeIdentityId && result.identities.some((identity) => identity.id === store.activeIdentityId)
+      ? store.activeIdentityId
+      : result.defaultActiveId;
+  const identityChanged =
+    store.activeIdentityId !== activeId ||
+    store.identities.length !== result.identities.length ||
+    store.identities.some((identity, index) => identity.id !== result.identities[index]?.id);
+  if (identityChanged) useWorkspaceStore.getState().setIdentities(result.identities, activeId);
+}

--- a/src/frontend-nextgen/src/services/workspace/invitationService.ts
+++ b/src/frontend-nextgen/src/services/workspace/invitationService.ts
@@ -1,3 +1,4 @@
+import type { MessageViewScope } from '@/domain/collaboration/types';
 import {
   acceptInvitation,
   createGroupInvitation,
@@ -91,9 +92,15 @@ export const invitationService = {
     return { ok: true, data: { isValid: true } };
   },
 
-  async acceptInvitation(token: string): Promise<DomainResult<InvitationAcceptResult>> {
+  async acceptInvitation(
+    token: string,
+    messageViewScope?: MessageViewScope,
+  ): Promise<DomainResult<InvitationAcceptResult>> {
     try {
-      const resp = await acceptInvitation(token);
+      const resp = await acceptInvitation(
+        token,
+        messageViewScope ? { message_view_scope: messageViewScope } : undefined,
+      );
       const data = resp.data;
       const targetId = data?.target_id ?? '';
       if (!targetId || !data?.target_type) {

--- a/src/frontend-nextgen/src/services/workspace/mappers.ts
+++ b/src/frontend-nextgen/src/services/workspace/mappers.ts
@@ -81,6 +81,7 @@ export function mapParticipant(dto: {
   name?: string;
   role: string;
   mode: 'auto' | 'muted' | 'present' | 'absent';
+  message_view_scope?: 'full' | 'participant';
 }): ParticipantView {
   return {
     actorId: dto.actor_id,
@@ -88,6 +89,7 @@ export function mapParticipant(dto: {
     name: dto.name ?? dto.actor_id,
     role: ROLE_NATIVE_TO_DOMAIN[dto.role] ?? 'member',
     mode: dto.mode,
+    ...(dto.message_view_scope ? { messageViewScope: dto.message_view_scope } : {}),
   };
 }
 

--- a/src/frontend-nextgen/src/services/workspace/sessionFileService.ts
+++ b/src/frontend-nextgen/src/services/workspace/sessionFileService.ts
@@ -129,7 +129,7 @@ export const sessionFileService = {
   },
 
   /**
-   * 批量解析 actor（上传者）的展示名。文件接口仅返回 owner.actor_id（如 human_327325 / bot:工号），
+   * 批量解析 actor（上传者）的展示名。文件接口仅返回 owner.actor_id（如 human_900003 / bot:工号），
    * 需经 POST /openapi/v1/collaboration/bots/query 用 {bot_ids} 反查 name。返回 {actorId: name} 映射；
    * 后端返回的 bot 列表与请求 id 列表非一一对应，按 bot_id 匹配，未返回的 id 不出现在映射中。
    * 失败时返回空映射（调用方回退到 actor_id 兜底展示）。

--- a/src/frontend-nextgen/src/services/workspace/sessionService.ts
+++ b/src/frontend-nextgen/src/services/workspace/sessionService.ts
@@ -1,4 +1,5 @@
 import type { SessionView } from '@/domain/collaboration';
+import type { MessageViewScope } from '@/domain/collaboration/types';
 import { extractLoginUrl, isAceLoginResponse } from '@/services/backendApi/aceLoginBody';
 import type { SessionParticipantMode } from '@/services/backendApi/collaboration/sessionController';
 import {
@@ -57,7 +58,12 @@ export interface VisibleSessionsOpts {
 }
 
 export const sessionService = {
-  async createNewSession(groupId: string, title?: string, contextQuery?: string): Promise<DomainResult<SessionView>> {
+  async createNewSession(
+    groupId: string,
+    title?: string,
+    contextQuery?: string,
+    messageViewScope?: MessageViewScope,
+  ): Promise<DomainResult<SessionView>> {
     try {
       // acting_bot_id 传当前角色 id（human_xxx 或 botId:ownerId），让后端以该身份创建会话。
       const actingBotId = useWorkspaceStore.getState().activeIdentityId || undefined;
@@ -65,6 +71,7 @@ export const sessionService = {
         title: title || undefined,
         input: contextQuery ? { query: contextQuery } : undefined,
         ...(actingBotId ? { acting_bot_id: actingBotId } : {}),
+        ...(messageViewScope ? { message_view_scope: messageViewScope } : {}),
       });
       return { ok: true, data: mapSessionListItem(resp.data!) };
     } catch (err) {
@@ -160,9 +167,13 @@ export const sessionService = {
     sessionId: string,
     actorId: string,
     mode: SessionParticipantMode,
+    messageViewScope?: MessageViewScope,
   ): Promise<DomainResult<SessionView>> {
     try {
-      await updateSessionMemberMode(sessionId, actorId, { mode });
+      await updateSessionMemberMode(sessionId, actorId, {
+        mode,
+        ...(messageViewScope ? { message_view_scope: messageViewScope } : {}),
+      });
       return this.getSessionDetail(sessionId);
     } catch (err) {
       const status = (err as { status?: number })?.status;
@@ -170,6 +181,24 @@ export const sessionService = {
         return { ok: false, error: toDomainError('SESSION_CONFLICT', '会话状态已变更，请刷新后重试。') };
       }
       return { ok: false, error: toDomainError('SESSION_MEMBER_MODE_FAILED', '更新会话成员状态失败，请稍后重试。') };
+    }
+  },
+
+  /** 仅修改成员消息可见域（不带 mode）；返回刷新后的会话详情。 */
+  async updateMemberScope(
+    sessionId: string,
+    actorId: string,
+    scope: MessageViewScope,
+  ): Promise<DomainResult<SessionView>> {
+    try {
+      await updateSessionMemberMode(sessionId, actorId, { message_view_scope: scope });
+      return this.getSessionDetail(sessionId);
+    } catch (err) {
+      const status = (err as { status?: number })?.status;
+      if (status === 409) {
+        return { ok: false, error: toDomainError('SESSION_CONFLICT', '会话状态已变更，请刷新后重试。') };
+      }
+      return { ok: false, error: toDomainError('SESSION_MEMBER_SCOPE_FAILED', '切换消息视角失败，请稍后重试。') };
     }
   },
 

--- a/src/frontend-nextgen/src/services/workspace/workspaceService.ts
+++ b/src/frontend-nextgen/src/services/workspace/workspaceService.ts
@@ -1,6 +1,7 @@
 import { useWorkspaceStore } from '@/stores/workspaceStore';
 import type { DomainResult } from './identityService';
 import { identityService } from './identityService';
+import { applyIdentityLoadResult } from './identityStore';
 import { TeamClawSupportProvider } from './supportProvider';
 
 // 为兼容既有 import 路径（index re-export 与 workspaceService.test），透传 supportProvider 的公开导出。
@@ -18,31 +19,22 @@ export {
 export const workspaceService = {
   /** 初始加载：拉取可协作身份并入 Store，可选高亮指定 group。路由参数由 useWorkspacePage 通过 URL 驱动。 */
   async initWorkspace(preferredGroupId?: string): Promise<DomainResult<{ defaultActiveId: string | null }>> {
-    const res = await identityService.loadIdentities();
-    if (!res.ok) return res;
-    // 若 store 已有 activeIdentityId（如 URL→Store effect 已按外链 session 切到用户身份），
-    // 不用持久化默认身份覆盖，避免协作广场跳转后被切回上次持久化的 bot 角色。
-    const currentActiveId = useWorkspaceStore.getState().activeIdentityId;
-    // 仅当当前 active 仍在新 identities 列表内才保留，否则回退持久化默认值。
-    const activeId =
-      currentActiveId && res.data.identities.some((i) => i.id === currentActiveId)
-        ? currentActiveId
-        : res.data.defaultActiveId;
-    // 仅当 identities 列表或 activeIdentityId 实际变化时才写入，避免 remount 时
-    // 重复 setIdentities 产生新 identities 引用 → resolveIdentity/loadGroups 重建 →
-    // loadGroups effect 重跑（GET /groups 重复调用）。
-    const cur = useWorkspaceStore.getState();
-    const identityChanged =
-      cur.activeIdentityId !== activeId ||
-      cur.identities.length !== res.data.identities.length ||
-      cur.identities.some((i, idx) => i.id !== res.data.identities[idx].id);
-    if (identityChanged) useWorkspaceStore.getState().setIdentities(res.data.identities, activeId);
-    // 仅当选中群尚未设置时才按 preferredGroupId 选中，避免 URL→Store effect 已设好
-    // 的 group + session 被 selectGroup 清掉 selectedSessionId（selectGroup 清会话选中态）。
-    if (preferredGroupId && !useWorkspaceStore.getState().selectedGroupId) {
-      useWorkspaceStore.getState().selectGroup(preferredGroupId);
+    useWorkspaceStore.getState().setIsIdentityListLoading(true);
+    try {
+      const res = await identityService.loadIdentities();
+      if (!res.ok) return res;
+      // 若 store 已有 activeIdentityId（如 URL→Store effect 已按外链 session 切到用户身份），
+      // 不用持久化默认身份覆盖，避免协作广场跳转后被切回上次持久化的 bot 角色。
+      applyIdentityLoadResult(res.data);
+      // 仅当选中群尚未设置时才按 preferredGroupId 选中，避免 URL→Store effect 已设好
+      // 的 group + session 被 selectGroup 清掉 selectedSessionId（selectGroup 清会话选中态）。
+      if (preferredGroupId && !useWorkspaceStore.getState().selectedGroupId) {
+        useWorkspaceStore.getState().selectGroup(preferredGroupId);
+      }
+      return { ok: true, data: { defaultActiveId: res.data.defaultActiveId } };
+    } finally {
+      useWorkspaceStore.getState().setIsIdentityListLoading(false);
     }
-    return { ok: true, data: { defaultActiveId: res.data.defaultActiveId } };
   },
   /** 切换身份时持久化到 localStorage，供下次初始化回填默认 active。 */
   persistIdentity(id: string) {

--- a/src/frontend-nextgen/src/shell/AppShell.tsx
+++ b/src/frontend-nextgen/src/shell/AppShell.tsx
@@ -3,7 +3,7 @@ import { useHumanIdentity } from '@/hooks/useHumanIdentity';
 import { useMinWidth } from '@/hooks/useMediaQuery';
 import { ensurePersonalSpaceOnAppEntry, initSpaceContext } from '@/hooks/useSpaceContext';
 import { getWorkIdentityRedirect, useWorkIdentityAccess } from '@/hooks/useWorkIdentityAccess';
-import { identityService } from '@/services/workspace/identityService';
+import { workspaceService } from '@/services/workspace/workspaceService';
 import { history, useLocation } from '@umijs/max';
 import React, { useEffect, useMemo, useState } from 'react';
 import { AppHeader } from './AppHeader';
@@ -56,16 +56,17 @@ export function AppShell({ children }: { children: React.ReactNode }) {
     if (area === 'manage') void initSpaceContext();
   }, [area]);
 
-  // 挂载即触发身份加载（listMyBots → workspaceStore.identities，由 useHumanIdentity 写回 store），
-  // 供全局 AccountBadge 消费。单飞复用 identityService，与 /work init 共用 inflight，零重复请求。
-  // 失败静默（AccountBadge 走 error 态）。
+  // 挂载即刷新协作身份列表。initWorkspace 会在成功后写回 workspaceStore.identities 与 activeIdentity，
+  // 避免只在 getHumanIdentity 能力已 ready（如 external auth / internal cookie）时跳过身份列表落 store。
+  // identityService 单飞保证与 /workspace 初始化共用同一 /mine 请求。
+  // 失败静默（AccountBadge / IdentitySelector 各自呈现 error 态）。
   //
   // 关键：currentUser 经 useHumanIdentity 反应式派生（内部走 capability 契约 getHumanIdentity，不直接
   // 透传后端 DTO），不在加载回调里一次性快照 —— Open Core（oauth-provider）下 /auth/user（AppLayout
   // boot 的 checkAuth）与 mine 并跑，早于 auth 落位 captured 的 mine 兜底身份会被冻结进顶栏，
   // 登录后头像/花名不一致（此前需切 tab 触发 re-render 才纠正）。
   useEffect(() => {
-    void identityService.loadIdentities();
+    void workspaceService.initWorkspace();
   }, []);
   const { identity } = useHumanIdentity();
   const currentUser = useMemo(

--- a/src/frontend-nextgen/src/shell/WorkspaceIdentitySwitcher.tsx
+++ b/src/frontend-nextgen/src/shell/WorkspaceIdentitySwitcher.tsx
@@ -1,8 +1,8 @@
 import { getCapabilities } from '@/capabilities';
 import { WorkspaceIdentitySelector } from '@/components/Workspace/IdentitySelector';
+import { resolveAuthenticatedDisplayName } from '@/domain/userIdentity';
 import { useHumanIdentity } from '@/hooks/useHumanIdentity';
 import { mapIdentityViewToIdentity } from '@/hooks/workspaceIdentityMapper';
-import { resolveAuthenticatedDisplayName } from '@/domain/userIdentity';
 import { workspaceService } from '@/services/workspace/workspaceService';
 import { useWorkspaceStore } from '@/stores/workspaceStore';
 import { useCallback, useMemo } from 'react';
@@ -10,7 +10,7 @@ import { useCallback, useMemo } from 'react';
 function useWorkspaceIdentitySwitcherModel() {
   const identityViews = useWorkspaceStore((state) => state.identities);
   const activeIdentityId = useWorkspaceStore((state) => state.activeIdentityId);
-  const { identity: humanIdentity } = useHumanIdentity();
+  const { identity: humanIdentity, status: humanIdentityStatus, error: humanIdentityError } = useHumanIdentity();
   const userProfilePresentation = getCapabilities().getUserProfilePresentation().value;
   const identities = useMemo(() => {
     const authenticatedUser = humanIdentity
@@ -38,12 +38,15 @@ function useWorkspaceIdentitySwitcherModel() {
     activeIdentityId,
     switchIdentity,
     userAvatarUrl: humanIdentity?.avatarUrl,
+    humanIdentityStatus,
+    humanIdentityError,
   };
 }
 
 /** 工作区一级导航顶部的协作身份入口。身份状态保持全局共享，不依赖对话页二级侧栏。 */
 export function WorkspaceIdentitySwitcher() {
   const model = useWorkspaceIdentitySwitcherModel();
+  const identityListLoading = useWorkspaceStore((state) => state.isIdentityListLoading);
 
   return (
     <WorkspaceIdentitySelector
@@ -52,6 +55,9 @@ export function WorkspaceIdentitySwitcher() {
       onChange={model.switchIdentity}
       userAvatarUrl={model.userAvatarUrl}
       layout="sidebar"
+      identityStatus={model.humanIdentityStatus}
+      identityError={model.humanIdentityError}
+      identityListLoading={identityListLoading}
     />
   );
 }

--- a/src/frontend-nextgen/src/shell/routeMeta.ts
+++ b/src/frontend-nextgen/src/shell/routeMeta.ts
@@ -101,7 +101,7 @@ export const routeMetaList: RouteMeta[] = [
   },
   {
     path: '/admin/work-orders',
-    title: '工单中心',
+    title: '通知中心',
     section: 'manage',
     navKey: 'admin',
     openCore: true,

--- a/src/frontend-nextgen/src/stores/workspaceStore.ts
+++ b/src/frontend-nextgen/src/stores/workspaceStore.ts
@@ -94,6 +94,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     set((state) => ({ expandedBotSectionKey: { ...state.expandedBotSectionKey, [botId]: sectionKey } })),
   selectBotSession: (sessionId) => set({ selectedBotSessionId: sessionId }),
   bumpHistoryRefresh: () => set((state) => ({ historyRefreshNonce: state.historyRefreshNonce + 1 })),
+  bumpWsReconnect: () => set((state) => ({ wsReconnectNonce: state.wsReconnectNonce + 1 })),
   setPendingGroupBootstrap: (value) => set({ pendingGroupBootstrap: value }),
   clearPendingGroupBootstrap: (runId) =>
     set((state) =>
@@ -109,6 +110,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
   setActivePanel: (p) => set({ activePanel: p }),
   setIsGroupsLoading: (v) => set({ isGroupsLoading: v }),
   setIsSessionsLoading: (v) => set({ isSessionsLoading: v }),
+  setIsIdentityListLoading: (v) => set({ isIdentityListLoading: v }),
   reset: () => set(initialState),
   resetWorkspace: () => set(groupFields),
 }));

--- a/src/frontend-nextgen/src/stores/workspaceStoreState.ts
+++ b/src/frontend-nextgen/src/stores/workspaceStoreState.ts
@@ -48,6 +48,8 @@ export interface WorkspaceState {
   selectedBotSessionId: string | null;
   /** 点击会话时递增的计数器;chat hooks 监听变化以强制重新拉取历史消息。 */
   historyRefreshNonce: number;
+  /** 消息视角切换后递增;chat hooks 监听变化以整体重建 ws 连接（重拉一次性 token）。 */
+  wsReconnectNonce: number;
   pendingGroupBootstrap: { groupId: string; sessionId: string; run: GroupInitialRun } | null;
   lastSessionByIdentity: Record<string, IdentityMemo>;
   sessionTabsByGroup: Record<string, SessionTab>;
@@ -56,6 +58,8 @@ export interface WorkspaceState {
   activePanel: ActivePanel;
   isGroupsLoading: boolean;
   isSessionsLoading: boolean;
+  /** /mine 及身份详情 enrich 是否仍在加载；用于区分“加载中”和“真实空列表”。 */
+  isIdentityListLoading: boolean;
   setIdentities: (items: IdentityView[], activeId: string | null) => void;
   setActiveIdentity: (id: string | null) => void;
   selectGroup: (groupId: string | null) => void;
@@ -70,6 +74,7 @@ export interface WorkspaceState {
   setBotExpandedSection: (botId: string, sectionKey: string) => void;
   selectBotSession: (sessionId: string | null) => void;
   bumpHistoryRefresh: () => void;
+  bumpWsReconnect: () => void;
   setPendingGroupBootstrap: (value: WorkspaceState['pendingGroupBootstrap']) => void;
   clearPendingGroupBootstrap: (runId?: string) => void;
   setSessionTabForGroup: (groupId: string, tab: SessionTab) => void;
@@ -78,6 +83,7 @@ export interface WorkspaceState {
   setActivePanel: (p: ActivePanel) => void;
   setIsGroupsLoading: (v: boolean) => void;
   setIsSessionsLoading: (v: boolean) => void;
+  setIsIdentityListLoading: (v: boolean) => void;
   reset: () => void;
   resetWorkspace: () => void;
 }
@@ -89,6 +95,7 @@ export const topLevelState = {
   view: 'chat' as WorkspaceView,
   collapsedGroups: [] as string[],
   historyRefreshNonce: 0,
+  wsReconnectNonce: 0,
   pendingGroupBootstrap: null as WorkspaceState['pendingGroupBootstrap'],
   lastSessionByIdentity: {} as Record<string, IdentityMemo>,
 } satisfies Record<string, unknown>;
@@ -112,6 +119,7 @@ export const groupViewState = {
   activePanel: 'none' as ActivePanel,
   isGroupsLoading: false,
   isSessionsLoading: false,
+  isIdentityListLoading: false,
 } satisfies Record<string, unknown>;
 
 export const initialState = { ...topLevelState, ...groupViewState };

--- a/src/frontend-nextgen/test/collaborationPrivacyPage.test.tsx
+++ b/src/frontend-nextgen/test/collaborationPrivacyPage.test.tsx
@@ -27,7 +27,7 @@ Object.assign(globalThis, { TextDecoder, TextEncoder });
 const { renderToStaticMarkup } = require('react-dom/server') as typeof import('react-dom/server');
 
 const bot: CollaborationBot = {
-  id: '20260825_mbu0ey8f:447147',
+  id: '20260825_mbu0ey8f:900004',
   name: '产品协作助手',
   engine: 'OpenClaw',
   joinedBcn: true,
@@ -89,7 +89,7 @@ describe('collaboration privacy accessible UI', () => {
     expect(pageSource).not.toContain('Mock 验证');
     expect(pageSource).not.toContain('sample-only Mock 数据');
     expect(pageSource).toContain(
-      '管理用户信息，以及归属于当前用户的所有 Bot 在 BCN 网络中的各类协作状态及好友审批策略。',
+      '管理用户信息，以及归属于当前用户的所有 Bot 在 BCN 网络中的各类协作状态及好友审批策略',
     );
     expect(mockSource).not.toContain('待接入助手');
     expect(mockSource).not.toContain('joined_bcn: false');
@@ -141,8 +141,8 @@ describe('collaboration privacy accessible UI', () => {
     expect(html).not.toContain('bg-gray-');
     expect(html).not.toContain('animate-pulse');
     expect(html).toContain('>Bot UUID<');
-    expect(html).toContain('title="20260825_mbu0ey8f:447147"');
-    expect(html).not.toContain('Bot ID：20260825_mbu0ey8f:447147');
+    expect(html).toContain('title="20260825_mbu0ey8f:900004"');
+    expect(html).not.toContain('Bot ID：20260825_mbu0ey8f:900004');
     expect(html).toContain('aria-label="复制 产品协作助手 的 Bot UUID"');
     expect(html).toContain('参与协作群聊');
     expect(html).toContain('控制当前 Bot 是否可参与群聊。关闭后无法加入新协作群，已加入的协作群也不再回复。');
@@ -174,7 +174,7 @@ describe('collaboration privacy accessible UI', () => {
       <IdentityCard
         identity={{
           displayName: '示例管理员',
-          employeeNumber: '447147',
+          employeeNumber: '900004',
           departmentPath: ['示例集团-产品部'],
           lastSyncedAt: '2026-08-18T08:00:00.000Z',
         }}
@@ -194,7 +194,7 @@ describe('collaboration privacy accessible UI', () => {
     expect(html).toContain('text-xs text-muted-foreground');
     expect(html).toContain('text-xs leading-5 text-muted-foreground');
     expect(html).not.toContain('text-sm leading-6 text-[var(--color-muted)]');
-    expect(html).toContain('工号 447147');
+    expect(html).toContain('工号 900004');
     expect(html).toContain('示例集团-产品部');
     expect(html).not.toContain('示例集团 / 产品部');
     expect(html).not.toContain('同步部门');
@@ -206,7 +206,7 @@ describe('collaboration privacy accessible UI', () => {
       <IdentityCard
         identity={{
           displayName: '组织接口名称',
-          employeeNumber: 'internal-447147',
+          employeeNumber: 'internal-900004',
           departmentPath: ['内部集团-产品部'],
           lastSyncedAt: '2026-08-18T08:00:00.000Z',
         }}
@@ -220,7 +220,7 @@ describe('collaboration privacy accessible UI', () => {
     expect(html).toContain('开源用户');
     expect(html).toContain('工号 external-user-1');
     expect(html).not.toContain('组织接口名称');
-    expect(html).not.toContain('internal-447147');
+    expect(html).not.toContain('internal-900004');
     expect(html).not.toContain('内部集团-产品部');
     expect(html).not.toContain('同步用户部门信息');
   });
@@ -362,9 +362,9 @@ describe('collaboration privacy accessible UI', () => {
         onSubmit={jest.fn()}
       />,
     );
-    expect(userHtml).toContain('其他用户以个人身份，无法在协作广场看到当前 Bot，也不能发起申请。');
-    expect(userHtml).toContain('其他用户以个人身份，在协作广场可见当前 Bot 并申请好友');
-    expect(userHtml).not.toContain('其他用户以个人身份，在协作广场可见当前 Bot，但仅选中组织范围的用户可申请好友');
+    expect(userHtml).toContain('其他用户无法发现该 Bot');
+    expect(userHtml).toContain('其他用户可见，也可申请好友');
+    expect(userHtml).not.toContain('仅选中组织范围内的用户可申请好友');
     expect(userHtml).not.toContain('该受众');
     expect(userHtml).not.toContain('所有主体');
 
@@ -378,9 +378,9 @@ describe('collaboration privacy accessible UI', () => {
         onSubmit={jest.fn()}
       />,
     );
-    expect(botHtml).toContain('其他 Bot 以 Bot 工作身份，无法在协作广场看到当前 Bot，也不能发起申请。');
-    expect(botHtml).toContain('其他 Bot 以 Bot 工作身份，在协作广场可见当前 Bot 并申请好友');
-    expect(botHtml).not.toContain('其他用户以个人身份，在协作广场可见当前 Bot，但仅选中组织范围的用户可申请好友');
+    expect(botHtml).toContain('其他 Bot 无法发现该 Bot');
+    expect(botHtml).toContain('其他 Bot 可见，也可申请好友');
+    expect(botHtml).not.toContain('其他用户可见');
   });
 
   test('Open Core 读取存量限制范围时 fail closed 且不展示组织选择', () => {
@@ -403,17 +403,25 @@ describe('collaboration privacy accessible UI', () => {
     expect(html).not.toContain('Mock');
   });
 
-  test('协作权限页内说明类 Tooltip 统一使用 200ms 延迟', () => {
-    const tooltipSources = [
-      'src/components/CollaborationPrivacy/PermissionCard/index.tsx',
-      'src/components/CollaborationPrivacy/RelationCard/index.tsx',
-      'src/components/CollaborationPrivacy/RequestList/index.tsx',
-    ].map((sourcePath) => readFileSync(path.join(process.cwd(), sourcePath), 'utf8'));
+  test('协作权限页内常态与动态说明 Tooltip 统一使用 200ms 延迟', () => {
+    const tooltipSource = readFileSync(
+      path.join(process.cwd(), 'src/components/CollaborationPrivacy/HelpTooltip/index.tsx'),
+      'utf8',
+    );
+    const relationSource = readFileSync(
+      path.join(process.cwd(), 'src/components/CollaborationPrivacy/RelationCard/index.tsx'),
+      'utf8',
+    );
+    const requestSource = readFileSync(
+      path.join(process.cwd(), 'src/components/CollaborationPrivacy/RequestList/index.tsx'),
+      'utf8',
+    );
 
-    for (const source of tooltipSources) {
-      expect(source).toContain('collaborationPrivacyTooltipDelayMs');
-      expect(source).not.toContain('<TooltipProvider>');
-    }
+    expect(tooltipSource).toContain('collaborationPrivacyTooltipDelayMs');
+    expect(tooltipSource).toContain('LabelHelpTooltip');
+    expect(tooltipSource).toContain('ControlStateTooltip');
+    expect(relationSource).not.toContain('Tooltip');
+    expect(requestSource).not.toContain('Tooltip');
   });
 
   test('Bot 可见性和好友审批编辑器使用单选组语义', () => {

--- a/src/frontend-nextgen/test/collaborationPrivacyService.test.ts
+++ b/src/frontend-nextgen/test/collaborationPrivacyService.test.ts
@@ -170,7 +170,7 @@ describe('CollaborationPrivacyService', () => {
   test('按需刷新只替换目标 Bot，不重新加载整个列表', async () => {
     const gateway = new FakeGateway();
     const service = new CollaborationPrivacyService(gateway);
-    await service.loadOverview('447147');
+    await service.loadOverview('900004');
 
     const refreshed = await service.refreshBot('joined');
 
@@ -188,7 +188,7 @@ describe('CollaborationPrivacyService', () => {
   test('BCN 未加入时拒绝任何写操作', async () => {
     const gateway = new FakeGateway();
     const service = new CollaborationPrivacyService(gateway);
-    await service.loadOverview('447147');
+    await service.loadOverview('900004');
 
     await expect(
       service.updateDirectSetting({ botId: 'disabled', setting: 'profilePublic', value: true }),
@@ -199,7 +199,7 @@ describe('CollaborationPrivacyService', () => {
   test('提交公开变更只创建对应 audience pending，不提前改变生效值', async () => {
     const gateway = new FakeGateway();
     const service = new CollaborationPrivacyService(gateway);
-    await service.loadOverview('447147');
+    await service.loadOverview('900004');
 
     const next = await service.submitPublication({
       botId: 'joined',
@@ -216,7 +216,7 @@ describe('CollaborationPrivacyService', () => {
   test('restricted 和 partial_exempt 缺少范围时不调用 Gateway', async () => {
     const gateway = new FakeGateway();
     const service = new CollaborationPrivacyService(gateway);
-    await service.loadOverview('447147');
+    await service.loadOverview('900004');
 
     await expect(
       service.submitPublication({
@@ -238,7 +238,7 @@ describe('CollaborationPrivacyService', () => {
   test('双公开均 none 时拒绝修改好友审批策略', async () => {
     const gateway = new FakeGateway();
     const service = new CollaborationPrivacyService(gateway);
-    await service.loadOverview('447147');
+    await service.loadOverview('900004');
 
     await expect(
       service.updateFriendApproval({
@@ -251,7 +251,7 @@ describe('CollaborationPrivacyService', () => {
   test('同一 audience 存在 pending 时拒绝重复提交', async () => {
     const gateway = new FakeGateway();
     const service = new CollaborationPrivacyService(gateway);
-    await service.loadOverview('447147');
+    await service.loadOverview('900004');
     await service.submitPublication({
       botId: 'joined',
       audience: 'user',
@@ -271,7 +271,7 @@ describe('CollaborationPrivacyService', () => {
   test('归一化后配置无变化时不创建工单', async () => {
     const gateway = new FakeGateway();
     const service = new CollaborationPrivacyService(gateway);
-    await service.loadOverview('447147');
+    await service.loadOverview('900004');
 
     await expect(
       service.submitPublication({
@@ -299,7 +299,7 @@ describe('CollaborationPrivacyService', () => {
   test('限制公开部门发生变化时仍提交变更并进入 pending', async () => {
     const gateway = new FakeGateway();
     const service = new CollaborationPrivacyService(gateway);
-    await service.loadOverview('447147');
+    await service.loadOverview('900004');
 
     const next = await service.submitPublication({
       botId: 'joined',
@@ -328,7 +328,7 @@ describe('CollaborationPrivacyService', () => {
     const gateway = new FakeGateway();
     gateway.holdPublications = true;
     const service = new CollaborationPrivacyService(gateway);
-    await service.loadOverview('447147');
+    await service.loadOverview('900004');
 
     const userRequest = service.submitPublication({
       botId: 'joined',
@@ -367,7 +367,7 @@ describe('CollaborationPrivacyService', () => {
     const gateway = new FakeGateway();
     gateway.holdDirectSettings = true;
     const service = new CollaborationPrivacyService(gateway);
-    await service.loadOverview('447147');
+    await service.loadOverview('900004');
 
     const request = service.updateDirectSetting({ botId: 'joined', setting: 'profilePublic', value: false });
     await expect(
@@ -383,8 +383,8 @@ describe('CollaborationPrivacyService', () => {
     const service = new CollaborationPrivacyService(gateway);
     const signal = new AbortController().signal;
 
-    await service.loadOverview('447147', signal);
-    await service.syncDepartment('447147', signal);
+    await service.loadOverview('900004', signal);
+    await service.syncDepartment('900004', signal);
     await service.updateDirectSetting({ botId: 'joined', setting: 'profilePublic', value: false }, signal);
     await service.submitPublication(
       {

--- a/src/frontend-nextgen/test/collaborationSquareModel.test.ts
+++ b/src/frontend-nextgen/test/collaborationSquareModel.test.ts
@@ -82,49 +82,49 @@ describe('collaboration square model', () => {
   });
 
   test('通用协作 Bot 与画像 Mapper 优先保留后端 Bot UUID，缺失时回退 Bot ID', () => {
-    expect(mapCollaborationBotDto({ bot_id: '20260825_mbu0ey8f', bot_uuid: '20260825_mbu0ey8f:447147' })).toEqual(
-      expect.objectContaining({ id: '20260825_mbu0ey8f:447147' }),
+    expect(mapCollaborationBotDto({ bot_id: '20260825_mbu0ey8f', bot_uuid: '20260825_mbu0ey8f:900004' })).toEqual(
+      expect.objectContaining({ id: '20260825_mbu0ey8f:900004' }),
     );
     expect(
-      mapBotProfileTransport({ bot_id: 'default', bot_uuid: 'default:447147', bot_name: '助手', owner_name: 'Owner' }),
-    ).toEqual(expect.objectContaining({ id: 'default:447147' }));
+      mapBotProfileTransport({ bot_id: 'default', bot_uuid: 'default:900004', bot_name: '助手', owner_name: 'Owner' }),
+    ).toEqual(expect.objectContaining({ id: 'default:900004' }));
     expect(mapBotProfileTransport({ bot_id: 'default', bot_name: '助手', owner_name: 'Owner' }).id).toBe('default');
   });
 
   test('Bot Catalog 使用 bot_uuid 作为页面与操作 canonical id，并消费 Search 返回的 is_friend', () => {
     expect(
-      resolveFriendRequestBotId({ bot_id: 'default', bot_uuid: '20260825_mbu0ey8f:447147', entity_id: '366656' }),
-    ).toBe('20260825_mbu0ey8f:447147');
+      resolveFriendRequestBotId({ bot_id: 'default', bot_uuid: '20260825_mbu0ey8f:900004', entity_id: '366656' }),
+    ).toBe('20260825_mbu0ey8f:900004');
     expect(resolveFriendRequestBotId({ bot_id: 'default', entity_id: '366656' })).toBe('default:366656');
     expect(resolveFriendRequestBotId({ bot_id: 'default' })).toBe('default');
     expect(
       mapPublicBotCatalogDto({
         bot_id: 'default',
-        bot_uuid: '20260825_mbu0ey8f:447147',
+        bot_uuid: '20260825_mbu0ey8f:900004',
         entity_id: '366656',
         is_friend: true,
       }),
     ).toEqual(
       expect.objectContaining({
-        id: '20260825_mbu0ey8f:447147',
+        id: '20260825_mbu0ey8f:900004',
         relationshipStatus: 'friend',
       }),
     );
 
     expect(
-      mapPublicBotCatalogDto({ bot_id: 'default', bot_uuid: '20260825_mbu0ey8f:447147', is_friend: false }),
+      mapPublicBotCatalogDto({ bot_id: 'default', bot_uuid: '20260825_mbu0ey8f:900004', is_friend: false }),
     ).toEqual(expect.objectContaining({ relationshipStatus: 'none' }));
 
     // 智能搜索 Discovery 的 recommendation.short_profile 映射为卡片 shortProfile。
     expect(
       mapPublicBotCatalogDto({
         bot_id: 'default',
-        bot_uuid: '20260825_mbu0ey8f:447147',
+        bot_uuid: '20260825_mbu0ey8f:900004',
         recommendation: { short_profile: '用于测试目的的专用 Bot' },
       }),
     ).toEqual(expect.objectContaining({ shortProfile: '用于测试目的的专用 Bot' }));
     expect(
-      mapPublicBotCatalogDto({ bot_id: 'default', bot_uuid: '20260825_mbu0ey8f:447147' })?.shortProfile,
+      mapPublicBotCatalogDto({ bot_id: 'default', bot_uuid: '20260825_mbu0ey8f:900004' })?.shortProfile,
     ).toBeUndefined();
 
     expect(
@@ -165,7 +165,7 @@ describe('collaboration square model', () => {
   });
 
   test('公开 Bot 主操作按当前 actor、关系和 self-target 决定', () => {
-    const human = { type: 'human' as const, id: '327325' };
+    const human = { type: 'human' as const, id: '900003' };
     const botActor = { type: 'bot' as const, id: 'bot-viewer' };
 
     expect(

--- a/src/frontend-nextgen/test/collaborationSquarePage.test.tsx
+++ b/src/frontend-nextgen/test/collaborationSquarePage.test.tsx
@@ -22,7 +22,7 @@ const bot = {
   capabilities: ['需求分析'],
   relationshipStatus: 'none' as const,
 };
-const botWithUuid = { ...bot, id: '20260825_mbu0ey8f:447147' };
+const botWithUuid = { ...bot, id: '20260825_mbu0ey8f:900004' };
 const group = {
   id: 'g1',
   name: '产品共创群',
@@ -51,7 +51,7 @@ describe('collaboration square accessible UI', () => {
     const html = renderToStaticMarkup(
       <SquareBotCard
         bot={bot}
-        activeActor={{ type: 'human', id: '327325' }}
+        activeActor={{ type: 'human', id: '900003' }}
         busy={false}
         onShare={jest.fn()}
         onPrimaryAction={jest.fn()}
@@ -60,7 +60,7 @@ describe('collaboration square accessible UI', () => {
     const friendHtml = renderToStaticMarkup(
       <SquareBotCard
         bot={{ ...bot, relationshipStatus: 'friend' }}
-        activeActor={{ type: 'human', id: '327325' }}
+        activeActor={{ type: 'human', id: '900003' }}
         busy={false}
         onShare={jest.fn()}
         onPrimaryAction={jest.fn()}
@@ -84,7 +84,7 @@ describe('collaboration square accessible UI', () => {
     const uuidHtml = renderToStaticMarkup(
       <SquareBotCard
         bot={botWithUuid}
-        activeActor={{ type: 'human', id: '327325' }}
+        activeActor={{ type: 'human', id: '900003' }}
         busy={false}
         onShare={jest.fn()}
         onPrimaryAction={jest.fn()}
@@ -96,7 +96,7 @@ describe('collaboration square accessible UI', () => {
     const profileHtml = renderToStaticMarkup(
       <SquareBotCard
         bot={{ ...bot, shortProfile: '用于测试的专用 Bot' }}
-        activeActor={{ type: 'human', id: '327325' }}
+        activeActor={{ type: 'human', id: '900003' }}
         busy={false}
         onShare={jest.fn()}
         onPrimaryAction={jest.fn()}
@@ -110,7 +110,7 @@ describe('collaboration square accessible UI', () => {
     const html = renderToStaticMarkup(
       <SquareBotCard
         bot={{ ...bot, isOwnedByLoggedInUser: true, relationshipStatus: 'none' }}
-        activeActor={{ type: 'human', id: '327325' }}
+        activeActor={{ type: 'human', id: '900003' }}
         busy={false}
         onShare={jest.fn()}
         onPrimaryAction={jest.fn()}

--- a/src/frontend-nextgen/test/collaborationSquareService.test.ts
+++ b/src/frontend-nextgen/test/collaborationSquareService.test.ts
@@ -6,7 +6,7 @@ import {
 } from '../src/services/collaborationSquare/collaborationSquareService';
 import { MockCollaborationSquareAdapter } from '../src/services/collaborationSquare/mockCollaborationSquareAdapter';
 
-const humanContext = { actorId: 'human_327325', userId: '327325' };
+const humanContext = { actorId: 'human_900003', userId: '900003' };
 
 const publicBot = (id: string, name = '项目助手'): PublicBot => ({
   id,
@@ -107,7 +107,7 @@ describe('collaboration square service', () => {
     const service = new CollaborationSquareService(gateway);
     const humanRequest = service.requestBotFriendship('b1', humanContext, undefined, {
       type: 'human',
-      id: '327325',
+      id: '900003',
     });
     const botRequest = service.requestBotFriendship('b1', humanContext, undefined, { type: 'bot', id: 'bot-viewer' });
 
@@ -226,7 +226,7 @@ describe('collaboration square service', () => {
         'bot:target',
         '  项目助手  ',
         humanContext,
-        { viewerActorType: 'human', viewerActorId: '327325' },
+        { viewerActorType: 'human', viewerActorId: '900003' },
         signal,
       ),
     ).resolves.toEqual(expect.objectContaining({ id: 'bot:target' }));
@@ -236,7 +236,7 @@ describe('collaboration square service', () => {
         page: 1,
         pageSize: 100,
         viewerActorType: 'human',
-        viewerActorId: '327325',
+        viewerActorId: '900003',
       },
       humanContext,
       signal,

--- a/src/frontend-nextgen/test/components/Admin/UserSearchDropdown.test.tsx
+++ b/src/frontend-nextgen/test/components/Admin/UserSearchDropdown.test.tsx
@@ -24,7 +24,7 @@ it('不支持员工目录时降级为手填工号：输入并回车 → onSelect
 });
 
 it('支持搜索：输入关键词 → 防抖后展示候选 → 点击选中回完整 SearchedUser 并清空输入', async () => {
-  mockSearch.mockResolvedValue([{ userId: '10086', displayName: '寻三', nickName: '寻三', email: 'x@alipay.com' }]);
+  mockSearch.mockResolvedValue([{ userId: '10086', displayName: '寻三', nickName: '寻三', email: 'demo@example.com' }]);
   extendCapabilities({
     getUserSearchCapability: () => ({ status: 'available', value: { search: mockSearch } }),
   });
@@ -41,13 +41,13 @@ it('支持搜索：输入关键词 → 防抖后展示候选 → 点击选中回
 
 it('花名为空时展示真名(工号)：nickName 缺失/为空 → 显示 realName(userId)', async () => {
   mockSearch.mockResolvedValue([
-    { userId: 'gl520932', displayName: '郭亮', nickName: '', realName: '郭亮', email: 'gl520932@alibaba-inc.com' },
+    { userId: '900002', displayName: '测试用户乙', nickName: '', realName: '测试用户乙', email: '900002@example.com' },
     {
-      userId: 'liang.guol',
-      displayName: '郭亮',
+      userId: 'mock.b',
+      displayName: '测试用户乙',
       nickName: undefined,
-      realName: '郭亮',
-      email: 'liang.guol@antgroup.com',
+      realName: '测试用户乙',
+      email: 'mock.b@example.com',
     },
   ]);
   extendCapabilities({
@@ -56,11 +56,11 @@ it('花名为空时展示真名(工号)：nickName 缺失/为空 → 显示 real
   const onSelect = jest.fn();
   render(<UserSearchDropdown onSelect={onSelect} />);
   const input = screen.getByLabelText('搜索员工') as HTMLInputElement;
-  fireEvent.change(input, { target: { value: '郭亮' } });
+  fireEvent.change(input, { target: { value: '测试用户乙' } });
   // 两条候选均显示真名(userId)
-  await screen.findByRole('button', { name: /郭亮\(gl520932\)/ });
-  fireEvent.click(screen.getByRole('button', { name: /郭亮\(liang\.guol\)/ }));
-  expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ realName: '郭亮' }));
+  await screen.findByRole('button', { name: /测试用户乙\(900002\)/ });
+  fireEvent.click(screen.getByRole('button', { name: /测试用户乙\(mock\.b\)/ }));
+  expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ realName: '测试用户乙' }));
 });
 
 it('已添加成员在候选中显示「已添加」且不可选', async () => {

--- a/src/frontend-nextgen/test/components/BotWorkshop/CapabilityPickerModal.test.tsx
+++ b/src/frontend-nextgen/test/components/BotWorkshop/CapabilityPickerModal.test.tsx
@@ -80,6 +80,32 @@ test('添加 MCP 只展示引用市场 MCP，不展示引用工坊 MCP', () => {
   expect(screen.queryByRole('button', { name: '引用工坊 MCP' })).not.toBeInTheDocument();
 });
 
+test('添加 MCP 渲染市场接口返回的候选项', () => {
+  render(
+    <CapabilityPickerModal
+      kind="mcp"
+      open
+      marketItems={[
+        {
+          serverCode: 'mcp.ant.faas.skylarkmcpserver.skylarkmcpserver',
+          name: '语雀 MCP',
+          description: '语雀 MCP 服务，覆盖文档读写与知识库管理。',
+          active: false,
+        },
+      ]}
+      skillCenterItems={[]}
+      workshopItems={[]}
+      myItems={[]}
+      existingIds={[]}
+      onOpenChange={jest.fn()}
+      onConfirm={jest.fn()}
+    />,
+  );
+
+  expect(screen.getByText('语雀 MCP')).toBeInTheDocument();
+  expect(screen.getByText('语雀 MCP 服务，覆盖文档读写与知识库管理。')).toBeInTheDocument();
+});
+
 test('MCP 按内部和开放平台分 Tab，并将搜索交给服务端查询', async () => {
   const searchMcp = jest.fn().mockResolvedValue(undefined);
   render(

--- a/src/frontend-nextgen/test/components/CollaborationPrivacy/FriendApprovalEditor.test.tsx
+++ b/src/frontend-nextgen/test/components/CollaborationPrivacy/FriendApprovalEditor.test.tsx
@@ -33,9 +33,9 @@ describe('FriendApprovalEditor', () => {
 
     expect(screen.getByRole('radiogroup', { name: '好友审批策略' })).toBeInTheDocument();
     expect(
-      screen.getByRole('radio', { name: '无需审批 符合 Bot 可见性限制的新申请直接建立好友关系' }),
+      screen.getByRole('radio', { name: '无需审批 新好友申请无需用户审批，直接通过' }),
     ).toBeInTheDocument();
-    expect(screen.getByRole('radio', { name: '全部审批 所有新好友申请都需要确认' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: '全部审批 新好友申请都需要用户审批后方可通过' })).toBeInTheDocument();
     expect(screen.queryByText('部分组织免审批')).not.toBeInTheDocument();
     expect(screen.queryByRole('textbox', { name: '搜索组织范围' })).not.toBeInTheDocument();
   });
@@ -59,7 +59,7 @@ describe('FriendApprovalEditor', () => {
     expect(screen.getByText(/当前策略“部分组织免审批”已下线/)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: '保存策略' })).toBeDisabled();
 
-    fireEvent.click(screen.getByRole('radio', { name: '全部审批 所有新好友申请都需要确认' }));
+    fireEvent.click(screen.getByRole('radio', { name: '全部审批 新好友申请都需要用户审批后方可通过' }));
     fireEvent.click(screen.getByRole('button', { name: '保存策略' }));
 
     expect(onSubmit).toHaveBeenCalledWith({
@@ -86,7 +86,11 @@ describe('FriendApprovalEditor', () => {
       />,
     );
 
-    expect(screen.getByRole('radio', { name: /部分组织免审批/ })).toHaveAttribute('aria-checked', 'true');
+    expect(
+      screen.getByRole('radio', {
+        name: '部分组织免审批 限定组织的用户申请可直接通过；其余组织的用户申请仍需当前用户审批',
+      }),
+    ).toHaveAttribute('aria-checked', 'true');
     expect(screen.getByRole('textbox', { name: '搜索组织范围' })).toBeInTheDocument();
   });
 });

--- a/src/frontend-nextgen/test/components/CollaborationPrivacy/PermissionCard.test.tsx
+++ b/src/frontend-nextgen/test/components/CollaborationPrivacy/PermissionCard.test.tsx
@@ -75,30 +75,36 @@ describe('PermissionCard', () => {
     expect(screen.getByText('OpenClaw')).toBeInTheDocument();
   });
 
-  it('explains the Bot friend approval entry point', async () => {
+  it('explains Bot visibility from the group label', async () => {
     const user = userEvent.setup();
     renderCard();
 
-    const infoTrigger = screen.getByRole('button', { name: '好友审批策略说明' });
-    await user.hover(infoTrigger);
+    await user.hover(screen.getByRole('button', { name: 'Bot 可见性功能说明' }));
 
     expect(
       await screen.findByText(
-        '统一控制其他用户和其他 Bot 申请添加当前 Bot 为好友时的审批方式。审批入口见「工单中心 - 待我处理」，也可通过顶栏铃铛「通知中心」查看。',
+        '分别控制其他用户和其他 Bot 能否在协作广场看到当前 Bot，并决定其是否可以发起好友申请。两个对象的可见性可单独设置。',
       ),
     ).toBeInTheDocument();
   });
 
-  it('explains that Bot friend approval covers both user and Bot friend requests', async () => {
+  it('explains Bot friend approval from the group label without duplicate row tooltips', async () => {
     const user = userEvent.setup();
     renderCard();
 
-    const infoTrigger = screen.getByRole('button', { name: 'Bot 好友审批说明' });
-    await user.hover(infoTrigger);
+    await user.hover(screen.getByRole('button', { name: 'Bot 好友审批功能说明' }));
 
-    expect(
-      await screen.findByText('统一控制其他用户和其他 Bot 申请添加当前 Bot 为好友时的审批方式。'),
-    ).toBeInTheDocument();
+    const tooltip = await screen.findByRole('tooltip');
+    expect(tooltip).toHaveTextContent(
+      '在其他用户或其他 Bot 发起好友申请后，统一控制是否需要审批。待审批的申请可前往「管理后台 / 通知中心 / 待我处理」处理。',
+    );
+    expect(screen.getByRole('link', { name: '管理后台 / 通知中心 / 待我处理' })).toHaveAttribute(
+      'href',
+      '/admin?tab=work-orders',
+    );
+    expect(screen.queryByRole('button', { name: '对用户可见性说明' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: '对 Bot 可见性说明' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: '好友审批策略说明' })).not.toBeInTheDocument();
   });
 
   it('keeps refresh and copy actions close to their related Bot information', () => {
@@ -148,10 +154,11 @@ describe('PermissionCard', () => {
     expect(screen.getByRole('switch', { name: '开启Bot 画像公开' })).toBeDisabled();
     expect(screen.getByText('Bot 画像公开')).toBeInTheDocument();
     expect(screen.getByText('Bot 可见性')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Bot 可见性说明' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: '对用户可见性说明' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: '对 Bot 可见性说明' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: '好友审批策略说明' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Bot 可见性功能说明' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Bot 好友审批功能说明' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: '对用户可见性说明' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: '对 Bot 可见性说明' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: '好友审批策略说明' })).not.toBeInTheDocument();
     expect(screen.getByText('好友审批策略')).toBeInTheDocument();
   });
 
@@ -159,12 +166,15 @@ describe('PermissionCard', () => {
     const user = userEvent.setup();
     renderCard({ ...bot, profilePublic: false, profilePublicStatus: 'unavailable' });
 
-    expect(screen.getByText('暂不可用')).toBeInTheDocument();
-    const statusTrigger = screen.getByRole('button', { name: 'Bot 画像公开暂不可用说明' });
+    const status = screen.getByText('暂不可用');
+    const statusTrigger = screen.getByRole('button', { name: 'Bot 画像公开暂不可用原因' });
+    const profileSwitch = screen.getByRole('switch', { name: '开启Bot 画像公开' });
+    expect(status).not.toHaveRole('button');
+    expect(statusTrigger.parentElement).toContainElement(profileSwitch);
     await user.hover(statusTrigger);
 
     expect(await screen.findByRole('tooltip')).toHaveTextContent('该 Bot 尚未对其他 Bot 开放可见，请先调整 Bot 可见性');
-    expect(screen.getByRole('switch', { name: '开启Bot 画像公开' })).toBeDisabled();
+    expect(profileSwitch).toBeDisabled();
   });
 
   it('restores the Bot profile visibility toggle and sends the confirmed target value', () => {

--- a/src/frontend-nextgen/test/components/CollaborationPrivacy/PublicationEditor.test.tsx
+++ b/src/frontend-nextgen/test/components/CollaborationPrivacy/PublicationEditor.test.tsx
@@ -49,12 +49,12 @@ describe('PublicationEditor', () => {
     expect(squareLink).toHaveAttribute('href', '/collaboration-square/bots');
     expect(squareLink).not.toHaveClass('underline');
     expect(squareLink.parentElement).toHaveTextContent(
-      '选择当前 Bot 在协作广场中的可见性，以及其他用户或 Bot 能否申请当前 Bot 为好友。[协作广场/公开Bot]',
+      '选择当前 Bot 在[协作广场/公开Bot]中的可见性，以及其他用户或 Bot 能否申请当前 Bot 为好友。',
     );
     fireEvent.click(squareLink);
     expect(history.push).toHaveBeenCalledWith('/collaboration-square/bots');
     expect(screen.getByRole('radio', { name: /限定组织可申请/ })).toHaveTextContent(
-      '其他用户以个人身份，在协作广场可见当前 Bot，但仅选中组织范围的用户可申请好友。',
+      '其他用户可见，仅选中组织范围内的用户可申请好友',
     );
     expect(screen.queryByText('可搜索组织范围，并连续添加多个范围。')).not.toBeInTheDocument();
 
@@ -62,10 +62,10 @@ describe('PublicationEditor', () => {
 
     expect(screen.getByRole('heading', { name: 'Bot 可见性：对 Bot' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: '[协作广场/公开Bot]' }).parentElement).toHaveTextContent(
-      '选择当前 Bot 在协作广场中的可见性，以及其他用户或 Bot 能否申请当前 Bot 为好友。[协作广场/公开Bot]',
+      '选择当前 Bot 在[协作广场/公开Bot]中的可见性，以及其他用户或 Bot 能否申请当前 Bot 为好友。',
     );
     expect(screen.getByRole('radio', { name: /限定组织可申请/ })).toHaveTextContent(
-      '其他 Bot 以 Bot 工作身份，在协作广场可见当前 Bot，但仅选中组织范围的 Bot 可申请好友。',
+      '其他 Bot 可见，仅选中组织范围内的用户的 Bot 可申请好友',
     );
   });
 

--- a/src/frontend-nextgen/test/components/CollaborationSquare/BotCard.test.tsx
+++ b/src/frontend-nextgen/test/components/CollaborationSquare/BotCard.test.tsx
@@ -8,7 +8,7 @@ const longDescription =
   '这是一个用于验证公开 Bot 卡片超长描述展示效果的说明文本，需要固定为两行，并在悬停后展示完整内容，避免卡片被持续撑高或撑宽。';
 
 const bot = {
-  id: 'bot-long-description:447147',
+  id: 'bot-long-description:900004',
   name: '长描述 Bot',
   ownerName: '示例用户',
   description: longDescription,
@@ -22,7 +22,7 @@ describe('SquareBotCard', () => {
     const { unmount } = render(
       <SquareBotCard
         bot={bot}
-        activeActor={{ type: 'human', id: '327325' }}
+        activeActor={{ type: 'human', id: '900003' }}
         busy={false}
         onShare={jest.fn()}
         onPrimaryAction={jest.fn()}

--- a/src/frontend-nextgen/test/components/CollaborationSquare/CreateGroupSessionModal.scope.test.tsx
+++ b/src/frontend-nextgen/test/components/CollaborationSquare/CreateGroupSessionModal.scope.test.tsx
@@ -1,0 +1,23 @@
+/** @jest-environment jsdom */
+import { CreateGroupSessionModal } from '@/components/CollaborationSquare/CreateGroupSessionModal';
+import type { PublicGroup } from '@/domain/collaborationSquare/types';
+import { describe, expect, it, jest } from '@jest/globals';
+import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/jest-globals';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+const group = { id: 'g1', name: '公开群' } as PublicGroup;
+
+describe('CreateGroupSessionModal 消息视角 radio', () => {
+  it('默认完整视角；选参与者视角后提交值携带 messageViewScope', () => {
+    const onSubmit = jest.fn();
+    render(<CreateGroupSessionModal open group={group} loading={false} onClose={jest.fn()} onSubmit={onSubmit} />);
+    const radios = screen.getAllByRole('radio');
+    expect(radios[0]).toBeChecked();
+    fireEvent.change(screen.getByLabelText(/会话名称/), { target: { value: '会话A' } });
+    fireEvent.change(screen.getByLabelText(/协作目标/), { target: { value: '目标B' } });
+    fireEvent.click(radios[1]);
+    fireEvent.click(screen.getByRole('button', { name: '创建会话' }));
+    expect(onSubmit).toHaveBeenCalledWith({ title: '会话A', query: '目标B', messageViewScope: 'participant' });
+  });
+});

--- a/src/frontend-nextgen/test/components/CollaborationSquare/PublicBotCatalogPanel.test.tsx
+++ b/src/frontend-nextgen/test/components/CollaborationSquare/PublicBotCatalogPanel.test.tsx
@@ -50,24 +50,24 @@ describe('PublicBotCatalogPanel identity display', () => {
       <PublicBotCatalogPanel
         vm={buildVm()}
         scrollRootRef={{ current: null }}
-        activeIdentity={{ id: 'human_447147', name: '447147', kind: 'user' }}
-        authenticatedUserId="447147"
-        authenticatedUserName="风太"
+        activeIdentity={{ id: 'human_900004', name: '900004', kind: 'user' }}
+        authenticatedUserId="900004"
+        authenticatedUserName="示例用户"
       />,
     );
-    expect(screen.getByText('当前工作身份：风太')).toBeInTheDocument();
+    expect(screen.getByText('当前工作身份：示例用户')).toBeInTheDocument();
 
     rerender(
       <PublicBotCatalogPanel
         vm={buildVm()}
         scrollRootRef={{ current: null }}
         activeIdentity={{ id: 'human_447148', name: '其他用户', kind: 'user' }}
-        authenticatedUserId="447147"
-        authenticatedUserName="风太"
+        authenticatedUserId="900004"
+        authenticatedUserName="示例用户"
       />,
     );
     expect(screen.getByText('当前工作身份：其他用户')).toBeInTheDocument();
-    expect(screen.queryByText('当前工作身份：风太')).not.toBeInTheDocument();
+    expect(screen.queryByText('当前工作身份：示例用户')).not.toBeInTheDocument();
   });
 
   it('does not replace a Bot identity whose compound id contains the human id', () => {
@@ -75,12 +75,12 @@ describe('PublicBotCatalogPanel identity display', () => {
       <PublicBotCatalogPanel
         vm={buildVm()}
         scrollRootRef={{ current: null }}
-        activeIdentity={{ id: 'bot_xxx:447147', name: '协作 Bot', kind: 'bot' }}
-        authenticatedUserId="447147"
-        authenticatedUserName="风太"
+        activeIdentity={{ id: 'bot_xxx:900004', name: '协作 Bot', kind: 'bot' }}
+        authenticatedUserId="900004"
+        authenticatedUserName="示例用户"
       />,
     );
     expect(screen.getByText('当前工作身份：协作 Bot')).toBeInTheDocument();
-    expect(screen.queryByText('当前工作身份：风太')).not.toBeInTheDocument();
+    expect(screen.queryByText('当前工作身份：示例用户')).not.toBeInTheDocument();
   });
 });

--- a/src/frontend-nextgen/test/components/CollaborationSquare/SquarePageShellDispatch.test.tsx
+++ b/src/frontend-nextgen/test/components/CollaborationSquare/SquarePageShellDispatch.test.tsx
@@ -151,8 +151,8 @@ describe('SquarePageShell three-way dispatch', () => {
 
   test('Bot 工作身份隐藏公开协作群入口，保留公开 Bot 与任务广场', () => {
     useWorkspaceStore.setState({
-      activeIdentityId: 'bot-1:447147',
-      identities: [{ id: 'bot-1:447147', kind: 'bot', displayName: 'Bot A', online: true }],
+      activeIdentityId: 'bot-1:900004',
+      identities: [{ id: 'bot-1:900004', kind: 'bot', displayName: 'Bot A', online: true }],
     });
 
     render(<SquarePageShell resource="bot" />);

--- a/src/frontend-nextgen/test/components/MessageViewScope.test.tsx
+++ b/src/frontend-nextgen/test/components/MessageViewScope.test.tsx
@@ -1,0 +1,64 @@
+/** @jest-environment jsdom */
+import {
+  MessageViewScopeBadge,
+  MessageViewScopeCheckbox,
+  MessageViewScopeField,
+  MessageViewScopeMenuButton,
+} from '@/components/MessageViewScope';
+import { describe, expect, it, jest } from '@jest/globals';
+import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/jest-globals';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+describe('MessageViewScopeMenuButton', () => {
+  it('主按钮打开菜单，点选项回调对应 scope 并关闭', () => {
+    const onSelect = jest.fn();
+    render(<MessageViewScopeMenuButton onSelect={onSelect} />);
+    fireEvent.click(screen.getByRole('button', { name: /新建会话/ }));
+    fireEvent.click(screen.getByText('参与者视角'));
+    expect(onSelect).toHaveBeenCalledWith('participant');
+  });
+
+  it('菜单默认勾选完整视角（高亮 + 勾图标可见）', () => {
+    render(<MessageViewScopeMenuButton onSelect={jest.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: /新建会话/ }));
+    const fullOption = screen.getByText('完整视角').closest('button');
+    expect(fullOption).toHaveClass('border-primary');
+    const participantOption = screen.getByText('参与者视角').closest('button');
+    expect(participantOption).not.toHaveClass('border-primary');
+  });
+});
+
+describe('MessageViewScopeCheckbox', () => {
+  it('勾选回调 true 并展示提示文案', () => {
+    const onCheckedChange = jest.fn();
+    render(<MessageViewScopeCheckbox checked={false} onCheckedChange={onCheckedChange} />);
+    expect(screen.getByText('未勾选时，可看到会话内的全部消息。')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('checkbox'));
+    expect(onCheckedChange).toHaveBeenCalledWith(true);
+  });
+});
+
+describe('MessageViewScopeBadge', () => {
+  it('full 渲染「完整视角」且为 primary tone', () => {
+    render(<MessageViewScopeBadge scope="full" />);
+    expect(screen.getByText('完整视角')).toHaveClass('bg-primary/10', 'text-primary');
+  });
+
+  it('participant 渲染「参与者视角」且为 neutral tone', () => {
+    render(<MessageViewScopeBadge scope="participant" />);
+    expect(screen.getByText('参与者视角')).toHaveClass('bg-muted', 'text-muted-foreground');
+  });
+});
+
+describe('MessageViewScopeField', () => {
+  it('受控 value=full 时首个 radio 选中；切换回调 participant', () => {
+    const onChange = jest.fn();
+    render(<MessageViewScopeField value="full" onChange={onChange} />);
+    const radios = screen.getAllByRole('radio');
+    expect(radios).toHaveLength(2);
+    expect(radios[0]).toBeChecked();
+    fireEvent.click(radios[1]);
+    expect(onChange).toHaveBeenCalledWith('participant');
+  });
+});

--- a/src/frontend-nextgen/test/components/Workspace/ChatPanel/ChatPanel.test.tsx
+++ b/src/frontend-nextgen/test/components/Workspace/ChatPanel/ChatPanel.test.tsx
@@ -236,13 +236,13 @@ describe('ChatPanel interactive', () => {
         role: 'user',
         content: '你好',
         status: 'history',
-        extra: { senderId: 'human_447147' },
+        extra: { senderId: 'human_900004' },
       } as never,
       botModeTarget as any,
       { id: 'bot-1', kind: 'bot', displayName: '当前 Bot', online: true },
       undefined,
-      '447147',
-      '风太',
+      '900004',
+      '示例用户',
     );
     const other = resolveSingleSender(
       {
@@ -255,11 +255,11 @@ describe('ChatPanel interactive', () => {
       botModeTarget as any,
       { id: 'bot-1', kind: 'bot', displayName: '当前 Bot', online: true },
       undefined,
-      '447147',
-      '风太',
+      '900004',
+      '示例用户',
     );
 
-    expect(current.name).toBe('风太');
+    expect(current.name).toBe('示例用户');
     expect(other.name).toBe('其他成员');
   });
 

--- a/src/frontend-nextgen/test/components/Workspace/IdentitySelector.test.tsx
+++ b/src/frontend-nextgen/test/components/Workspace/IdentitySelector.test.tsx
@@ -17,8 +17,8 @@ const resolveBcsEndpointMock = resolveBcsEndpoint as jest.MockedFunction<typeof 
 
 const identities: Identity[] = [
   {
-    id: 'human_447147',
-    name: '风太',
+    id: 'human_900004',
+    name: '示例用户',
     kind: 'user',
     avatar: '风',
   },
@@ -46,6 +46,15 @@ const identities: Identity[] = [
   },
 ];
 
+describe('WorkspaceIdentitySelector loading and empty states', () => {
+  it('loading uses a spinner row instead of a temporary empty-state copy', () => {
+    render(<WorkspaceIdentitySelector identities={[]} activeId={null} onChange={() => {}} identityListLoading />);
+
+    expect(screen.getByRole('button', { name: '协作身份加载中' })).toBeInTheDocument();
+    expect(screen.queryByText('暂无可协作身份')).not.toBeInTheDocument();
+  });
+});
+
 describe('WorkspaceIdentitySelector', () => {
   beforeEach(() => {
     extendCapabilities({
@@ -69,7 +78,9 @@ describe('WorkspaceIdentitySelector', () => {
 
     fireEvent.click(screen.getByRole('button', { name: '当前协作身份：协作 Bot' }));
     expect(
-      screen.queryByText('当前工作身份决定你以个人或指定 Bot 身份使用工作区各项功能，并影响各菜单中可查看的数据和可执行的操作。'),
+      screen.queryByText(
+        '当前工作身份决定你以个人或指定 Bot 身份使用工作区各项功能，并影响各菜单中可查看的数据和可执行的操作。',
+      ),
     ).not.toBeInTheDocument();
     expect(await screen.findByText('隐藏 Bot')).toBeInTheDocument();
     expect(screen.getByText('ClaudeCode')).toBeInTheDocument();
@@ -115,28 +126,30 @@ describe('WorkspaceIdentitySelector', () => {
     render(
       <WorkspaceIdentitySelector
         identities={identities}
-        activeId="human_447147"
+        activeId="human_900004"
         userAvatarUrl="https://cdn.example.com/avatar.png"
         onChange={() => {}}
       />,
     );
 
-    expect(screen.getByRole('img', { name: '风太' })).toHaveAttribute('src', 'https://cdn.example.com/avatar.png');
+    expect(screen.getByRole('img', { name: '示例用户' })).toHaveAttribute('src', 'https://cdn.example.com/avatar.png');
     expect(screen.getByText('用户')).toBeInTheDocument();
-    expect(screen.getByText('工号：447147')).toBeInTheDocument();
+    expect(screen.getByText('工号：900004')).toBeInTheDocument();
     expect(screen.queryByText('OpenClaw')).not.toBeInTheDocument();
     expect(screen.queryByText('可参与群聊：')).not.toBeInTheDocument();
   });
 
   it('通过信息图标提供客观的数据范围说明，不使用观察者主体文案', async () => {
-    render(<WorkspaceIdentitySelector identities={identities} activeId="human_447147" onChange={() => {}} />);
+    render(<WorkspaceIdentitySelector identities={identities} activeId="human_900004" onChange={() => {}} />);
 
     const infoTrigger = screen.getByLabelText('协作身份说明');
     expect(infoTrigger).toBeInTheDocument();
     fireEvent.pointerMove(infoTrigger);
 
     expect(
-      await screen.findByText('当前工作身份决定你以个人或指定 Bot 身份使用工作区各项功能，并影响各菜单中可查看的数据和可执行的操作。'),
+      await screen.findByText(
+        '当前工作身份决定你以个人或指定 Bot 身份使用工作区各项功能，并影响各菜单中可查看的数据和可执行的操作。',
+      ),
     ).toBeInTheDocument();
     expect(screen.queryByText(/我参与的会话|当前身份可见/)).not.toBeInTheDocument();
   });
@@ -150,11 +163,15 @@ describe('WorkspaceIdentitySelector', () => {
     expect(screen.getByLabelText('工作身份说明')).toHaveClass('top-px', 'text-muted-foreground/70');
     expect(screen.getByLabelText('工作身份说明').querySelector('svg')).toHaveClass('h-3', 'w-3');
     expect(
-      screen.queryByText('当前工作身份决定你以个人或指定 Bot 身份使用工作区各项功能，并影响各菜单中可查看的数据和可执行的操作。'),
+      screen.queryByText(
+        '当前工作身份决定你以个人或指定 Bot 身份使用工作区各项功能，并影响各菜单中可查看的数据和可执行的操作。',
+      ),
     ).not.toBeInTheDocument();
     fireEvent.pointerMove(screen.getByLabelText('工作身份说明'));
     expect(
-      await screen.findByText('当前工作身份决定你以个人或指定 Bot 身份使用工作区各项功能，并影响各菜单中可查看的数据和可执行的操作。'),
+      await screen.findByText(
+        '当前工作身份决定你以个人或指定 Bot 身份使用工作区各项功能，并影响各菜单中可查看的数据和可执行的操作。',
+      ),
     ).toBeInTheDocument();
     expect(screen.getByLabelText('协作 Bot')).toHaveStyle({ width: '24px', height: '24px' });
     expect(screen.getByText('协作 Bot')).toHaveClass('text-xs');
@@ -177,7 +194,7 @@ describe('WorkspaceIdentitySelector', () => {
   });
 
   it('只有一个协作身份时不显示切换提示', () => {
-    render(<WorkspaceIdentitySelector identities={[identities[0]]} activeId="human_447147" onChange={() => {}} />);
+    render(<WorkspaceIdentitySelector identities={[identities[0]]} activeId="human_900004" onChange={() => {}} />);
 
     expect(screen.queryByText('可切换身份')).not.toBeInTheDocument();
   });
@@ -236,7 +253,7 @@ describe('WorkspaceIdentitySelector', () => {
     render(
       <WorkspaceIdentitySelector
         identities={identities}
-        activeId="human_447147"
+        activeId="human_900004"
         onChange={() => {}}
         onOpenPermissions={onOpenPermissions}
       />,
@@ -244,15 +261,15 @@ describe('WorkspaceIdentitySelector', () => {
 
     expect(screen.queryByRole('button', { name: '进入协作权限设置' })).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: '当前协作身份：风太' }));
+    fireEvent.click(screen.getByRole('button', { name: '当前协作身份：示例用户' }));
     const permissionsButton = await screen.findByRole('button', { name: '进入协作权限设置' });
     expect(permissionsButton).toBeInTheDocument();
-    expect(screen.getByText('切换协作身份')).toBeInTheDocument();
+    expect(screen.getByText('切换工作身份')).toBeInTheDocument();
     fireEvent.click(permissionsButton);
 
     expect(onOpenPermissions).toHaveBeenCalledTimes(1);
     await waitFor(() => {
-      expect(screen.queryByText('切换协作身份')).not.toBeInTheDocument();
+      expect(screen.queryByText('切换工作身份')).not.toBeInTheDocument();
     });
   });
 
@@ -268,20 +285,20 @@ describe('WorkspaceIdentitySelector', () => {
     );
 
     expect(screen.queryByRole('button', { name: '进入协作权限设置' })).not.toBeInTheDocument();
-    expect(screen.queryByText('切换协作身份')).not.toBeInTheDocument();
+    expect(screen.queryByText('切换工作身份')).not.toBeInTheDocument();
     expect(onOpenPermissions).not.toHaveBeenCalled();
   });
 
-  it('内部形态关闭接入新的 Bot 入口', async () => {
+  it('能力关闭时不展示接入外部 Bot 入口', async () => {
     extendCapabilities({
       getBotRegistrationEnabled: () => ({ status: 'available', value: false }),
     });
-    render(<WorkspaceIdentitySelector identities={identities} activeId="human_447147" onChange={() => {}} />);
+    render(<WorkspaceIdentitySelector identities={identities} activeId="human_900004" onChange={() => {}} />);
 
-    fireEvent.click(screen.getByRole('button', { name: '当前协作身份：风太' }));
+    fireEvent.click(screen.getByRole('button', { name: '当前协作身份：示例用户' }));
     await screen.findByText('隐藏 Bot');
 
-    expect(screen.queryByRole('button', { name: '接入新的 Bot' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: '接入外部 Bot' })).not.toBeInTheDocument();
     expect(getRegistrationTokenMock).not.toHaveBeenCalled();
   });
 
@@ -296,14 +313,25 @@ describe('WorkspaceIdentitySelector', () => {
         note: 'Use this token for bot registration within 6 hours',
       },
     });
-    render(<WorkspaceIdentitySelector identities={identities} activeId="human_447147" onChange={() => {}} />);
+    render(<WorkspaceIdentitySelector identities={identities} activeId="human_900004" onChange={() => {}} />);
 
-    fireEvent.click(screen.getByRole('button', { name: '当前协作身份：风太' }));
+    fireEvent.click(screen.getByRole('button', { name: '当前协作身份：示例用户' }));
     expect(getRegistrationTokenMock).not.toHaveBeenCalled();
-    fireEvent.click(await screen.findByRole('button', { name: '接入新的 Bot' }));
+    const registrationButton = await screen.findByRole('button', { name: '接入外部 Bot' });
+    const registrationInfo = screen.getByLabelText('接入外部 Bot 说明');
+    fireEvent.focus(registrationInfo);
+    expect(
+      await screen.findByText('获取接入指令，将当前平台之外创建的 Bot 接入当前协作网络。'),
+    ).toBeInTheDocument();
+    fireEvent.click(registrationButton);
 
     await waitFor(() => expect(getRegistrationTokenMock).toHaveBeenCalledTimes(1));
     const dialog = await screen.findByRole('dialog');
+    expect(screen.queryByText('Bot 接入')).not.toBeInTheDocument();
+    expect(dialog).toHaveTextContent('接入外部 Bot');
+    expect(dialog).toHaveTextContent(
+      '选择接入方式，复制命令后在对应环境中执行，即可完成外部 Bot 的初始化接入。',
+    );
     expect(dialog).toHaveTextContent('用户自助接入');
     expect(dialog).toHaveTextContent('install.sh --token token-1 --bcs-endpoint http://127.0.0.1:21000');
     expect(dialog).not.toHaveTextContent('Use this token for bot registration within 6 hours');
@@ -323,18 +351,18 @@ describe('WorkspaceIdentitySelector', () => {
 
   it('打开入口和点击当前身份不会切换，点击其他身份后关闭 Popover', async () => {
     const onChange = jest.fn();
-    render(<WorkspaceIdentitySelector identities={identities} activeId="human_447147" onChange={onChange} />);
+    render(<WorkspaceIdentitySelector identities={identities} activeId="human_900004" onChange={onChange} />);
 
-    const trigger = screen.getByRole('button', { name: '当前协作身份：风太' });
+    const trigger = screen.getByRole('button', { name: '当前协作身份：示例用户' });
     fireEvent.click(trigger);
-    const currentOption = await screen.findByRole('button', { name: /风太 用户/ });
+    const currentOption = await screen.findByRole('button', { name: /示例用户 用户/ });
     fireEvent.click(currentOption);
     expect(onChange).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByRole('button', { name: /协作 Bot/ }));
     expect(onChange).toHaveBeenCalledWith('bot-online');
     await waitFor(() => {
-      expect(screen.queryByText('切换协作身份')).not.toBeInTheDocument();
+      expect(screen.queryByText('切换工作身份')).not.toBeInTheDocument();
     });
   });
 });

--- a/src/frontend-nextgen/test/domain/collaboration/messageViewScope.test.ts
+++ b/src/frontend-nextgen/test/domain/collaboration/messageViewScope.test.ts
@@ -1,0 +1,50 @@
+import {
+  DEFAULT_MESSAGE_VIEW_SCOPE,
+  MESSAGE_VIEW_SCOPE_LABEL,
+  MESSAGE_VIEW_SCOPE_OPTIONS,
+  PARTICIPANT_ONLY_CHECKBOX,
+} from '@/domain/collaboration/messageViewScope';
+import { mapParticipant } from '@/services/workspace/mappers';
+import { describe, expect, it } from '@jest/globals';
+
+describe('messageViewScope 常量', () => {
+  it('默认 full，选项覆盖 full/participant 且文案非空', () => {
+    expect(DEFAULT_MESSAGE_VIEW_SCOPE).toBe('full');
+    expect(MESSAGE_VIEW_SCOPE_OPTIONS.map((option) => option.value)).toEqual(['full', 'participant']);
+    for (const option of MESSAGE_VIEW_SCOPE_OPTIONS) {
+      expect(option.label).toBeTruthy();
+      expect(option.description).toBeTruthy();
+    }
+  });
+
+  it('成员卡标签文案与选项文案一致', () => {
+    expect(MESSAGE_VIEW_SCOPE_LABEL).toEqual({ full: '完整视角', participant: '参与者视角' });
+    for (const option of MESSAGE_VIEW_SCOPE_OPTIONS) {
+      expect(MESSAGE_VIEW_SCOPE_LABEL[option.value]).toBe(option.label);
+    }
+  });
+
+  it('加入会话 checkbox 文案齐备', () => {
+    expect(PARTICIPANT_ONLY_CHECKBOX.label).toBe('只看公开及与我相关的消息');
+    expect(PARTICIPANT_ONLY_CHECKBOX.hint).toBeTruthy();
+    expect(PARTICIPANT_ONLY_CHECKBOX.tooltip).toBeTruthy();
+  });
+});
+
+describe('mapParticipant 回显 message_view_scope', () => {
+  it('有值时映射为 messageViewScope', () => {
+    const view = mapParticipant({
+      actor_id: 'human_1',
+      actor_kind: 'human',
+      role: 'consultant',
+      mode: 'present',
+      message_view_scope: 'participant',
+    });
+    expect(view.messageViewScope).toBe('participant');
+  });
+
+  it('无值时不回显', () => {
+    const view = mapParticipant({ actor_id: 'human_1', actor_kind: 'human', role: 'consultant', mode: 'present' });
+    expect(view.messageViewScope).toBeUndefined();
+  });
+});

--- a/src/frontend-nextgen/test/domain/userIdentity.test.ts
+++ b/src/frontend-nextgen/test/domain/userIdentity.test.ts
@@ -1,46 +1,42 @@
-import {
-  isSameHumanIdentity,
-  normalizeHumanUserId,
-  resolveAuthenticatedDisplayName,
-} from '@/domain/userIdentity';
+import { isSameHumanIdentity, normalizeHumanUserId, resolveAuthenticatedDisplayName } from '@/domain/userIdentity';
 import { describe, expect, it } from '@jest/globals';
 
 describe('user identity display matching', () => {
   it.each([
-    ['human_447147', '447147'],
-    ['user_id:447147', '447147'],
-    ['447147', '447147'],
+    ['human_900004', '900004'],
+    ['user_id:900004', '900004'],
+    ['900004', '900004'],
   ])('normalizes known human id %s to %s', (candidate, expected) => {
     expect(normalizeHumanUserId(candidate, 'human')).toBe(expected);
   });
 
   it('does not treat the me placeholder as a real user id', () => {
     expect(normalizeHumanUserId('me', 'human')).toBe('');
-    expect(isSameHumanIdentity('me', '447147', 'human')).toBe(false);
+    expect(isSameHumanIdentity('me', '900004', 'human')).toBe(false);
   });
 
   it('does not normalize Bot compound ids into human ids', () => {
-    expect(normalizeHumanUserId('bot_xxx:447147')).toBe('');
-    expect(normalizeHumanUserId('bot_xxx:447147', 'bot')).toBe('');
-    expect(isSameHumanIdentity('bot_xxx:447147', '447147')).toBe(false);
+    expect(normalizeHumanUserId('bot_xxx:900004')).toBe('');
+    expect(normalizeHumanUserId('bot_xxx:900004', 'bot')).toBe('');
+    expect(isSameHumanIdentity('bot_xxx:900004', '900004')).toBe(false);
   });
 
   it('matches the authenticated human only by canonical id', () => {
-    expect(isSameHumanIdentity('human_447147', '447147', 'human')).toBe(true);
-    expect(isSameHumanIdentity('human_447148', '447147', 'human')).toBe(false);
+    expect(isSameHumanIdentity('human_900004', '900004', 'human')).toBe(true);
+    expect(isSameHumanIdentity('human_447148', '900004', 'human')).toBe(false);
   });
 
   it('uses the authenticated name only for the matching human', () => {
     expect(
       resolveAuthenticatedDisplayName(
-        { id: 'human_447147', kind: 'human', name: '旧名称' },
-        { userId: '447147', name: '风太' },
+        { id: 'human_900004', kind: 'human', name: '旧名称' },
+        { userId: '900004', name: '示例用户' },
       ),
-    ).toBe('风太');
+    ).toBe('示例用户');
     expect(
       resolveAuthenticatedDisplayName(
         { id: 'human_447148', kind: 'human', name: '其他成员' },
-        { userId: '447147', name: '风太' },
+        { userId: '900004', name: '示例用户' },
       ),
     ).toBe('其他成员');
   });
@@ -49,7 +45,7 @@ describe('user identity display matching', () => {
     expect(
       resolveAuthenticatedDisplayName(
         { id: 'human_447148', kind: 'human', name: '' },
-        { userId: '447147', name: '风太' },
+        { userId: '900004', name: '示例用户' },
       ),
     ).toBe('human_447148');
   });
@@ -57,15 +53,12 @@ describe('user identity display matching', () => {
   it('falls back to the candidate name and id when the authenticated name is empty', () => {
     expect(
       resolveAuthenticatedDisplayName(
-        { id: 'human_447147', kind: 'human', name: '会话回显名称' },
-        { userId: '447147', name: '  ' },
+        { id: 'human_900004', kind: 'human', name: '会话回显名称' },
+        { userId: '900004', name: '  ' },
       ),
     ).toBe('会话回显名称');
-    expect(
-      resolveAuthenticatedDisplayName(
-        { id: 'human_447147', kind: 'human' },
-        { userId: '447147', name: '' },
-      ),
-    ).toBe('human_447147');
+    expect(resolveAuthenticatedDisplayName({ id: 'human_900004', kind: 'human' }, { userId: '900004', name: '' })).toBe(
+      'human_900004',
+    );
   });
 });

--- a/src/frontend-nextgen/test/hooks/useBotWorkshopEditorIdentity.test.tsx
+++ b/src/frontend-nextgen/test/hooks/useBotWorkshopEditorIdentity.test.tsx
@@ -16,14 +16,14 @@ afterEach(() => {
 it('预发 Tern 身份就绪后同步 user_id 并开放编辑页请求', async () => {
   mockedUseHumanIdentity.mockReturnValue({
     status: 'ready',
-    identity: { userId: '327325', displayName: '测试用户', online: true },
+    identity: { userId: '900003', displayName: '测试用户', online: true },
   });
 
   const { result } = renderHook(() => useBotWorkshopEditorIdentity());
 
   expect(result.current.ready).toBe(true);
-  expect(result.current.userId).toBe('327325');
-  await waitFor(() => expect(useIdentityStore.getState().currentIdentityId).toBe('327325'));
+  expect(result.current.userId).toBe('900003');
+  await waitFor(() => expect(useIdentityStore.getState().currentIdentityId).toBe('900003'));
 });
 
 it('身份加载期间暂停编辑页请求', () => {

--- a/src/frontend-nextgen/test/hooks/useCollaborationPrivacy.test.tsx
+++ b/src/frontend-nextgen/test/hooks/useCollaborationPrivacy.test.tsx
@@ -13,7 +13,7 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 const mockedUseHumanIdentity = jest.spyOn(identityModule, 'useHumanIdentity');
 
 const overview = {
-  currentUser: { displayName: '真实用户', employeeNumber: '447147', departmentPath: ['协作平台'] },
+  currentUser: { displayName: '真实用户', employeeNumber: '900004', departmentPath: ['协作平台'] },
   organizationOptions: [],
   bots: [],
 } as CollaborationPrivacyOverview;
@@ -54,14 +54,14 @@ describe('useCollaborationPrivacy identity wiring', () => {
   it('waits for identity and passes the employee number to the overview service', async () => {
     mockedUseHumanIdentity.mockReturnValue({
       status: 'ready',
-      identity: { userId: '447147', displayName: '真实用户', online: true },
+      identity: { userId: '900004', displayName: '真实用户', online: true },
     });
     const mockedLoadOverview = jest.spyOn(collaborationPrivacyService, 'loadOverview').mockResolvedValue(overview);
 
     renderHook(() => useCollaborationPrivacy());
 
     await waitFor(() =>
-      expect(mockedLoadOverview).toHaveBeenCalledWith('447147', expect.any(AbortSignal), { target: 'currentUser' }),
+      expect(mockedLoadOverview).toHaveBeenCalledWith('900004', expect.any(AbortSignal), { target: 'currentUser' }),
     );
   });
 
@@ -77,7 +77,7 @@ describe('useCollaborationPrivacy identity wiring', () => {
   it('用户身份只显示用户内容，不显示 Bot 管理卡片', async () => {
     mockedUseHumanIdentity.mockReturnValue({
       status: 'ready',
-      identity: { userId: '447147', displayName: '真实用户', online: true },
+      identity: { userId: '900004', displayName: '真实用户', online: true },
     });
     useWorkspaceStore.setState({
       activeIdentityId: 'human-1',
@@ -94,11 +94,11 @@ describe('useCollaborationPrivacy identity wiring', () => {
   it('Bot 身份只显示当前 Bot 的管理卡片', async () => {
     mockedUseHumanIdentity.mockReturnValue({
       status: 'ready',
-      identity: { userId: '447147', displayName: '真实用户', online: true },
+      identity: { userId: '900004', displayName: '真实用户', online: true },
     });
     useWorkspaceStore.setState({
-      activeIdentityId: 'bot-1:447147',
-      identities: [{ id: 'bot-1:447147', kind: 'bot', displayName: 'Bot A', online: true }],
+      activeIdentityId: 'bot-1:900004',
+      identities: [{ id: 'bot-1:900004', kind: 'bot', displayName: 'Bot A', online: true }],
     });
     jest.spyOn(collaborationPrivacyService, 'loadOverview').mockResolvedValue(overviewWithBots);
 
@@ -112,20 +112,20 @@ describe('useCollaborationPrivacy identity wiring', () => {
   it('Bot 身份只按选中 Bot 请求，不携带全量范围', async () => {
     mockedUseHumanIdentity.mockReturnValue({
       status: 'ready',
-      identity: { userId: '447147', displayName: '真实用户', online: true },
+      identity: { userId: '900004', displayName: '真实用户', online: true },
     });
     useWorkspaceStore.setState({
-      activeIdentityId: 'bot-1:447147',
-      identities: [{ id: 'bot-1:447147', kind: 'bot', displayName: 'Bot A', online: true }],
+      activeIdentityId: 'bot-1:900004',
+      identities: [{ id: 'bot-1:900004', kind: 'bot', displayName: 'Bot A', online: true }],
     });
     const mockedLoadOverview = jest.spyOn(collaborationPrivacyService, 'loadOverview').mockResolvedValue(overview);
 
     renderHook(() => useCollaborationPrivacy());
 
     await waitFor(() =>
-      expect(mockedLoadOverview).toHaveBeenCalledWith('447147', expect.any(AbortSignal), {
+      expect(mockedLoadOverview).toHaveBeenCalledWith('900004', expect.any(AbortSignal), {
         target: 'activeBot',
-        botId: 'bot-1:447147',
+        botId: 'bot-1:900004',
       }),
     );
     expect(mockedLoadOverview).toHaveBeenCalledTimes(1);
@@ -134,13 +134,13 @@ describe('useCollaborationPrivacy identity wiring', () => {
   it('切换工作身份时取消上一次在途请求并按新范围重取', async () => {
     mockedUseHumanIdentity.mockReturnValue({
       status: 'ready',
-      identity: { userId: '447147', displayName: '真实用户', online: true },
+      identity: { userId: '900004', displayName: '真实用户', online: true },
     });
     useWorkspaceStore.setState({
-      activeIdentityId: 'bot-1:447147',
+      activeIdentityId: 'bot-1:900004',
       identities: [
-        { id: 'bot-1:447147', kind: 'bot', displayName: 'Bot A', online: true },
-        { id: 'bot-2:447147', kind: 'bot', displayName: 'Bot B', online: true },
+        { id: 'bot-1:900004', kind: 'bot', displayName: 'Bot A', online: true },
+        { id: 'bot-2:900004', kind: 'bot', displayName: 'Bot B', online: true },
       ],
     });
     const mockedLoadOverview = jest.spyOn(collaborationPrivacyService, 'loadOverview').mockResolvedValue(overview);
@@ -149,26 +149,26 @@ describe('useCollaborationPrivacy identity wiring', () => {
     await waitFor(() => expect(mockedLoadOverview).toHaveBeenCalledTimes(1));
 
     act(() => {
-      workspaceService.switchIdentity('bot-2:447147');
+      workspaceService.switchIdentity('bot-2:900004');
     });
     await waitFor(() => expect(mockedLoadOverview).toHaveBeenCalledTimes(2));
 
     const signals = mockedLoadOverview.mock.calls.map((call: unknown[]) => call[1] as AbortSignal);
     expect(signals[0].aborted).toBe(true);
     expect(signals[1].aborted).toBe(false);
-    expect(mockedLoadOverview.mock.calls[1][2]).toEqual({ target: 'activeBot', botId: 'bot-2:447147' });
+    expect(mockedLoadOverview.mock.calls[1][2]).toEqual({ target: 'activeBot', botId: 'bot-2:900004' });
   });
 
   it('切换身份后仅最新请求可以更新页面状态', async () => {
     mockedUseHumanIdentity.mockReturnValue({
       status: 'ready',
-      identity: { userId: '447147', displayName: '真实用户', online: true },
+      identity: { userId: '900004', displayName: '真实用户', online: true },
     });
     useWorkspaceStore.setState({
-      activeIdentityId: 'bot-1:447147',
+      activeIdentityId: 'bot-1:900004',
       identities: [
-        { id: 'bot-1:447147', kind: 'bot', displayName: 'Bot A', online: true },
-        { id: 'bot-2:447147', kind: 'bot', displayName: 'Bot B', online: true },
+        { id: 'bot-1:900004', kind: 'bot', displayName: 'Bot A', online: true },
+        { id: 'bot-2:900004', kind: 'bot', displayName: 'Bot B', online: true },
       ],
     });
     let resolveFirst!: (value: CollaborationPrivacyOverview) => void;
@@ -191,7 +191,7 @@ describe('useCollaborationPrivacy identity wiring', () => {
     const { result } = renderHook(() => useCollaborationPrivacy());
     await waitFor(() => expect(mockedLoadOverview).toHaveBeenCalledTimes(1));
     act(() => {
-      workspaceService.switchIdentity('bot-2:447147');
+      workspaceService.switchIdentity('bot-2:900004');
     });
     await waitFor(() => expect(mockedLoadOverview).toHaveBeenCalledTimes(2));
 
@@ -213,13 +213,13 @@ describe('useCollaborationPrivacy identity wiring', () => {
   it('守护：生产入口任何身份下都不会回落到遗留全量 hydrate', async () => {
     mockedUseHumanIdentity.mockReturnValue({
       status: 'ready',
-      identity: { userId: '447147', displayName: '真实用户', online: true },
+      identity: { userId: '900004', displayName: '真实用户', online: true },
     });
     useWorkspaceStore.setState({
-      activeIdentityId: 'bot-1:447147',
+      activeIdentityId: 'bot-1:900004',
       identities: [
         { id: 'human-1', kind: 'user', displayName: '真实用户', online: true },
-        { id: 'bot-1:447147', kind: 'bot', displayName: 'Bot A', online: true },
+        { id: 'bot-1:900004', kind: 'bot', displayName: 'Bot A', online: true },
       ],
     });
     const mockedLoadOverview = jest.spyOn(collaborationPrivacyService, 'loadOverview').mockResolvedValue(overview);
@@ -243,13 +243,13 @@ describe('useCollaborationPrivacy identity wiring', () => {
   it('同一页面内切换 Human 与 Bot 身份时更新内容并关闭旧身份编辑态', async () => {
     mockedUseHumanIdentity.mockReturnValue({
       status: 'ready',
-      identity: { userId: '447147', displayName: '真实用户', online: true },
+      identity: { userId: '900004', displayName: '真实用户', online: true },
     });
     useWorkspaceStore.setState({
       activeIdentityId: 'human-1',
       identities: [
         { id: 'human-1', kind: 'user', displayName: '真实用户', online: true },
-        { id: 'bot-1:447147', kind: 'bot', displayName: 'Bot A', online: true },
+        { id: 'bot-1:900004', kind: 'bot', displayName: 'Bot A', online: true },
       ],
     });
     const mockedLoadOverview = jest
@@ -262,7 +262,7 @@ describe('useCollaborationPrivacy identity wiring', () => {
     expect(result.current.visibleBots).toEqual([]);
 
     act(() => {
-      workspaceService.switchIdentity('bot-1:447147');
+      workspaceService.switchIdentity('bot-1:900004');
     });
     await waitFor(() => expect(result.current.visibleBots.map((bot) => bot.id)).toEqual(['bot-1']));
     expect(result.current.showIdentityCard).toBe(false);
@@ -293,7 +293,7 @@ describe('useCollaborationPrivacy identity wiring', () => {
     );
     expect(scopes).toEqual([
       { target: 'currentUser' },
-      { target: 'activeBot', botId: 'bot-1:447147' },
+      { target: 'activeBot', botId: 'bot-1:900004' },
       { target: 'currentUser' },
     ]);
   });

--- a/src/frontend-nextgen/test/hooks/useCollaborationSquare.test.tsx
+++ b/src/frontend-nextgen/test/hooks/useCollaborationSquare.test.tsx
@@ -22,8 +22,8 @@ jest.mock('@/components/ui/notify', () => ({ notifyError: jest.fn(), notifySucce
 const mockedUseHumanIdentity = useHumanIdentity as jest.MockedFunction<typeof useHumanIdentity>;
 const mockedNotifyError = notifyError as jest.MockedFunction<typeof notifyError>;
 const mockedNotifySuccess = notifySuccess as jest.MockedFunction<typeof notifySuccess>;
-const humanContext = { actorId: 'human_327325', userId: '327325' };
-const viewerFields = { viewerActorType: 'human', viewerActorId: '327325' };
+const humanContext = { actorId: 'human_900003', userId: '900003' };
+const viewerFields = { viewerActorType: 'human', viewerActorId: '900003' };
 
 interface PendingRequest {
   query: PublicBotSearchQuery | undefined;
@@ -75,9 +75,9 @@ describe('useCollaborationSquare Bot Search', () => {
     useWorkspaceStore.getState().reset();
     useWorkspaceStore
       .getState()
-      .setIdentities([{ id: 'human_327325', kind: 'user', displayName: '当前用户', online: true }], 'human_327325');
+      .setIdentities([{ id: 'human_900003', kind: 'user', displayName: '当前用户', online: true }], 'human_900003');
     mockedUseHumanIdentity.mockReturnValue({
-      identity: { userId: '327325', displayName: '当前用户', online: true },
+      identity: { userId: '900003', displayName: '当前用户', online: true },
       status: 'ready',
     });
     mockedNotifyError.mockClear();
@@ -526,7 +526,7 @@ describe('useCollaborationSquare Bot Search', () => {
     expect(result.current.createSessionTarget).toEqual(group);
 
     await act(async () => {
-      result.current.submitCreateSession({ title: '测试会话', query: '测试协作目标' });
+      result.current.submitCreateSession({ title: '测试会话', query: '测试协作目标', messageViewScope: 'full' });
       await Promise.resolve();
       await Promise.resolve();
     });
@@ -534,6 +534,7 @@ describe('useCollaborationSquare Bot Search', () => {
     expect(createGroupSession).toHaveBeenCalledWith(group.id, humanContext, {
       title: '测试会话',
       query: '测试协作目标',
+      messageViewScope: 'full',
     });
     expect(legacyCreateGroupSession).not.toHaveBeenCalled();
     expect(history.push).toHaveBeenCalledWith(
@@ -573,7 +574,7 @@ describe('useCollaborationSquare Bot Search', () => {
 
     expect(legacyProfile).toHaveBeenCalledWith(bot.id);
     expect(realProfile).not.toHaveBeenCalled();
-    expect(realFriendship).toHaveBeenCalledWith(bot.id, humanContext, undefined, { type: 'human', id: '327325' });
+    expect(realFriendship).toHaveBeenCalledWith(bot.id, humanContext, undefined, { type: 'human', id: '900003' });
     expect(legacyFriendship).not.toHaveBeenCalled();
     expect(useCollaborationSquareStore.getState().bots[0].relationshipStatus).toBe('applying');
 
@@ -598,7 +599,7 @@ describe('useCollaborationSquare Bot Search', () => {
 
     expect(requestFriendship).toHaveBeenCalledWith(bot.id, humanContext, 'default:366656', {
       type: 'human',
-      id: '327325',
+      id: '900003',
     });
     unmount();
   });
@@ -626,9 +627,9 @@ describe('useCollaborationSquare Bot Search', () => {
 
     expect(requestFriendship).toHaveBeenCalledWith(botA.id, humanContext, botA.friendRequestBotId, {
       type: 'human',
-      id: '327325',
+      id: '900003',
     });
-    expect(useCollaborationSquareStore.getState().busyKeys).toEqual(['bot:human:327325:default:entity-a']);
+    expect(useCollaborationSquareStore.getState().busyKeys).toEqual(['bot:human:900003:default:entity-a']);
     expect(useCollaborationSquareStore.getState().bots.map((bot) => bot.relationshipStatus)).toEqual(['none', 'none']);
 
     await act(async () => {
@@ -747,7 +748,7 @@ describe('useCollaborationSquare Bot Search', () => {
     useWorkspaceStore
       .getState()
       .setIdentities(
-        [{ id: 'human_327325', kind: 'user', displayName: '当前用户', online: true }, botIdentity],
+        [{ id: 'human_900003', kind: 'user', displayName: '当前用户', online: true }, botIdentity],
         botIdentity.id,
       );
     const bot = resultBot('bot-target');
@@ -768,7 +769,7 @@ describe('useCollaborationSquare Bot Search', () => {
       await Promise.resolve();
     });
 
-    expect(requestFriendship).toHaveBeenCalledWith(bot.id, { actorId: 'bot-viewer', userId: '327325' }, undefined, {
+    expect(requestFriendship).toHaveBeenCalledWith(bot.id, { actorId: 'bot-viewer', userId: '900003' }, undefined, {
       type: 'bot',
       id: 'bot-viewer',
     });
@@ -784,7 +785,7 @@ describe('useCollaborationSquare Bot Search', () => {
     useWorkspaceStore
       .getState()
       .setIdentities(
-        [{ id: 'human_327325', kind: 'user', displayName: '当前用户', online: true }, botIdentity],
+        [{ id: 'human_900003', kind: 'user', displayName: '当前用户', online: true }, botIdentity],
         botIdentity.id,
       );
     const friend = { ...resultBot('bot-friend'), relationshipStatus: 'friend' as const };
@@ -840,9 +841,9 @@ describe('useCollaborationSquare Task Plaza', () => {
     useWorkspaceStore.getState().reset();
     useWorkspaceStore
       .getState()
-      .setIdentities([{ id: 'human_327325', kind: 'user', displayName: '当前用户', online: true }], 'human_327325');
+      .setIdentities([{ id: 'human_900003', kind: 'user', displayName: '当前用户', online: true }], 'human_900003');
     mockedUseHumanIdentity.mockReturnValue({
-      identity: { userId: '327325', displayName: '当前用户', online: true },
+      identity: { userId: '900003', displayName: '当前用户', online: true },
       status: 'ready',
     });
   });

--- a/src/frontend-nextgen/test/hooks/useCollaborationSquareActorContext.test.tsx
+++ b/src/frontend-nextgen/test/hooks/useCollaborationSquareActorContext.test.tsx
@@ -13,13 +13,13 @@ describe('useCollaborationSquareActorContext', () => {
     useWorkspaceStore.getState().reset();
     useWorkspaceStore.getState().setIdentities(
       [
-        { id: 'human_327325', kind: 'user', displayName: '当前用户', online: true },
-        { id: 'bot-1:327325', kind: 'bot', displayName: '当前 Bot', online: true },
+        { id: 'human_900003', kind: 'user', displayName: '当前用户', online: true },
+        { id: 'bot-1:900003', kind: 'bot', displayName: '当前 Bot', online: true },
       ],
-      'human_327325',
+      'human_900003',
     );
     mockedUseHumanIdentity.mockReturnValue({
-      identity: { userId: '327325', displayName: '当前用户', online: true },
+      identity: { userId: '900003', displayName: '当前用户', online: true },
       status: 'ready',
     });
   });
@@ -30,19 +30,19 @@ describe('useCollaborationSquareActorContext', () => {
 
     expect(result.current).toMatchObject({
       humanIdentityStatus: 'ready',
-      humanBotContext: { actorId: 'human_327325', userId: '327325' },
-      viewer: { viewerActorType: 'human', viewerActorId: '327325' },
-      activeActor: { type: 'human', id: '327325' },
+      humanBotContext: { actorId: 'human_900003', userId: '900003' },
+      viewer: { viewerActorType: 'human', viewerActorId: '900003' },
+      activeActor: { type: 'human', id: '900003' },
     });
     expect(reset).not.toHaveBeenCalled();
 
-    act(() => useWorkspaceStore.getState().setActiveIdentity('bot-1:327325'));
+    act(() => useWorkspaceStore.getState().setActiveIdentity('bot-1:900003'));
 
     expect(result.current).toMatchObject({
       humanIdentityStatus: 'ready',
-      humanBotContext: { actorId: 'bot-1:327325', userId: '327325' },
-      viewer: { viewerActorType: 'bot', viewerActorId: 'bot-1:327325' },
-      activeActor: { type: 'bot', id: 'bot-1:327325' },
+      humanBotContext: { actorId: 'bot-1:900003', userId: '900003' },
+      viewer: { viewerActorType: 'bot', viewerActorId: 'bot-1:900003' },
+      activeActor: { type: 'bot', id: 'bot-1:900003' },
     });
     expect(reset).toHaveBeenCalledTimes(1);
   });

--- a/src/frontend-nextgen/test/pages/MyTask/MyTaskPage.test.tsx
+++ b/src/frontend-nextgen/test/pages/MyTask/MyTaskPage.test.tsx
@@ -77,7 +77,7 @@ describe('MyTaskPage work identity visibility', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockedUseHumanIdentity.mockReturnValue({
-      identity: { userId: '327325', displayName: '当前用户', online: true },
+      identity: { userId: '900003', displayName: '当前用户', online: true },
       status: 'ready',
     });
     mockedUseOwnedBots.mockReturnValue({
@@ -93,7 +93,7 @@ describe('MyTaskPage work identity visibility', () => {
 
   it('用户工作身份只展示用户任务，并禁止定时任务请求', () => {
     mockedUseWorkIdentityAccess.mockReturnValue(
-      access({ id: 'human_327325', kind: 'user', displayName: '当前用户', online: true }),
+      access({ id: 'human_900003', kind: 'user', displayName: '当前用户', online: true }),
     );
 
     render(<MyTaskPage />);
@@ -101,13 +101,13 @@ describe('MyTaskPage work identity visibility', () => {
     expect(screen.getByTestId('user-task-tab')).toBeInTheDocument();
     expect(screen.queryByTestId('routine-task-tab')).not.toBeInTheDocument();
     expect(screen.queryByText('定时任务')).not.toBeInTheDocument();
-    expect(mockedUseMyTaskTasks).toHaveBeenLastCalledWith('327325', 1, 10, 'all', true);
+    expect(mockedUseMyTaskTasks).toHaveBeenLastCalledWith('900003', 1, 10, 'all', true);
     expect(mockedUseRoutineTasks.mock.calls.at(-1)?.at(-1)).toBe(false);
   });
 
   it('Bot 工作身份只展示当前 Bot 的定时任务，并禁止用户任务请求', () => {
     mockedUseWorkIdentityAccess.mockReturnValue(
-      access({ id: 'bot-123:327325', kind: 'bot', displayName: '当前 Bot', online: true }),
+      access({ id: 'bot-123:900003', kind: 'bot', displayName: '当前 Bot', online: true }),
     );
 
     render(<MyTaskPage />);
@@ -130,12 +130,12 @@ describe('MyTaskPage work identity visibility', () => {
   });
 
   it('工作身份从用户切换为 Bot 后同步切换内容', () => {
-    let currentAccess = access({ id: 'human_327325', kind: 'user', displayName: '当前用户', online: true });
+    let currentAccess = access({ id: 'human_900003', kind: 'user', displayName: '当前用户', online: true });
     mockedUseWorkIdentityAccess.mockImplementation(() => currentAccess);
     const view = render(<MyTaskPage />);
     expect(screen.getByTestId('user-task-tab')).toBeInTheDocument();
 
-    currentAccess = access({ id: 'bot-456:327325', kind: 'bot', displayName: '切换后 Bot', online: true });
+    currentAccess = access({ id: 'bot-456:900003', kind: 'bot', displayName: '切换后 Bot', online: true });
     act(() => view.rerender(<MyTaskPage />));
 
     expect(screen.queryByTestId('user-task-tab')).not.toBeInTheDocument();

--- a/src/frontend-nextgen/test/pages/MyTask/useMyTaskTasks.test.tsx
+++ b/src/frontend-nextgen/test/pages/MyTask/useMyTaskTasks.test.tsx
@@ -19,7 +19,7 @@ describe('useMyTaskTasks enabled gate', () => {
   });
 
   it('Bot 工作身份禁用时不请求用户任务', async () => {
-    const { result } = renderHook(() => useMyTaskTasks('327325', 1, 10, 'all', false));
+    const { result } = renderHook(() => useMyTaskTasks('900003', 1, 10, 'all', false));
 
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(mockedListMyTasks).not.toHaveBeenCalled();
@@ -33,7 +33,7 @@ describe('useMyTaskTasks enabled gate', () => {
         resolveRequest = resolve;
       }) as ReturnType<typeof listMyTasks>,
     );
-    const { result, rerender } = renderHook(({ enabled }) => useMyTaskTasks('327325', 1, 10, 'all', enabled), {
+    const { result, rerender } = renderHook(({ enabled }) => useMyTaskTasks('900003', 1, 10, 'all', enabled), {
       initialProps: { enabled: true },
     });
 

--- a/src/frontend-nextgen/test/pages/Workspace/InviteAcceptPanel.scope.test.tsx
+++ b/src/frontend-nextgen/test/pages/Workspace/InviteAcceptPanel.scope.test.tsx
@@ -1,0 +1,41 @@
+/** @jest-environment jsdom */
+import { InviteAcceptPanel } from '@/pages/Workspace/InviteAcceptPanel';
+import { useInviteAccept } from '@/pages/Workspace/hooks/useInviteAccept';
+import { describe, expect, it, jest } from '@jest/globals';
+import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/jest-globals';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+jest.mock('@/pages/Workspace/hooks/useInviteAccept');
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const hook = useInviteAccept as unknown as jest.Mock<any>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let acceptMock: jest.Mock<any>;
+
+function setupConfirmState() {
+  acceptMock = jest.fn<any>().mockResolvedValue(undefined);
+  hook.mockReturnValue({ status: 'confirm', accept: acceptMock, resetToConfirm: jest.fn() });
+}
+
+function renderPanel() {
+  setupConfirmState();
+  return render(
+    <MemoryRouter initialEntries={['/workspace/invite/groups/tk']}>
+      <Routes>
+        <Route path="/workspace/invite/:type/:token" element={<InviteAcceptPanel />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('InviteAcceptPanel 视角选择', () => {
+  it('确认页展示 radio，默认完整视角；选参与者视角后确认加入传 scope', () => {
+    renderPanel();
+    const radios = screen.getAllByRole('radio');
+    expect(radios[0]).toBeChecked();
+    fireEvent.click(radios[1]);
+    fireEvent.click(screen.getByRole('button', { name: '确认加入' }));
+    expect(acceptMock).toHaveBeenCalledWith('participant');
+  });
+});

--- a/src/frontend-nextgen/test/pages/Workspace/InviteAcceptPanel.test.tsx
+++ b/src/frontend-nextgen/test/pages/Workspace/InviteAcceptPanel.test.tsx
@@ -37,7 +37,7 @@ describe('InviteAcceptPanel', () => {
     );
     expect(await screen.findByText(/是否确认加入/)).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: '确认加入' }));
-    await waitFor(() => expect(svc.acceptInvitation).toHaveBeenCalledWith('tk-1'));
+    await waitFor(() => expect(svc.acceptInvitation).toHaveBeenCalled());
   });
 
   it('uses sessions path segment to show session join copy', async () => {

--- a/src/frontend-nextgen/test/pages/Workspace/components/BotSessionSidebar/BotSessionSidebar.test.tsx
+++ b/src/frontend-nextgen/test/pages/Workspace/components/BotSessionSidebar/BotSessionSidebar.test.tsx
@@ -173,7 +173,7 @@ describe('BotSessionSidebar', () => {
         view="chat"
         availableViews={['chat', 'group']}
         onViewChange={() => {}}
-        identities={[{ id: 'identity:me', name: '风太', kind: 'user', avatar: '风' }]}
+        identities={[{ id: 'identity:me', name: '示例用户', kind: 'user', avatar: '风' }]}
         activeIdentityId="identity:me"
         chatBots={[]}
         friendBots={[]}
@@ -209,7 +209,7 @@ describe('BotSessionSidebar', () => {
         view="chat"
         availableViews={['chat', 'group']}
         onViewChange={() => {}}
-        identities={[{ id: 'identity:me', name: '风太', kind: 'user', avatar: '风' }]}
+        identities={[{ id: 'identity:me', name: '示例用户', kind: 'user', avatar: '风' }]}
         activeIdentityId="identity:me"
         chatBots={[bots[0]]}
         friendBots={[]}
@@ -375,7 +375,7 @@ describe('BotSessionSidebar', () => {
         view="chat"
         availableViews={['chat', 'group']}
         onViewChange={() => {}}
-        identities={[{ id: 'identity:me', name: '风太', kind: 'user', avatar: '风' }]}
+        identities={[{ id: 'identity:me', name: '示例用户', kind: 'user', avatar: '风' }]}
         activeIdentityId="identity:me"
         chatBots={bots}
         friendBots={[]}
@@ -398,10 +398,10 @@ describe('BotSessionSidebar', () => {
       />,
     );
 
-    expect(screen.queryByRole('button', { name: '当前协作身份：风太' })).not.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: '风太管理的 Bot (2)' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: '风太管理的 Bot (2)' })).toHaveClass('min-h-9');
-    expect(screen.getByRole('button', { name: '风太的好友 Bot (0)' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: '当前协作身份：示例用户' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '示例用户管理的 Bot (2)' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '示例用户管理的 Bot (2)' })).toHaveClass('min-h-9');
+    expect(screen.getByRole('button', { name: '示例用户的好友 Bot (0)' })).toBeInTheDocument();
   });
 
   it('Bot 卡片触发区支持键盘展开,新建会话不触发展开', async () => {
@@ -772,7 +772,7 @@ describe('BotSessionSidebar', () => {
         view="chat"
         availableViews={['chat', 'group']}
         onViewChange={() => {}}
-        identities={[{ id: 'identity:me', name: '风太', kind: 'user', avatar: '风' }]}
+        identities={[{ id: 'identity:me', name: '示例用户', kind: 'user', avatar: '风' }]}
         activeIdentityId="identity:me"
         chatBots={bots}
         friendBots={[]}
@@ -800,7 +800,7 @@ describe('BotSessionSidebar', () => {
     const hintButton = screen.getByRole('button', { name: 'AgentCoding Bot 使用提示' });
     expect(hintButton).toHaveClass('h-7', 'w-7');
     expect(hintButton.closest('.flex.min-h-9')).toContainElement(
-      screen.getByRole('button', { name: '风太管理的 Bot (2)' }),
+      screen.getByRole('button', { name: '示例用户管理的 Bot (2)' }),
     );
     await userEvent.setup().hover(hintButton);
     const workshopLink = await screen.findByRole('link', { name: 'Bot 工坊' });

--- a/src/frontend-nextgen/test/pages/Workspace/components/GroupChatPane/CollabPanel.joinScope.test.tsx
+++ b/src/frontend-nextgen/test/pages/Workspace/components/GroupChatPane/CollabPanel.joinScope.test.tsx
@@ -1,0 +1,63 @@
+/** @jest-environment jsdom */
+import { CollabPanel } from '@/pages/Workspace/components/GroupChatPane/CollabPanel';
+import type { CollabPanelState } from '@/pages/Workspace/hooks/useCollabPanel';
+import { describe, expect, it, jest } from '@jest/globals';
+import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/jest-globals';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+function makePanel(overrides: Partial<CollabPanelState> = {}): CollabPanelState {
+  return {
+    visible: true,
+    humanAbsentOnly: true,
+    botActorId: null,
+    botMode: null,
+    botName: 'Alpha',
+    human: { actorId: 'human_1', kind: 'human', name: '章梧', role: 'member', mode: 'absent' },
+    humanJoined: false,
+    humanName: '章梧',
+    humanAvatarUrl: undefined,
+    canSwitchToHuman: true,
+    switchingBotMode: false,
+    joining: false,
+    humanViewScope: null,
+    switchingViewScope: false,
+    setBotMode: jest.fn<any>().mockResolvedValue(undefined),
+    joinSession: jest.fn<any>().mockResolvedValue(true),
+    leaveSession: jest.fn<any>().mockResolvedValue(true),
+    switchToHuman: jest.fn(),
+    setViewScope: jest.fn<any>().mockResolvedValue(true),
+    ...overrides,
+  };
+}
+
+describe('加入当前会话确认弹窗携带 message_view_scope', () => {
+  it('勾选「只看公开及与我相关的消息」后确认 → joinSession("participant")', () => {
+    const panel = makePanel();
+    render(<CollabPanel panel={panel} />);
+    fireEvent.click(screen.getByRole('button', { name: '加入当前会话' }));
+    expect(screen.getByText('只看公开及与我相关的消息')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('checkbox'));
+    fireEvent.click(screen.getByRole('button', { name: '确认加入' }));
+    expect(panel.joinSession).toHaveBeenCalledWith('participant');
+  });
+
+  it('不勾选确认 → joinSession("full")；弹窗每次打开重置为未勾选', () => {
+    const panel = makePanel();
+    const { unmount } = render(<CollabPanel panel={panel} />);
+    fireEvent.click(screen.getByRole('button', { name: '加入当前会话' }));
+    fireEvent.click(screen.getByRole('checkbox'));
+    fireEvent.click(screen.getByRole('button', { name: '取消' }));
+    fireEvent.click(screen.getByRole('button', { name: '加入当前会话' }));
+    expect(screen.getByRole('checkbox')).not.toBeChecked();
+    fireEvent.click(screen.getByRole('button', { name: '确认加入' }));
+    expect(panel.joinSession).toHaveBeenCalledWith('full');
+    unmount();
+  });
+
+  it('弹窗展示「其他须知」提示盒', () => {
+    render(<CollabPanel panel={makePanel()} />);
+    fireEvent.click(screen.getByRole('button', { name: '加入当前会话' }));
+    expect(screen.getByText('其他须知：')).toBeInTheDocument();
+  });
+});

--- a/src/frontend-nextgen/test/pages/Workspace/components/GroupChatPane/CollabPanel.test.tsx
+++ b/src/frontend-nextgen/test/pages/Workspace/components/GroupChatPane/CollabPanel.test.tsx
@@ -20,10 +20,13 @@ function makePanel(overrides: Partial<CollabPanelState> = {}): CollabPanelState 
     canSwitchToHuman: true,
     switchingBotMode: false,
     joining: false,
+    humanViewScope: null,
+    switchingViewScope: false,
     setBotMode: jest.fn<any>().mockResolvedValue(undefined),
     joinSession: jest.fn<any>().mockResolvedValue(true),
     leaveSession: jest.fn<any>().mockResolvedValue(true),
     switchToHuman: jest.fn(),
+    setViewScope: jest.fn<any>().mockResolvedValue(true),
     ...overrides,
   };
 }

--- a/src/frontend-nextgen/test/pages/Workspace/components/GroupChatPane/CollabPanel.viewScope.test.tsx
+++ b/src/frontend-nextgen/test/pages/Workspace/components/GroupChatPane/CollabPanel.viewScope.test.tsx
@@ -1,0 +1,82 @@
+/** @jest-environment jsdom */
+import { CollabPanel } from '@/pages/Workspace/components/GroupChatPane/CollabPanel';
+import type { CollabPanelState } from '@/pages/Workspace/hooks/useCollabPanel';
+import { describe, expect, it, jest } from '@jest/globals';
+import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/jest-globals';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+function makePanel(overrides: Partial<CollabPanelState> = {}): CollabPanelState {
+  return {
+    visible: true,
+    humanAbsentOnly: false,
+    botActorId: null,
+    botMode: null,
+    botName: 'Alpha',
+    human: {
+      actorId: 'human_1',
+      kind: 'human',
+      name: '章梧',
+      role: 'member',
+      mode: 'present',
+      messageViewScope: 'full',
+    },
+    humanJoined: true,
+    humanName: '章梧',
+    humanAvatarUrl: undefined,
+    canSwitchToHuman: true,
+    switchingBotMode: false,
+    joining: false,
+    humanViewScope: 'full',
+    switchingViewScope: false,
+    setBotMode: jest.fn<any>().mockResolvedValue(undefined),
+    joinSession: jest.fn<any>().mockResolvedValue(true),
+    leaveSession: jest.fn<any>().mockResolvedValue(true),
+    switchToHuman: jest.fn(),
+    setViewScope: jest.fn<any>().mockResolvedValue(true),
+    ...overrides,
+  };
+}
+
+describe('隐身条视角切换按钮', () => {
+  it('human present 且回显 full：渲染「切换到参与者视角」按钮，点击切到 participant', () => {
+    const panel = makePanel();
+    render(<CollabPanel panel={panel} />);
+    expect(screen.getByText('在会话中隐身')).toBeInTheDocument();
+    const btn = screen.getByRole('button', { name: /切换到参与者视角/ });
+    fireEvent.click(btn);
+    expect(panel.setViewScope).toHaveBeenCalledWith('participant');
+  });
+
+  it('回显 participant：渲染「切换到完整视角」按钮，点击切回 full；标题行出现「参与者视角」Badge', () => {
+    const panel = makePanel({ humanViewScope: 'participant' });
+    render(<CollabPanel panel={panel} />);
+    const btn = screen.getByRole('button', { name: /切换到完整视角/ });
+    fireEvent.click(btn);
+    expect(panel.setViewScope).toHaveBeenCalledWith('full');
+    expect(screen.getByText('参与者视角')).toBeInTheDocument();
+  });
+
+  it('回显 full：标题行出现「完整视角」Badge', () => {
+    render(<CollabPanel panel={makePanel()} />);
+    expect(screen.getByText('完整视角')).toBeInTheDocument();
+  });
+
+  it('switchingViewScope 进行中切换按钮禁用', () => {
+    render(<CollabPanel panel={makePanel({ switchingViewScope: true })} />);
+    expect(screen.getByRole('button', { name: /切换到参与者视角/ })).toBeDisabled();
+  });
+
+  it('scope 回显缺失（humanViewScope=null）不渲染切换按钮与视角 Badge', () => {
+    render(<CollabPanel panel={makePanel({ humanViewScope: null })} />);
+    expect(screen.getByText('在会话中隐身')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /切换到/ })).not.toBeInTheDocument();
+    expect(screen.queryByText('完整视角')).not.toBeInTheDocument();
+    expect(screen.queryByText('参与者视角')).not.toBeInTheDocument();
+  });
+
+  it('bot 视角面板不渲染切换按钮', () => {
+    render(<CollabPanel panel={makePanel({ botActorId: 'b:1', botMode: 'auto' })} />);
+    expect(screen.queryByRole('button', { name: /切换到/ })).not.toBeInTheDocument();
+  });
+});

--- a/src/frontend-nextgen/test/pages/Workspace/components/GroupSidebar/GroupItem.createSessionScope.test.tsx
+++ b/src/frontend-nextgen/test/pages/Workspace/components/GroupSidebar/GroupItem.createSessionScope.test.tsx
@@ -1,0 +1,87 @@
+/** @jest-environment jsdom */
+import type { GroupView } from '@/domain/collaboration';
+import { GroupItem } from '@/pages/Workspace/components/GroupSidebar/GroupItem';
+import { describe, expect, it, jest } from '@jest/globals';
+import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/jest-globals';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+Object.defineProperty(globalThis, 'ResizeObserver', {
+  configurable: true,
+  value: class ResizeObserverMock {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  },
+});
+
+const group: GroupView = {
+  groupId: 'g1',
+  name: '协作群',
+  kind: 'free_chat',
+  status: 'active',
+  participants: [],
+  sessions: [],
+  lastMessageAt: 1,
+  createdAt: 1,
+  participantCount: 0,
+  isPublic: false,
+  deliveryPolicy: 'send_to_driver' as const,
+};
+
+function renderItem(
+  onCreateSession: (groupId: string, scope?: 'full' | 'participant') => void,
+  viewerKind: 'user' | 'bot',
+) {
+  return render(
+    <GroupItem
+      group={group}
+      viewerKind={viewerKind}
+      expanded={false}
+      sessions={[]}
+      sessionTab="all"
+      onSessionTabChange={jest.fn()}
+      favoriteSessionIds={[]}
+      selectedGroupId={null}
+      selectedSessionId={null}
+      onSelectGroup={jest.fn()}
+      onToggleGroupExpanded={jest.fn()}
+      onSelectSession={jest.fn()}
+      onToggleFavorite={jest.fn()}
+      onCreateSession={onCreateSession}
+      onManageGroup={jest.fn()}
+      onManageSession={jest.fn()}
+      onShareGroup={jest.fn()}
+      onDissolveGroup={jest.fn()}
+      hasMoreSessions={false}
+      isLoadingMoreSessions={false}
+      onLoadMoreSessions={jest.fn()}
+    />,
+  );
+}
+
+describe('GroupItem 新建会话视角菜单', () => {
+  it('human 身份：点「+」打开菜单，选参与者视角以该 scope 创建', () => {
+    const onCreateSession = jest.fn();
+    renderItem(onCreateSession, 'user');
+    fireEvent.click(screen.getByRole('button', { name: /新建会话/ }));
+    fireEvent.click(screen.getByText('参与者视角'));
+    expect(onCreateSession).toHaveBeenCalledWith('g1', 'participant');
+  });
+
+  it('human 身份：选完整视角以 full 创建', () => {
+    const onCreateSession = jest.fn();
+    renderItem(onCreateSession, 'user');
+    fireEvent.click(screen.getByRole('button', { name: /新建会话/ }));
+    fireEvent.click(screen.getByText('完整视角'));
+    expect(onCreateSession).toHaveBeenCalledWith('g1', 'full');
+  });
+
+  it('bot 身份：点「+」不弹菜单，直接以单参创建（不传 scope）', () => {
+    const onCreateSession = jest.fn();
+    renderItem(onCreateSession, 'bot');
+    fireEvent.click(screen.getByRole('button', { name: /新建会话/ }));
+    expect(screen.queryByText('参与者视角')).toBeNull();
+    expect(onCreateSession).toHaveBeenCalledWith('g1');
+  });
+});

--- a/src/frontend-nextgen/test/pages/Workspace/components/GroupSidebar/GroupSidebar.test.tsx
+++ b/src/frontend-nextgen/test/pages/Workspace/components/GroupSidebar/GroupSidebar.test.tsx
@@ -48,6 +48,7 @@ function makeProps(partial: Partial<React.ComponentProps<typeof GroupSidebar>> =
   return {
     view: 'group' as 'chat' | 'group',
     onViewChange: jest.fn(),
+    viewerKind: 'user' as const,
     groups: [baseGroup],
     isLoading: false,
     onSelectGroup: jest.fn(),
@@ -254,19 +255,12 @@ describe('GroupSidebar', () => {
     expect(onManageGroup).toHaveBeenCalledWith('g1');
     expect(onToggleGroupExpanded).not.toHaveBeenCalled();
     const createSessionButton = screen.getByRole('button', { name: '新建会话' });
-    expect(createSessionButton).toHaveClass(
-      'h-7',
-      'w-7',
-      'rounded-md',
-      'text-muted-foreground',
-      'hover:bg-primary/10',
-      'hover:text-primary',
-    );
     const scopeButton = screen.getByRole('button', { name: '会话范围：全部会话' });
     expect(scopeButton).toHaveClass('h-7', 'w-7');
     expect(scopeButton.querySelector('svg.lucide-list-filter')).toBeInTheDocument();
     fireEvent.click(createSessionButton);
-    expect(onCreateSession).toHaveBeenCalledWith('g1');
+    fireEvent.click(screen.getByText('参与者视角'));
+    expect(onCreateSession).toHaveBeenCalledWith('g1', 'participant');
     expect(onToggleGroupExpanded).not.toHaveBeenCalled();
   });
 
@@ -282,9 +276,9 @@ describe('GroupSidebar', () => {
     const secondGroup = { ...baseGroup, groupId: 'g2', name: '新品发布协作组', sessions: [] };
     render(<GroupSidebar {...makeProps({ groups: [baseGroup, secondGroup] })} />);
 
-    const groupList = screen.getByText(/^协作群 \(\d+\)$/).nextElementSibling;
-    expect(groupList).toHaveClass('divide-y', 'divide-border/70');
     const sessionList = screen.getByLabelText('协作群会话列表：主站群');
+    const groupList = sessionList.parentElement?.parentElement;
+    expect(groupList).toHaveClass('divide-y', 'divide-border/70');
     expect(sessionList).toHaveClass('border-t');
     expect(sessionList).not.toHaveClass('border-b', 'ml-[60px]', 'border-l', 'pl-2');
     expect(sessionList.firstElementChild).not.toHaveClass('border-b');
@@ -321,7 +315,9 @@ describe('GroupSidebar', () => {
       'shadow-md',
     );
     expect(filterPanel).not.toHaveClass('mx-[18px]', 'mt-2');
-    const sidebarScrollArea = screen.getByText(/^协作群 \(\d+\)$/).parentElement?.parentElement;
+    const sidebarScrollArea = screen
+      .getByLabelText('协作群会话列表：主站群')
+      .parentElement?.parentElement?.parentElement;
     expect(sidebarScrollArea).not.toContainElement(filterPanel);
     expect(screen.getByRole('radiogroup', { name: '协作群类型' })).toHaveClass('min-w-0');
     expect(screen.getByRole('radiogroup', { name: '协作群类型' }).querySelector('.flex')).toHaveClass(
@@ -370,7 +366,7 @@ describe('GroupSidebar', () => {
 
   it('协作身份移出二级侧栏，群卡片保留可读间距并降低标题字重', () => {
     render(<GroupSidebar {...makeProps()} />);
-    expect(screen.queryByRole('button', { name: '当前协作身份：风太' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: '当前协作身份：示例用户' })).not.toBeInTheDocument();
     const groupTrigger = screen.getByRole('button', { name: /主站群/ });
     expect(groupTrigger.parentElement).toHaveClass('min-h-16', 'bg-primary/5', 'px-4', 'py-2.5');
     expect(groupTrigger).toHaveClass('px-0', 'py-1');

--- a/src/frontend-nextgen/test/pages/Workspace/components/ManagePanel/ManagePanel.test.tsx
+++ b/src/frontend-nextgen/test/pages/Workspace/components/ManagePanel/ManagePanel.test.tsx
@@ -94,7 +94,7 @@ it('member list resolves only the authenticated human and preserves other human 
   const otherHumanGroup: GroupView = {
     ...group,
     participants: [
-      { actorId: 'human_447147', kind: 'human', name: '447147', role: 'owner', mode: 'present' },
+      { actorId: 'human_900004', kind: 'human', name: '900004', role: 'owner', mode: 'present' },
       { actorId: 'human_447148', kind: 'human', name: '其他成员', role: 'member', mode: 'present' },
     ],
     participantCount: 2,
@@ -103,15 +103,15 @@ it('member list resolves only the authenticated human and preserves other human 
     <GroupManagePanel
       {...groupProps()}
       group={otherHumanGroup}
-      activeIdentity={{ id: 'bot_xxx:447147', kind: 'bot', displayName: '协作 Bot', online: true }}
-      authenticatedUserId="447147"
-      authenticatedUserName="风太"
+      activeIdentity={{ id: 'bot_xxx:900004', kind: 'bot', displayName: '协作 Bot', online: true }}
+      authenticatedUserId="900004"
+      authenticatedUserName="示例用户"
     />,
   );
 
-  expect(screen.getByText('风太')).toBeInTheDocument();
+  expect(screen.getByText('示例用户')).toBeInTheDocument();
   expect(screen.getByText('其他成员')).toBeInTheDocument();
-  expect(screen.queryByText('447147')).not.toBeInTheDocument();
+  expect(screen.queryByText('900004')).not.toBeInTheDocument();
 });
 
 it('group panel advanced tab renders dingtalk binding form', () => {

--- a/src/frontend-nextgen/test/pages/Workspace/components/ManagePanel/MemberList.test.tsx
+++ b/src/frontend-nextgen/test/pages/Workspace/components/ManagePanel/MemberList.test.tsx
@@ -156,4 +156,73 @@ describe('MemberList', () => {
     expect(screen.getByText('禁言')).toHaveClass('bg-muted', 'text-muted-foreground');
     expect(screen.getByText('旁观')).toHaveClass('bg-muted', 'text-muted-foreground');
   });
+
+  it('human 成员回显 messageViewScope 时展示对应视角标签', () => {
+    renderMembers(
+      [
+        {
+          ...baseParticipant,
+          actorId: 'human-participant',
+          kind: 'human',
+          name: '参与者用户',
+          role: 'member',
+          mode: 'present',
+          messageViewScope: 'participant',
+        },
+        {
+          ...baseParticipant,
+          actorId: 'human-full',
+          kind: 'human',
+          name: '完整视角用户',
+          role: 'member',
+          mode: 'present',
+          messageViewScope: 'full',
+        },
+      ],
+      { groupKind: 'task_master_slave', showMode: true },
+    );
+
+    expect(memberRow('human-participant').textContent).toContain('参与者视角');
+    expect(memberRow('human-full').textContent).toContain('完整视角');
+    // 视角标签色：full 主色蓝（primary），participant 灰（neutral）。
+    expect(screen.getByText('完整视角')).toHaveClass('bg-primary/10', 'text-primary');
+    expect(screen.getByText('参与者视角')).toHaveClass('bg-muted', 'text-muted-foreground');
+  });
+
+  it('human 成员无 messageViewScope 回显时不展示视角标签', () => {
+    renderMembers(
+      [
+        {
+          ...baseParticipant,
+          actorId: 'human-plain',
+          kind: 'human',
+          name: '普通用户',
+          role: 'member',
+          mode: 'present',
+        },
+      ],
+      { groupKind: 'task_master_slave', showMode: true },
+    );
+
+    expect(memberRow('human-plain').textContent).not.toContain('完整视角');
+    expect(memberRow('human-plain').textContent).not.toContain('参与者视角');
+  });
+
+  it('bot 成员即使误带 messageViewScope 也不展示视角标签（按 kind 门控）', () => {
+    renderMembers(
+      [
+        {
+          ...baseParticipant,
+          actorId: 'bot-scope',
+          name: '带视角 Bot',
+          mode: 'auto',
+          messageViewScope: 'participant',
+        },
+      ],
+      { groupKind: 'task_master_slave', showMode: true },
+    );
+
+    expect(memberRow('bot-scope').textContent).not.toContain('参与者视角');
+    expect(memberRow('bot-scope').textContent).not.toContain('完整视角');
+  });
 });

--- a/src/frontend-nextgen/test/pages/Workspace/components/Modals/CreateGroupModal.scope.test.tsx
+++ b/src/frontend-nextgen/test/pages/Workspace/components/Modals/CreateGroupModal.scope.test.tsx
@@ -1,0 +1,97 @@
+/** @jest-environment jsdom */
+import { CreateGroupModal } from '@/pages/Workspace/components/Modals/CreateGroupModal';
+import { collaborationCandidateService } from '@/services/workspace/collaborationCandidateService';
+import { groupService } from '@/services/workspace/groupService';
+import { beforeEach, expect, it, jest } from '@jest/globals';
+import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/jest-globals';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+jest.mock('@/pages/Workspace/components/Modals/YamlEditor', () => ({
+  YamlCodeEditor: ({ value, onChange }: { value: string; onChange: (value: string) => void }) => (
+    <textarea id="create-group-yaml" value={value} onChange={(event) => onChange(event.target.value)} />
+  ),
+}));
+jest.mock('@/services/workspace/groupService');
+jest.mock('@/services/workspace/collaborationCandidateService');
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const gs = groupService as unknown as Record<string, jest.Mock<any>>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const cs = collaborationCandidateService as unknown as Record<string, jest.Mock<any>>;
+
+const userIdentity = { id: 'actor-1', kind: 'user' as const, displayName: '我', online: true };
+const botIdentity = { id: 'actor-bot', kind: 'bot' as const, displayName: '我 Bot', online: true };
+const bots = [
+  {
+    id: 'b1',
+    name: 'Alpha',
+    summary: '代码助手',
+    online: true,
+    status: 'online' as const,
+    reachability: 'reachable' as const,
+    visibility: 'public' as const,
+    isFriend: true,
+  },
+];
+
+Object.defineProperty(globalThis, 'ResizeObserver', {
+  configurable: true,
+  value: class ResizeObserverMock {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  },
+});
+
+beforeEach(() => {
+  gs.createGroup.mockReset();
+  gs.createGroup.mockResolvedValue({ ok: true, data: { groupId: 'g9' } });
+  cs.listFriends.mockReset();
+  cs.listCandidates.mockReset();
+  cs.listMine.mockReset();
+  cs.listFriends.mockResolvedValue({ ok: true, data: { items: bots, total: 1, offset: 0, limit: 50, hasMore: false } });
+  cs.listCandidates.mockResolvedValue({
+    ok: true,
+    data: { items: [], total: 0, offset: 0, limit: 50, hasMore: false },
+  });
+  cs.listMine.mockResolvedValue({ ok: true, data: { items: bots, total: 1, offset: 0, limit: 50, hasMore: false } });
+});
+
+async function selectLeader(label: string, optionName: RegExp) {
+  fireEvent.click(screen.getByRole('button', { name: label }));
+  fireEvent.click(await screen.findByRole('option', { name: optionName }));
+}
+
+it('用户身份建群展示视角 radio，选参与者视角后 human 参与者条目携带 scope', async () => {
+  render(<CreateGroupModal open activeIdentity={userIdentity} onClose={jest.fn()} onCreated={jest.fn()} />);
+  const radios = screen.getAllByRole('radio', { name: /完整视角|参与者视角/ });
+  expect(radios).toHaveLength(2);
+  expect(radios[0]).toBeChecked();
+  fireEvent.click(radios[1]);
+
+  fireEvent.click(await screen.findByRole('button', { name: /Alpha/ }));
+  await selectLeader('群主 Bot', /Alpha/);
+  fireEvent.click(screen.getByRole('button', { name: '确认创建' }));
+
+  await waitFor(() =>
+    expect(gs.createGroup).toHaveBeenCalledWith(
+      expect.objectContaining({
+        participants: [{ actor_id: 'actor-1', message_view_scope: 'participant' }, { actor_id: 'b1' }],
+      }),
+    ),
+  );
+}, 30_000);
+
+it('bot 身份建群不展示视角 radio 且参与者不携带 scope', async () => {
+  render(<CreateGroupModal open activeIdentity={botIdentity} onClose={jest.fn()} onCreated={jest.fn()} />);
+  expect(screen.queryAllByRole('radio', { name: /完整视角|参与者视角/ })).toHaveLength(0);
+  fireEvent.click(await screen.findByRole('button', { name: /Alpha/ }));
+  fireEvent.click(screen.getByRole('button', { name: '确认创建' }));
+  await waitFor(() =>
+    expect(gs.createGroup).toHaveBeenCalledWith(
+      expect.objectContaining({
+        participants: [{ actor_id: 'actor-bot' }, { actor_id: 'b1' }],
+      }),
+    ),
+  );
+});

--- a/src/frontend-nextgen/test/pages/Workspace/components/Modals/CreateGroupModal.test.tsx
+++ b/src/frontend-nextgen/test/pages/Workspace/components/Modals/CreateGroupModal.test.tsx
@@ -101,28 +101,28 @@ it('发起协作顶栏只在当前 human ID 匹配时使用认证用户名，Bot
   const { rerender } = render(
     <CreateGroupModal
       open
-      activeIdentity={{ id: 'human_447147', kind: 'user', displayName: '447147', online: true }}
-      authenticatedUserId="447147"
-      authenticatedUserName="风太"
+      activeIdentity={{ id: 'human_900004', kind: 'user', displayName: '900004', online: true }}
+      authenticatedUserId="900004"
+      authenticatedUserName="示例用户"
       onClose={jest.fn()}
       onCreated={jest.fn()}
     />,
   );
-  expect(screen.getByText('风太')).toBeInTheDocument();
-  expect(screen.queryByText('447147')).not.toBeInTheDocument();
+  expect(screen.getByText('示例用户')).toBeInTheDocument();
+  expect(screen.queryByText('900004')).not.toBeInTheDocument();
 
   rerender(
     <CreateGroupModal
       open
-      activeIdentity={{ id: 'bot_xxx:447147', kind: 'bot', displayName: '协作 Bot', online: true }}
-      authenticatedUserId="447147"
-      authenticatedUserName="风太"
+      activeIdentity={{ id: 'bot_xxx:900004', kind: 'bot', displayName: '协作 Bot', online: true }}
+      authenticatedUserId="900004"
+      authenticatedUserName="示例用户"
       onClose={jest.fn()}
       onCreated={jest.fn()}
     />,
   );
   expect(screen.getByText('协作 Bot')).toBeInTheDocument();
-  expect(screen.queryByText('风太')).not.toBeInTheDocument();
+  expect(screen.queryByText('示例用户')).not.toBeInTheDocument();
 });
 
 it('free_chat strategy posts delivery_policy on confirm', async () => {
@@ -142,7 +142,7 @@ it('free_chat strategy posts delivery_policy on confirm', async () => {
         name: '我的群',
         driverBotUuid: 'b1',
         originator: 'actor-1',
-        participants: [{ actor_id: 'actor-1' }, { actor_id: 'b1' }],
+        participants: [{ actor_id: 'actor-1', message_view_scope: 'full' }, { actor_id: 'b1' }],
       }),
     ),
   );
@@ -163,7 +163,7 @@ it('task_master_slave uses the selected manager as driver_bot_uuid', async () =>
       expect.objectContaining({
         strategy: 'manager_worker',
         driverBotUuid: 'b1',
-        participants: [{ actor_id: 'actor-1' }, { actor_id: 'b1' }],
+        participants: [{ actor_id: 'actor-1', message_view_scope: 'full' }, { actor_id: 'b1' }],
       }),
     ),
   );

--- a/src/frontend-nextgen/test/pages/Workspace/components/Modals/GroupParticipantPicker.test.tsx
+++ b/src/frontend-nextgen/test/pages/Workspace/components/Modals/GroupParticipantPicker.test.tsx
@@ -8,8 +8,8 @@ import '@testing-library/jest-dom/jest-globals';
 import { fireEvent, render, screen } from '@testing-library/react';
 
 const unknownBot = {
-  id: 'b2:327325',
-  name: 'b2:327325',
+  id: 'b2:900003',
+  name: 'b2:900003',
   online: false,
   status: 'hidden',
   reachability: 'reachable',
@@ -52,7 +52,7 @@ it('renders an unresolved collaboration friend as a disabled unknown option', ()
     />,
   );
 
-  const option = screen.getByRole('button', { name: /b2:327325/ });
+  const option = screen.getByRole('button', { name: /b2:900003/ });
   expect(option).toBeDisabled();
   expect(option).toHaveClass('bg-muted/50');
   expect(screen.getByText('未知')).toBeInTheDocument();

--- a/src/frontend-nextgen/test/pages/Workspace/hooks/useBcnChatDetailRedirect.test.tsx
+++ b/src/frontend-nextgen/test/pages/Workspace/hooks/useBcnChatDetailRedirect.test.tsx
@@ -32,17 +32,17 @@ beforeEach(() => {
   jest.clearAllMocks();
   svc.loadGroupDetail.mockResolvedValue(
     groupDetail([
-      { actorId: 'human_327325', kind: 'human' },
+      { actorId: 'human_900003', kind: 'human' },
       { actorId: 'bot-x:2088', kind: 'bot' },
     ]),
   );
 });
 
 it('bot_uuid 命中群固定成员名册 → membership=direct 重定向', async () => {
-  mountWith('id=g1&bot_uuid=human_327325&session=s1');
+  mountWith('id=g1&bot_uuid=human_900003&session=s1');
   await waitFor(() =>
     expect(mockedReplace).toHaveBeenCalledWith(
-      '/workspace?tab=group&group=g1&session=s1&bot=human_327325&membership=direct',
+      '/workspace?tab=group&group=g1&session=s1&bot=human_900003&membership=direct',
     ),
   );
   expect(svc.loadGroupDetail).toHaveBeenCalledWith('g1');
@@ -58,17 +58,17 @@ it('bot_uuid 不在名册（仅参与临时会话）→ membership=session_only 
 });
 
 it('bot_uuid 无前缀工号与名册 human_ 前缀归一化匹配 → direct', async () => {
-  mountWith('id=g1&bot_uuid=327325&session=s1');
+  mountWith('id=g1&bot_uuid=900003&session=s1');
   await waitFor(() => expect(mockedReplace).toHaveBeenCalledWith(expect.stringContaining('membership=direct')));
-  expect(mockedReplace).toHaveBeenCalledWith(expect.stringContaining('bot=327325'));
+  expect(mockedReplace).toHaveBeenCalledWith(expect.stringContaining('bot=900003'));
 });
 
 it('群详情接口失败 → 降级为不带 membership（由 workspace 自动纠正）', async () => {
   svc.loadGroupDetail.mockResolvedValue({ ok: false, error: { friendlyMessage: 'x' } });
-  mountWith('id=g1&bot_uuid=human_327325&session=s1');
+  mountWith('id=g1&bot_uuid=human_900003&session=s1');
   // membership 降级但 bot= 身份透传不受影响（身份定位与参与方式判定相互独立）。
   await waitFor(() =>
-    expect(mockedReplace).toHaveBeenCalledWith('/workspace?tab=group&group=g1&session=s1&bot=human_327325'),
+    expect(mockedReplace).toHaveBeenCalledWith('/workspace?tab=group&group=g1&session=s1&bot=human_900003'),
   );
 });
 
@@ -79,17 +79,17 @@ it('缺 bot_uuid → 不调群详情、不带 membership/bot，仍重定向（wo
 });
 
 it('bcs_grp_ 前缀群 → 不判定参与方式（交由 workspace BCS 路由），直接重定向', async () => {
-  mountWith('id=bcs_grp_abc&bot_uuid=human_327325&session=s1');
+  mountWith('id=bcs_grp_abc&bot_uuid=human_900003&session=s1');
   await waitFor(() =>
-    expect(mockedReplace).toHaveBeenCalledWith('/workspace?tab=group&group=bcs_grp_abc&session=s1&bot=human_327325'),
+    expect(mockedReplace).toHaveBeenCalledWith('/workspace?tab=group&group=bcs_grp_abc&session=s1&bot=human_900003'),
   );
   expect(svc.loadGroupDetail).not.toHaveBeenCalled();
 });
 
 it('缺 id 或 session → status=invalid 且不发生跳转', async () => {
-  const { result } = mountWith('bot_uuid=human_327325&session=s1');
+  const { result } = mountWith('bot_uuid=human_900003&session=s1');
   expect(result.current.status).toBe('invalid');
-  const { result: r2 } = mountWith('id=g1&bot_uuid=human_327325');
+  const { result: r2 } = mountWith('id=g1&bot_uuid=human_900003');
   expect(r2.current.status).toBe('invalid');
   await waitFor(() => Promise.resolve());
   expect(mockedReplace).not.toHaveBeenCalled();
@@ -97,6 +97,6 @@ it('缺 id 或 session → status=invalid 且不发生跳转', async () => {
 });
 
 it('参数齐全时进入 redirecting 状态', () => {
-  const { result } = mountWith('id=g1&bot_uuid=human_327325&session=s1');
+  const { result } = mountWith('id=g1&bot_uuid=human_900003&session=s1');
   expect(result.current.status).toBe('redirecting');
 });

--- a/src/frontend-nextgen/test/pages/Workspace/hooks/useBotModels.test.tsx
+++ b/src/frontend-nextgen/test/pages/Workspace/hooks/useBotModels.test.tsx
@@ -40,16 +40,16 @@ beforeEach(() => {
 
 it('托管 Bot 会话保持拉取模型列表', async () => {
   const { result } = renderHook(() =>
-    useBotModels(managedBot, { ...session, botId: managedBot.botId }, 'human_327325', jest.fn()),
+    useBotModels(managedBot, { ...session, botId: managedBot.botId }, 'human_900003', jest.fn()),
   );
 
   await waitFor(() => expect(result.current.isLoadingModels).toBe(false));
-  expect(mockedListModels).toHaveBeenCalledWith(managedBot, 'human_327325');
+  expect(mockedListModels).toHaveBeenCalledWith(managedBot, 'human_900003');
   expect(result.current.activeModelId).toBe('session-model');
 });
 
 it('好友 Bot 会话不拉取模型列表，保留会话模型只读展示', async () => {
-  const { result } = renderHook(() => useBotModels(friendBot, session, 'human_327325', jest.fn()));
+  const { result } = renderHook(() => useBotModels(friendBot, session, 'human_900003', jest.fn()));
 
   await waitFor(() => expect(result.current.isLoadingModels).toBe(false));
   expect(mockedListModels).not.toHaveBeenCalled();
@@ -62,7 +62,7 @@ it('好友 Bot 的模型选择按钮禁用', () => {
     <BotModelSelectorContainer
       chatBots={[friendBot]}
       session={session}
-      activeIdentityId="human_327325"
+      activeIdentityId="human_900003"
       onSessionModelChange={jest.fn()}
     />,
   );

--- a/src/frontend-nextgen/test/pages/Workspace/hooks/useBotSessionFilesFeature.test.tsx
+++ b/src/frontend-nextgen/test/pages/Workspace/hooks/useBotSessionFilesFeature.test.tsx
@@ -51,7 +51,7 @@ beforeEach(() => {
 });
 
 it('托管 Bot 的 / 命令保留 skill 入口', () => {
-  const { result } = renderHook(() => useBotSessionFilesFeature(bot, session, 'human_327325', jest.fn()));
+  const { result } = renderHook(() => useBotSessionFilesFeature(bot, session, 'human_900003', jest.fn()));
 
   const items = result.current.command.categories[0]?.items ?? [];
   expect(items.map((item) => item.name)).toContain('skill');
@@ -59,7 +59,7 @@ it('托管 Bot 的 / 命令保留 skill 入口', () => {
 
 it('好友 Bot 的 / 命令不展示 skill 入口', () => {
   const { result } = renderHook(() =>
-    useBotSessionFilesFeature({ ...bot, isFriendBot: true }, session, 'human_327325', jest.fn()),
+    useBotSessionFilesFeature({ ...bot, isFriendBot: true }, session, 'human_900003', jest.fn()),
   );
 
   const items = result.current.command.categories[0]?.items ?? [];

--- a/src/frontend-nextgen/test/pages/Workspace/hooks/useBotSessions.test.ts
+++ b/src/frontend-nextgen/test/pages/Workspace/hooks/useBotSessions.test.ts
@@ -338,10 +338,10 @@ const friendBot: ChatBotView = {
 
 it('展开「好友 Bot」分类下的 bot：按 isFriendBot 调用会话列表接口（服务层据此附带 f_user_id）', async () => {
   useWorkspaceStore.getState().setView('chat');
-  const { result } = renderHook(() => useBotSessions([friendBot], ['botfriend:999'], 'human_327325', false));
+  const { result } = renderHook(() => useBotSessions([friendBot], ['botfriend:999'], 'human_900003', false));
   // 懒加载必须以好友 bot 实体（isFriendBot=true、realBotId 拆分）与当前用户 id 调用 listSessionsPage；
   // 服务层 withFriendBotRequestParams 据此在 GET /openapi/v1/bots/{realBotId}/sessions 上附带 f_user_id。
-  await waitFor(() => expect(svc.listSessionsPage).toHaveBeenCalledWith(friendBot, 'human_327325', 1, 10));
+  await waitFor(() => expect(svc.listSessionsPage).toHaveBeenCalledWith(friendBot, 'human_900003', 1, 10));
   const [calledBot] = svc.listSessionsPage.mock.calls[0];
   expect(calledBot.isFriendBot).toBe(true);
   expect(calledBot.realBotId).toBe('botfriend');
@@ -350,7 +350,7 @@ it('展开「好友 Bot」分类下的 bot：按 isFriendBot 调用会话列表�
 
 it('openSession 好友 bot：展开时分区归属记为 friend（缺省 mine 会让侧栏好友分区折叠）', async () => {
   useWorkspaceStore.getState().setView('chat');
-  const { result } = renderHook(() => useBotSessions([friendBot], [], 'human_327325', false));
+  const { result } = renderHook(() => useBotSessions([friendBot], [], 'human_900003', false));
   act(() => {
     result.current.openSession('botfriend:999', 's1');
   });

--- a/src/frontend-nextgen/test/pages/Workspace/hooks/useBotSkills.test.tsx
+++ b/src/frontend-nextgen/test/pages/Workspace/hooks/useBotSkills.test.tsx
@@ -23,13 +23,13 @@ beforeEach(() => {
 });
 
 it('托管 Bot 保持拉取 Skills', async () => {
-  renderHook(() => useBotSkills(bot, 'human_327325'));
+  renderHook(() => useBotSkills(bot, 'human_900003'));
 
-  await waitFor(() => expect(mockedListSkills).toHaveBeenCalledWith(bot, 'human_327325'));
+  await waitFor(() => expect(mockedListSkills).toHaveBeenCalledWith(bot, 'human_900003'));
 });
 
 it('好友 Bot 不拉取 Skills', async () => {
-  const { result } = renderHook(() => useBotSkills({ ...bot, isFriendBot: true }, 'human_327325'));
+  const { result } = renderHook(() => useBotSkills({ ...bot, isFriendBot: true }, 'human_900003'));
 
   await waitFor(() => expect(result.current.isLoading).toBe(false));
   expect(mockedListSkills).not.toHaveBeenCalled();

--- a/src/frontend-nextgen/test/pages/Workspace/hooks/useCollabPanel.test.ts
+++ b/src/frontend-nextgen/test/pages/Workspace/hooks/useCollabPanel.test.ts
@@ -94,7 +94,7 @@ it('joinSession 通过 PATCH participants/{bot_uuid} 将当前用户置为 prese
     ok = await result.current.joinSession();
   });
   expect(ok).toBe(true);
-  expect(updateMemberMode).toHaveBeenCalledWith('s1', 'human_1', 'present');
+  expect(updateMemberMode).toHaveBeenCalledWith('s1', 'human_1', 'present', undefined);
   expect(useWorkspaceStore.getState().activeIdentityId).toBe('human_1');
   expect(useWorkspaceStore.getState().selectedGroupId).toBe('g1');
   expect(useWorkspaceStore.getState().selectedSessionId).toBe('s1');
@@ -237,7 +237,7 @@ it('bot 视角加入会话：human 不在 participants 时用 store 人类身份
     ok = await result.current.joinSession();
   });
   expect(ok).toBe(true);
-  expect(updateMemberMode).toHaveBeenCalledWith('s1', 'human_1', 'present');
+  expect(updateMemberMode).toHaveBeenCalledWith('s1', 'human_1', 'present', undefined);
   // 加入后切换身份也必须命中 store 身份（规范化 id 精确匹配不到）。
   expect(useWorkspaceStore.getState().activeIdentityId).toBe('human_1');
 });
@@ -249,4 +249,68 @@ it('去发言：authenticatedUserId 无 human_ 前缀时 setActiveIdentity 仍�
   useWorkspaceStore.getState().selectSession('s1');
   act(() => result.current.switchToHuman());
   expect(useWorkspaceStore.getState().activeIdentityId).toBe('human_1');
+});
+
+it('humanViewScope 回显 human 成员的 messageViewScope（缺失为 null）', () => {
+  const withScope = makeSession([
+    { actorId: 'human_1', kind: 'human', name: '章梧', role: 'member', mode: 'present', messageViewScope: 'full' },
+  ]);
+  const { result } = renderHook(() => useCollabPanel(withScope, humanIdentity, updateMemberMode));
+  expect(result.current.humanViewScope).toBe('full');
+
+  const withoutScope = makeSession([
+    { actorId: 'human_1', kind: 'human', name: '章梧', role: 'member', mode: 'present' },
+  ]);
+  const { result: result2 } = renderHook(() => useCollabPanel(withoutScope, humanIdentity, updateMemberMode));
+  expect(result2.current.humanViewScope).toBeNull();
+});
+
+it('setViewScope("participant") 调 updateMemberScope、递增 wsReconnectNonce 并返回 true', async () => {
+  const session = makeSession([
+    { actorId: 'human_1', kind: 'human', name: '章梧', role: 'member', mode: 'present', messageViewScope: 'full' },
+  ]);
+  const updateMemberScope = jest.fn<any>().mockResolvedValue(true);
+  const { result } = renderHook(() =>
+    useCollabPanel(session, humanIdentity, updateMemberMode, undefined, undefined, updateMemberScope),
+  );
+  const before = useWorkspaceStore.getState().wsReconnectNonce;
+  let ok = false;
+  await act(async () => {
+    ok = await result.current.setViewScope('participant');
+  });
+  expect(ok).toBe(true);
+  expect(updateMemberScope).toHaveBeenCalledWith('s1', 'human_1', 'participant');
+  expect(useWorkspaceStore.getState().wsReconnectNonce).toBe(before + 1);
+});
+
+it('updateMemberScope 失败时 setViewScope 返回 false 且不递增 wsReconnectNonce', async () => {
+  const session = makeSession([
+    { actorId: 'human_1', kind: 'human', name: '章梧', role: 'member', mode: 'present', messageViewScope: 'full' },
+  ]);
+  const updateMemberScope = jest.fn<any>().mockResolvedValue(false);
+  const { result } = renderHook(() =>
+    useCollabPanel(session, humanIdentity, updateMemberMode, undefined, undefined, updateMemberScope),
+  );
+  const before = useWorkspaceStore.getState().wsReconnectNonce;
+  let ok = true;
+  await act(async () => {
+    ok = await result.current.setViewScope('participant');
+  });
+  expect(ok).toBe(false);
+  expect(useWorkspaceStore.getState().wsReconnectNonce).toBe(before);
+});
+
+it('未注入 updateMemberScope 时 setViewScope 返回 false 且不调用', async () => {
+  const session = makeSession([
+    { actorId: 'human_1', kind: 'human', name: '章梧', role: 'member', mode: 'present', messageViewScope: 'full' },
+  ]);
+  const { result } = renderHook(() => useCollabPanel(session, humanIdentity, updateMemberMode));
+  const before = useWorkspaceStore.getState().wsReconnectNonce;
+  let ok = true;
+  await act(async () => {
+    ok = await result.current.setViewScope('participant');
+  });
+  expect(ok).toBe(false);
+  expect(updateMemberMode).not.toHaveBeenCalled();
+  expect(useWorkspaceStore.getState().wsReconnectNonce).toBe(before);
 });

--- a/src/frontend-nextgen/test/pages/Workspace/hooks/useFriendBots.test.tsx
+++ b/src/frontend-nextgen/test/pages/Workspace/hooks/useFriendBots.test.tsx
@@ -14,43 +14,43 @@ const mockedListFriends = collaborationCandidateService.listFriends as jest.Mock
 beforeEach(() => {
   jest.resetAllMocks();
   mockedGetCurrentOpenApiUserId.mockReturnValue({
-    getCurrentOpenApiUserId: () => ({ status: 'available', value: '327325' }),
+    getCurrentOpenApiUserId: () => ({ status: 'available', value: '900003' }),
   });
   mockedListFriends.mockResolvedValue({
     ok: true,
     data: {
-      items: [{ id: 'friend-bot:327325', name: '好友 Bot', online: true }],
+      items: [{ id: 'friend-bot:900003', name: '好友 Bot', online: true }],
       total: 1,
     },
   });
 });
 
 it('queries Human friends with the Human actor type', async () => {
-  const { result } = renderHook(() => useFriendBots('human_327325', true, true));
+  const { result } = renderHook(() => useFriendBots('human_900003', true, true));
 
   await act(async () => Promise.resolve());
 
-  expect(mockedListFriends).toHaveBeenCalledWith('327325', {
+  expect(mockedListFriends).toHaveBeenCalledWith('900003', {
     actorType: 'human',
     offset: 0,
     limit: 100,
   });
   expect(result.current.friendBots).toEqual([
-    expect.objectContaining({ botId: 'friend-bot:327325', displayName: '好友 Bot' }),
+    expect.objectContaining({ botId: 'friend-bot:900003', displayName: '好友 Bot' }),
   ]);
 });
 
 it('queries Bot friends with the full Bot uuid as actor_id', async () => {
-  const { result } = renderHook(() => useFriendBots('friend-owner-bot:327325', false, true));
+  const { result } = renderHook(() => useFriendBots('friend-owner-bot:900003', false, true));
 
   await act(async () => Promise.resolve());
 
-  expect(mockedListFriends).toHaveBeenCalledWith('friend-owner-bot:327325', {
+  expect(mockedListFriends).toHaveBeenCalledWith('friend-owner-bot:900003', {
     actorType: 'bot',
     offset: 0,
     limit: 100,
   });
   expect(result.current.friendBots).toEqual([
-    expect.objectContaining({ botId: 'friend-bot:327325', displayName: '好友 Bot' }),
+    expect.objectContaining({ botId: 'friend-bot:900003', displayName: '好友 Bot' }),
   ]);
 });

--- a/src/frontend-nextgen/test/pages/Workspace/hooks/useGroupChat.test.ts
+++ b/src/frontend-nextgen/test/pages/Workspace/hooks/useGroupChat.test.ts
@@ -135,6 +135,7 @@ beforeEach(() => {
     isLoadingMoreHistory: false,
     subscribeToSupportState: jest.fn<any>(() => jest.fn<any>()),
     subscribeToConnectionStatus: jest.fn<any>(() => jest.fn<any>()),
+    subscribeToViewScopeChanged: jest.fn<any>(() => jest.fn<any>()),
   };
   mockedProviderFactory.mockReturnValue(mockProvider);
 
@@ -347,6 +348,38 @@ it('stop calls chat.abort, reconnect calls provider.reconnect', async () => {
   expect(mockChat.abort).toHaveBeenCalled();
   await result.current.reconnect();
   expect(mockProvider.reconnect).toHaveBeenCalled();
+});
+
+it('bumpWsReconnect 触发 provider.reconnect；mount 首跳不触发', async () => {
+  renderHook(() => useGroupChat(session));
+  await waitFor(() => expect(mockProvider.connect).toHaveBeenCalled());
+  expect(mockProvider.reconnect).not.toHaveBeenCalled();
+  act(() => useWorkspaceStore.getState().bumpWsReconnect());
+  await waitFor(() => expect(mockProvider.reconnect).toHaveBeenCalledTimes(1));
+});
+
+it('bumpWsReconnect 重连成功后以不变参数刷新历史消息（loadHistory 再调一次）', async () => {
+  renderHook(() => useGroupChat(session));
+  await waitFor(() => expect(mockProvider.loadHistory).toHaveBeenCalledTimes(1));
+  act(() => useWorkspaceStore.getState().bumpWsReconnect());
+  await waitFor(() => expect(mockProvider.reconnect).toHaveBeenCalledTimes(1));
+  await waitFor(() => expect(mockProvider.loadHistory).toHaveBeenCalledTimes(2));
+  expect(mockChat.setMessages).toHaveBeenCalledTimes(2);
+});
+
+it('view_scope_changed 推送路径同样刷新历史消息（loadHistory 再调一次）', async () => {
+  let viewScopeListener: (() => void) | null = null;
+  mockProvider.subscribeToViewScopeChanged = jest.fn<any>((cb: () => void) => {
+    viewScopeListener = cb;
+    return () => {
+      viewScopeListener = null;
+    };
+  });
+  renderHook(() => useGroupChat(session));
+  await waitFor(() => expect(mockProvider.loadHistory).toHaveBeenCalledTimes(1));
+  expect(viewScopeListener).not.toBeNull();
+  act(() => viewScopeListener?.());
+  await waitFor(() => expect(mockProvider.loadHistory).toHaveBeenCalledTimes(2));
 });
 
 it('loadMoreHistory prepends deduped older messages and syncs hasMore from provider', async () => {

--- a/src/frontend-nextgen/test/pages/Workspace/hooks/useGroupSessions.multiGroup.test.ts
+++ b/src/frontend-nextgen/test/pages/Workspace/hooks/useGroupSessions.multiGroup.test.ts
@@ -170,7 +170,7 @@ it('createSessionIn creates in the given group and selects group + session', asy
   await waitFor(() => expect(result.current.sessionsByGroupId.g2).toHaveLength(0));
 
   const created = await act(async () => result.current.createSessionIn('g2', '跨群新建'));
-  expect(ss.createNewSession).toHaveBeenCalledWith('g2', '跨群新建', undefined);
+  expect(ss.createNewSession).toHaveBeenCalledWith('g2', '跨群新建', undefined, undefined);
   expect(created?.sessionId).toBe('g2-s9');
   expect(result.current.sessionsByGroupId.g2.map((s) => s.sessionId)).toContain('g2-s9');
   expect(useWorkspaceStore.getState().selectedGroupId).toBe('g2');

--- a/src/frontend-nextgen/test/pages/Workspace/hooks/useInviteAccept.scope.test.ts
+++ b/src/frontend-nextgen/test/pages/Workspace/hooks/useInviteAccept.scope.test.ts
@@ -1,0 +1,35 @@
+/** @jest-environment jsdom */
+import { useInviteAccept } from '@/pages/Workspace/hooks/useInviteAccept';
+import { invitationService } from '@/services/workspace/invitationService';
+import { beforeEach, expect, it, jest } from '@jest/globals';
+import { act, renderHook } from '@testing-library/react';
+
+jest.mock('@/services/workspace/invitationService');
+jest.mock('@/services/workspace/sessionService');
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const inv = invitationService as unknown as Record<string, jest.Mock<any>>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  inv.getAcceptPageState.mockResolvedValue({ ok: true, data: { isValid: true } });
+  inv.acceptInvitation.mockResolvedValue({
+    ok: true,
+    data: { targetType: 'group', targetId: 'g1', alreadyJoined: false },
+  });
+});
+
+it('accept(scope) 透传给 invitationService.acceptInvitation', async () => {
+  const { result } = renderHook(() => useInviteAccept('tk'));
+  await act(async () => {
+    await result.current.accept('participant');
+  });
+  expect(inv.acceptInvitation).toHaveBeenCalledWith('tk', 'participant');
+});
+
+it('不传 scope 时透传 undefined', async () => {
+  const { result } = renderHook(() => useInviteAccept('tk'));
+  await act(async () => {
+    await result.current.accept();
+  });
+  expect(inv.acceptInvitation).toHaveBeenCalledWith('tk', undefined);
+});

--- a/src/frontend-nextgen/test/pages/Workspace/hooks/useOpenDefaultGroupSession.test.ts
+++ b/src/frontend-nextgen/test/pages/Workspace/hooks/useOpenDefaultGroupSession.test.ts
@@ -14,10 +14,10 @@ beforeEach(() => {
   useWorkspaceStore.getState().resetWorkspace();
   useWorkspaceStore.setState({
     identities: [
-      { id: 'human_327325', kind: 'user', displayName: '我', online: true },
-      { id: '20260528_udt1y38n:327325', kind: 'bot', displayName: '驾驶 Bot', online: true },
+      { id: 'human_900003', kind: 'user', displayName: '我', online: true },
+      { id: '20260528_udt1y38n:900003', kind: 'bot', displayName: '驾驶 Bot', online: true },
     ],
-    activeIdentityId: '20260528_udt1y38n:327325',
+    activeIdentityId: '20260528_udt1y38n:900003',
   });
   useWorkspaceStore.getState().selectGroup(null);
   useWorkspaceStore.getState().selectSession(null);
@@ -33,7 +33,7 @@ it('opens the created initial session without a fallback list request', async ()
   expect(ss.loadSessionsByIdsOrBcs).not.toHaveBeenCalled();
   expect(useWorkspaceStore.getState().selectedGroupId).toBe('g-new');
   expect(useWorkspaceStore.getState().selectedSessionId).toBe('s-initial');
-  expect(useWorkspaceStore.getState().activeIdentityId).toBe('20260528_udt1y38n:327325');
+  expect(useWorkspaceStore.getState().activeIdentityId).toBe('20260528_udt1y38n:900003');
 });
 
 it('opens the first default session of the created group', async () => {

--- a/src/frontend-nextgen/test/pages/Workspace/hooks/useSessionMemberSync.test.ts
+++ b/src/frontend-nextgen/test/pages/Workspace/hooks/useSessionMemberSync.test.ts
@@ -15,8 +15,8 @@ type Map = Record<string, SessionView[]>;
 /** 包装子 hook:用真实 React state 承载 map,applyMapUpdate 走 setState 以触发重渲染。 */
 function useHarness(initial: Map, selectedId: string | null) {
   const [map, setMap] = useState<Map>(initial);
-  const { updateMemberMode } = useSessionMemberSync(selectedId, setMap, 0, map);
-  return { map, setMap, updateMemberMode };
+  const { updateMemberMode, updateMemberScope } = useSessionMemberSync(selectedId, setMap, 0, map);
+  return { map, setMap, updateMemberMode, updateMemberScope };
 }
 
 beforeEach(() => {
@@ -131,7 +131,7 @@ it('updateMemberMode 成功后用 PATCH 响应刷新对应会话 participants', 
   const { result } = renderHook(() => useHarness(initial, 's1'));
   const ok = await act(() => result.current.updateMemberMode('s1', 'b1', 'muted'));
   expect(ok).toBe(true);
-  expect(ss.updateMemberMode).toHaveBeenCalledWith('s1', 'b1', 'muted');
+  expect(ss.updateMemberMode).toHaveBeenCalledWith('s1', 'b1', 'muted', undefined);
   await waitFor(() => {
     expect(result.current.map.g1[0].participants.find((p) => p.actorId === 'b1')?.mode).toBe('muted');
   });
@@ -185,5 +185,66 @@ it('updateMemberMode 失败时返回 false', async () => {
   });
   const { result } = renderHook(() => useHarness({}, 's1'));
   const ok = await act(() => result.current.updateMemberMode('s1', 'b1', 'muted'));
+  expect(ok).toBe(false);
+});
+
+it('updateMemberScope 成功后就地刷新对应会话的 scope 回显', async () => {
+  ss.updateMemberScope.mockResolvedValue({
+    ok: true,
+    data: {
+      sessionId: 's1',
+      groupId: 'g1',
+      title: '一号',
+      kind: 'chat',
+      status: 'running',
+      participants: [
+        {
+          actorId: 'human_1',
+          kind: 'human' as const,
+          name: '章梧',
+          role: 'member' as const,
+          mode: 'present' as const,
+          messageViewScope: 'participant' as const,
+        },
+      ],
+      lastMessageAt: 1,
+      createdAt: 1,
+      favorite: false,
+    },
+  });
+  const initial: Map = {
+    g1: [
+      {
+        sessionId: 's1',
+        groupId: 'g1',
+        title: '一号',
+        kind: 'chat',
+        status: 'running',
+        participants: [],
+        lastMessageAt: 1,
+        createdAt: 1,
+        favorite: true,
+      },
+    ],
+  };
+  const { result } = renderHook(() => useHarness(initial, 's1'));
+  const ok = await act(() => result.current.updateMemberScope('s1', 'human_1', 'participant'));
+  expect(ok).toBe(true);
+  expect(ss.updateMemberScope).toHaveBeenCalledWith('s1', 'human_1', 'participant');
+  await waitFor(() => {
+    expect(result.current.map.g1[0].participants.find((p) => p.actorId === 'human_1')?.messageViewScope).toBe(
+      'participant',
+    );
+  });
+  expect(result.current.map.g1[0].favorite).toBe(true);
+});
+
+it('updateMemberScope 失败时返回 false', async () => {
+  ss.updateMemberScope.mockResolvedValue({
+    ok: false,
+    error: { code: 'X', friendlyMessage: '切换消息视角失败', canRetry: false },
+  });
+  const { result } = renderHook(() => useHarness({}, 's1'));
+  const ok = await act(() => result.current.updateMemberScope('s1', 'human_1', 'participant'));
   expect(ok).toBe(false);
 });

--- a/src/frontend-nextgen/test/pages/Workspace/hooks/useViewScopeChangedNotice.test.ts
+++ b/src/frontend-nextgen/test/pages/Workspace/hooks/useViewScopeChangedNotice.test.ts
@@ -1,0 +1,55 @@
+/** @jest-environment jsdom */
+import { useViewScopeChangedNotice } from '@/pages/Workspace/hooks/useViewScopeChangedNotice';
+import type { GroupChatProvider } from '@/services/workspace/groupChatProvider';
+import { beforeEach, expect, it, jest } from '@jest/globals';
+import { act, renderHook } from '@testing-library/react';
+import { toast } from 'sonner';
+
+// 自动 mock（不引用 @jest/globals 的 jest 绑定），避免 import 排序把 sonner 前置导致工厂执行时 jest 未初始化。
+jest.mock('sonner');
+
+const toastInfo = toast.info as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+it('provider 发出 view_scope_changed 时 toast 提示重连', () => {
+  let listener: (() => void) | null = null;
+  const provider = {
+    subscribeToViewScopeChanged: jest.fn((cb: () => void) => {
+      listener = cb;
+      return () => {
+        listener = null;
+      };
+    }),
+  } as unknown as GroupChatProvider;
+
+  renderHook(() => useViewScopeChangedNotice(provider));
+  expect(listener).not.toBeNull();
+  act(() => listener?.());
+  expect(toastInfo).toHaveBeenCalledWith('消息视角已更新，正在重连');
+});
+
+it('toast 同时调用 onViewScopeChanged 回调（推送路径刷新历史）', () => {
+  let listener: (() => void) | null = null;
+  const provider = {
+    subscribeToViewScopeChanged: jest.fn((cb: () => void) => {
+      listener = cb;
+      return () => {
+        listener = null;
+      };
+    }),
+  } as unknown as GroupChatProvider;
+  const onViewScopeChanged = jest.fn();
+
+  renderHook(() => useViewScopeChangedNotice(provider, onViewScopeChanged));
+  act(() => listener?.());
+  expect(toastInfo).toHaveBeenCalledWith('消息视角已更新，正在重连');
+  expect(onViewScopeChanged).toHaveBeenCalledTimes(1);
+});
+
+it('provider 为 null 时不订阅', () => {
+  renderHook(() => useViewScopeChangedNotice(null));
+  expect(toastInfo).not.toHaveBeenCalled();
+});

--- a/src/frontend-nextgen/test/pages/Workspace/hooks/useWsReconnectNonce.test.ts
+++ b/src/frontend-nextgen/test/pages/Workspace/hooks/useWsReconnectNonce.test.ts
@@ -1,0 +1,51 @@
+/** @jest-environment jsdom */
+import { useWsReconnectNonce } from '@/pages/Workspace/hooks/useWsReconnectNonce';
+import type { GroupChatProvider } from '@/services/workspace/groupChatProvider';
+import { useWorkspaceStore } from '@/stores/workspaceStore';
+import { beforeEach, expect, it, jest } from '@jest/globals';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { toast } from 'sonner';
+
+// 自动 mock（不引用 @jest/globals 的 jest 绑定），避免 import 排序把 sonner 前置导致工厂执行时 jest 未初始化。
+jest.mock('sonner');
+
+const toastError = toast.error as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useWorkspaceStore.getState().resetWorkspace();
+});
+
+function makeProvider(reconnect: () => Promise<void>) {
+  return { reconnect: jest.fn(reconnect) } as unknown as GroupChatProvider & {
+    reconnect: jest.Mock;
+  };
+}
+
+it('nonce 变化触发 reconnect，resolve 后调用一次 onReconnected', async () => {
+  const provider = makeProvider(() => Promise.resolve());
+  const onReconnected = jest.fn();
+  renderHook(() => useWsReconnectNonce(provider, onReconnected));
+  // mount 首跳忽略
+  expect(provider.reconnect).not.toHaveBeenCalled();
+  act(() => useWorkspaceStore.getState().bumpWsReconnect());
+  await waitFor(() => expect(provider.reconnect).toHaveBeenCalledTimes(1));
+  await waitFor(() => expect(onReconnected).toHaveBeenCalledTimes(1));
+});
+
+it('reconnect reject 时不调用 onReconnected 且 toast.error', async () => {
+  const provider = makeProvider(() => Promise.reject(new Error('重连失败原因')));
+  const onReconnected = jest.fn();
+  renderHook(() => useWsReconnectNonce(provider, onReconnected));
+  act(() => useWorkspaceStore.getState().bumpWsReconnect());
+  await waitFor(() => expect(toastError).toHaveBeenCalledWith('重连失败原因'));
+  expect(onReconnected).not.toHaveBeenCalled();
+});
+
+it('未传 onReconnected 时 reconnect 行为不变', async () => {
+  const provider = makeProvider(() => Promise.resolve());
+  renderHook(() => useWsReconnectNonce(provider));
+  act(() => useWorkspaceStore.getState().bumpWsReconnect());
+  await waitFor(() => expect(provider.reconnect).toHaveBeenCalledTimes(1));
+  expect(toastError).not.toHaveBeenCalled();
+});

--- a/src/frontend-nextgen/test/services/admin/adminService.api.test.ts
+++ b/src/frontend-nextgen/test/services/admin/adminService.api.test.ts
@@ -26,12 +26,12 @@ function setUserIdentity(value: { userId: string; displayName?: string | null } 
 
 beforeEach(() => {
   jest.resetAllMocks();
-  // 命中缓存用例取能力 user_id='327325'；未就绪用例（setUserIdentity(null)）走 ensureUserId 补拉，默认失败降级为 error（不发业务请求）。
+  // 命中缓存用例取能力 user_id='900003'；未就绪用例（setUserIdentity(null)）走 ensureUserId 补拉，默认失败降级为 error（不发业务请求）。
   (identityService.loadIdentities as unknown as jest.Mock<any>).mockResolvedValue({
     ok: false,
     error: { code: 'IDENTITY_LOAD_FAILED', friendlyMessage: '', canRetry: true },
   });
-  setUserIdentity({ userId: '327325', displayName: null });
+  setUserIdentity({ userId: '900003', displayName: null });
 });
 
 describe('adminService 网络参数对齐 clawweb=Avernet', () => {
@@ -39,7 +39,7 @@ describe('adminService 网络参数对齐 clawweb=Avernet', () => {
     sc.listSpaces.mockResolvedValue({ success: true, data: { items: [], total: 0 } });
     await adminService.listSpaces({ page: 2, pageSize: 10, keyword: '风控' });
     expect(sc.listSpaces).toHaveBeenCalledWith({
-      user_id: '327325',
+      user_id: '900003',
       page_no: 2,
       page_size: 10,
       keyword: '风控',
@@ -50,7 +50,7 @@ describe('adminService 网络参数对齐 clawweb=Avernet', () => {
     sc.listSpaces.mockResolvedValue({ success: true, data: { items: [], total: 0 } });
     await adminService.listSpaces({ page: 1, pageSize: 100, scope: 'accessible' });
     expect(sc.listSpaces).toHaveBeenCalledWith({
-      user_id: '327325',
+      user_id: '900003',
       page_no: 1,
       page_size: 100,
       scope: 'accessible',
@@ -59,7 +59,7 @@ describe('adminService 网络参数对齐 clawweb=Avernet', () => {
     sc.listSpaces.mockClear();
     await adminService.listSpaces({ page: 1, pageSize: 20 });
     expect(sc.listSpaces).toHaveBeenCalledWith({
-      user_id: '327325',
+      user_id: '900003',
       page_no: 1,
       page_size: 20,
     });
@@ -67,13 +67,13 @@ describe('adminService 网络参数对齐 clawweb=Avernet', () => {
 
   it('createTeamSpace 传 user_id + user_name(花名) query + body space_name', async () => {
     // 能力命中花名缓存（不调 loadIdentities）。
-    setUserIdentity({ userId: '327325', displayName: '风太' });
+    setUserIdentity({ userId: '900003', displayName: '示例用户' });
     sc.createSpace.mockResolvedValue({
       success: true,
       data: { space_id: 1, space_name: '新团队', space_type: 'TEAM' },
     });
     await adminService.createTeamSpace({ spaceName: '新团队' });
-    expect(sc.createSpace).toHaveBeenCalledWith({ space_name: '新团队' }, { user_id: '327325', user_name: '风太' });
+    expect(sc.createSpace).toHaveBeenCalledWith({ space_name: '新团队' }, { user_id: '900003', user_name: '示例用户' });
   });
 
   it('createTeamSpace 取不到花名时不传 user_name（仅 user_id）', async () => {
@@ -83,7 +83,7 @@ describe('adminService 网络参数对齐 clawweb=Avernet', () => {
       data: { space_id: 1, space_name: '新团队', space_type: 'TEAM' },
     });
     await adminService.createTeamSpace({ spaceName: '新团队' });
-    expect(sc.createSpace).toHaveBeenCalledWith({ space_name: '新团队' }, { user_id: '327325' });
+    expect(sc.createSpace).toHaveBeenCalledWith({ space_name: '新团队' }, { user_id: '900003' });
   });
 
   it('addMember body 用 member_user_id + role=MEMBER，user_id 为操作者', async () => {
@@ -92,41 +92,41 @@ describe('adminService 网络参数对齐 clawweb=Avernet', () => {
     expect(sc.addSpaceMember).toHaveBeenCalledWith(
       10001,
       { member_user_id: 'u1', role: 'MEMBER' },
-      { user_id: '327325' },
+      { user_id: '900003' },
     );
   });
 
   it('addMember 传 userName(花名) 时 body 带 member_user_name', async () => {
     sc.addSpaceMember.mockResolvedValue({ success: true, data: { user_id: 'u1', role: 'MEMBER' } });
-    await adminService.addMember(10001, 'u1', 'MEMBER', '风太');
+    await adminService.addMember(10001, 'u1', 'MEMBER', '示例用户');
     expect(sc.addSpaceMember).toHaveBeenCalledWith(
       10001,
-      { member_user_id: 'u1', role: 'MEMBER', member_user_name: '风太' },
-      { user_id: '327325' },
+      { member_user_id: 'u1', role: 'MEMBER', member_user_name: '示例用户' },
+      { user_id: '900003' },
     );
   });
 
   it('removeMember path=被删成员，user_id=操作者', async () => {
     sc.removeSpaceMember.mockResolvedValue({ success: true, data: { deleted: true } });
     await adminService.removeMember(10001, 'u1');
-    expect(sc.removeSpaceMember).toHaveBeenCalledWith(10001, 'u1', { user_id: '327325' });
+    expect(sc.removeSpaceMember).toHaveBeenCalledWith(10001, 'u1', { user_id: '900003' });
   });
 
   it('updateRole path=被改成员，body role，user_id=操作者', async () => {
     sc.updateMemberRole.mockResolvedValue({ success: true, data: { user_id: 'u1', role: 'ADMIN' } });
     await adminService.updateRole(10001, 'u1', 'ADMIN');
-    expect(sc.updateMemberRole).toHaveBeenCalledWith(10001, 'u1', { role: 'ADMIN' }, { user_id: '327325' });
+    expect(sc.updateMemberRole).toHaveBeenCalledWith(10001, 'u1', { role: 'ADMIN' }, { user_id: '900003' });
   });
 
   it('requestJoin 传 user_id + user_name(花名) query + body reason', async () => {
     // 能力命中花名缓存（不调 loadIdentities）。
-    setUserIdentity({ userId: '327325', displayName: '风太' });
+    setUserIdentity({ userId: '900003', displayName: '示例用户' });
     sc.requestJoinSpace.mockResolvedValue({ success: true, data: {} });
     await adminService.requestJoin(10001, '希望加入');
     expect(sc.requestJoinSpace).toHaveBeenCalledWith(
       10001,
       { reason: '希望加入' },
-      { user_id: '327325', user_name: '风太' },
+      { user_id: '900003', user_name: '示例用户' },
     );
   });
 
@@ -134,7 +134,7 @@ describe('adminService 网络参数对齐 clawweb=Avernet', () => {
     // 默认 displayName=null → ensureUserName 返回 null，仅 user_id。
     sc.requestJoinSpace.mockResolvedValue({ success: true, data: {} });
     await adminService.requestJoin(10001, '希望加入');
-    expect(sc.requestJoinSpace).toHaveBeenCalledWith(10001, { reason: '希望加入' }, { user_id: '327325' });
+    expect(sc.requestJoinSpace).toHaveBeenCalledWith(10001, { reason: '希望加入' }, { user_id: '900003' });
   });
 
   it('listMembers 传 page_no + user_id', async () => {
@@ -142,7 +142,7 @@ describe('adminService 网络参数对齐 clawweb=Avernet', () => {
     await adminService.listMembers(10001, { page: 1, pageSize: 20 });
     expect(sc.listSpaceMembers).toHaveBeenCalledWith(
       10001,
-      expect.objectContaining({ user_id: '327325', page_no: 1, page_size: 20 }),
+      expect.objectContaining({ user_id: '900003', page_no: 1, page_size: 20 }),
     );
   });
 

--- a/src/frontend-nextgen/test/services/admin/adminService.batch.test.ts
+++ b/src/frontend-nextgen/test/services/admin/adminService.batch.test.ts
@@ -31,7 +31,7 @@ beforeEach(() => {
     ok: false,
     error: { code: 'IDENTITY_LOAD_FAILED', friendlyMessage: '', canRetry: true },
   });
-  setUserIdentity({ userId: '327325', displayName: null });
+  setUserIdentity({ userId: '900003', displayName: null });
 });
 
 /**
@@ -39,7 +39,9 @@ beforeEach(() => {
  *  - resolve 一个信封（success envelope 或业务失败 envelope）；
  *  - reject 一个 BackendRequestError（网络异常，且可控制 message 是否可读以验证「请求异常」回退）。
  */
-function mockAddByUserId(map: Record<string, { resolve?: Record<string, unknown> | null; reject?: BackendRequestError } | null>): void {
+function mockAddByUserId(
+  map: Record<string, { resolve?: Record<string, unknown> | null; reject?: BackendRequestError } | null>,
+): void {
   sc.addSpaceMember.mockImplementation((_spaceId: unknown, body: { member_user_id: string }) => {
     const entry = map[body.member_user_id];
     if (!entry || entry.resolve === null || entry.reject) {
@@ -60,7 +62,11 @@ describe('adminService.addMembersBatch：Promise.allSettled + {error} 归属', (
       ok2: { resolve: { success: true, data: { user_id: 'ok2', role: 'MEMBER' } } },
       ok3: { resolve: { success: true, data: { user_id: 'ok3', role: 'MEMBER' } } },
     });
-    const r = await adminService.addMembersBatch(10001, [{ userId: 'ok1' }, { userId: 'ok2' }, { userId: 'ok3' }], 'MEMBER');
+    const r = await adminService.addMembersBatch(
+      10001,
+      [{ userId: 'ok1' }, { userId: 'ok2' }, { userId: 'ok3' }],
+      'MEMBER',
+    );
     expect(r.succeeded.map((m) => m.userId).sort()).toEqual(['ok1', 'ok2', 'ok3']);
     expect(r.failed).toEqual([]);
     expect(sc.addSpaceMember).toHaveBeenCalledTimes(3);
@@ -87,7 +93,13 @@ describe('adminService.addMembersBatch：Promise.allSettled + {error} 归属', (
   it('网络异常无可读 message → 失败原因回退「请求异常」', async () => {
     // 5xx + 空 body + 空 message → toServiceError 得 message='' → 聚合回退「请求异常」
     mockAddByUserId({
-      neterr: { reject: new BackendRequestError('', { status: 500, data: {}, apiPath: '/openapi/v1/bots/spaces/10001/members' }) },
+      neterr: {
+        reject: new BackendRequestError('', {
+          status: 500,
+          data: {},
+          apiPath: '/openapi/v1/bots/spaces/10001/members',
+        }),
+      },
     });
     const r = await adminService.addMembersBatch(10001, [{ userId: 'neterr' }], 'MEMBER');
     expect(r.succeeded).toEqual([]);
@@ -123,12 +135,12 @@ describe('adminService.addMembersBatch：Promise.allSettled + {error} 归属', (
       named: { resolve: { success: true, data: { user_id: 'named', role: 'MEMBER' } } },
       plain: { resolve: { success: true, data: { user_id: 'plain', role: 'MEMBER' } } },
     });
-    await adminService.addMembersBatch(
-      10001,
-      [{ userId: 'named', userName: '花名甲' }, { userId: 'plain' }],
-      'MEMBER',
-    );
-    const calls = sc.addSpaceMember.mock.calls as unknown as [unknown, Record<string, unknown>, Record<string, unknown>][];
+    await adminService.addMembersBatch(10001, [{ userId: 'named', userName: '花名甲' }, { userId: 'plain' }], 'MEMBER');
+    const calls = sc.addSpaceMember.mock.calls as unknown as [
+      unknown,
+      Record<string, unknown>,
+      Record<string, unknown>,
+    ][];
     const namedCall = calls.find((c) => c[1]?.member_user_id === 'named');
     const plainCall = calls.find((c) => c[1]?.member_user_id === 'plain');
     expect(namedCall?.[1]).toMatchObject({ member_user_id: 'named', member_user_name: '花名甲', role: 'MEMBER' });
@@ -142,9 +154,13 @@ describe('adminService.addMembersBatch：Promise.allSettled + {error} 归属', (
       b: { resolve: { success: true, data: { user_id: 'b', role: 'ADMIN' } } },
     });
     await adminService.addMembersBatch(10001, [{ userId: 'a' }, { userId: 'b' }], 'ADMIN');
-    const calls = sc.addSpaceMember.mock.calls as unknown as [unknown, Record<string, unknown>, Record<string, unknown>][];
+    const calls = sc.addSpaceMember.mock.calls as unknown as [
+      unknown,
+      Record<string, unknown>,
+      Record<string, unknown>,
+    ][];
     expect(calls.every((c) => c[1]?.role === 'ADMIN')).toBe(true);
-    expect(calls.every((c) => c[2]?.user_id === '327325')).toBe(true);
+    expect(calls.every((c) => c[2]?.user_id === '900003')).toBe(true);
   });
 
   it('空批次 → 不发请求、succeeded/failed 均为空', async () => {

--- a/src/frontend-nextgen/test/services/admin/notificationService.test.ts
+++ b/src/frontend-nextgen/test/services/admin/notificationService.test.ts
@@ -26,16 +26,16 @@ function setUserIdentity(value: { userId: string; displayName?: string | null } 
 
 beforeEach(() => {
   jest.resetAllMocks();
-  // 命中缓存用例取能力 user_id='327325'；未就绪用例（setUserIdentity(null)）走 ensureUserId 补拉，默认失败降级为 unsupported（不发业务请求）。
+  // 命中缓存用例取能力 user_id='900003'；未就绪用例（setUserIdentity(null)）走 ensureUserId 补拉，默认失败降级为 unsupported（不发业务请求）。
   (identityService.loadIdentities as unknown as jest.Mock<any>).mockResolvedValue({
     ok: false,
     error: { code: 'IDENTITY_LOAD_FAILED', friendlyMessage: '', canRetry: true },
   });
-  setUserIdentity({ userId: '327325', displayName: null });
+  setUserIdentity({ userId: '900003', displayName: null });
 });
 
 describe('notificationService.fetchUnreadCount', () => {
-  it('走专用 unread-count 端点并读 data.badge_count（待审批+未读通知总数），注入 user_id=327325', async () => {
+  it('走专用 unread-count 端点并读 data.badge_count（待审批+未读通知总数），注入 user_id=900003', async () => {
     nc.fetchUnreadCount.mockResolvedValue({
       success: true,
       code: 'SUCCESS',
@@ -44,7 +44,7 @@ describe('notificationService.fetchUnreadCount', () => {
     });
     const r = await notificationService.fetchUnreadCount();
     expect(nc.fetchUnreadCount).toHaveBeenCalledTimes(1);
-    expect(nc.fetchUnreadCount).toHaveBeenCalledWith({ user_id: '327325' });
+    expect(nc.fetchUnreadCount).toHaveBeenCalledWith({ user_id: '900003' });
     expect(r.data).toBe(7);
     expect(r.error).toBeUndefined();
   });
@@ -94,7 +94,7 @@ describe('notificationService.fetchRecentNotifications', () => {
     });
     const r = await notificationService.fetchRecentNotifications(3);
     expect(nc.listNotificationsForBell).toHaveBeenCalledWith({
-      user_id: '327325',
+      user_id: '900003',
       item_type: 'ALL',
       page_no: 1,
       page_size: 3,

--- a/src/frontend-nextgen/test/services/admin/userIdentity.test.ts
+++ b/src/frontend-nextgen/test/services/admin/userIdentity.test.ts
@@ -17,7 +17,7 @@ const loadIdentities = identityService.loadIdentities as unknown as jest.Mock<an
 
 type HumanIdentityValue = { userId: string; displayName: string } | null;
 
-/** 镜像 resolveOpenApiUserId：'human_327325'/'human:327325'/'me' → '327325'/'327325'/'me'。 */
+/** 镜像 resolveOpenApiUserId：'human_900003'/'human:900003'/'me' → '900003'/'900003'/'me'。 */
 function humanIdOf(id: string): string {
   const colon = id.indexOf(':');
   const afterColon = colon >= 0 ? id.slice(colon + 1) : id;
@@ -52,15 +52,15 @@ beforeEach(() => {
 
 describe('readUserId', () => {
   it('经 canonical getHumanIdentity 能力得当前操作者 user_id', () => {
-    setHumanIdentity({ userId: '327325', displayName: '风太' });
-    expect(readUserId()).toBe('327325');
+    setHumanIdentity({ userId: '900003', displayName: '示例用户' });
+    expect(readUserId()).toBe('900003');
   });
 
   it('即便 activeIdentityId 存在也忽略——以 capability 为唯一源（内部 staffNo 覆盖 BCS-id 形 store 值）', () => {
     // 模拟内部部署：store 的 activeIdentityId 为 BCS-id 形（human_<BCS>），但能力返回 staffNo
     useWorkspaceStore.setState({ activeIdentityId: 'human_gYJSGDajzYPV', identities: [] });
-    setHumanIdentity({ userId: '327325', displayName: '风太' });
-    expect(readUserId()).toBe('327325');
+    setHumanIdentity({ userId: '900003', displayName: '示例用户' });
+    expect(readUserId()).toBe('900003');
   });
 
   it('阿里云 BCS id 经 resolveUserId 幂等透传', () => {
@@ -69,12 +69,12 @@ describe('readUserId', () => {
   });
 
   it('capability 偶尔下发带前缀 id 时 resolveUserId 仍剥前缀兜底', () => {
-    setHumanIdentity({ userId: 'human_327325', displayName: '风太' });
-    expect(readUserId()).toBe('327325');
+    setHumanIdentity({ userId: 'human_900003', displayName: '示例用户' });
+    expect(readUserId()).toBe('900003');
   });
 
   it('capability 未就绪返回 null（不读 activeIdentityId）', () => {
-    useWorkspaceStore.setState({ activeIdentityId: 'human_327325' });
+    useWorkspaceStore.setState({ activeIdentityId: 'human_900003' });
     setHumanIdentity(null);
     expect(readUserId()).toBeNull();
   });
@@ -82,9 +82,9 @@ describe('readUserId', () => {
 
 describe('ensureUserId', () => {
   it('能力命中直接返回，不调 loadIdentities（内部 staffNo 同步命中）', async () => {
-    setHumanIdentity({ userId: '327325', displayName: '风太' });
+    setHumanIdentity({ userId: '900003', displayName: '示例用户' });
     const id = await ensureUserId();
-    expect(id).toBe('327325');
+    expect(id).toBe('900003');
     expect(loadIdentities).not.toHaveBeenCalled();
   });
 
@@ -124,17 +124,17 @@ describe('ensureUserId', () => {
 
 describe('readUserName', () => {
   it('固定形态：返回能力内 displayName（内部 __TERN__ 花名）', () => {
-    setHumanIdentity({ userId: '327325', displayName: '风太' });
-    expect(readUserName()).toBe('风太');
+    setHumanIdentity({ userId: '900003', displayName: '示例用户' });
+    expect(readUserName()).toBe('示例用户');
   });
 
   it('动态形态：从 identities 解析当前 human 花名', () => {
     setHumanIdentityDynamic();
     useWorkspaceStore.setState({
-      activeIdentityId: 'human_327325',
-      identities: [{ id: 'human_327325', kind: 'user', displayName: '风太', online: true }],
+      activeIdentityId: 'human_900003',
+      identities: [{ id: 'human_900003', kind: 'user', displayName: '示例用户', online: true }],
     });
-    expect(readUserName()).toBe('风太');
+    expect(readUserName()).toBe('示例用户');
   });
 
   it('identities 未就绪返回 null', () => {
@@ -145,8 +145,8 @@ describe('readUserName', () => {
 
 describe('ensureUserName', () => {
   it('能力命中直接返回花名，不调 loadIdentities', async () => {
-    setHumanIdentity({ userId: '327325', displayName: '风太' });
-    expect(await ensureUserName()).toBe('风太');
+    setHumanIdentity({ userId: '900003', displayName: '示例用户' });
+    expect(await ensureUserName()).toBe('示例用户');
     expect(loadIdentities).not.toHaveBeenCalled();
   });
 
@@ -155,13 +155,13 @@ describe('ensureUserName', () => {
     loadIdentities.mockResolvedValue({
       ok: true,
       data: {
-        identities: [{ id: 'human_327325', kind: 'user', displayName: '风太', online: true }],
-        defaultActiveId: 'human_327325',
+        identities: [{ id: 'human_900003', kind: 'user', displayName: '示例用户', online: true }],
+        defaultActiveId: 'human_900003',
       },
     });
-    expect(await ensureUserName()).toBe('风太');
+    expect(await ensureUserName()).toBe('示例用户');
     expect(loadIdentities).toHaveBeenCalledTimes(1);
-    expect(useWorkspaceStore.getState().activeIdentityId).toBe('human_327325');
+    expect(useWorkspaceStore.getState().activeIdentityId).toBe('human_900003');
   });
 
   it('补拉失败 → 返回 null', async () => {

--- a/src/frontend-nextgen/test/services/admin/workOrderService.api.test.ts
+++ b/src/frontend-nextgen/test/services/admin/workOrderService.api.test.ts
@@ -29,12 +29,12 @@ function setUserIdentity(value: { userId: string; displayName?: string | null } 
 
 beforeEach(() => {
   jest.resetAllMocks();
-  // 命中缓存用例取能力 user_id='327325'；未就绪用例（setUserIdentity(null)）走 ensureUserId 补拉，默认失败降级为 error（不发业务请求）。
+  // 命中缓存用例取能力 user_id='900003'；未就绪用例（setUserIdentity(null)）走 ensureUserId 补拉，默认失败降级为 error（不发业务请求）。
   (identityService.loadIdentities as unknown as jest.Mock<any>).mockResolvedValue({
     ok: false,
     error: { code: 'IDENTITY_LOAD_FAILED', friendlyMessage: '', canRetry: true },
   });
-  setUserIdentity({ userId: '327325', displayName: null });
+  setUserIdentity({ userId: '900003', displayName: null });
 });
 
 describe('workOrderService.list 参数对齐 clawweb=Avernet', () => {
@@ -42,7 +42,7 @@ describe('workOrderService.list 参数对齐 clawweb=Avernet', () => {
     wc.listWorkOrders.mockResolvedValue({ success: true, data: { items: [], total: 0 } });
     await workOrderService.list({ view: 'initiated_mine', category: 'NOTIFICATION', page: 2, pageSize: 10 });
     expect(wc.listWorkOrders).toHaveBeenCalledWith({
-      user_id: '327325',
+      user_id: '900003',
       page_no: 2,
       page_size: 10,
       query_type: 'INITIATED_BY_ME',
@@ -59,7 +59,7 @@ describe('workOrderService.list 参数对齐 clawweb=Avernet', () => {
         item_type: 'APPROVAL',
         page_no: 1,
         page_size: 20,
-        user_id: '327325',
+        user_id: '900003',
       }),
     );
   });
@@ -87,7 +87,7 @@ describe('workOrderService.approve / reject → 统一审批入口', () => {
     expect(wc.submitWorkOrderApproval).toHaveBeenCalledWith(
       30001,
       { decision: 'APPROVED', review_remark: null },
-      { user_id: '327325' },
+      { user_id: '900003' },
     );
   });
 
@@ -97,7 +97,7 @@ describe('workOrderService.approve / reject → 统一审批入口', () => {
     expect(wc.submitWorkOrderApproval).toHaveBeenCalledWith(
       30001,
       { decision: 'APPROVED', review_remark: '同意' },
-      { user_id: '327325' },
+      { user_id: '900003' },
     );
   });
 
@@ -107,25 +107,25 @@ describe('workOrderService.approve / reject → 统一审批入口', () => {
     expect(wc.submitWorkOrderApproval).toHaveBeenCalledWith(
       30001,
       { decision: 'REJECTED', review_remark: '理由不充分' },
-      { user_id: '327325' },
+      { user_id: '900003' },
     );
   });
 
   it('approve 传 user_name(花名) query（同 requestJoin 契约，审批人随 user_id 写入工单）', async () => {
     // 能力命中花名缓存（不调 loadIdentities）。
-    setUserIdentity({ userId: '327325', displayName: '风太' });
+    setUserIdentity({ userId: '900003', displayName: '示例用户' });
     wc.submitWorkOrderApproval.mockResolvedValue({ success: true, data: {} });
     await workOrderService.approve(30001);
     expect(wc.submitWorkOrderApproval).toHaveBeenCalledWith(
       30001,
       { decision: 'APPROVED', review_remark: null },
-      { user_id: '327325', user_name: '风太' },
+      { user_id: '900003', user_name: '示例用户' },
     );
   });
 
   it('getDetail 注入 user_id', async () => {
     wc.getWorkOrderDetail.mockResolvedValue({ success: true, data: { work_order_id: 30001, status: 'PENDING' } });
     await workOrderService.getDetail(30001);
-    expect(wc.getWorkOrderDetail).toHaveBeenCalledWith(30001, { user_id: '327325' });
+    expect(wc.getWorkOrderDetail).toHaveBeenCalledWith(30001, { user_id: '900003' });
   });
 });

--- a/src/frontend-nextgen/test/services/backendApi/bcsfuseController.test.ts
+++ b/src/frontend-nextgen/test/services/backendApi/bcsfuseController.test.ts
@@ -42,7 +42,7 @@ describe('bcsfuse worker config controller', () => {
     const spy = jest.spyOn(globalThis, 'fetch').mockImplementation(() =>
       response({
         success: true,
-        worker_id: '20260720_4kekavkp:447147',
+        worker_id: '20260720_4kekavkp:900004',
         fusion_enable: true,
         version: 10,
         server_ip: '11.38.221.87',
@@ -50,15 +50,15 @@ describe('bcsfuse worker config controller', () => {
     );
     const signal = new AbortController().signal;
 
-    await expect(getWorkerConfig('20260720_4kekavkp:447147', signal)).resolves.toEqual({
+    await expect(getWorkerConfig('20260720_4kekavkp:900004', signal)).resolves.toEqual({
       success: true,
-      worker_id: '20260720_4kekavkp:447147',
+      worker_id: '20260720_4kekavkp:900004',
       fusion_enable: true,
       version: 10,
       server_ip: '11.38.221.87',
     });
     expect(spy).toHaveBeenCalledWith(
-      '/openapi/v1/bcsfuse/workers/20260720_4kekavkp:447147/config',
+      '/openapi/v1/bcsfuse/workers/20260720_4kekavkp:900004/config',
       expect.objectContaining({ method: 'GET', signal }),
     );
   });
@@ -101,15 +101,15 @@ describe('bcsfuse worker config controller', () => {
     const spy = jest
       .spyOn(globalThis, 'fetch')
       .mockImplementation(() =>
-        response({ success: true, worker_id: '20260825_mbu0ey8f:447147', fusion_enable: false, version: 2 }),
+        response({ success: true, worker_id: '20260825_mbu0ey8f:900004', fusion_enable: false, version: 2 }),
       );
     const signal = new AbortController().signal;
 
     await expect(
-      updateWorkerConfig('20260825_mbu0ey8f:447147', { fusion_enable: false }, signal),
+      updateWorkerConfig('20260825_mbu0ey8f:900004', { fusion_enable: false }, signal),
     ).resolves.toMatchObject({ fusion_enable: false });
     expect(spy).toHaveBeenCalledWith(
-      '/openapi/v1/bcsfuse/workers/20260825_mbu0ey8f:447147/config',
+      '/openapi/v1/bcsfuse/workers/20260825_mbu0ey8f:900004/config',
       expect.objectContaining({
         method: 'PUT',
         signal,

--- a/src/frontend-nextgen/test/services/backendApi/bots/botController.test.ts
+++ b/src/frontend-nextgen/test/services/backendApi/bots/botController.test.ts
@@ -25,22 +25,22 @@ describe('botController OpenAPI contracts', () => {
   test('lists owned Bot engines with the explicit user id and pagination contract', async () => {
     const spy = jest.spyOn(globalThis, 'fetch').mockImplementation(() => response({ total: 1, items: [] }));
 
-    await listBots({ user_id: '447147', page: 1, page_size: 100 });
+    await listBots({ user_id: '900004', page: 1, page_size: 100 });
 
     expect(spy).toHaveBeenCalledWith(
-      '/openapi/v1/bots?user_id=447147&page=1&page_size=100',
+      '/openapi/v1/bots?user_id=900004&page=1&page_size=100',
       expect.objectContaining({ method: 'GET' }),
     );
   });
 
   test('adds the current OpenAPI user id to inventory requests', async () => {
-    useWorkspaceStore.setState({ activeIdentityId: 'human_327325' });
+    useWorkspaceStore.setState({ activeIdentityId: 'human_900003' });
     const spy = jest.spyOn(globalThis, 'fetch').mockImplementation(() => response({ total: 0, items: [] }));
 
     await listBotInventory({ page: 1, page_size: 20 });
 
     expect(spy).toHaveBeenCalledWith(
-      '/openapi/v1/bots/all?page=1&page_size=20&user_id=327325',
+      '/openapi/v1/bots/all?page=1&page_size=20&user_id=900003',
       expect.objectContaining({ method: 'GET' }),
     );
   });

--- a/src/frontend-nextgen/test/services/backendApi/bots/botEditorController.test.ts
+++ b/src/frontend-nextgen/test/services/backendApi/bots/botEditorController.test.ts
@@ -240,7 +240,7 @@ test('LOCAL Skill 请求携带当前用户、Bot owner 与分页参数', async (
     await botEditorController.listSkills('bot-1', {
       source: 'LOCAL',
       owner_id: 'owner-1',
-      user_id: '168944',
+      user_id: '900005',
       page: 2,
       page_size: 20,
     });
@@ -249,7 +249,7 @@ test('LOCAL Skill 请求携带当前用户、Bot owner 与分页参数', async (
     expect(Object.fromEntries(url.searchParams)).toEqual({
       source: 'LOCAL',
       owner_id: 'owner-1',
-      user_id: '168944',
+      user_id: '900005',
       page: '2',
       page_size: '20',
     });

--- a/src/frontend-nextgen/test/services/backendApi/collaborationControllers.test.ts
+++ b/src/frontend-nextgen/test/services/backendApi/collaborationControllers.test.ts
@@ -160,10 +160,10 @@ describe('collaboration session controller', () => {
       request_id: 'r',
     });
     const signal = new AbortController().signal;
-    await sessionController.createSession('group-1', { kind: 'chat', acting_bot_id: 'human_327325' }, signal);
+    await sessionController.createSession('group-1', { kind: 'chat', acting_bot_id: 'human_900003' }, signal);
     expect(backendRequest).toHaveBeenCalledWith('/openapi/v1/collaboration/groups/group-1/sessions', {
       method: 'POST',
-      data: { kind: 'chat', acting_bot_id: 'human_327325' },
+      data: { kind: 'chat', acting_bot_id: 'human_900003' },
       injectUserId: false,
       signal,
     });
@@ -413,7 +413,7 @@ describe('managed collaboration bot controller', () => {
     };
 
     await botController.patchCollaborationBot(
-      '20260715_vl4oht43:447147',
+      '20260715_vl4oht43:900004',
       {
         friend_ext: friendExt,
         friend_check_in_strategy: 'DEPT_FREE',
@@ -421,7 +421,7 @@ describe('managed collaboration bot controller', () => {
       signal,
     );
 
-    expect(backendRequest).toHaveBeenCalledWith('/openapi/v1/collaboration/bots/20260715_vl4oht43:447147', {
+    expect(backendRequest).toHaveBeenCalledWith('/openapi/v1/collaboration/bots/20260715_vl4oht43:900004', {
       method: 'PATCH',
       data: {
         friend_ext: friendExt,
@@ -436,9 +436,9 @@ describe('managed collaboration bot controller', () => {
     backendRequest.mockResolvedValue({ code: 20000, data: { items: [], total: 0 }, request_id: 'r' });
     const signal = new AbortController().signal;
 
-    await botController.listBotFriendships('human_327325', { offset: 0, limit: 100 }, signal);
+    await botController.listBotFriendships('human_900003', { offset: 0, limit: 100 }, signal);
 
-    expect(backendRequest).toHaveBeenCalledWith('/openapi/v1/collaboration/bots/human_327325/friendships', {
+    expect(backendRequest).toHaveBeenCalledWith('/openapi/v1/collaboration/bots/human_900003/friendships', {
       method: 'GET',
       params: { offset: 0, limit: 100 },
       injectUserId: false,
@@ -450,9 +450,9 @@ describe('managed collaboration bot controller', () => {
     backendRequest.mockResolvedValue({ code: 20100, data: { request_id: 'r1', state: 'pending' }, request_id: 'r' });
     const signal = new AbortController().signal;
 
-    await botController.createBotFriendRequest('human_327325', { to_bot_uuid: 'bot-1' }, signal);
+    await botController.createBotFriendRequest('human_900003', { to_bot_uuid: 'bot-1' }, signal);
 
-    expect(backendRequest).toHaveBeenCalledWith('/openapi/v1/collaboration/bots/human_327325/friend-requests', {
+    expect(backendRequest).toHaveBeenCalledWith('/openapi/v1/collaboration/bots/human_900003/friend-requests', {
       method: 'POST',
       data: { to_bot_uuid: 'bot-1' },
       injectUserId: false,
@@ -473,7 +473,7 @@ describe('collaboration publication controller', () => {
 
     await publicationController.publishBotPublic(
       'bot-1',
-      '447147',
+      '900004',
       {
         public_scope: 'user',
         visibility: 'public',
@@ -484,7 +484,7 @@ describe('collaboration publication controller', () => {
 
     expect(backendRequest).toHaveBeenCalledWith('/openapi/v1/collaboration/bots/bot-1/public', {
       method: 'POST',
-      params: { user_id: '447147' },
+      params: { user_id: '900004' },
       data: {
         public_scope: 'user',
         visibility: 'public',

--- a/src/frontend-nextgen/test/services/backendApi/collaborationFriendConnectionController.test.ts
+++ b/src/frontend-nextgen/test/services/backendApi/collaborationFriendConnectionController.test.ts
@@ -48,7 +48,7 @@ describe('collaboration friend connection controller', () => {
         direction: 'sent',
         status: 'pending',
         actor_type: 'human',
-        actor_id: '327325',
+        actor_id: '900003',
         page: 1,
         page_size: 100,
       },
@@ -61,7 +61,7 @@ describe('collaboration friend connection controller', () => {
         direction: 'sent',
         status: 'pending',
         actor_type: 'human',
-        actor_id: '327325',
+        actor_id: '900003',
         page: 1,
         page_size: 100,
       },
@@ -76,11 +76,11 @@ describe('collaboration friend connection controller', () => {
       data: { items: [{ actor: { type: 'bot', id: 'bot-1' }, is_online: false }], total: 1 },
     });
 
-    await listFriendConnections({ actor_type: 'human', actor_id: '327325' });
+    await listFriendConnections({ actor_type: 'human', actor_id: '900003' });
 
     expect(backendRequest).toHaveBeenCalledWith('/openapi/v1/collaboration/friend-connections', {
       method: 'GET',
-      params: { actor_type: 'human', actor_id: '327325' },
+      params: { actor_type: 'human', actor_id: '900003' },
       injectUserId: false,
     });
   });
@@ -104,14 +104,14 @@ describe('collaboration friend connection controller', () => {
     backendRequest.mockResolvedValue({ code: 20000, data: {} });
 
     await deleteFriendConnection({
-      from_actor: { type: 'human', id: '327325' },
+      from_actor: { type: 'human', id: '900003' },
       to_actor: { type: 'bot', id: 'bot-1' },
     });
 
     expect(backendRequest).toHaveBeenCalledWith('/openapi/v1/collaboration/friend-connections', {
       method: 'DELETE',
       data: {
-        from_actor: { type: 'human', id: '327325' },
+        from_actor: { type: 'human', id: '900003' },
         to_actor: { type: 'bot', id: 'bot-1' },
       },
       injectUserId: false,

--- a/src/frontend-nextgen/test/services/backendApi/orgUserController.test.ts
+++ b/src/frontend-nextgen/test/services/backendApi/orgUserController.test.ts
@@ -12,11 +12,11 @@ beforeEach(() => {
 
 describe('/openapi/v1/org/user controller', () => {
   it('passes the required employee number as an explicit user_id query parameter', async () => {
-    await getOrgUser('447147');
+    await getOrgUser('900004');
 
     expect(backendRequest).toHaveBeenCalledWith('/openapi/v1/org/user', {
       method: 'GET',
-      params: { user_id: '447147' },
+      params: { user_id: '900004' },
       injectUserId: false,
       signal: undefined,
     });
@@ -25,11 +25,11 @@ describe('/openapi/v1/org/user controller', () => {
   it('forwards the abort signal without falling back to implicit identity injection', async () => {
     const signal = new AbortController().signal;
 
-    await getOrgUser('447147', signal);
+    await getOrgUser('900004', signal);
 
     expect(backendRequest).toHaveBeenCalledWith('/openapi/v1/org/user', {
       method: 'GET',
-      params: { user_id: '447147' },
+      params: { user_id: '900004' },
       injectUserId: false,
       signal,
     });

--- a/src/frontend-nextgen/test/services/bcs/bcsManifestController.test.ts
+++ b/src/frontend-nextgen/test/services/bcs/bcsManifestController.test.ts
@@ -12,9 +12,9 @@ describe('listBotRenderScreens', () => {
       data: { total: 1, items: [{ id: 1, name: 'lib', cdn_url: 'https://cdn/lib.js' }] },
     });
 
-    const screens = await listBotRenderScreens('20260811_lklnq6d0:327325');
+    const screens = await listBotRenderScreens('20260811_lklnq6d0:900003');
 
-    expect(mocked.listRenderScreens).toHaveBeenCalledWith('20260811_lklnq6d0', '327325');
+    expect(mocked.listRenderScreens).toHaveBeenCalledWith('20260811_lklnq6d0', '900003');
     expect(screens).toEqual([
       {
         id: 1,

--- a/src/frontend-nextgen/test/services/botWorkshop/botWorkshopService.test.ts
+++ b/src/frontend-nextgen/test/services/botWorkshop/botWorkshopService.test.ts
@@ -370,14 +370,14 @@ describe('botWorkshopService', () => {
     expect(
       botWorkshopService.getCreateSpaces('cloud', '10001', 'mock-user', {
         id: '10001',
-        name: '风太的个人空间',
+        name: '示例用户的个人空间',
         ownership: 'personal',
         canCreate: true,
       }),
     ).toEqual([
       {
         id: '10001',
-        name: '风太的个人空间',
+        name: '示例用户的个人空间',
         ownership: 'personal',
         canCreate: true,
       },

--- a/src/frontend-nextgen/test/services/collaborationPrivacy/collaborationPrivacyApiAdapter.test.ts
+++ b/src/frontend-nextgen/test/services/collaborationPrivacy/collaborationPrivacyApiAdapter.test.ts
@@ -101,7 +101,7 @@ describe('collaborationPrivacyApiAdapter', () => {
     listMyBots.mockResolvedValue({
       code: 20000,
       data: {
-        items: [createPhysicalBot({ bot_id: 'bot-1:447147' })],
+        items: [createPhysicalBot({ bot_id: 'bot-1:900004' })],
         total: 1,
         offset: 0,
         limit: 20,
@@ -109,11 +109,11 @@ describe('collaborationPrivacyApiAdapter', () => {
     });
 
     await expect(
-      enrichedAdapter.listManagedBots({ user_id: '447147' }, new AbortController().signal),
+      enrichedAdapter.listManagedBots({ user_id: '900004' }, new AbortController().signal),
     ).resolves.toMatchObject({
-      items: [expect.objectContaining({ bot_id: 'bot-1:447147', engine: 'openclaw' })],
+      items: [expect.objectContaining({ bot_id: 'bot-1:900004', engine: 'openclaw' })],
     });
-    expect(listBots).toHaveBeenCalledWith({ page: 1, page_size: 100, user_id: '447147' }, expect.any(AbortSignal));
+    expect(listBots).toHaveBeenCalledWith({ page: 1, page_size: 100, user_id: '900004' }, expect.any(AbortSignal));
   });
 
   it('keeps the managed Bot list usable when the optional /bots engine enrichment fails', async () => {
@@ -142,7 +142,7 @@ describe('collaborationPrivacyApiAdapter', () => {
       data: { items: [createPhysicalBot()], total: 1, offset: 0, limit: 20 },
     });
 
-    await expect(enrichedAdapter.listManagedBots({ user_id: '447147' })).resolves.toMatchObject({
+    await expect(enrichedAdapter.listManagedBots({ user_id: '900004' })).resolves.toMatchObject({
       items: [expect.objectContaining({ bot_id: 'bot-1' })],
       total: 1,
       offset: 0,

--- a/src/frontend-nextgen/test/services/collaborationPrivacy/collaborationPrivacyRuntimeAdapter.test.ts
+++ b/src/frontend-nextgen/test/services/collaborationPrivacy/collaborationPrivacyRuntimeAdapter.test.ts
@@ -5,7 +5,7 @@ import { createCollaborationPrivacyRuntimeAdapter } from '@/services/collaborati
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
 const orgUser: OrgUserDto = {
-  user_id: '447147',
+  user_id: '900004',
   username: 'testuser',
   display_name: '测试用户',
   full_name: '测试用户',
@@ -108,7 +108,7 @@ describe('collaborationPrivacyRuntimeAdapter.submitPublication', () => {
       visibility_field: null,
       error_msg: null,
     });
-    await adapter.loadOverview('447147');
+    await adapter.loadOverview('900004');
 
     const command: PublicationCommand = {
       botId: 'bot-1',
@@ -132,7 +132,7 @@ describe('collaborationPrivacyRuntimeAdapter.submitPublication', () => {
       visibility_field: 'view',
       error_msg: null,
     });
-    await adapter.loadOverview('447147');
+    await adapter.loadOverview('900004');
 
     const result = await adapter.submitPublication({
       botId: 'bot-1',

--- a/src/frontend-nextgen/test/services/collaborationPrivacy/mappers.test.ts
+++ b/src/frontend-nextgen/test/services/collaborationPrivacy/mappers.test.ts
@@ -46,7 +46,7 @@ describe('collaboration privacy service mappers', () => {
   it('maps the current user and Bot publication states from the real /mine fields', () => {
     const mapped = mapBotDtoToDomain(
       createBot({
-        bot_id: '20260715_vl4oht43:447147',
+        bot_id: '20260715_vl4oht43:900004',
         visibility: 'public',
         user_visibility: 'private',
         friend_ext: {},

--- a/src/frontend-nextgen/test/services/collaborationPrivacyRuntimeWiring.test.ts
+++ b/src/frontend-nextgen/test/services/collaborationPrivacyRuntimeWiring.test.ts
@@ -33,7 +33,7 @@ function createBotDto(): CollaborationBotDto {
 
 function createUserDto(): OrgUserDto {
   return {
-    user_id: '447147',
+    user_id: '900004',
     username: 'S090011826218',
     display_name: '真实用户',
     full_name: '真实用户',
@@ -175,10 +175,10 @@ describe('collaboration privacy runtime wiring', () => {
     const adapter = createCollaborationPrivacyRuntimeAdapter(dependencies);
     const signal = new AbortController().signal;
 
-    await expect(adapter.loadOverview('447147', signal)).resolves.toMatchObject({
+    await expect(adapter.loadOverview('900004', signal)).resolves.toMatchObject({
       currentUser: {
         displayName: '真实用户',
-        employeeNumber: '447147',
+        employeeNumber: '900004',
         departmentPath: ['蚂蚁集团-大安全-协作平台'],
       },
       bots: [
@@ -192,9 +192,9 @@ describe('collaboration privacy runtime wiring', () => {
       organizationOptions: [],
     });
 
-    expect(listManagedBots).toHaveBeenCalledWith({ kind: 'bot', user_id: '447147' }, signal);
+    expect(listManagedBots).toHaveBeenCalledWith({ kind: 'bot', user_id: '900004' }, signal);
     expect(getManagedBot).not.toHaveBeenCalled();
-    expect(getOrgUser).toHaveBeenCalledWith('447147', signal);
+    expect(getOrgUser).toHaveBeenCalledWith('900004', signal);
     expect(getWorkerConfig).toHaveBeenCalledWith('bot-real-1', signal);
   });
 
@@ -301,8 +301,8 @@ describe('collaboration privacy runtime wiring', () => {
     );
     const adapter = createCollaborationPrivacyRuntimeAdapter(dependencies);
 
-    await expect(adapter.loadOverview('447147')).resolves.toMatchObject({
-      currentUser: { employeeNumber: '447147' },
+    await expect(adapter.loadOverview('900004')).resolves.toMatchObject({
+      currentUser: { employeeNumber: '900004' },
       bots: [expect.objectContaining({ profilePublic: false, profilePublicStatus: 'unavailable' })],
     });
   });
@@ -312,8 +312,8 @@ describe('collaboration privacy runtime wiring', () => {
     getWorkerConfig.mockRejectedValueOnce(new Error('BCSFuse unavailable'));
     const adapter = createCollaborationPrivacyRuntimeAdapter(dependencies);
 
-    await expect(adapter.loadOverview('447147')).resolves.toMatchObject({
-      currentUser: { employeeNumber: '447147' },
+    await expect(adapter.loadOverview('900004')).resolves.toMatchObject({
+      currentUser: { employeeNumber: '900004' },
       bots: [expect.objectContaining({ id: 'bot-real-1', profilePublic: false, profilePublicStatus: 'unavailable' })],
     });
   });
@@ -328,7 +328,7 @@ describe('collaboration privacy runtime wiring', () => {
     listOrgDepts.mockImplementation(async () => pendingDepartments);
     const adapter = createCollaborationPrivacyRuntimeAdapter(dependencies);
 
-    const loadPromise = adapter.loadOverview('447147');
+    const loadPromise = adapter.loadOverview('900004');
     await new Promise<void>((resolve) => {
       setTimeout(resolve, 0);
     });
@@ -348,7 +348,7 @@ describe('collaboration privacy runtime wiring', () => {
     const controller = new AbortController();
     controller.abort();
 
-    await expect(adapter.loadOverview('447147', controller.signal)).rejects.toMatchObject({ name: 'AbortError' });
+    await expect(adapter.loadOverview('900004', controller.signal)).rejects.toMatchObject({ name: 'AbortError' });
   });
 
   it('refreshes one Bot through the detail endpoint without reloading the managed Bot list', async () => {
@@ -359,7 +359,7 @@ describe('collaboration privacy runtime wiring', () => {
       user_visibility: 'public',
     });
     const adapter = createCollaborationPrivacyRuntimeAdapter(dependencies);
-    await adapter.loadOverview('447147');
+    await adapter.loadOverview('900004');
     listManagedBots.mockClear();
     const signal = new AbortController().signal;
 
@@ -420,7 +420,7 @@ describe('collaboration privacy runtime wiring', () => {
     const adapter = createCollaborationPrivacyRuntimeAdapter(dependencies);
     const signal = new AbortController().signal;
 
-    await expect(adapter.loadOverview('447147', signal)).resolves.toMatchObject({
+    await expect(adapter.loadOverview('900004', signal)).resolves.toMatchObject({
       bots: [
         {
           publication: {
@@ -455,7 +455,7 @@ describe('collaboration privacy runtime wiring', () => {
       items: [
         {
           ...createBotDto(),
-          bot_id: '20260715_vl4oht43:447147',
+          bot_id: '20260715_vl4oht43:900004',
           visibility: 'public',
           user_visibility: 'private',
           friend_ext: {},
@@ -467,10 +467,10 @@ describe('collaboration privacy runtime wiring', () => {
     }));
     const adapter = createCollaborationPrivacyRuntimeAdapter(dependencies);
 
-    await expect(adapter.loadOverview('447147')).resolves.toMatchObject({
+    await expect(adapter.loadOverview('900004')).resolves.toMatchObject({
       bots: [
         {
-          id: '20260715_vl4oht43:447147',
+          id: '20260715_vl4oht43:900004',
           publication: {
             user: { scope: 'none', organizationPaths: [] },
             bot: { scope: 'all', organizationPaths: [] },
@@ -503,7 +503,7 @@ describe('collaboration privacy runtime wiring', () => {
     }));
     const adapter = createCollaborationPrivacyRuntimeAdapter(dependencies);
 
-    await expect(adapter.loadOverview('447147')).resolves.toMatchObject({
+    await expect(adapter.loadOverview('900004')).resolves.toMatchObject({
       bots: [
         {
           id: 'bot-real-1',
@@ -525,7 +525,7 @@ describe('collaboration privacy runtime wiring', () => {
       items: [
         {
           kind: 'human',
-          bot_id: 'human_447147',
+          bot_id: 'human_900004',
           name: '真实用户',
           visibility: 'private',
           status: 'online',
@@ -541,7 +541,7 @@ describe('collaboration privacy runtime wiring', () => {
     }));
     const adapter = createCollaborationPrivacyRuntimeAdapter(dependencies);
 
-    await expect(adapter.loadOverview('447147')).resolves.toMatchObject({
+    await expect(adapter.loadOverview('900004')).resolves.toMatchObject({
       bots: [expect.objectContaining({ id: 'bot-real-1' })],
     });
   });
@@ -549,10 +549,10 @@ describe('collaboration privacy runtime wiring', () => {
   it('routes ready mutations and department search to real controllers', async () => {
     const { dependencies, apiAdapter, listOrgDepts, publishBotPublic } = createDependencies();
     const adapter = createCollaborationPrivacyRuntimeAdapter(dependencies);
-    await adapter.loadOverview('447147');
+    await adapter.loadOverview('900004');
 
     const signal = new AbortController().signal;
-    await adapter.syncDepartment('447147', signal);
+    await adapter.syncDepartment('900004', signal);
     await adapter.searchDepartments('协作', signal);
     await adapter.updateDirectSetting({ botId: 'bot-real-1', setting: 'profilePublic', value: true }, signal);
     const publicationResult = await adapter.submitPublication(
@@ -574,7 +574,7 @@ describe('collaboration privacy runtime wiring', () => {
     expect(listOrgDepts).toHaveBeenCalledWith({ keyword: '协作' }, signal);
     expect(publishBotPublic).toHaveBeenCalledWith(
       'bot-real-1',
-      '447147',
+      '900004',
       {
         public_scope: 'user',
         visibility: 'public',
@@ -593,7 +593,7 @@ describe('collaboration privacy runtime wiring', () => {
       version: 2,
     });
     const adapter = createCollaborationPrivacyRuntimeAdapter(dependencies);
-    await adapter.loadOverview('447147');
+    await adapter.loadOverview('900004');
 
     await expect(
       adapter.updateDirectSetting({ botId: 'bot-real-1', setting: 'profilePublic', value: true }),
@@ -605,7 +605,7 @@ describe('collaboration privacy runtime wiring', () => {
   it('maps Bot all-public to agent/public without department restrictions', async () => {
     const { dependencies, publishBotPublic } = createDependencies();
     const adapter = createCollaborationPrivacyRuntimeAdapter(dependencies);
-    await adapter.loadOverview('447147');
+    await adapter.loadOverview('900004');
     const signal = new AbortController().signal;
 
     await adapter.submitPublication(
@@ -619,7 +619,7 @@ describe('collaboration privacy runtime wiring', () => {
 
     expect(publishBotPublic).toHaveBeenCalledWith(
       'bot-real-1',
-      '447147',
+      '900004',
       {
         public_scope: 'agent',
         visibility: 'public',
@@ -636,8 +636,8 @@ describe('collaboration privacy runtime wiring', () => {
       message: 'OK',
       data: {
         success: true,
-        puid: 'antprocess-agentclaw_botpublic_20260715-vl4oht43-44714720260825190956',
-        approval_url: 'https://approval.example.com/ticket/dispatch/publication-20260715-vl4oht43-44714720260825190956',
+        puid: 'antprocess-agentclaw_botpublic_20260715-vl4oht43-90000420260825190956',
+        approval_url: 'https://approval.example.com/ticket/dispatch/publication-20260715-vl4oht43-90000420260825190956',
         state: 'CREATED' as const,
         last_operate: null,
         error_msg: null,
@@ -646,7 +646,7 @@ describe('collaboration privacy runtime wiring', () => {
       request_id: '0be8c63017876561947632931e7aaa',
     }));
     const adapter = createCollaborationPrivacyRuntimeAdapter(dependencies);
-    await adapter.loadOverview('447147');
+    await adapter.loadOverview('900004');
 
     await expect(
       adapter.submitPublication({
@@ -657,9 +657,9 @@ describe('collaboration privacy runtime wiring', () => {
     ).resolves.toMatchObject({
       status: 'pending',
       publication: {
-        id: 'antprocess-agentclaw_botpublic_20260715-vl4oht43-44714720260825190956',
+        id: 'antprocess-agentclaw_botpublic_20260715-vl4oht43-90000420260825190956',
         audience: 'user',
-        approvalUrl: 'https://approval.example.com/ticket/dispatch/publication-20260715-vl4oht43-44714720260825190956',
+        approvalUrl: 'https://approval.example.com/ticket/dispatch/publication-20260715-vl4oht43-90000420260825190956',
       },
     });
   });
@@ -676,7 +676,7 @@ describe('collaboration privacy runtime wiring', () => {
       },
     }));
     const adapter = createCollaborationPrivacyRuntimeAdapter(dependencies);
-    await adapter.loadOverview('447147');
+    await adapter.loadOverview('900004');
 
     const result = await adapter.submitPublication({
       botId: 'bot-real-1',
@@ -711,7 +711,7 @@ describe('collaboration privacy runtime wiring', () => {
       },
     }));
     const adapter = createCollaborationPrivacyRuntimeAdapter(dependencies);
-    await adapter.loadOverview('447147');
+    await adapter.loadOverview('900004');
 
     await expect(
       adapter.submitPublication({
@@ -741,7 +741,7 @@ describe('collaboration privacy runtime wiring', () => {
       },
     }));
     const adapter = createCollaborationPrivacyRuntimeAdapter(dependencies);
-    await adapter.loadOverview('447147');
+    await adapter.loadOverview('900004');
 
     await expect(
       adapter.submitPublication({
@@ -769,7 +769,7 @@ describe('collaboration privacy runtime wiring', () => {
       },
     }));
     const adapter = createCollaborationPrivacyRuntimeAdapter(dependencies);
-    await adapter.loadOverview('447147');
+    await adapter.loadOverview('900004');
 
     await expect(
       adapter.submitPublication({
@@ -786,7 +786,7 @@ describe('collaboration privacy runtime wiring', () => {
   it('routes task-claim and dream toggles through their correct paths', async () => {
     const { dependencies, patchManagedBot } = createDependencies();
     const adapter = createCollaborationPrivacyRuntimeAdapter(dependencies);
-    await adapter.loadOverview('447147');
+    await adapter.loadOverview('900004');
 
     await expect(
       adapter.updateDirectSetting({ botId: 'bot-real-1', setting: 'taskClaimingEnabled', value: true }),
@@ -802,7 +802,7 @@ describe('collaboration privacy runtime wiring', () => {
   it('double-writes claim on (grant + PATCH) and accepts when both succeed', async () => {
     const { dependencies } = createDependencies();
     const adapter = createCollaborationPrivacyRuntimeAdapter(dependencies);
-    await adapter.loadOverview('447147');
+    await adapter.loadOverview('900004');
 
     const updated = await adapter.enableTaskClaim('bot-real-1');
     expect(updated.taskClaimingEnabled).toBe(true);
@@ -818,7 +818,7 @@ describe('collaboration privacy runtime wiring', () => {
   it('rolls back the grant when the claim-on PATCH fails', async () => {
     const { dependencies, patchManagedBot } = createDependencies();
     const adapter = createCollaborationPrivacyRuntimeAdapter(dependencies);
-    await adapter.loadOverview('447147');
+    await adapter.loadOverview('900004');
 
     patchManagedBot.mockRejectedValueOnce(new Error('patch down'));
     await expect(adapter.enableTaskClaim('bot-real-1')).rejects.toThrow('patch down');
@@ -828,7 +828,7 @@ describe('collaboration privacy runtime wiring', () => {
   it('patches friend approval through the real Bot controller while preserving all existing friend_ext fields', async () => {
     const { dependencies, patchManagedBot } = createDependencies();
     const adapter = createCollaborationPrivacyRuntimeAdapter(dependencies);
-    await adapter.loadOverview('447147');
+    await adapter.loadOverview('900004');
     const signal = new AbortController().signal;
     const config: FriendApprovalConfig = {
       mode: 'partial_exempt',
@@ -864,7 +864,7 @@ describe('collaboration privacy runtime wiring', () => {
       friend_check_in_strategy: 'DEPT_FREE',
     });
     const adapter = createCollaborationPrivacyRuntimeAdapter(dependencies);
-    await adapter.loadOverview('447147');
+    await adapter.loadOverview('900004');
 
     await adapter.updateFriendApproval({
       botId: 'bot-real-1',
@@ -900,7 +900,7 @@ describe('collaboration privacy runtime wiring', () => {
     const config: FriendApprovalConfig = { mode: 'all', exemptOrganizationPaths: [] };
 
     await expect(adapter.updateFriendApproval({ botId: 'bot-real-1', config })).rejects.toThrow('协作权限数据尚未加载');
-    await adapter.loadOverview('447147');
+    await adapter.loadOverview('900004');
     await expect(adapter.updateFriendApproval({ botId: 'missing-bot', config })).rejects.toThrow(
       '未找到要更新好友审批策略的 Bot',
     );
@@ -927,7 +927,7 @@ describe('collaboration privacy runtime wiring', () => {
       const { dependencies, patchManagedBot } = createDependencies();
       patchManagedBot.mockResolvedValueOnce(response);
       const adapter = createCollaborationPrivacyRuntimeAdapter(dependencies);
-      await adapter.loadOverview('447147');
+      await adapter.loadOverview('900004');
 
       await expect(
         adapter.updateFriendApproval({
@@ -964,7 +964,7 @@ describe('collaboration privacy runtime wiring', () => {
     const { dependencies, patchManagedBot } = createDependencies();
     patchManagedBot.mockRejectedValueOnce(new Error('network failed'));
     const adapter = createCollaborationPrivacyRuntimeAdapter(dependencies);
-    await adapter.loadOverview('447147');
+    await adapter.loadOverview('900004');
 
     await expect(
       adapter.updateFriendApproval({
@@ -1018,8 +1018,8 @@ describe('collaboration privacy load scope wiring', () => {
     const adapter = createCollaborationPrivacyRuntimeAdapter(dependencies);
     const signal = new AbortController().signal;
 
-    await expect(adapter.loadOverview('447147', signal, { target: 'currentUser' })).resolves.toMatchObject({
-      currentUser: { employeeNumber: '447147', departmentPath: ['蚂蚁集团-大安全-协作平台'] },
+    await expect(adapter.loadOverview('900004', signal, { target: 'currentUser' })).resolves.toMatchObject({
+      currentUser: { employeeNumber: '900004', departmentPath: ['蚂蚁集团-大安全-协作平台'] },
       bots: [],
       organizationOptions: [],
     });
@@ -1037,7 +1037,7 @@ describe('collaboration privacy load scope wiring', () => {
     const signal = new AbortController().signal;
 
     await expect(
-      adapter.loadOverview('447147', signal, { target: 'activeBot', botId: 'bot-real-2:447147' }),
+      adapter.loadOverview('900004', signal, { target: 'activeBot', botId: 'bot-real-2:900004' }),
     ).resolves.toMatchObject({
       bots: [{ id: 'bot-real-2', name: 'Bot B', profilePublic: true, profilePublicStatus: 'ready' }],
     });
@@ -1059,9 +1059,9 @@ describe('collaboration privacy load scope wiring', () => {
     const adapter = createCollaborationPrivacyRuntimeAdapter(dependencies);
 
     await expect(
-      adapter.loadOverview('447147', undefined, { target: 'activeBot', botId: 'bot-unknown' }),
+      adapter.loadOverview('900004', undefined, { target: 'activeBot', botId: 'bot-unknown' }),
     ).resolves.toMatchObject({
-      currentUser: { employeeNumber: '447147' },
+      currentUser: { employeeNumber: '900004' },
       bots: [],
     });
 
@@ -1075,7 +1075,7 @@ describe('collaboration privacy load scope wiring', () => {
     useThreeBotList(listManagedBots);
     const adapter = createCollaborationPrivacyRuntimeAdapter(dependencies);
 
-    await expect(adapter.loadOverview('447147')).resolves.toMatchObject({
+    await expect(adapter.loadOverview('900004')).resolves.toMatchObject({
       bots: [
         { id: 'bot-real-1', profilePublicStatus: 'ready' },
         { id: 'bot-real-2', profilePublicStatus: 'ready' },

--- a/src/frontend-nextgen/test/services/collaborationSquare/collaborationSquareApiAdapter.test.ts
+++ b/src/frontend-nextgen/test/services/collaborationSquare/collaborationSquareApiAdapter.test.ts
@@ -20,7 +20,7 @@ const mockedCreateFriendConnectionRequest = jest.spyOn(friendConnectionControlle
 const mockedCreateBotSession = jest.spyOn(botSessionController, 'createBotSession');
 const mockedCreateGroupSession = jest.spyOn(sessionController, 'createSession');
 const mockedListBbsTasks = jest.spyOn(bbsTaskController, 'listBbsTasks');
-const humanContext = { actorId: 'human_327325', userId: '327325' };
+const humanContext = { actorId: 'human_900003', userId: '900003' };
 
 beforeEach(() => {
   mockedSearchPublicBots.mockReset();
@@ -212,16 +212,16 @@ describe('CollaborationSquareApiAdapter', () => {
     mockedListFriendConnections.mockResolvedValue({ code: 20000, data: { items: [], total: 0 } });
     mockedListFriendConnectionRequests.mockResolvedValue({ code: 20000, data: { items: [], total: 0 } });
     const adapter = new CollaborationSquareApiAdapter();
-    const viewer = { viewerActorType: 'human' as const, viewerActorId: '327325' };
+    const viewer = { viewerActorType: 'human' as const, viewerActorId: '900003' };
 
     await adapter.listBots({ page: 1, pageSize: 5, ...viewer });
     expect(mockedSearchPublicBots).toHaveBeenCalledWith(
-      { page: 1, page_size: 5, viewer_actor_type: 'human', viewer_actor_id: '327325' },
+      { page: 1, page_size: 5, viewer_actor_type: 'human', viewer_actor_id: '900003' },
       undefined,
     );
     // Search 路径仅补读 pending 申请，回填 actor 跟随 viewer（human）。
     expect(mockedListFriendConnectionRequests).toHaveBeenCalledWith(
-      expect.objectContaining({ actor_type: 'human', actor_id: '327325', direction: 'sent', status: 'pending' }),
+      expect.objectContaining({ actor_type: 'human', actor_id: '900003', direction: 'sent', status: 'pending' }),
       undefined,
     );
 
@@ -233,7 +233,7 @@ describe('CollaborationSquareApiAdapter', () => {
         min_score: 0.1,
         runtime_state: 'online',
         viewer_actor_type: 'human',
-        viewer_actor_id: '327325',
+        viewer_actor_id: '900003',
       },
       undefined,
     );
@@ -249,7 +249,7 @@ describe('CollaborationSquareApiAdapter', () => {
             bot_type: 'assistant',
             description: '',
             engine: 'OpenClaw',
-            entity_id: '327325',
+            entity_id: '900003',
             name: '我的公开 Bot',
             owner_name: '当前用户',
             status: 'online',
@@ -265,8 +265,8 @@ describe('CollaborationSquareApiAdapter', () => {
         items: [
           {
             request_id: 'request-owned-bot',
-            from_actor: { type: 'human', id: '327325' },
-            to_actor: { type: 'bot', id: 'owned-bot:327325' },
+            from_actor: { type: 'human', id: '900003' },
+            to_actor: { type: 'bot', id: 'owned-bot:900003' },
             status: 'pending',
           },
         ],
@@ -275,7 +275,7 @@ describe('CollaborationSquareApiAdapter', () => {
     });
 
     const result = await new CollaborationSquareApiAdapter().listBotPage(
-      { viewerActorType: 'human', viewerActorId: '327325' },
+      { viewerActorType: 'human', viewerActorId: '900003' },
       humanContext,
     );
 
@@ -483,7 +483,7 @@ describe('CollaborationSquareApiAdapter', () => {
         items: [
           {
             request_id: 'request-1',
-            from_actor: { type: 'human', id: '327325' },
+            from_actor: { type: 'human', id: '900003' },
             to_actor: { type: 'bot', id: 'bot-applying:e2' },
             status: 'pending',
           },
@@ -500,7 +500,7 @@ describe('CollaborationSquareApiAdapter', () => {
         direction: 'sent',
         status: 'pending',
         actor_type: 'human',
-        actor_id: '327325',
+        actor_id: '900003',
         page: 1,
         page_size: 100,
       },
@@ -577,7 +577,7 @@ describe('CollaborationSquareApiAdapter', () => {
           items: [
             {
               request_id: 'request-1',
-              from_actor: { type: 'human', id: '327325' },
+              from_actor: { type: 'human', id: '900003' },
               to_actor: { type: 'bot', id: 'bot-applying:e2' },
               status: 'pending',
             },
@@ -591,7 +591,7 @@ describe('CollaborationSquareApiAdapter', () => {
           items: [
             {
               request_id: 'request-2',
-              from_actor: { type: 'human', id: '327325' },
+              from_actor: { type: 'human', id: '900003' },
               to_actor: { type: 'bot', id: 'bot-other' },
               status: 'pending',
             },
@@ -602,7 +602,7 @@ describe('CollaborationSquareApiAdapter', () => {
 
     const result = await new CollaborationSquareApiAdapter().discoverBots({ keyword: 'workflow' }, humanContext);
 
-    expect(mockedListFriendConnections).toHaveBeenCalledWith({ actor_type: 'human', actor_id: '327325' }, undefined);
+    expect(mockedListFriendConnections).toHaveBeenCalledWith({ actor_type: 'human', actor_id: '900003' }, undefined);
     expect(mockedListFriendConnectionRequests).toHaveBeenCalledTimes(2);
     expect(result.map((bot) => [bot.id, bot.relationshipStatus])).toEqual([
       ['bot-friend:e1', 'friend'],
@@ -635,7 +635,7 @@ describe('CollaborationSquareApiAdapter', () => {
     });
     expect(mockedCreateFriendConnectionRequest).toHaveBeenCalledWith({
       to_actor: { type: 'bot', id: 'bot-1' },
-      from_actor: { type: 'human', id: '327325' },
+      from_actor: { type: 'human', id: '900003' },
     });
   });
 
@@ -650,7 +650,7 @@ describe('CollaborationSquareApiAdapter', () => {
     ).resolves.toEqual({ status: 'applying' });
     expect(mockedCreateFriendConnectionRequest).toHaveBeenCalledWith({
       to_actor: { type: 'bot', id: 'explicit-bot-uuid' },
-      from_actor: { type: 'human', id: '327325' },
+      from_actor: { type: 'human', id: '900003' },
     });
   });
 
@@ -669,7 +669,7 @@ describe('CollaborationSquareApiAdapter', () => {
     ).resolves.toEqual({ status: 'applying' });
     expect(mockedCreateFriendConnectionRequest).toHaveBeenCalledWith({
       to_actor: { type: 'bot', id: '20260410_kt9ermvn:431368' },
-      from_actor: { type: 'human', id: '327325' },
+      from_actor: { type: 'human', id: '900003' },
     });
   });
 
@@ -749,7 +749,7 @@ describe('CollaborationSquareApiAdapter', () => {
     });
     expect(mockedCreateBotSession).toHaveBeenCalledWith(
       'bot-1',
-      { user_id: '327325', owner_id: '2088', f_user_id: '327325' },
+      { user_id: '900003', owner_id: '2088', f_user_id: '900003' },
       {},
     );
   });
@@ -765,7 +765,7 @@ describe('CollaborationSquareApiAdapter', () => {
         isOwnedByLoggedInUser: true,
       }),
     ).resolves.toEqual({ sessionId: 'session-owned' });
-    expect(mockedCreateBotSession).toHaveBeenCalledWith('bot-1', { user_id: '327325', owner_id: '2088' }, {});
+    expect(mockedCreateBotSession).toHaveBeenCalledWith('bot-1', { user_id: '900003', owner_id: '2088' }, {});
   });
 
   it('rejects a session response without session_id as a protocol error', async () => {
@@ -811,7 +811,7 @@ describe('CollaborationSquareApiAdapter', () => {
         status: 'running',
         participants: [
           {
-            actor_id: 'human_327325',
+            actor_id: 'human_900003',
             actor_kind: 'human',
             role: 'consultant',
             mode: 'present',
@@ -828,7 +828,7 @@ describe('CollaborationSquareApiAdapter', () => {
       defaultRole: '顾问',
       memberSource: 'session_temp',
     });
-    expect(mockedCreateGroupSession).toHaveBeenCalledWith('group-1', { kind: 'chat', acting_bot_id: 'human_327325' });
+    expect(mockedCreateGroupSession).toHaveBeenCalledWith('group-1', { kind: 'chat', acting_bot_id: 'human_900003' });
   });
 
   it('rejects a public group session response without session_id or caller role', async () => {

--- a/src/frontend-nextgen/test/services/collaborationSquare/collaborationSquareRuntimeWiring.test.ts
+++ b/src/frontend-nextgen/test/services/collaborationSquare/collaborationSquareRuntimeWiring.test.ts
@@ -161,8 +161,8 @@ describe('collaboration square BOT runtime wiring', () => {
 
     await expect(
       collaborationSquareBotService.requestBotFriendship('bot-real-1', {
-        actorId: 'human_327325',
-        userId: '327325',
+        actorId: 'human_900003',
+        userId: '900003',
       }),
     ).resolves.toEqual({ status: 'applying' });
 
@@ -173,7 +173,7 @@ describe('collaboration square BOT runtime wiring', () => {
         method: 'POST',
         body: JSON.stringify({
           to_actor: { type: 'bot', id: 'bot-real-1' },
-          from_actor: { type: 'human', id: '327325' },
+          from_actor: { type: 'human', id: '900003' },
         }),
       }),
     );
@@ -203,14 +203,14 @@ describe('collaboration square BOT runtime wiring', () => {
 
     await expect(
       collaborationSquareBotService.openBotConversation('bot-real-1:2088', {
-        actorId: 'human_327325',
-        userId: '327325',
+        actorId: 'human_900003',
+        userId: '900003',
       }),
     ).resolves.toEqual({ sessionId: 'session-real-1' });
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock.mock.calls[0][0]).toBe(
-      '/openapi/v1/bots/bot-real-1/sessions?user_id=327325&owner_id=2088&f_user_id=327325',
+      '/openapi/v1/bots/bot-real-1/sessions?user_id=900003&owner_id=2088&f_user_id=900003',
     );
     expect(fetchMock.mock.calls[0][1]).toEqual(expect.objectContaining({ method: 'POST', body: '{}' }));
     expect(

--- a/src/frontend-nextgen/test/services/collaborationSquare/createGroupSessionScope.test.ts
+++ b/src/frontend-nextgen/test/services/collaborationSquare/createGroupSessionScope.test.ts
@@ -1,0 +1,33 @@
+import * as sessionController from '@/services/backendApi/collaboration/sessionController';
+import { CollaborationSquareApiAdapter } from '@/services/collaborationSquare/collaborationSquareApiAdapter';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+jest.mock('@/services/backendApi/collaboration/sessionController');
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const sc = sessionController as unknown as Record<string, jest.Mock<any>>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  sc.createSession.mockResolvedValue({
+    code: 20100,
+    message: '',
+    request_id: 'r',
+    data: { session_id: 's1', group_id: 'g1', participants: [], status: 'running', created_at: 1, updated_at: 1 },
+  });
+});
+
+describe('collaborationSquareApiAdapter.createGroupSession 透传 message_view_scope', () => {
+  it('options.messageViewScope 进入请求体', async () => {
+    const adapter = new CollaborationSquareApiAdapter();
+    await adapter.createGroupSession('g1', undefined, { title: 't', query: 'q', messageViewScope: 'participant' });
+    const body = sc.createSession.mock.calls[0][1] as Record<string, unknown>;
+    expect(body.message_view_scope).toBe('participant');
+  });
+
+  it('不传时请求体无该键', async () => {
+    const adapter = new CollaborationSquareApiAdapter();
+    await adapter.createGroupSession('g1', undefined, { title: 't' });
+    const body = sc.createSession.mock.calls[0][1] as Record<string, unknown>;
+    expect(Object.prototype.hasOwnProperty.call(body, 'message_view_scope')).toBe(false);
+  });
+});

--- a/src/frontend-nextgen/test/services/workspace/botChatProvider.test.ts
+++ b/src/frontend-nextgen/test/services/workspace/botChatProvider.test.ts
@@ -132,9 +132,9 @@ describe('botChatProvider', () => {
       message: 'OK',
       request_id: 'r',
     });
-    const p = createBotChatProvider({ bot, userId: 'human_327325', sessionId: 'sid-1' });
+    const p = createBotChatProvider({ bot, userId: 'human_900003', sessionId: 'sid-1' });
     await p.connect();
-    expect(mockedGetConnection).toHaveBeenCalledWith('b', { user_id: '327325', owner_id: '2088' });
+    expect(mockedGetConnection).toHaveBeenCalledWith('b', { user_id: '900003', owner_id: '2088' });
   });
 
   it('好友 Bot 的 connection 携带 f_user_id', async () => {
@@ -145,12 +145,12 @@ describe('botChatProvider', () => {
       request_id: 'r',
     });
     const friendBot = { ...bot, isFriendBot: true };
-    const provider = createBotChatProvider({ bot: friendBot, userId: 'human_327325', sessionId: 'sid-1' });
+    const provider = createBotChatProvider({ bot: friendBot, userId: 'human_900003', sessionId: 'sid-1' });
     await provider.connect();
     expect(mockedGetConnection).toHaveBeenCalledWith('b', {
-      user_id: '327325',
+      user_id: '900003',
       owner_id: '2088',
-      f_user_id: '327325',
+      f_user_id: '900003',
       session_id: 'sid-1',
     });
   });

--- a/src/frontend-nextgen/test/services/workspace/botSessionFileService.test.ts
+++ b/src/frontend-nextgen/test/services/workspace/botSessionFileService.test.ts
@@ -23,12 +23,12 @@ function file(name: string, size = 100): File {
 describe('botSessionFileService.resolveContentUrl', () => {
   it('使用 gateway 内容地址', () => {
     mocked.buildBotSessionFileContentUrl.mockReturnValue('/openapi/v1/bots/bot-1/sessions/s1/files/sr_1/content?x=1');
-    const url = botSessionFileService.resolveContentUrl('bot-1', 's1', 'sr_1', 'human_327325', '327325', 'attachment');
+    const url = botSessionFileService.resolveContentUrl('bot-1', 's1', 'sr_1', 'human_900003', '900003', 'attachment');
     expect(mocked.buildBotSessionFileContentUrl).toHaveBeenCalledWith(
       'bot-1',
       's1',
       'sr_1',
-      { user_id: '327325', owner_id: '327325' },
+      { user_id: '900003', owner_id: '900003' },
       'attachment',
     );
     expect(url).toBe('/openapi/v1/bots/bot-1/sessions/s1/files/sr_1/content?x=1');
@@ -240,8 +240,8 @@ describe('botSessionFileService 列表/删除/下载', () => {
   });
   it('loadReady 将 human_ 前缀的 user_id 归一化为工号', async () => {
     mocked.listReady.mockResolvedValue({ files: [] });
-    await botSessionFileService.loadReady('bot-1', 'sess-1', 'human_327325');
-    expect(mocked.listReady).toHaveBeenCalledWith('bot-1', 'sess-1', { user_id: '327325' });
+    await botSessionFileService.loadReady('bot-1', 'sess-1', 'human_900003');
+    expect(mocked.listReady).toHaveBeenCalledWith('bot-1', 'sess-1', { user_id: '900003' });
   });
   it('remove 成功', async () => {
     mocked.deleteFile.mockResolvedValue({ deleted: true });

--- a/src/frontend-nextgen/test/services/workspace/botSessionService.test.ts
+++ b/src/frontend-nextgen/test/services/workspace/botSessionService.test.ts
@@ -108,7 +108,7 @@ describe('botSessionService', () => {
       },
     });
 
-    const res = await botSessionService.listOwnedBots('human_327325');
+    const res = await botSessionService.listOwnedBots('human_900003');
     expect(res.ok).toBe(true);
     expect(res.ok && res.data).toEqual([
       expect.objectContaining({
@@ -153,9 +153,9 @@ describe('botSessionService', () => {
       message: 'OK',
       request_id: 'r',
     });
-    const res = await botSessionService.listSessions(bot, 'human_327325');
+    const res = await botSessionService.listSessions(bot, 'human_900003');
     expect(mocked.listBotSessions).toHaveBeenCalledWith('20260402_ab', {
-      user_id: '327325',
+      user_id: '900003',
       owner_id: '2088',
       page: 1,
       page_size: 50,
@@ -182,10 +182,10 @@ describe('botSessionService', () => {
       message: 'OK',
       request_id: 'r',
     });
-    const res = await botSessionService.createSession(bot, 'human_327325', '新');
+    const res = await botSessionService.createSession(bot, 'human_900003', '新');
     expect(mocked.createBotSession).toHaveBeenCalledWith(
       '20260402_ab',
-      { user_id: '327325', owner_id: '2088' },
+      { user_id: '900003', owner_id: '2088' },
       { title: '新' },
     );
     expect((res as any).data.sessionId).toBe('sid-new');
@@ -198,9 +198,9 @@ describe('botSessionService', () => {
       message: 'OK',
       request_id: 'r',
     });
-    const res = await botSessionService.deleteSession(bot, 'human_327325', 'sid-9');
+    const res = await botSessionService.deleteSession(bot, 'human_900003', 'sid-9');
     expect(mocked.deleteBotSession).toHaveBeenCalledWith('20260402_ab', 'sid-9', {
-      user_id: '327325',
+      user_id: '900003',
       owner_id: '2088',
     });
     expect(res.ok).toBe(true);
@@ -243,9 +243,9 @@ describe('botSessionService', () => {
       message: 'OK',
       request_id: 'r',
     });
-    await botSessionService.listMessages(bot, 'human_327325', 's');
+    await botSessionService.listMessages(bot, 'human_900003', 's');
     expect(mocked.listBotSessionMessages).toHaveBeenCalledWith('20260402_ab', 's', {
-      user_id: '327325',
+      user_id: '900003',
       owner_id: '2088',
       page: 1,
       page_size: 50,
@@ -265,9 +265,9 @@ describe('botSessionService', () => {
       message: 'OK',
       request_id: 'r',
     });
-    const res = await botSessionService.listModels(bot, 'human_327325');
+    const res = await botSessionService.listModels(bot, 'human_900003');
     expect(mocked.listBotModels).toHaveBeenCalledWith('20260402_ab', {
-      user_id: '327325',
+      user_id: '900003',
       owner_id: '2088',
       page: 1,
       page_size: 50,
@@ -290,11 +290,11 @@ describe('botSessionService', () => {
       message: 'OK',
       request_id: 'r',
     });
-    const res = await botSessionService.updateSessionModel(bot, 'human_327325', 's1', 'openai/gpt-5.3');
+    const res = await botSessionService.updateSessionModel(bot, 'human_900003', 's1', 'openai/gpt-5.3');
     expect(mocked.updateBotSession).toHaveBeenCalledWith(
       '20260402_ab',
       's1',
-      { user_id: '327325' },
+      { user_id: '900003' },
       { model: 'openai/gpt-5.3' },
     );
     expect(res.ok && res.data.model).toBe('openai/gpt-5.3');
@@ -312,7 +312,7 @@ describe('botSessionService', () => {
     };
     const messageDto = { message_id: 'm1', session_id: 's1', role: 'user', content: 'q', gmt_create: '' };
     const friendBot = { ...bot, isFriendBot: true };
-    const baseParams = { user_id: '327325', owner_id: '2088', f_user_id: '327325' };
+    const baseParams = { user_id: '900003', owner_id: '2088', f_user_id: '900003' };
 
     mocked.listBotSessions.mockResolvedValue({ data: { items: [], total: 0 } });
     mocked.createBotSession.mockResolvedValue({ data: sessionDto });
@@ -326,63 +326,63 @@ describe('botSessionService', () => {
     mocked.listFavoriteSessions.mockResolvedValue({ data: { items: [], total: 0 } });
     mocked.listBotModels.mockResolvedValue({ data: { items: [], total: 0 } });
 
-    await botSessionService.listSessionsPage(friendBot, 'human_327325', 1, 10);
+    await botSessionService.listSessionsPage(friendBot, 'human_900003', 1, 10);
     expect(mocked.listBotSessions).toHaveBeenLastCalledWith('20260402_ab', {
       ...baseParams,
       page: 1,
       page_size: 10,
     });
 
-    await botSessionService.createSession(friendBot, 'human_327325');
+    await botSessionService.createSession(friendBot, 'human_900003');
     expect(mocked.createBotSession).toHaveBeenLastCalledWith('20260402_ab', baseParams, { title: undefined });
 
-    await botSessionService.getSessionDetail(friendBot, 'human_327325', 's1');
+    await botSessionService.getSessionDetail(friendBot, 'human_900003', 's1');
     expect(mocked.getBotSession).toHaveBeenLastCalledWith('20260402_ab', 's1', baseParams);
 
-    await botSessionService.deleteSession(friendBot, 'human_327325', 's1');
+    await botSessionService.deleteSession(friendBot, 'human_900003', 's1');
     expect(mocked.deleteBotSession).toHaveBeenLastCalledWith('20260402_ab', 's1', baseParams);
 
-    await botSessionService.updateSessionTitle(friendBot, 'human_327325', 's1', '新标题');
+    await botSessionService.updateSessionTitle(friendBot, 'human_900003', 's1', '新标题');
     expect(mocked.updateBotSession).toHaveBeenLastCalledWith('20260402_ab', 's1', baseParams, { title: '新标题' });
 
-    await botSessionService.clearContext(friendBot, 'human_327325', 's1');
+    await botSessionService.clearContext(friendBot, 'human_900003', 's1');
     expect(mocked.deleteBotSessionMessages).toHaveBeenLastCalledWith('20260402_ab', 's1', baseParams);
 
-    await botSessionService.listMessages(friendBot, 'human_327325', 's1');
+    await botSessionService.listMessages(friendBot, 'human_900003', 's1');
     expect(mocked.listBotSessionMessages).toHaveBeenLastCalledWith('20260402_ab', 's1', {
       ...baseParams,
       page: 1,
       page_size: 50,
     });
 
-    await botSessionService.toggleFavorite(friendBot, 'human_327325', 's1', true);
+    await botSessionService.toggleFavorite(friendBot, 'human_900003', 's1', true);
     expect(mocked.favoriteBotSession).toHaveBeenLastCalledWith('20260402_ab', 's1', baseParams);
-    await botSessionService.toggleFavorite(friendBot, 'human_327325', 's1', false);
+    await botSessionService.toggleFavorite(friendBot, 'human_900003', 's1', false);
     expect(mocked.unfavoriteBotSession).toHaveBeenLastCalledWith('20260402_ab', 's1', baseParams);
 
-    await botSessionService.listFavoriteSessionsPage(friendBot, 'human_327325', 1, 10);
+    await botSessionService.listFavoriteSessionsPage(friendBot, 'human_900003', 1, 10);
     expect(mocked.listFavoriteSessions).toHaveBeenLastCalledWith('20260402_ab', {
       ...baseParams,
       page: 1,
       page_size: 10,
     });
 
-    await botSessionService.listModels(friendBot, 'human_327325');
+    await botSessionService.listModels(friendBot, 'human_900003');
     expect(mocked.listBotModels).toHaveBeenLastCalledWith('20260402_ab', {
       ...baseParams,
       page: 1,
       page_size: 50,
     });
 
-    await botSessionService.updateSessionModel(friendBot, 'human_327325', 's1', 'openai/gpt-5.3');
+    await botSessionService.updateSessionModel(friendBot, 'human_900003', 's1', 'openai/gpt-5.3');
     expect(mocked.updateBotSession).toHaveBeenLastCalledWith('20260402_ab', 's1', baseParams, {
       model: 'openai/gpt-5.3',
     });
 
     mocked.listBotSessions.mockClear();
-    await botSessionService.listSessionsPage(bot, 'human_327325', 1, 10);
+    await botSessionService.listSessionsPage(bot, 'human_900003', 1, 10);
     expect(mocked.listBotSessions).toHaveBeenLastCalledWith('20260402_ab', {
-      user_id: '327325',
+      user_id: '900003',
       owner_id: '2088',
       page: 1,
       page_size: 10,
@@ -416,9 +416,9 @@ it('listSessionsPage 与收藏分页复用统一标题映射并透传分页参�
       total: 12,
     },
   });
-  const all = await botSessionService.listSessionsPage(bot, 'human_327325', 2, 10);
+  const all = await botSessionService.listSessionsPage(bot, 'human_900003', 2, 10);
   expect(mocked.listBotSessions).toHaveBeenCalledWith('20260402_ab', {
-    user_id: '327325',
+    user_id: '900003',
     owner_id: '2088',
     page: 2,
     page_size: 10,
@@ -432,7 +432,7 @@ it('listSessionsPage 与收藏分页复用统一标题映射并透传分页参�
       total: 1,
     },
   });
-  const favorites = await botSessionService.listFavoriteSessionsPage(bot, 'human_327325', 1, 10);
+  const favorites = await botSessionService.listFavoriteSessionsPage(bot, 'human_900003', 1, 10);
   expect(favorites).toMatchObject({
     ok: true,
     data: { total: 1, items: [{ sessionId: 'sid-f', title: '收藏标题', favorite: true }] },

--- a/src/frontend-nextgen/test/services/workspace/collaborationCandidateService.test.ts
+++ b/src/frontend-nextgen/test/services/workspace/collaborationCandidateService.test.ts
@@ -67,15 +67,15 @@ describe('collaborationCandidateService', () => {
       },
     });
 
-    const res = await collaborationCandidateService.listFriends('actor-1:327325', { actorType: 'bot' });
+    const res = await collaborationCandidateService.listFriends('actor-1:900003', { actorType: 'bot' });
 
     expect(connections.listFriendConnections).toHaveBeenCalledWith({
       actor_type: 'bot',
-      actor_id: 'actor-1:327325',
+      actor_id: 'actor-1:900003',
     });
     expect(bc.listBotFriendships).not.toHaveBeenCalled();
     expect(bots.listBotMetadata).toHaveBeenCalledWith(
-      { user_id: '327325', page: 1, page_size: 2 },
+      { user_id: '900003', page: 1, page_size: 2 },
       {
         bots: [
           { bot_id: 'b1', owner_id: 'actor-1' },
@@ -118,19 +118,19 @@ describe('collaborationCandidateService', () => {
     connections.listFriendConnections.mockResolvedValue({
       code: 20000,
       data: {
-        items: [{ actor: { type: 'bot', id: 'b1:327325' } }],
+        items: [{ actor: { type: 'bot', id: 'b1:900003' } }],
         total: 1,
       },
     });
     bots.listBotMetadata.mockResolvedValue({
       code: 200000,
       data: {
-        items: [{ bot_id: 'b1', owner_id: '327325', bot_name: '蒜蓉粉丝虾', status: 'online', engine: 'OpenAI' }],
+        items: [{ bot_id: 'b1', owner_id: '900003', bot_name: '蒜蓉粉丝虾', status: 'online', engine: 'OpenAI' }],
         total: 1,
       },
     });
 
-    const res = await collaborationCandidateService.listFriends('human_327325', {
+    const res = await collaborationCandidateService.listFriends('human_900003', {
       actorType: 'human',
       offset: 0,
       limit: 100,
@@ -138,15 +138,15 @@ describe('collaborationCandidateService', () => {
 
     expect(connections.listFriendConnections).toHaveBeenCalledWith({
       actor_type: 'human',
-      actor_id: '327325',
+      actor_id: '900003',
     });
     expect(bc.listBotFriendships).not.toHaveBeenCalled();
     expect(bots.listBotMetadata).toHaveBeenCalledWith(
-      { user_id: '327325', page: 1, page_size: 1 },
-      { bots: [{ bot_id: 'b1', owner_id: '327325' }] },
+      { user_id: '900003', page: 1, page_size: 1 },
+      { bots: [{ bot_id: 'b1', owner_id: '900003' }] },
     );
     expect(res.ok && res.data.items[0]).toMatchObject({
-      id: 'b1:327325',
+      id: 'b1:900003',
       name: '蒜蓉粉丝虾',
       engine: 'OpenAI',
     });
@@ -156,7 +156,7 @@ describe('collaborationCandidateService', () => {
     connections.listFriendConnections.mockResolvedValue({
       code: 20000,
       data: {
-        items: [{ actor: { type: 'bot', id: 'b1:327325' } }, { actor: { type: 'bot', id: 'b2:327325' } }],
+        items: [{ actor: { type: 'bot', id: 'b1:900003' } }, { actor: { type: 'bot', id: 'b2:900003' } }],
         total: 2,
       },
     });
@@ -166,7 +166,7 @@ describe('collaborationCandidateService', () => {
         items: [
           {
             kind: 'bot',
-            bot_id: 'b1:327325',
+            bot_id: 'b1:900003',
             name: '协作 Alpha',
             status: 'online',
             reachability: 'reachable',
@@ -177,18 +177,18 @@ describe('collaborationCandidateService', () => {
       },
     });
 
-    const res = await collaborationCandidateService.listFriends('human_327325', {
+    const res = await collaborationCandidateService.listFriends('human_900003', {
       actorType: 'human',
       detailSource: 'collaboration',
     });
 
-    expect(bc.queryCollaborationBots).toHaveBeenCalledWith({ bot_ids: ['b1:327325', 'b2:327325'] });
+    expect(bc.queryCollaborationBots).toHaveBeenCalledWith({ bot_ids: ['b1:900003', 'b2:900003'] });
     expect(bots.listBotMetadata).not.toHaveBeenCalled();
     expect(res.ok && res.data.items).toEqual([
-      expect.objectContaining({ id: 'b1:327325', name: '协作 Alpha', isFriend: true }),
+      expect.objectContaining({ id: 'b1:900003', name: '协作 Alpha', isFriend: true }),
       expect.objectContaining({
-        id: 'b2:327325',
-        name: 'b2:327325',
+        id: 'b2:900003',
+        name: 'b2:900003',
         online: false,
         detailsResolved: false,
       }),

--- a/src/frontend-nextgen/test/services/workspace/groupChatProvider.test.ts
+++ b/src/frontend-nextgen/test/services/workspace/groupChatProvider.test.ts
@@ -19,7 +19,7 @@ const fakeSdkProvider = jest.fn<any>().mockImplementation((cfg: any) => {
   lastOriginalSend = send;
   const inner: any = {
     config: cfg,
-    transport: { send },
+    transport: { send, onMessage: jest.fn<any>() },
     request: jest.fn<any>().mockResolvedValue(undefined),
     abort: jest.fn<any>(),
     connect: jest.fn<any>(),
@@ -36,6 +36,7 @@ const fakeSdkProvider = jest.fn<any>().mockImplementation((cfg: any) => {
   inner.connect.mockImplementation(async () => {
     inner.isConnected = true;
   });
+  inner.originalOnMessage = inner.transport.onMessage;
   return inner;
 });
 
@@ -47,7 +48,7 @@ beforeEach(() => {
     lastOriginalSend = send;
     const inner: any = {
       config: cfg,
-      transport: { send },
+      transport: { send, onMessage: jest.fn<any>() },
       request: jest.fn<any>().mockResolvedValue(undefined),
       abort: jest.fn<any>(),
       connect: jest.fn<any>(),
@@ -64,6 +65,7 @@ beforeEach(() => {
     inner.connect.mockImplementation(async () => {
       inner.isConnected = true;
     });
+    inner.originalOnMessage = inner.transport.onMessage;
     return inner;
   });
 });
@@ -195,7 +197,7 @@ describe('groupChatProvider', () => {
     const provider = createGroupChatProvider({
       sessionId: 's1',
       groupId: 'g1',
-      identityId: 'human_327325',
+      identityId: 'human_900003',
       createSdkProvider: fakeSdkProvider as unknown as Parameters<
         typeof createGroupChatProvider
       >[0]['createSdkProvider'],
@@ -207,15 +209,15 @@ describe('groupChatProvider', () => {
     await provider.request({
       content: '@波士顿龙虾 你在干嘛',
       sessionId: 's1',
-      mentions: ['20260528_udt1y38n:327325'],
+      mentions: ['20260528_udt1y38n:900003'],
     });
     expect(inner.inner.request).toHaveBeenCalledWith({
       query: '@波士顿龙虾 你在干嘛',
       groupId: 'g1',
       sessionId: 's1',
-      senderId: '327325',
-      botUuid: 'human_327325',
-      mentions: ['20260528_udt1y38n:327325'],
+      senderId: '900003',
+      botUuid: 'human_900003',
+      mentions: ['20260528_udt1y38n:900003'],
     });
   });
 
@@ -229,7 +231,7 @@ describe('groupChatProvider', () => {
     const provider = createGroupChatProvider({
       sessionId: 's1',
       groupId: 'g1',
-      identityId: 'human_327325',
+      identityId: 'human_900003',
       createSdkProvider: fakeSdkProvider as unknown as Parameters<
         typeof createGroupChatProvider
       >[0]['createSdkProvider'],
@@ -255,8 +257,8 @@ describe('groupChatProvider', () => {
       query: '看图',
       groupId: 'g1',
       sessionId: 's1',
-      senderId: '327325',
-      botUuid: 'human_327325',
+      senderId: '900003',
+      botUuid: 'human_900003',
       attachments,
     });
   });
@@ -293,7 +295,7 @@ describe('groupChatProvider', () => {
     expect(lastOriginalSend).toHaveBeenCalledWith(
       expect.objectContaining({
         method: 'connect',
-        params: { group_id: 'g1', session_id: 's1' },
+        params: { group_id: 'g1', session_id: 's1', view_actor_id: 'me' },
       }),
     );
 
@@ -345,6 +347,31 @@ describe('groupChatProvider', () => {
     expect(firstInner.disconnect).toHaveBeenCalledTimes(1);
     expect(fakeSdkProvider.mock.calls[1][0].url).toBe('wss://x.test/openapi/v1/collaboration/messages/ws?token=tk-2');
     expect(secondInner).not.toBe(firstInner);
+  });
+
+  it('并发 reconnect 共享同一 in-flight：token 仅重拉一次、SDK provider 仅再构造一次', async () => {
+    sc.createSessionToken.mockResolvedValue({
+      code: 20000,
+      message: '',
+      request_id: 'r',
+      data: { token: 'tk', expires_at: 999 },
+    });
+    const provider = createGroupChatProvider({
+      sessionId: 's-reconnect-race',
+      groupId: 'g1',
+      identityId: 'me',
+      createSdkProvider: fakeSdkProvider as unknown as Parameters<
+        typeof createGroupChatProvider
+      >[0]['createSdkProvider'],
+      wsOrigin: 'wss://x.test',
+    });
+
+    await provider.connect();
+    await Promise.all([provider.reconnect(), provider.reconnect()]);
+
+    // connect 1 次 + 并发 reconnect 合并为 1 次
+    expect(sc.createSessionToken).toHaveBeenCalledTimes(2);
+    expect(fakeSdkProvider).toHaveBeenCalledTimes(2);
   });
 
   it('兼容不提供 hydration 扩展能力的 SDK 版本', async () => {
@@ -688,5 +715,94 @@ describe('groupChatProvider', () => {
     expect(older).toEqual([]);
     // 只有首屏那次调用，未额外翻页请求。
     expect(sc.listSessionMessages).toHaveBeenCalledTimes(1);
+  });
+
+  it('connect 帧注入 view_actor_id=当前身份 id（human/bot 统一）', async () => {
+    sc.createSessionToken.mockResolvedValue({
+      code: 20000,
+      message: '',
+      request_id: 'r',
+      data: { token: 'tk', expires_at: 999 },
+    });
+    const provider = createGroupChatProvider({
+      sessionId: 's1',
+      groupId: 'g1',
+      identityId: 'human_900003',
+      createSdkProvider: fakeSdkProvider as unknown as Parameters<
+        typeof createGroupChatProvider
+      >[0]['createSdkProvider'],
+      wsOrigin: 'wss://x.test',
+    });
+    await provider.connect();
+    const inner = provider as unknown as { inner: { transport: { send: jest.Mock } } };
+    await inner.inner.transport.send({ type: 'req', id: 'c1', method: 'connect', params: { group_id: 'g1' } });
+    expect(lastOriginalSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'connect',
+        params: { group_id: 'g1', session_id: 's1', view_actor_id: 'human_900003' },
+      }),
+    );
+    // chat.send 帧不注入 view_actor_id
+    await inner.inner.transport.send({ type: 'req', id: 's1', method: 'chat.send', params: { message: 'hi' } });
+    const sendCalls = (lastOriginalSend as jest.Mock).mock.calls;
+    const chatSendParams = sendCalls[sendCalls.length - 1][0].params as Record<string, unknown>;
+    expect(chatSendParams.view_actor_id).toBeUndefined();
+  });
+
+  it('入站 view_scope_changed 帧触发通知与自动重连（重拉 token），且不透传给 SDK parser', async () => {
+    sc.createSessionToken
+      .mockResolvedValueOnce({ code: 20000, message: '', request_id: 'r1', data: { token: 'tk-1', expires_at: 999 } })
+      .mockResolvedValueOnce({ code: 20000, message: '', request_id: 'r2', data: { token: 'tk-2', expires_at: 999 } });
+    const provider = createGroupChatProvider({
+      sessionId: 's-scope',
+      groupId: 'g1',
+      identityId: 'me',
+      createSdkProvider: fakeSdkProvider as unknown as Parameters<
+        typeof createGroupChatProvider
+      >[0]['createSdkProvider'],
+      wsOrigin: 'wss://x.test',
+    });
+    const onChanged = jest.fn();
+    provider.subscribeToViewScopeChanged(onChanged);
+    await provider.connect();
+    const firstInner = provider as unknown as {
+      inner: { transport: { onMessage?: (msg: unknown) => void }; originalOnMessage: jest.Mock };
+    };
+    const originalOnMessage = firstInner.inner.originalOnMessage;
+
+    firstInner.inner.transport.onMessage?.({ method: 'view_scope_changed' });
+
+    expect(onChanged).toHaveBeenCalledTimes(1);
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
+    expect(sc.createSessionToken).toHaveBeenCalledTimes(2);
+    // 关闭事件帧不透传给 SDK 原 onMessage
+    expect(originalOnMessage).not.toHaveBeenCalledWith({ method: 'view_scope_changed' });
+  });
+
+  it('普通入站帧正常透传给 SDK 原 onMessage', async () => {
+    sc.createSessionToken.mockResolvedValue({
+      code: 20000,
+      message: '',
+      request_id: 'r',
+      data: { token: 'tk', expires_at: 999 },
+    });
+    const provider = createGroupChatProvider({
+      sessionId: 's-pass',
+      groupId: 'g1',
+      identityId: 'me',
+      createSdkProvider: fakeSdkProvider as unknown as Parameters<
+        typeof createGroupChatProvider
+      >[0]['createSdkProvider'],
+      wsOrigin: 'wss://x.test',
+    });
+    await provider.connect();
+    const inner = provider as unknown as {
+      inner: { transport: { onMessage?: (msg: unknown) => void }; originalOnMessage: jest.Mock };
+    };
+    const rawFrame = { group_id: 'g1', message: 'hello' };
+    inner.inner.transport.onMessage?.(rawFrame);
+    expect(inner.inner.originalOnMessage).toHaveBeenCalledWith(rawFrame);
   });
 });

--- a/src/frontend-nextgen/test/services/workspace/groupChatProviderHelpers.test.ts
+++ b/src/frontend-nextgen/test/services/workspace/groupChatProviderHelpers.test.ts
@@ -3,6 +3,7 @@ import { buildGroupChatBridgeRequest } from '@/pages/Workspace/hooks/groupChatRe
 import type { GroupChatRequest } from '@/services/workspace/groupChatProvider';
 import {
   buildGroupChatPayload,
+  isViewScopeChangedFrame,
   resolveGroupGatewayOrigin,
   resolveGroupWsOrigin,
 } from '@/services/workspace/groupChatProviderHelpers';
@@ -133,5 +134,19 @@ describe('resolveGroupGatewayOrigin — 资源标签直连网关', () => {
 
   it('renderoffice PROD hostname 返回 https prod 网关', () => {
     expect(resolveGroupGatewayOrigin('app.example.com')).toBe('https://gateway.example.com');
+  });
+});
+
+describe('isViewScopeChangedFrame', () => {
+  it('匹配 method/type/event 三种载体', () => {
+    expect(isViewScopeChangedFrame({ method: 'view_scope_changed' })).toBe(true);
+    expect(isViewScopeChangedFrame({ type: 'view_scope_changed' })).toBe(true);
+    expect(isViewScopeChangedFrame({ event: 'view_scope_changed' })).toBe(true);
+  });
+
+  it('普通消息帧与非对象不匹配', () => {
+    expect(isViewScopeChangedFrame({ method: 'chat.update', group_id: 'g1' })).toBe(false);
+    expect(isViewScopeChangedFrame(null)).toBe(false);
+    expect(isViewScopeChangedFrame('view_scope_changed')).toBe(false);
   });
 });

--- a/src/frontend-nextgen/test/services/workspace/groupService.test.ts
+++ b/src/frontend-nextgen/test/services/workspace/groupService.test.ts
@@ -369,6 +369,50 @@ describe('loadGroupDetail', () => {
     await groupService.loadGroupDetail('g1');
     expect(sc.listGroupSessions).toHaveBeenCalledWith('g1', { offset: 0, limit: 50 });
   });
+
+  it('participants 回显 message_view_scope 时映射为 messageViewScope，无值时不回显', async () => {
+    const detailData = (participants: unknown[]) => ({
+      code: 20000,
+      message: '',
+      request_id: 'r',
+      data: {
+        group_id: 'g1',
+        name: 'X',
+        strategy: 'chat',
+        collaboration: { strategy: 'chat', delivery_policy: { bot_final_delivery: 'send_to_driver' } },
+        status: 'active',
+        participants,
+        originator_actor_id: 'bot-1',
+        updated_at: 1,
+        created_at: 1,
+      },
+    });
+    gc.getGroup.mockResolvedValue(
+      detailData([
+        {
+          actor_id: 'human-1',
+          actor_kind: 'human',
+          name: '成员甲',
+          role: 'consultant',
+          mode: 'present',
+          message_view_scope: 'participant',
+        },
+        { actor_id: 'human-2', actor_kind: 'human', name: '成员乙', role: 'consultant', mode: 'present' },
+      ]),
+    );
+    sc.listGroupSessions.mockResolvedValue({
+      code: 20000,
+      message: '',
+      request_id: 'r',
+      data: { items: [], offset: 0, limit: 50, total: 0 },
+    });
+
+    const res = await groupService.loadGroupDetail('g1');
+    expect(res.ok).toBe(true);
+    const participants = res.ok ? res.data.participants : [];
+    expect(participants[0].messageViewScope).toBe('participant');
+    expect(participants[1].messageViewScope).toBeUndefined();
+  });
 });
 
 describe('policy', () => {

--- a/src/frontend-nextgen/test/services/workspace/identityService.test.ts
+++ b/src/frontend-nextgen/test/services/workspace/identityService.test.ts
@@ -66,7 +66,7 @@ describe('identityService.loadIdentities', () => {
       request_id: 'r',
       data: {
         items: [
-          { kind: 'human', bot_id: 'human-1', name: '风太', avatar_url: 'avatar-x', status: 'online' },
+          { kind: 'human', bot_id: 'human-1', name: '示例用户', avatar_url: 'avatar-x', status: 'online' },
           { kind: 'bot', bot_id: 'b1', name: 'Bot一号', avatar_url: 'u1', status: 'online', engine: 'OpenClaw' },
           { kind: 'bot', bot_id: 'b2', name: 'Bot二号', avatar_url: 'u2', status: 'offline' },
         ],
@@ -82,7 +82,7 @@ describe('identityService.loadIdentities', () => {
     expect(data.identities[0]).toMatchObject({
       kind: 'user',
       id: 'human-1',
-      displayName: '风太',
+      displayName: '示例用户',
       avatarUrl: 'avatar-x',
       online: true,
     });
@@ -356,7 +356,7 @@ describe('identityService.loadIdentities', () => {
       request_id: 'r',
       data: {
         items: [
-          { kind: 'human', bot_id: 'human_447147', name: '风太', status: 'online' },
+          { kind: 'human', bot_id: 'human_900004', name: '示例用户', status: 'online' },
           { kind: 'bot', bot_id: 'b1', name: 'Bot一号', status: 'online' },
         ],
         total: 2,
@@ -382,7 +382,7 @@ describe('identityService.loadIdentities', () => {
     expect((res as SuccessResult).data.identities).toContainEqual(
       expect.objectContaining({ id: 'b1', engine: 'Hermes', botType: 'service' }),
     );
-    expect(listBots).toHaveBeenCalledWith({ page: 1, page_size: 100, user_id: '447147' });
+    expect(listBots).toHaveBeenCalledWith({ page: 1, page_size: 100, user_id: '900004' });
   });
 
   it('maps bot runtime status from mine reachability', async () => {

--- a/src/frontend-nextgen/test/services/workspace/identityStore.test.ts
+++ b/src/frontend-nextgen/test/services/workspace/identityStore.test.ts
@@ -1,0 +1,45 @@
+import { applyIdentityLoadResult } from '@/services/workspace/identityStore';
+import { useWorkspaceStore } from '@/stores/workspaceStore';
+import { describe, expect, it } from '@jest/globals';
+
+describe('applyIdentityLoadResult', () => {
+  it('keeps the active identity when it still exists and avoids writing an unchanged list', () => {
+    useWorkspaceStore.setState({
+      identities: [{ id: 'human-1', kind: 'user', displayName: '我', online: true }],
+      activeIdentityId: 'human-1',
+    });
+    applyIdentityLoadResult({
+      identities: [{ id: 'human-1', kind: 'user', displayName: '我', online: true }],
+      defaultActiveId: 'human-1',
+    });
+
+    expect(useWorkspaceStore.getState().activeIdentityId).toBe('human-1');
+    expect(useWorkspaceStore.getState().identities).toHaveLength(1);
+  });
+
+  it('falls back when the active identity is no longer present', () => {
+    useWorkspaceStore.setState({
+      identities: [{ id: 'bot-old', kind: 'bot', displayName: 'Old Bot', online: true }],
+      activeIdentityId: 'bot-old',
+    });
+    applyIdentityLoadResult({
+      identities: [{ id: 'human-1', kind: 'user', displayName: '我', online: true }],
+      defaultActiveId: 'human-1',
+    });
+
+    expect(useWorkspaceStore.getState().activeIdentityId).toBe('human-1');
+  });
+
+  it('falls back to the default identity when none is active', () => {
+    useWorkspaceStore.setState({ identities: [], activeIdentityId: null });
+    applyIdentityLoadResult({
+      identities: [
+        { id: 'human-1', kind: 'user', displayName: '我', online: true },
+        { id: 'bot-1', kind: 'bot', displayName: 'Bot', online: true },
+      ],
+      defaultActiveId: 'bot-1',
+    });
+
+    expect(useWorkspaceStore.getState().activeIdentityId).toBe('bot-1');
+  });
+});

--- a/src/frontend-nextgen/test/services/workspace/messageViewScopePassthrough.test.ts
+++ b/src/frontend-nextgen/test/services/workspace/messageViewScopePassthrough.test.ts
@@ -1,0 +1,96 @@
+import * as invitationController from '@/services/backendApi/collaboration/collaborationInvitationController';
+import * as sessionController from '@/services/backendApi/collaboration/sessionController';
+import { buildCreateGroupBody } from '@/services/workspace/groupCreateRequest';
+import { invitationService } from '@/services/workspace/invitationService';
+import { sessionService } from '@/services/workspace/sessionService';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+jest.mock('@/services/backendApi/collaboration/sessionController');
+jest.mock('@/services/backendApi/collaboration/collaborationInvitationController');
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const sc = sessionController as unknown as Record<string, jest.Mock<any>>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const ic = invitationController as unknown as Record<string, jest.Mock<any>>;
+
+const sessionDto = {
+  session_id: 's1',
+  group_id: 'g1',
+  title: '会话',
+  status: 'running',
+  participants: [],
+  created_at: 1,
+  updated_at: 1,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  sc.createSession.mockResolvedValue({ code: 20100, message: '', request_id: 'r', data: sessionDto });
+  sc.getSession.mockResolvedValue({ code: 20000, message: '', request_id: 'r', data: sessionDto });
+  sc.updateSessionMemberMode.mockResolvedValue({ code: 20000, message: '', request_id: 'r', data: null });
+  ic.acceptInvitation.mockResolvedValue({
+    code: 20000,
+    message: '',
+    request_id: 'r',
+    data: { target_type: 'group', target_id: 'g1', joined: true },
+  });
+});
+
+describe('createNewSession 透传 message_view_scope', () => {
+  it('传 scope 时请求体携带 message_view_scope', async () => {
+    await sessionService.createNewSession('g1', undefined, undefined, 'participant');
+    const body = sc.createSession.mock.calls[0][1] as Record<string, unknown>;
+    expect(body.message_view_scope).toBe('participant');
+  });
+
+  it('不传 scope 时请求体不出现该键（后端继承/默认规则生效）', async () => {
+    await sessionService.createNewSession('g1');
+    const body = sc.createSession.mock.calls[0][1] as Record<string, unknown>;
+    expect(Object.prototype.hasOwnProperty.call(body, 'message_view_scope')).toBe(false);
+  });
+});
+
+describe('updateMemberMode 透传 message_view_scope', () => {
+  it('传 scope 时 PATCH body 同时携带 mode 与 scope', async () => {
+    await sessionService.updateMemberMode('s1', 'human_1', 'present', 'participant');
+    expect(sc.updateSessionMemberMode).toHaveBeenCalledWith('s1', 'human_1', {
+      mode: 'present',
+      message_view_scope: 'participant',
+    });
+  });
+
+  it('不传 scope 时 body 仅含 mode（旧调用不变）', async () => {
+    await sessionService.updateMemberMode('s1', 'b1', 'muted');
+    expect(sc.updateSessionMemberMode).toHaveBeenCalledWith('s1', 'b1', { mode: 'muted' });
+  });
+});
+
+describe('acceptInvitation 透传 message_view_scope', () => {
+  it('传 scope 时 body 携带字段', async () => {
+    await invitationService.acceptInvitation('tk', 'participant');
+    expect(ic.acceptInvitation).toHaveBeenCalledWith('tk', { message_view_scope: 'participant' });
+  });
+
+  it('不传 scope 时第二参为 undefined（wire body 为 {}）', async () => {
+    await invitationService.acceptInvitation('tk');
+    expect(ic.acceptInvitation).toHaveBeenCalledWith('tk', undefined);
+  });
+});
+
+describe('buildCreateGroupBody 将 scope 挂在指定参与者条目', () => {
+  it('human 条目携带 message_view_scope，bot 条目不携带', () => {
+    const body = buildCreateGroupBody({
+      name: '群',
+      strategy: 'chat',
+      driverBotUuid: 'bot_1',
+      originator: 'human_1',
+      participants: [{ actor_id: 'human_1', message_view_scope: 'participant' }, { actor_id: 'bot_1' }],
+    });
+    expect(body.participants[0]).toEqual({
+      actor_id: 'human_1',
+      role: 'consultant',
+      message_view_scope: 'participant',
+    });
+    expect(Object.prototype.hasOwnProperty.call(body.participants[1], 'message_view_scope')).toBe(false);
+  });
+});

--- a/src/frontend-nextgen/test/services/workspace/sessionFileService.test.ts
+++ b/src/frontend-nextgen/test/services/workspace/sessionFileService.test.ts
@@ -40,9 +40,9 @@ it('loadFiles maps dto and resolves owner name from participants', async () => {
 
 it('loadFiles prefers the authenticated name only for the matching human owner', async () => {
   c.listSessionFiles.mockResolvedValue({ data: { items: [dto], total: 1 } });
-  const res = await sessionFileService.loadFiles('s1', [], {}, { userId: '2088', name: '风太' });
+  const res = await sessionFileService.loadFiles('s1', [], {}, { userId: '2088', name: '示例用户' });
   const item = res.ok ? res.data.items[0] : null;
-  expect(item?.ownerName).toBe('风太');
+  expect(item?.ownerName).toBe('示例用户');
 });
 
 it('loadFiles falls back to cleaned actor_id when no participant matches', async () => {

--- a/src/frontend-nextgen/test/services/workspace/sessionService.test.ts
+++ b/src/frontend-nextgen/test/services/workspace/sessionService.test.ts
@@ -1,9 +1,10 @@
 /** @jest-environment jsdom */
+import type { IdentityView } from '@/domain/collaboration';
 import * as sessionController from '@/services/backendApi/collaboration/sessionController';
 import { sessionService } from '@/services/workspace/sessionService';
 import { useErrorNotifyStore } from '@/stores/errorNotifyStore';
 import { useWorkspaceStore } from '@/stores/workspaceStore';
-import { beforeEach, expect, it, jest } from '@jest/globals';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 
 // 使用 auto-mock（不带 factory），避免在 hoisted factory 内引用 jest.fn() —— 与 @jest/globals 一起会触发 TDZ。
 // auto-mock 会把 createSession/updateSession/deleteSession/listGroupSessions 替成 jest.fn()，下方强取即可。
@@ -45,7 +46,7 @@ it('createNewSession 以 activeIdentityId 作为 acting_bot_id 传递当前角�
   useWorkspaceStore.getState().reset();
   useWorkspaceStore
     .getState()
-    .setIdentities([{ id: 'human_327325', kind: 'user', displayName: '当前用户', online: true }], 'human_327325');
+    .setIdentities([{ id: 'human_900003', kind: 'user', displayName: '当前用户', online: true }], 'human_900003');
   try {
     sc.createSession.mockResolvedValue({
       code: 20000,
@@ -65,11 +66,68 @@ it('createNewSession 以 activeIdentityId 作为 acting_bot_id 传递当前角�
     expect(sc.createSession).toHaveBeenCalledWith('g1', {
       title: '新会话',
       input: { query: '协作目标' },
-      acting_bot_id: 'human_327325',
+      acting_bot_id: 'human_900003',
     });
   } finally {
     useWorkspaceStore.getState().reset();
   }
+});
+
+describe('createNewSession acting_bot_id = 当前角色 id（契约锁定）', () => {
+  const identities: IdentityView[] = [
+    { id: 'human_1', kind: 'user', displayName: '章梧', online: true },
+    { id: 'bot_a:1', kind: 'bot', displayName: 'Alpha', online: true },
+  ];
+
+  const mockCreateSession = () => {
+    sc.createSession.mockResolvedValue({
+      code: 20000,
+      message: '',
+      request_id: 'r',
+      data: {
+        session_id: 'g1:s1',
+        group_id: 'g1',
+        title: '',
+        status: 'running',
+        participants: [],
+        created_at: 1,
+        updated_at: 2,
+      },
+    });
+  };
+
+  beforeEach(() => {
+    // reset() 为 resetWorkspace() 的超集，且额外清空 activeIdentityId（属顶层状态），保证用例间隔离。
+    useWorkspaceStore.getState().reset();
+  });
+
+  afterEach(() => {
+    useWorkspaceStore.getState().reset();
+  });
+
+  it('bot 身份激活时，acting_bot_id 为当前 bot 角色 id', async () => {
+    useWorkspaceStore.getState().setIdentities(identities, 'bot_a:1');
+    mockCreateSession();
+    await sessionService.createNewSession('g1');
+    const body = sc.createSession.mock.calls[0][1];
+    expect(body.acting_bot_id).toBe('bot_a:1');
+  });
+
+  it('human 身份激活时，acting_bot_id 为当前 human 角色 id', async () => {
+    useWorkspaceStore.getState().setIdentities(identities, 'human_1');
+    mockCreateSession();
+    await sessionService.createNewSession('g1');
+    const body = sc.createSession.mock.calls[0][1];
+    expect(body.acting_bot_id).toBe('human_1');
+  });
+
+  it('无激活身份时，请求体不含 acting_bot_id 键', async () => {
+    useWorkspaceStore.getState().setIdentities(identities, null);
+    mockCreateSession();
+    await sessionService.createNewSession('g1');
+    const body = sc.createSession.mock.calls[0][1];
+    expect(Object.prototype.hasOwnProperty.call(body, 'acting_bot_id')).toBe(false);
+  });
 });
 
 it('setFavorite true calls collect API and returns collected status', async () => {
@@ -187,6 +245,39 @@ it('updateMemberMode maps failure to friendly error', async () => {
   const res = await sessionService.updateMemberMode('s1', 'human_1', 'present');
   expect(res.ok).toBe(false);
   expect(!res.ok && res.error.friendlyMessage).toContain('更新会话成员状态失败');
+});
+
+it('updateMemberScope PATCH 仅携带 message_view_scope（无 mode 键）并刷新会话详情', async () => {
+  sc.updateSessionMemberMode.mockResolvedValue({
+    code: 20000,
+    message: '',
+    request_id: 'r',
+    data: {
+      actor_id: 'human_1',
+      actor_kind: 'human',
+      name: '章梧',
+      role: 'consultant',
+      mode: 'present',
+      message_view_scope: 'participant',
+    },
+  });
+  sc.getSession.mockResolvedValue({
+    code: 20000,
+    message: '',
+    request_id: 'r',
+    data: memberDetail,
+  });
+  const res = await sessionService.updateMemberScope('s1', 'human_1', 'participant');
+  expect(sc.updateSessionMemberMode).toHaveBeenCalledWith('s1', 'human_1', { message_view_scope: 'participant' });
+  expect(sc.getSession).toHaveBeenCalledWith('s1');
+  expect(res.ok).toBe(true);
+});
+
+it('updateMemberScope maps failure to friendly error', async () => {
+  sc.updateSessionMemberMode.mockRejectedValue(new Error('boom'));
+  const res = await sessionService.updateMemberScope('s1', 'human_1', 'participant');
+  expect(res.ok).toBe(false);
+  expect(!res.ok && res.error.friendlyMessage).toContain('切换消息视角失败');
 });
 
 it('getSessionDetail returns SessionView with participants', async () => {

--- a/src/frontend-nextgen/test/shell/AppShell.test.tsx
+++ b/src/frontend-nextgen/test/shell/AppShell.test.tsx
@@ -19,6 +19,14 @@ jest.mock('@/hooks/useSpaceContext', () => ({
   initSpaceContext: mockInitSpaceContext,
   ensurePersonalSpaceOnAppEntry: mockEnsurePersonalSpaceOnAppEntry,
 }));
+const mockInitWorkspace = jest.fn(async () => ({
+  ok: true as const,
+  data: { defaultActiveId: 'human-1' },
+}));
+
+jest.mock('@/services/workspace/workspaceService', () => ({
+  workspaceService: { initWorkspace: mockInitWorkspace },
+}));
 jest.mock('@/services/workspace/identityService', () => ({
   identityService: {
     loadIdentities: jest.fn(async () => ({
@@ -47,6 +55,7 @@ beforeEach(() => {
   useWorkspaceStore.getState().reset();
   useExternalAuthStore.getState().reset();
   window.localStorage.clear();
+  mockInitWorkspace.mockClear();
 });
 
 it('Open Core 体验提示位于 AppHeader 前', () => {
@@ -99,6 +108,17 @@ it('将 mine 返回的 Human 身份传给顶栏账号区', async () => {
   const view = render(<AppShell>工作内容</AppShell>);
 
   await waitFor(() => expect(view.getByTestId('app-header')).toHaveTextContent('验收用户'));
+});
+
+it('挂载即通过 initWorkspace 写回协作身份，避免 human capability ready 跳过落库', async () => {
+  useExternalAuthStore.getState().setAuthenticated({
+    userId: 'external-user-1',
+    displayName: '外部用户',
+    provider: 'alipay',
+  });
+  render(<AppShell>工作内容</AppShell>);
+
+  await waitFor(() => expect(mockInitWorkspace).toHaveBeenCalledTimes(1));
 });
 
 it('登录回归：/auth/user（checkAuth）晚于 mine 落位时，顶栏账号区随 externalAuthStore 刷新', async () => {

--- a/src/frontend-nextgen/test/shell/AppShellResponsive.test.tsx
+++ b/src/frontend-nextgen/test/shell/AppShellResponsive.test.tsx
@@ -27,6 +27,11 @@ jest.mock('@/hooks/useSpaceContext', () => ({
   initSpaceContext: jest.fn(async () => undefined),
   ensurePersonalSpaceOnAppEntry: jest.fn(async () => undefined),
 }));
+jest.mock('@/services/workspace/workspaceService', () => ({
+  workspaceService: {
+    initWorkspace: jest.fn(async () => ({ ok: true as const, data: { defaultActiveId: null } })),
+  },
+}));
 jest.mock('@/services/workspace/identityService', () => ({
   identityService: {
     loadIdentities: jest.fn(async () => ({
@@ -134,8 +139,8 @@ describe('AppShell 工作身份路由保护', () => {
   it('Bot 工作身份可直访我的任务', () => {
     mockLocation.pathname = '/work/my-task';
     useWorkspaceStore.setState({
-      activeIdentityId: 'bot-1:447147',
-      identities: [{ id: 'bot-1:447147', kind: 'bot', displayName: 'Bot A', online: true }],
+      activeIdentityId: 'bot-1:900004',
+      identities: [{ id: 'bot-1:900004', kind: 'bot', displayName: 'Bot A', online: true }],
     });
 
     renderShell();
@@ -147,8 +152,8 @@ describe('AppShell 工作身份路由保护', () => {
   it('Bot 工作身份直访公开协作群时替换到公开 Bot 且不挂载页面', () => {
     mockLocation.pathname = '/collaboration-square/groups';
     useWorkspaceStore.setState({
-      activeIdentityId: 'bot-1:447147',
-      identities: [{ id: 'bot-1:447147', kind: 'bot', displayName: 'Bot A', online: true }],
+      activeIdentityId: 'bot-1:900004',
+      identities: [{ id: 'bot-1:900004', kind: 'bot', displayName: 'Bot A', online: true }],
     });
 
     renderShell();

--- a/src/frontend-nextgen/test/shell/AppSidebar.test.tsx
+++ b/src/frontend-nextgen/test/shell/AppSidebar.test.tsx
@@ -54,8 +54,8 @@ it('用户工作身份在展开与折叠导航中展示我的任务', () => {
 
 it('Bot 工作身份在展开与折叠导航中继续展示我的任务', () => {
   useWorkspaceStore.setState({
-    activeIdentityId: 'bot-1:447147',
-    identities: [{ id: 'bot-1:447147', kind: 'bot', displayName: 'Bot A', online: true }],
+    activeIdentityId: 'bot-1:900004',
+    identities: [{ id: 'bot-1:900004', kind: 'bot', displayName: 'Bot A', online: true }],
   });
 
   const expanded = render(


### PR DESCRIPTION
## Problem
The nextgen open core export was behind the latest TeamClaw message-view-scope feature, which lets users choose whether they see every collaboration message in a session or only public and personally relevant messages. Without this export, Open Core users cannot select a view scope when creating groups, joining sessions, or switching scopes at runtime, and the work-orders admin tab still used the outdated "工单中心" label.

## Solution
- Synced the open core export to TeamClaw source commit `3414cb6b` and updated `OPEN_CORE_MANIFEST.json`.
- Added the `MessageViewScope` domain model with two scopes: `full` (all session messages, default) and `participant` (public, directed, and own messages only).
- Added shared scope UI components: radio field, badge, checkbox, and menu button.
- Create-group flow: humans can select the default session view scope; the chosen scope is attached to the human participant on submit.
- Join-session flow: the collaborator panel exposes a participant-only checkbox, and invite acceptance carries the selected scope.
- Runtime scope switching: scope changes trigger a WebSocket reconnect (`useWsReconnectNonce`); server-pushed `view_scope_changed` closes also reconnect and show a user notice (`useViewScopeChangedNotice`).
- Session member sync and provider state subscriptions now keep member view scopes current.
- Relabeled the admin `workOrders` tab from 工单中心 to 通知中心 (identifier unchanged, aligned with the work-orders endpoints).
- Added and updated extensive unit tests across scope domain logic, group creation, invite acceptance, collab panel, member list, group chat provider, and session services.

## Validation
- Mechanical export from TeamClaw source commit `3414cb6b` (`sourceDirty: false`); no manual code changes beyond the export.
- Diff scope: `src/frontend-nextgen` (187 files, +3134/-1012).
- Did not run frontend unit tests locally; CI will run the frontend gate on this PR.

## Compatibility and risk
- View-scope options require matching backend/BCS support; scope values absent from older backends fall back to the existing default behavior.
- The `workOrders` admin tab identifier is unchanged, so deep links and overlays remain compatible.
- Rollback path: revert this PR to restore the previous export.

## Spec
- Open Core export schema: `src/frontend-nextgen/OPEN_CORE_MANIFEST.json` (exportSchemaVersion 1)