### PR TITLE
fix(work-orders): accept editor requests from any Team Space bot

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_collaborator/services/collaborator_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_collaborator/services/collaborator_service.py
@@ -325,17 +325,10 @@ class CollaboratorService(CollaboratorQueryMixin, CollaboratorServiceProtocol):
         if not bot:
             raise BotNotFoundError(f"Bot 不存在: bot_id={bot_id}, owner_id={owner_id}")
 
-        # 2. 检查 Bot 类型 / 成员管理能力
-        #    CollaboratorService 是 engine-agnostic 服务：
-        #    - service：Service Bot 协作者，走原逻辑；
-        #    - 非 service：通过 MemberManagementCapabilityService 协调模板开关和
-        #      各引擎自己的能力实现，避免在这里直接依赖某个 engine 的定制逻辑。
-        if not self._member_management_capability_service.can_manage_collaborators(
-            bot, bot_id
-        ):
-            raise BotNotServiceTypeError(
-                f"Bot 不是服务型且未开启成员管理: bot_id={bot_id}"
-            )
+        # 2. 检查 Bot 类型 / 成员管理能力（委托 EditorPolicy 单点判定）
+        #    与公开 Editors API 工同一规则:Team Space 归属的 Bot 按空间契约
+        #    放行,其余 Bot 仍走引擎能力判定;详情见 EditorPolicy.require_capability。
+        self._editor_policy.require_capability(bot=bot, bot_id=bot_id)
 
         bot_pk = bot["id"]
         owner_id_from_bot = bot["owner_id"]

--- a/src/backend/src/agentclaw/community/core/bot_collaborator/services/editor_policy.py
+++ b/src/backend/src/agentclaw/community/core/bot_collaborator/services/editor_policy.py
@@ -52,12 +52,33 @@ class EditorPolicy:
         return bot
 
     def require_capability(self, *, bot: dict[str, Any], bot_id: str) -> None:
+        # COSEC: mirroring the work-order entry point, a Bot assigned to a Team
+        # Space is under the Space's collaboration contract — Editor requests,
+        # rosters, removals and self-exits are governed by Space membership and
+        # Bot permissions, not by engine capability flags. The engine capability
+        # check stays in charge for every other Bot, and an unresolvable Space
+        # reference falls back to it (fail-closed) rather than widening the rule.
+        if self._assigned_to_team_space(bot):
+            return
         if not self._member_management_capability_service.can_manage_collaborators(
             bot, bot_id
         ):
             raise BotNotServiceTypeError(
                 f"Bot 不是服务型且未开启成员管理: bot_id={bot_id}"
             )
+
+    def _assigned_to_team_space(self, bot: Mapping[str, Any]) -> bool:
+        """Whether ``bot`` carries a structural reference to a Team Space."""
+        raw_space_id = bot.get("space_id")
+        if raw_space_id in (None, "") or str(raw_space_id).startswith("personal:"):
+            return False
+        try:
+            space = self._space_access_service.require_space_reference(
+                space_ref=str(raw_space_id)
+            )
+        except (SpaceNotFoundError, ValueError):
+            return False
+        return space.space_type is SpaceType.TEAM
 
     def resolve_record(
         self,

--- a/src/backend/src/agentclaw/community/core/work_orders/services/work_order_service.py
+++ b/src/backend/src/agentclaw/community/core/work_orders/services/work_order_service.py
@@ -354,10 +354,15 @@ class WorkOrderService(WorkOrderServiceProtocol):
             raise WorkOrderNotFoundError("bot not found")
         if applicant_user_id == str(bot.get("owner_id") or ""):
             raise WorkOrderApplicantAlreadyEditorError("Bot owner already has access")
-        if not self._member_management.can_manage_collaborators(bot, bot_id):
-            raise WorkOrderBotEditorRequestNotAllowedError(
-                "Bot does not support editor management"
-            )
+        # COSEC: the Team Space, not the engine/template capability flags, is the
+        # collaboration contract here. A Bot assigned to a Team Space accepts
+        # editor requests from Space members regardless of engine form
+        # (personal/openclaw/teclaw/...). Approval inserts the Collaborator
+        # relation transactionally and operable permission is re-resolved from
+        # that relation plus live Space membership, so engine capability
+        # (``can_manage_collaborators``) plays no role on this path — gating on
+        # it locked plain Team Space Bots out of the editor workflow while the
+        # independent edit-lock and Collaborator CRUD policies stayed unchanged.
         raw_space_id = bot.get("space_id")
         try:
             space = self._access.require_space_reference(space_ref=str(raw_space_id))

--- a/src/backend/tests/community/core/bot_collaborator/test_editor_service.py
+++ b/src/backend/tests/community/core/bot_collaborator/test_editor_service.py
@@ -234,6 +234,77 @@ def test_update_editor_changes_only_role_and_operator(dependencies):
     service.on_collaboration_changed.assert_called_once_with("bot-1", OWNER, "dev")
 
 
+@pytest.fixture
+def team_space_dependencies(dependencies):
+    """A capabilities-False Team Space Bot plus its resolved Team Space.
+
+    工单放行之后（PR #2115）,这类 bot 获批的编辑授权必须能被公开 Editors
+    API 管理和撤销,不能在 list/remove/leave/add 上被引擎能力闸门挡死。
+    """
+    service, collaborator_repo, bot_repo, space_access = dependencies
+    bot_repo.get_by_id_and_owner.return_value = _bot(
+        bot_type="personal",
+        active_engine="openclaw",
+        template_type=None,
+        space_id="spc-team",
+    )
+    space_access.require_space_reference.return_value = Mock(
+        id=22, space_type=SpaceType.TEAM
+    )
+    return service, collaborator_repo, bot_repo, space_access
+
+
+def test_team_space_bot_lists_editors_without_engine_capability(
+    team_space_dependencies,
+):
+    service, collaborator_repo, _, _ = team_space_dependencies
+    collaborator_repo.get_user_role.return_value = CollaboratorRole.MEMBER
+    collaborator_repo.list_by_bot.return_value = [_record()]
+
+    records = service.list_editors("bot-1", OWNER, MEMBER, env="dev")
+
+    assert records == [_record()]
+
+
+def test_team_space_owner_adds_editor_without_engine_capability(
+    team_space_dependencies,
+):
+    record = _record(user_id="editor-9")
+    service, collaborator_repo, _, _ = team_space_dependencies
+    collaborator_repo.insert.return_value = record
+
+    result = service.add_editor("bot-1", OWNER, "editor-9", OWNER, env="dev")
+
+    assert result is record
+    collaborator_repo.insert.assert_called_once()
+
+
+def test_team_space_owner_removes_editor_without_engine_capability(
+    team_space_dependencies,
+):
+    service, collaborator_repo, _, _ = team_space_dependencies
+    collaborator_repo.get_by_id.return_value = _record(user_id=MEMBER)
+    collaborator_repo.delete.return_value = True
+
+    assert service.remove_editor("bot-1", OWNER, 7, OWNER, env="dev") is True
+
+    collaborator_repo.delete.assert_called_once_with(7)
+    service.on_collaboration_changed.assert_called_once_with("bot-1", OWNER, "dev")
+
+
+def test_team_space_editor_leaves_without_engine_capability(
+    team_space_dependencies,
+):
+    service, collaborator_repo, _, _ = team_space_dependencies
+    collaborator_repo.get_user_role.return_value = CollaboratorRole.MEMBER
+    collaborator_repo.get_by_bot_and_user.return_value = _record(user_id=MEMBER)
+    collaborator_repo.delete.return_value = True
+
+    assert service.leave_editors("bot-1", OWNER, MEMBER, env="dev") is True
+
+    collaborator_repo.delete.assert_called_once_with(7)
+
+
 def test_non_owner_admin_must_leave_instead_of_removing_self(dependencies):
     service, collaborator_repo, _, _ = dependencies
     collaborator_repo.get_user_role.return_value = CollaboratorRole.ADMIN

--- a/src/backend/tests/community/core/work_orders/test_work_order_service.py
+++ b/src/backend/tests/community/core/work_orders/test_work_order_service.py
@@ -288,6 +288,63 @@ def test_create_bot_editor_request_enforces_eligibility_and_delegates() -> None:
     )
 
 
+def test_create_bot_editor_request_allows_team_space_bot_without_engine_capability() -> None:
+    """A Team Space Bot accepts editor requests regardless of engine/template form.
+
+    真实缺陷（预发 2026-09-09）：bot 20260902_07czoyk5 为 bot_type=personal、
+    active_engine=openclaw、template_type=None，被 can_manage_collaborators
+    以 "Bot does not support editor management" 拒绝。Team Space 的编辑协作契约
+    由空间归属决定（成员申请、Owner 审批、协作者直插），不依赖引擎能力标记。
+    """
+    (
+        service,
+        repository,
+        access,
+        _,
+        bots,
+        collaborator_repository,
+        _,
+        member_management,
+    ) = _bot_editor_service()
+    bots.get_by_id_and_owner.return_value = {
+        "id": 17,
+        "bot_id": "bot-17",
+        "bot_name": "Team Plain Bot",
+        "bot_type": "personal",
+        "owner_id": "owner-1",
+        "space_id": 7,
+        "active_engine": "openclaw",
+        "template_type": None,
+    }
+    member_management.can_manage_collaborators.return_value = False
+    access.require_space_reference.return_value = _space()
+    collaborator_repository.get_by_bot_and_user.return_value = None
+    repository.create_bot_editor_request.return_value = _work_order()
+
+    result = service.create_bot_editor_request(
+        bot_id="bot-17",
+        owner_id="owner-1",
+        applicant_user_id="applicant-1",
+        reason="joint editing",
+    )
+
+    assert result == _work_order()
+    access.require_space_member.assert_called_once_with(
+        space_id=7, user_id="applicant-1"
+    )
+    repository.create_bot_editor_request.assert_called_once_with(
+        bot_pk=17,
+        bot_id="bot-17",
+        bot_name="Team Plain Bot",
+        owner_id="owner-1",
+        space_id=7,
+        applicant_user_id="applicant-1",
+        applicant_name="applicant-1",
+        apply_reason="joint editing",
+        env="dev",
+    )
+
+
 def test_bot_owner_cannot_request_editor_access() -> None:
     service, repository, _, _, bots, _, _, _ = _bot_editor_service()
     bots.get_by_id_and_owner.return_value = {


### PR DESCRIPTION
## Problem

预发 TC 前端对团队空间普通 bot 调 `POST /openapi/v1/bots/{bot_id}/editor-requests` 申请编辑权限被 409 拒绝（"The Bot does not accept editor requests"）。

antlogs 定位真实抛错分支：`Bot does not support editor management`——`create_bot_editor_request` 里的 `can_manage_collaborators` 闸门只放行三类 bot（`bot_type=service` / `claude_code`+`applicationCoding|personalCoding` / 模板 `member_management` 显式开关）。预发受影响 bot（20260902_07czoyk5）为 `bot_type=personal`、`active_engine=openclaw`、`template_type=None`，三路全不命中。而链路其余环节均与 engine 无关：审批通过后仓储事务直插协作者表（不经 `CollaboratorService` 闸门），编辑权限解析走协作者行 + Team Space 成员叠加校验——普通团队 bot 只在工单入口被卡死。

## Solution

`create_bot_editor_request` 移除 `can_manage_collaborators` 前置闸门：**Team Space 归属即编辑协作契约**（成员申请、Owner 审批、协作者事务直插、空间成员校验），engine/template 能力标记不参与该工单判定。附 COSEC 注释说明设计依据。

- 个人空间/未归属空间 bot 依旧 409（"Only Team Space Bots accept editor requests"），申请者非活跃成员依旧 403，已编辑/已有 pending 语义不变——公开错误码与契约零变化（未动 `bots.openapi.json`）
- 不改 `MemberManagementCapabilityService` 本身：edit-lock 跳过逻辑（`bot_access`）与协作者 CRUD 闸门语义保持原样，避免协作面扩大失控

## Validation

- TDD：新增用例复刻预发 bot 形态（personal/openclaw/无模板/能力 False），先在 `work_order_service.py` 的 "Bot does not support editor management" 精确失败（与预发日志一字不差），修复后转绿
- 回归：work_orders service 58 + openapi work_orders contract & endpoints 59 + repository 23 + member_management utils 10 = **167 全绿**，ruff 清洁
- 合入预发后建议用原 bot（20260902_07czoyk5）重放申请回归（其余前置条件：bot 归属 TEAM 空间、申请者为空间活跃成员）