### PR TITLE
fix(bcs): make session scope CAS immune to participants serialization drift

### DIFF
--- a/src/bcs/crates/services/bcs-session-store/src/mysql.rs
+++ b/src/bcs/crates/services/bcs-session-store/src/mysql.rs
@@ -10,8 +10,8 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use bcs_db_api::{
-    DbPlugin, DbRow, DbSqlFlavor, DbStatement, DbTransactionParam, DbTransactionStep, DbValue,
-    db_get_column, db_get_column_opt,
+    DbError, DbPlugin, DbRow, DbSqlFlavor, DbStatement, DbTransactionParam, DbTransactionStep,
+    DbValue, db_get_column, db_get_column_opt,
 };
 use bcs_event_store::EventAppendTransactionPlan;
 use tracing::info;
@@ -97,6 +97,41 @@ impl MySqlSessionStore {
             self.flavor.unix_ts("s.gmt_create"),
             self.flavor.unix_ts("s.gmt_modified"),
         )
+    }
+
+    /// Internal: load a Session together with the raw stored `participants`
+    /// TEXT bytes in a single read.
+    ///
+    /// The raw bytes are the CAS identity for scope-update optimistic locking.
+    /// Comparing re-serialized JSON against stored TEXT breaks on schema
+    /// evolution: a row written before a `Participant` field existed parses
+    /// equal (serde defaults) but serializes differently, so a re-serialized
+    /// expectation never matches the stored bytes and the CAS can never win.
+    async fn load_with_raw_participants(
+        &self,
+        session_id: &str,
+    ) -> ServiceResult<Option<(Session, String)>> {
+        let select_cols = self.select_cols();
+        let sql = format!(
+            "SELECT {select_cols} FROM bcs_group_sessions \
+             WHERE env = ? AND session_id = ? LIMIT 1"
+        );
+        let rows = self
+            .db
+            .query(DbStatement::with_params(
+                &sql,
+                vec![DbValue::from(self.env.as_str()), DbValue::from(session_id)],
+            ))
+            .await
+            .map_err(|e| ServiceError::InternalError(format!("session db: {e}")))?;
+        let Some(row) = rows.into_iter().next() else {
+            return Ok(None);
+        };
+        let raw = db_get_column_opt::<String>(&row, "participants")
+            .map_err(|e| ServiceError::InternalError(format!("participants: {e}")))?
+            .unwrap_or_default();
+        let session = row_to_session(&row)?;
+        Ok(Some((session, raw)))
     }
 
     /// Internal: execute the INSERT and return the constructed Session on success.
@@ -244,6 +279,18 @@ fn transaction_lock_suffix(flavor: DbSqlFlavor) -> &'static str {
         DbSqlFlavor::Mysql => " FOR UPDATE",
         DbSqlFlavor::Sqlite => "",
     }
+}
+
+/// Whether a transaction failed because its CAS lock query (step 0) matched no
+/// row, so a later step could not resolve its `query_result(0, 0, ..)` binding.
+/// This means the guarded row changed or vanished concurrently — a retryable
+/// conflict, not an internal error. Mirrors the bcs-group-store helper.
+fn transaction_lock_row_is_missing(error: &DbError) -> bool {
+    matches!(
+        error,
+        DbError::InvalidInput(message)
+            if message.contains("references missing row 0 from step 0")
+    )
 }
 
 /// Read a TEXT column from a row and parse it as JSON.
@@ -1809,12 +1856,10 @@ impl SessionRepoPort for MySqlSessionStore {
         mode: Option<ParticipantMode>,
         message_view_scope: MessageViewScope,
     ) -> ServiceResult<Session> {
-        let mut current = self
-            .get(session_id)
-            .await
+        let (mut current, stored_participants_json) = self
+            .load_with_raw_participants(session_id)
+            .await?
             .ok_or_else(|| ServiceError::SessionNotFound(session_id.to_string()))?;
-        let expected_participants_json = serde_json::to_string(&current.participants)
-            .map_err(|error| ServiceError::SessionInvalidParams(error.to_string()))?;
         let participant = current
             .participants
             .iter_mut()
@@ -1851,7 +1896,7 @@ impl SessionRepoPort for MySqlSessionStore {
                     DbValue::from(participants_json.as_str()),
                     DbValue::from(self.env.as_str()),
                     DbValue::from(session_id),
-                    DbValue::from(expected_participants_json.as_str()),
+                    DbValue::from(stored_participants_json.as_str()),
                 ],
             ))
             .await
@@ -1868,9 +1913,9 @@ impl SessionRepoPort for MySqlSessionStore {
         &self,
         command: UpdateSessionParticipantMessageViewScopeWithEvent,
     ) -> ServiceResult<Session> {
-        let mut candidate = self
-            .get(&command.session_id)
-            .await
+        let (mut candidate, stored_participants_json) = self
+            .load_with_raw_participants(&command.session_id)
+            .await?
             .ok_or_else(|| ServiceError::SessionNotFound(command.session_id.clone()))?;
         if serde_json::to_value(&candidate.participants).ok()
             != serde_json::to_value(&command.expected_participants).ok()
@@ -1910,8 +1955,6 @@ impl SessionRepoPort for MySqlSessionStore {
         candidate.updated_at = current_millis();
         validate_session_event_scope(&candidate, &command.event)?;
 
-        let expected_json = serde_json::to_string(&command.expected_participants)
-            .map_err(|error| ServiceError::SessionInvalidParams(error.to_string()))?;
         let participants_json = serde_json::to_string(&candidate.participants)
             .map_err(|error| ServiceError::SessionInvalidParams(error.to_string()))?;
         let lock_sql = format!(
@@ -1930,7 +1973,7 @@ impl SessionRepoPort for MySqlSessionStore {
                 vec![
                     DbValue::from(self.env.as_str()),
                     DbValue::from(command.session_id.as_str()),
-                    DbValue::from(expected_json.as_str()),
+                    DbValue::from(stored_participants_json.as_str()),
                 ],
             )),
             DbTransactionStep::Execute(DbStatement::with_transaction_params(
@@ -1939,7 +1982,7 @@ impl SessionRepoPort for MySqlSessionStore {
                     DbTransactionParam::value(participants_json.as_str()),
                     DbTransactionParam::value(self.env.as_str()),
                     DbTransactionParam::query_result(0, 0, "session_id"),
-                    DbTransactionParam::value(expected_json.as_str()),
+                    DbTransactionParam::value(stored_participants_json.as_str()),
                 ],
             )),
         ];
@@ -1953,10 +1996,16 @@ impl SessionRepoPort for MySqlSessionStore {
         })?;
         steps.extend(event_plan.steps);
         self.db.transaction(steps).await.map_err(|error| {
-            ServiceError::Conflict(format!(
-                "Session '{}' changed during participant scope update: {error}",
-                command.session_id
-            ))
+            if transaction_lock_row_is_missing(&error) {
+                // The CAS lock row vanished: a concurrent writer changed or
+                // deleted the session between the pre-check read and the lock.
+                ServiceError::Conflict(format!(
+                    "Session '{}' changed during participant scope update",
+                    command.session_id
+                ))
+            } else {
+                ServiceError::InternalError(format!("session db: {error}"))
+            }
         })?;
         Ok(candidate)
     }

--- a/src/bcs/crates/services/bcs-session-store/tests/conformance_session_repo.rs
+++ b/src/bcs/crates/services/bcs-session-store/tests/conformance_session_repo.rs
@@ -1,15 +1,22 @@
 use std::collections::BTreeMap;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 use async_trait::async_trait;
 use bcs_db_api::{
     DbError, DbExecuteResult, DbHealth, DbPlugin, DbResult, DbRow, DbStatement, DbTransactionStep,
-    DbTransactionStepResult,
+    DbTransactionStepResult, DbValue,
 };
 use bcs_db_local::LocalSqliteDbPlugin;
-use bcs_service_api::port::repo::{NewSessionParams, SessionRepoPort};
-use bcs_service_api::{Participant, ParticipantRole, SessionKind};
+use bcs_service_api::port::NewEvent;
+use bcs_service_api::port::repo::{
+    AppendEventRecord, NewSessionParams, SessionRepoPort,
+    UpdateSessionParticipantMessageViewScopeWithEvent,
+};
+use bcs_service_api::types::{
+    EVENT_SCHEMA_VERSION_V1, EventScope, EventSubject, MessageViewScope,
+};
+use bcs_service_api::{Participant, ParticipantMode, ParticipantRole, ServiceError, SessionKind};
 use bcs_session_store::{MemorySessionRepo, MySqlSessionStore};
 
 #[path = "../../../bootstrap/bcs/src/migrations.rs"]
@@ -273,4 +280,249 @@ async fn fallible_session_lookup_distinguishes_missing_rows_and_failures() {
     assert!(error.to_string().contains("forced session query failure"));
     let malformed = MySqlSessionStore::sqlite(Arc::new(MalformedMembershipRowDb), "dev".to_string());
     assert!(malformed.try_get("group_1:session").await.is_err());
+}
+
+fn scope_change_event(session_id: &str, group_id: &str) -> AppendEventRecord {
+    AppendEventRecord {
+        event: NewEvent {
+            event_id: "evt-scope-change-1".to_string(),
+            event_type: "session.participant.message_view_scope_changed".to_string(),
+            schema_version: EVENT_SCHEMA_VERSION_V1.to_string(),
+            producer: "session-store-test".to_string(),
+            producer_key: "evt-scope-change-1".to_string(),
+            occurred_at: "2026-09-10T00:00:00.000Z".to_string(),
+            subject: EventSubject {
+                subject_type: "session.participant".to_string(),
+                id: "human-1".to_string(),
+            },
+            scope: EventScope {
+                group_id: Some(group_id.to_string()),
+                session_id: Some(session_id.to_string()),
+                ..EventScope::default()
+            },
+            stream_key: format!("session:{session_id}"),
+            actor: None,
+            correlation_id: None,
+            causation_event_id: None,
+            trace_id: None,
+            data: BTreeMap::new(),
+        },
+        recorded_at: "2026-09-10T00:00:00.001Z".to_string(),
+        retention_until_ms: 2_000_000_000_000,
+        env: "dev".to_string(),
+    }
+}
+
+/// Rewrite the stored `participants` TEXT into pre-`message_view_scope` legacy
+/// bytes: structurally identical after parsing (the field defaults to `full`),
+/// but byte-different from what the current serializer produces.
+async fn rewrite_participants_as_legacy_bytes(db: &Arc<dyn DbPlugin>, session_id: &str) {
+    let rows = db
+        .query(DbStatement::with_params(
+            "SELECT participants FROM bcs_group_sessions WHERE env = ? AND session_id = ?",
+            vec![DbValue::from("dev"), DbValue::from(session_id)],
+        ))
+        .await
+        .expect("read participants");
+    let raw = rows[0]
+        .get_string("participants")
+        .expect("participants column")
+        .expect("participants not null");
+    let mut parsed: Vec<serde_json::Value> = serde_json::from_str(&raw).expect("participants json");
+    for participant in parsed.iter_mut() {
+        participant
+            .as_object_mut()
+            .expect("participant object")
+            .remove("message_view_scope");
+    }
+    let legacy = serde_json::to_string(&parsed).expect("legacy json");
+    db.execute(DbStatement::with_params(
+        "UPDATE bcs_group_sessions SET participants = ? WHERE env = ? AND session_id = ?",
+        vec![
+            DbValue::from(legacy.as_str()),
+            DbValue::from("dev"),
+            DbValue::from(session_id),
+        ],
+    ))
+    .await
+    .expect("rewrite legacy participants");
+}
+
+async fn create_legacy_scope_session(
+    repo: &MySqlSessionStore,
+    db: &Arc<dyn DbPlugin>,
+) -> bcs_service_api::Session {
+    let session = repo
+        .create(
+            "group-legacy",
+            NewSessionParams {
+                participants: vec![
+                    Participant::bot("bot-1", ParticipantRole::Driver),
+                    Participant::human("human-1", ParticipantRole::Observer),
+                ],
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("create session");
+    rewrite_participants_as_legacy_bytes(db, &session.id).await;
+    session
+}
+
+#[tokio::test]
+async fn sqlite_scope_update_with_event_succeeds_on_legacy_participants_bytes() {
+    let db = sqlite_db().await;
+    let repo = MySqlSessionStore::sqlite(db.clone(), "dev".to_string());
+    let session = create_legacy_scope_session(&repo, &db).await;
+
+    let stored = repo.get(&session.id).await.expect("stored session");
+    let updated = repo
+        .update_participant_message_view_scope_with_event(
+            UpdateSessionParticipantMessageViewScopeWithEvent {
+                session_id: session.id.clone(),
+                expected_participants: stored.participants.clone(),
+                actor_id: "human-1".to_string(),
+                message_view_scope: MessageViewScope::Participant,
+                mode: None,
+                event: scope_change_event(&session.id, &session.group_id),
+            },
+        )
+        .await
+        .expect("legacy participants bytes must not break the scope CAS");
+
+    let human = updated
+        .participants
+        .iter()
+        .find(|participant| participant.bot_uuid == "human-1")
+        .expect("human participant");
+    assert_eq!(human.message_view_scope, MessageViewScope::Participant);
+
+    let reloaded = repo.get(&session.id).await.expect("reload session");
+    let stored_human = reloaded
+        .participants
+        .iter()
+        .find(|participant| participant.bot_uuid == "human-1")
+        .expect("human participant");
+    assert_eq!(
+        stored_human.message_view_scope,
+        MessageViewScope::Participant
+    );
+}
+
+#[tokio::test]
+async fn sqlite_mode_and_scope_update_succeeds_on_legacy_participants_bytes() {
+    let db = sqlite_db().await;
+    let repo = MySqlSessionStore::sqlite(db.clone(), "dev".to_string());
+    let session = create_legacy_scope_session(&repo, &db).await;
+
+    let updated = repo
+        .update_participant_mode_and_message_view_scope(
+            &session.id,
+            "human-1",
+            Some(ParticipantMode::Present),
+            MessageViewScope::Participant,
+        )
+        .await
+        .expect("legacy participants bytes must not break the scope CAS");
+
+    let human = updated
+        .participants
+        .iter()
+        .find(|participant| participant.bot_uuid == "human-1")
+        .expect("human participant");
+    assert_eq!(human.message_view_scope, MessageViewScope::Participant);
+    assert_eq!(human.mode, Some(ParticipantMode::Present));
+}
+
+/// Wraps a real DbPlugin and, when armed, mutates the session participants
+/// immediately before delegating a transaction — simulating a concurrent
+/// writer landing between the store's pre-check read and its lock step.
+struct ScopeRaceDb {
+    inner: Arc<dyn DbPlugin>,
+    sabotage: AtomicBool,
+}
+
+#[async_trait]
+impl DbPlugin for ScopeRaceDb {
+    async fn query(&self, statement: DbStatement) -> DbResult<Vec<DbRow>> {
+        self.inner.query(statement).await
+    }
+
+    async fn execute(&self, statement: DbStatement) -> DbResult<DbExecuteResult> {
+        self.inner.execute(statement).await
+    }
+
+    async fn transaction(
+        &self,
+        steps: Vec<DbTransactionStep>,
+    ) -> DbResult<Vec<DbTransactionStepResult>> {
+        if self.sabotage.swap(false, Ordering::SeqCst) {
+            self.inner
+                .execute(DbStatement::with_params(
+                    "UPDATE bcs_group_sessions SET participants = ? WHERE env = ?",
+                    vec![DbValue::from("[]"), DbValue::from("dev")],
+                ))
+                .await?;
+        }
+        self.inner.transaction(steps).await
+    }
+
+    async fn health_check(&self) -> DbResult<DbHealth> {
+        self.inner.health_check().await
+    }
+}
+
+#[tokio::test]
+async fn sqlite_scope_update_race_reports_clean_conflict() {
+    let inner = sqlite_db().await;
+    let db = Arc::new(ScopeRaceDb {
+        inner,
+        sabotage: AtomicBool::new(false),
+    });
+    let repo = MySqlSessionStore::sqlite(db.clone() as Arc<dyn DbPlugin>, "dev".to_string());
+    let session = repo
+        .create(
+            "group-race",
+            NewSessionParams {
+                participants: vec![Participant::human("human-1", ParticipantRole::Observer)],
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("create session");
+
+    let stored = repo.get(&session.id).await.expect("stored session");
+    db.sabotage.store(true, Ordering::SeqCst);
+
+    let error = repo
+        .update_participant_message_view_scope_with_event(
+            UpdateSessionParticipantMessageViewScopeWithEvent {
+                session_id: session.id.clone(),
+                expected_participants: stored.participants.clone(),
+                actor_id: "human-1".to_string(),
+                message_view_scope: MessageViewScope::Participant,
+                mode: None,
+                event: scope_change_event(&session.id, &session.group_id),
+            },
+        )
+        .await
+        .expect_err("concurrent writer must produce a conflict");
+
+    match &error {
+        ServiceError::Conflict(message) => {
+            assert!(
+                !message.contains("references missing row"),
+                "conflict must not leak transaction binding internals: {message}"
+            );
+            assert!(
+                !message.contains("transaction parameter"),
+                "conflict must not leak transaction binding internals: {message}"
+            );
+            assert!(
+                message.contains(&session.id),
+                "conflict should identify the session: {message}"
+            );
+        }
+        other => panic!("expected Conflict, got {other:?}"),
+    }
 }


### PR DESCRIPTION
## Problem

Changing a Human participant's `message_view_scope` on any session whose `participants` TEXT was written before the field existed (i.e. every session predating #1986) fails deterministically with:

```
40900 conflict: Session '...' changed during participant scope update:
invalid database input: transaction parameter 2 references missing row 0 from step 0
```

The scope-update optimistic lock in `MySqlSessionStore` compared the raw stored TEXT bytes against a **re-serialization** of the parsed struct. Legacy rows parse equal (serde defaults `message_view_scope` to `full`) but serialize differently, so the CAS predicate could never match: the lock SELECT returned zero rows and the transaction binding surfaced the miss as a leaked internal db-api error wrapped in Conflict. The structural pre-check passed (both sides normalized), so the failure only appeared at the byte CAS.

## Solution

- Add `load_with_raw_participants`: one SELECT returns the parsed `Session` **and** the raw stored `participants` bytes. Both SQL CAS paths (`update_participant_message_view_scope_with_event` and the non-event `update_participant_mode_and_message_view_scope`) now use the stored bytes as the CAS predicate — stored-bytes vs stored-bytes, immune to schema evolution. The structural pre-check against the caller's snapshot is unchanged; a successful update still rewrites the column with canonical JSON, so legacy rows self-heal on first scope change.
- Add `transaction_lock_row_is_missing` (mirrors the existing bcs-group-store helper): a missing CAS lock row is now reported as a clean retryable 409 Conflict without leaking transaction binding internals; other transaction failures map to InternalError (500) instead of being misreported as conflicts.

## Validation

- New tests (bcs-session-store, sqlite flavor): scope update with event succeeds on legacy participants bytes; mode+scope update succeeds on legacy bytes; a concurrent writer landing between pre-check and lock yields a clean Conflict whose message contains no `references missing row` / `transaction parameter` internals. All three were verified to fail before the fix (the first reproduces the production error verbatim).
- `cargo test --package bcs-session-store --package bcs-session --package bcs-app-session`: all pass (38 + 79 + sub-suites).
- `cargo check --workspace --all-targets`: clean.
- Not run: real MySQL E2E (no deployment available here); the sqlite flavor exercises the same store code path, and the CAS comparison semantics (`WHERE participants = ?` byte equality on TEXT) are identical on both backends.