### PR TITLE
fix(clawevolve): use origin bot owner for automatic analysis

### DIFF
--- a/src/evolverun/clawweb/public/modules/clawevolve/server/services/evolve/__tests__/auto-analysis-bot-owner.test.ts
+++ b/src/evolverun/clawweb/public/modules/clawevolve/server/services/evolve/__tests__/auto-analysis-bot-owner.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createFailedRunAutoAnalysisObserver } from "../run-analysis-starter.js";
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("failed-run automatic analysis identity", () => {
+  it.each([
+    ["gateway-client", "20260508_2k59gf2s:331844", "331844"],
+    ["another-caller", "bot-1:331844", "331844"],
+    [null, "bot-1:331844", "331844"],
+    ["331844", null, "331844"],
+    ["331844", "bot-1", "331844"],
+    ["331844", "bot-1: ", "331844"],
+    ["331844", ":another-owner", "331844"],
+    ["331844", "bot-1:another-owner:extra", "331844"],
+    ["gateway-client", " bot-1:331844 ", "331844"],
+  ])("resolves caller %s and origin %s to owner %s", async (userId, originBotId, expectedOwner) => {
+    const run = { workflow_id: "wf-1", origin_bot_id: originBotId, user_id: userId };
+    const start = vi.fn().mockResolvedValue({ ok: true });
+    const observer = createFailedRunAutoAnalysisObserver({
+      flowRunRepo: { findByFlowId: async () => run },
+      starter: { start },
+      isWorkflowEnabled: async () => true,
+    });
+
+    await observer({ flowId: "flow-1", status: "failed" });
+
+    expect(start).toHaveBeenCalledExactlyOnceWith({ flowId: "flow-1", userId: expectedOwner });
+    expect(run.user_id).toBe(userId);
+  });
+
+  it.each(["running", "waiting", "succeeded", "canceled"])("does not analyze %s runs", async (status) => {
+    const start = vi.fn();
+    const observer = createFailedRunAutoAnalysisObserver({
+      flowRunRepo: { findByFlowId: async () => ({ workflow_id: "wf-1", origin_bot_id: "bot:331844", user_id: "gateway-client" }) },
+      starter: { start },
+      isWorkflowEnabled: async () => true,
+    });
+    await observer({ flowId: "flow-1", status });
+    expect(start).not.toHaveBeenCalled();
+  });
+
+  it("does not bypass the workflow switch", async () => {
+    const start = vi.fn();
+    const observer = createFailedRunAutoAnalysisObserver({
+      flowRunRepo: { findByFlowId: async () => ({ workflow_id: "wf-1", origin_bot_id: "bot:331844", user_id: "gateway-client" }) },
+      starter: { start },
+      isWorkflowEnabled: async () => false,
+    });
+    await observer({ flowId: "flow-1", status: "failed" });
+    expect(start).not.toHaveBeenCalled();
+  });
+
+  it("skips runs without an owner or caller identity", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const start = vi.fn();
+    const observer = createFailedRunAutoAnalysisObserver({
+      flowRunRepo: { findByFlowId: async () => ({ workflow_id: "wf-1", origin_bot_id: "bot:", user_id: null }) },
+      starter: { start },
+      isWorkflowEnabled: async () => true,
+    });
+    await observer({ flowId: "flow-1", status: "failed" });
+    expect(start).not.toHaveBeenCalled();
+  });
+});

--- a/src/evolverun/clawweb/public/modules/clawevolve/server/services/evolve/run-analysis-starter.ts
+++ b/src/evolverun/clawweb/public/modules/clawevolve/server/services/evolve/run-analysis-starter.ts
@@ -270,7 +270,13 @@ export function createFailedRunAutoAnalysisObserver(input: {
       : enabled.has("*") || enabled.has(run.workflow_id);
     if (!isEnabled) return;
     const originParts = String(run.origin_bot_id ?? "").split(":");
-    const userId = String(run.user_id ?? originParts[1] ?? "").trim();
+    // Automated runs can record a service caller (e.g. gateway-client) as
+    // user_id. Bot permissions and runtime resolution need the origin owner,
+    // not that caller. Keep the original run identity unchanged for auditing.
+    const originOwnerId = originParts.length === 2 && originParts[0].trim()
+      ? originParts[1].trim()
+      : "";
+    const userId = originOwnerId || String(run.user_id ?? "").trim();
     if (!userId) {
       console.warn(`[task-guard][auto-analysis] skipped flow=${flowId}: run user is missing`);
       return;


### PR DESCRIPTION
## Problem
Failed-run automatic analysis prioritizes `flow_runs.user_id` when selecting the identity used for Bot permissions and runtime lookup. Gateway-triggered runs can store `gateway-client` there, even though `origin_bot_id` contains the actual Bot and owner. This makes candidate selection fail before an analysis task is created.

## Solution
- Prefer the owner from a valid, non-empty `botId:ownerId` origin identity.
- Fall back to the existing run user ID when the origin owner is missing or malformed.
- Preserve the original run record, Bot-level authorization, and manual-analysis behavior.
- Add regression coverage for service callers, differing caller/owner identities, missing or malformed origin identities, non-failed runs, and the workflow switch.

## Validation
- Confirmed the gateway-caller regression fails before the fix.
- Focused Vitest suite: 15 tests passed.
- `npm run check --workspace @avernet/clawevolve`: passed.
- `npm run build --workspace @avernet/clawevolve`: passed (bundle-size warnings remain).
- `git diff --check` and the pre-push gate: passed.
- No production tasks were retriggered; this change has not been deployed.

## Compatibility and risk
Only the automatic-analysis owner-selection path changes. Bot permissions and runtime validation still apply. No database migration, public API change, or ClawMind/OCB source change is required. Existing failed runs are not backfilled automatically.