### PR TITLE
test(task): cover task execution regressions

### DIFF
--- a/src/backend/src/agentclaw/community/core/task/task_runner/client/open_api_bot_adapter.py
+++ b/src/backend/src/agentclaw/community/core/task/task_runner/client/open_api_bot_adapter.py
@@ -23,7 +23,7 @@ from agentclaw.community.core.task.task_runner.client.ports import (
 
 
 # api_key_prefix 未设置时,回落取 api_key 前多少位作 URL 路径段。
-# 取 10:与 IntegrationDouble/_Key 约定一致(api_key="ak1234567890" → prefix="ak12345678")。
+# 取 8 位，与 IntegrationDouble/_Key 的约定一致。
 # 不同环境可在 ApiKeyProvider.api_key_prefix 显式提供真实前缀(优先),此处仅兜底。
 _DEFAULT_KEY_PREFIX_LEN = 8
 

--- a/src/backend/tests/community/core/task/task_center/test_engine.py
+++ b/src/backend/tests/community/core/task/task_center/test_engine.py
@@ -1086,3 +1086,23 @@ class TestPrepareModeCoverageSerial:
         node = svc._get_node(graph, "c1")
         assert node.run_info.extend_props.get("dispatch_error") is not None
         assert node.status == Status.PENDING
+
+    def test_start_run_exception_clears_assignment_and_keeps_node_pending(self, svc, graph):
+        """执行后端异常不能中断整轮；节点应清理在途执行者并留待 harness 重派。"""
+        class _RaisingRunner(StubRunner):
+            async def start_run(self, toDoTaskList: list[TaskNode]) -> list[bool]:
+                self.run_calls.append(list(toDoTaskList))
+                raise RuntimeError("transport unavailable")
+
+        planner = StubPlanner(lambda _graph: [_child("c1")])
+        runner = _RaisingRunner()
+        eng = _engine(svc, planner=planner, runner=runner)
+
+        _run(eng.on_execute("t1"))
+
+        node = svc._get_node(graph, "c1")
+        assert len(runner.run_calls) == 1
+        assert node.status == Status.PENDING
+        assert node.run_info.run_mode in (None, "")
+        assert node.run_info.assignee in (None, "")
+        assert node.run_info.extend_props["dispatch_error"] == "start_run_failed"

--- a/src/backend/tests/community/core/task/task_runner/integration/test_dispatch_single_bot.py
+++ b/src/backend/tests/community/core/task/task_runner/integration/test_dispatch_single_bot.py
@@ -1,5 +1,7 @@
 import asyncio
 
+import pytest
+
 from agentclaw.community.core.task.domain.models import (
     AcceptanceCriteria,
     Context,
@@ -7,11 +9,16 @@ from agentclaw.community.core.task.domain.models import (
     Metadata,
     RuntimeInfo,
     Status,
+    TaskExecutionGraph,
     TaskNode,
     TaskSpec,
 )
+from agentclaw.community.core.task.task_dispatch.dispatcher import TaskDispatcher
+from agentclaw.community.core.task.task_plan.static_plan import StaticPlanDefinition
+from agentclaw.community.core.task.task_plan.static_plan_runtime import StaticPlanRuntime
 from agentclaw.community.core.task.task_runner.client.open_api_bot_adapter import (
     OpenApiAuthError,
+    OpenApiBadRequestError,
 )
 from agentclaw.community.core.task.task_runner.client.prompt_formatter import (
     PromptFormatterImpl,
@@ -45,10 +52,11 @@ def _node(assignee="bot9:ent1", extend_props=None):
 
 
 class _Bot:
-    def __init__(self, run_id="mid_1", session_id=None, grant_fail=False):
+    def __init__(self, run_id="mid_1", session_id=None, grant_fail=False, send_error=None):
         self._rid = run_id
         self._sid = session_id
         self._gf = grant_fail
+        self._send_error = send_error
         self.sent = []
 
     async def ensure_grant(self, bot_id):
@@ -61,6 +69,8 @@ class _Bot:
             BotSendResult,
         )
 
+        if self._send_error is not None:
+            raise self._send_error
         self.sent.append((bot_id, message, metadata))
         return BotSendResult(run_id=self._rid, session_id=self._sid)
 
@@ -111,6 +121,30 @@ def test_dispatch_single_bot_registers_handle():
     assert bot.sent[0][0] == "bot9:ent1"
     assert poller.registered[0].run_id == "mid_1"
     assert poller.registered[0].loop_task_id == "t1::c1"
+
+
+@pytest.mark.parametrize(
+    "send_error",
+    [OpenApiAuthError("403"), OpenApiBadRequestError("400")],
+    ids=["auth", "bad-request"],
+)
+def test_dispatch_single_bot_rejects_non_retryable_openapi_error(send_error):
+    """不可重试的 OpenAPI 4xx 派发失败应留给 harness，不能注册虚假执行句柄。"""
+    bot = _Bot(send_error=send_error)
+    poller = _Poller()
+    executor = TaskExecutor(
+        bot=bot,
+        bcs=None,
+        formatter=PromptFormatterImpl(),
+        context=_Ctx(),
+        sink=None,
+        poller=poller,
+        task_settings=_TaskSettingsOff(),
+    )
+
+    assert _run(executor.dispatch([_node()])) == [False]
+    assert bot.sent == []
+    assert poller.registered == []
 
 
 
@@ -242,6 +276,11 @@ def test_prompt_formatter_skill_report_on_uses_http_post():
     assert '"success": true' not in s
     assert '"verdict": "DONE"' in s
     assert '"acceptances_metric"' in s
+    assert "阶段1 在本条消息正文给出的真实业务产出" in s
+    assert "收到 HTTP 200 即视为本节点上报完成" in s
+    assert "严禁在收尾轮再次贴出阶段1执行产出" in s
+    assert "上报只能用 exec/curl" in s
+    assert "不得对同一节点重复 POST" in s
 
 def test_prompt_formatter_relay_appends_protocol_and_chinese_constraint():
     """# 接自 接力分支(static_plan):交接正文 + 执行闭环(禁联网/平台回收/接力交接,不含 HTTP 上报协议)+ 中文输出约束。"""
@@ -280,6 +319,30 @@ def test_prompt_formatter_relay_appends_protocol_and_chinese_constraint():
     assert "按问题智能匹配能力" not in s
     # 中文输出约束
     assert "必须使用中文" in s
+
+
+def test_static_relay_prompt_waits_for_every_member_and_preserves_markdown():
+    """静态协作接力必须在全员完成后唯一汇总，并要求结构化 Markdown 产出。"""
+    relay = (
+        "# 接自:上游Bot\n"
+        "## 群组成\n- driver Bot\n- consultant Bot\n"
+        "## 上游产出正文\n上游结论\n"
+        "## 本角色任务\n联合完成评审"
+    )
+    node = _node()
+    node.task_spec.metadata.instruction = relay
+
+    prompt = PromptFormatterImpl().format_execute(
+        {"mode": "execute", "node_instruction": relay},
+        node,
+    )
+
+    assert "只有当所有成员(含 driver 作 worker)都已在本群回复各自产出后" in prompt
+    assert "若仍有成员未回复,继续等待,不得提前收尾" in prompt
+    assert "执行产出与 gap交接只在此轮给出" in prompt
+    assert "正文须保留 markdown 排版" in prompt
+    assert "标题、段落、列表、表格、加粗" in prompt
+    assert "4) 汇总与交接" not in prompt
 
 
 
@@ -332,6 +395,63 @@ class _TaskSettingsOff:
 
     def set_enabled(self, *, setting_type, enabled, env, operator=None):
         return False
+
+
+def test_static_plan_owner_reaches_final_openapi_bot_identity():
+    """static plan owner 透传必须跨 runtime、dispatcher 和 executor 到达最终 Bot ID。"""
+    definition = StaticPlanDefinition.from_yaml(
+        """
+        template_id: owner-propagation
+        nodes:
+          - id: worker
+            type: bot
+            bot_id: worker-bot
+            task: 完成执行
+        """
+    )
+    graph = TaskExecutionGraph(
+        run_id=1,
+        loop_round=0,
+        status=Status.RUNNING,
+        task_id="t1",
+        extend_props={"owner_user_id": "owner-1"},
+    )
+    root = TaskNode(
+        node_id="t1",
+        task_id="t1",
+        status=Status.PLANNING,
+        task_spec=TaskSpec(
+            Metadata("t1", "root", "root"),
+            Context(""),
+            Goal("root", []),
+        ),
+        run_info=RuntimeInfo(),
+        node_run_graph=graph,
+    )
+    graph.tasks.append(root)
+    runtime = StaticPlanRuntime(definition, {})
+    graph.tasks.extend(runtime.nodes("t1", root.task_spec))
+    ready = list(runtime.ready(graph).ready)
+
+    class _GraphView:
+        def query_task_dashboard(self, task_id):
+            assert task_id == "t1"
+            return graph
+
+    dispatched = _run(TaskDispatcher(_GraphView()).dispatch(ready))
+    bot = _Bot()
+    executor = TaskExecutor(
+        bot=bot,
+        bcs=None,
+        formatter=PromptFormatterImpl(),
+        context=_Ctx(),
+        sink=None,
+        poller=_Poller(),
+        task_settings=_TaskSettingsOff(),
+    )
+
+    assert _run(executor.dispatch(dispatched)) == [True]
+    assert bot.sent[0][0] == "worker-bot:owner-1"
 
 
 def test_dispatch_skill_report_on_skips_poller_registration():

--- a/src/backend/tests/community/core/task/task_runner/integration/test_open_api_bot_adapter.py
+++ b/src/backend/tests/community/core/task/task_runner/integration/test_open_api_bot_adapter.py
@@ -32,14 +32,14 @@ def test_parse_bot_id():
 
 class _KeyNoPrefix:
     api_key = "ak1234567890"
-    api_key_prefix = ""    # 未设置 → 回落取 api_key 前 10 位
+    api_key_prefix = ""    # 未设置 → 回落取 api_key 前 8 位
     base_url = "http://b:8890"
     cookie = "sess=1"
     referer = "http://b/"
 
 
 def test_ensure_grant_falls_back_to_api_key_prefix_when_unset():
-    # api_key_prefix 为空时,URL 用 api_key 前 N 位(默认 10,与 _Key.ak12345678 约定一致)作 prefix
+    # api_key_prefix 为空时，URL 使用 api_key 前 8 位作为 prefix。
     seen: dict = {}
 
     def h(req):
@@ -151,6 +151,22 @@ def test_send_and_wait_returns_completed_run():
     assert run["status"] == "COMPLETED"
     assert run["result"]["content"] == "ans"
     assert calls["n"] >= 2  # 先 RUNNING 再 COMPLETED,至少轮询 2 次
+
+
+def test_send_and_wait_async_uses_optional_defaults():
+    """异步便捷接口只要求 bot_id/message；其余参数应保持可选默认值。"""
+    def h(req):
+        if req.url.path == "/openapi/v1/messages" and req.method == "POST":
+            return httpx.Response(200, json={"data": {"message_id": "mid_default"}})
+        if req.url.path.endswith("/allowed-bots") and req.method == "GET":
+            return httpx.Response(200, json={"data": {"allowed_bots": ["bot9:ent1"]}})
+        if req.url.path == "/openapi/v1/messages/mid_default" and req.method == "GET":
+            return httpx.Response(200, json={"data": {"status": "COMPLETED"}})
+        return httpx.Response(404)
+
+    run = _run(_adapter(h).send_and_wait_async(bot_id="bot9:ent1", message="hi"))
+
+    assert run["status"] == "COMPLETED"
 
 
 def test_send_and_wait_timeout_raises():

--- a/src/backend/tests/community/core/task/task_runner/integration/test_open_api_bot_adapter_live.py
+++ b/src/backend/tests/community/core/task/task_runner/integration/test_open_api_bot_adapter_live.py
@@ -1,22 +1,10 @@
-"""OpenApiBotAdapter.send_and_wait live 集成测试(unittest;打真实 BaaS Open API,不经 MockTransport)。
+"""OpenApiBotAdapter live integration test against an explicitly configured endpoint.
 
-默认跳过:下方配置常量置空占位,手动填入真实 BaaS Open API 配置(API_KEY / BASE_URL / BOT_ID 等)后,
-skipUnless 条件满足才会真正执行(unittest 默认不缓冲 stdout,可直接看打印的 run dict)。
+The test is disabled by default. Configure it only through environment variables;
+credentials and session state must never be committed to the repository.
 """
 
-import sys
-
-# 1. 临时从 Python 搜索路径中移除导致冲突的 plugins/forwarder 路径
-sys.path = [p for p in sys.path if 'plugins/forwarder' not in p.replace('\\', '/')]
-
-# 2. 如果之前已经有地方错误地导入了本地的 httpx，从缓存中清除它
-if 'httpx' in sys.modules:
-    # 检查缓存里的是不是那个假的（没有 AsyncClient 的）
-    if not hasattr(sys.modules['httpx'], 'AsyncClient'):
-        del sys.modules['httpx']
-
-# 3. 强制导入官方真正的 httpx 并注入到系统缓存中
-import httpx
+from __future__ import annotations
 
 import os
 import unittest
@@ -26,40 +14,42 @@ from agentclaw.community.core.task.task_runner.client.open_api_bot_adapter impor
 )
 
 
-# ===== live 配置(API_KEY/BASE_URL 支持同名环境变量覆盖;外面未设则用此处填的值作默认)=====
-API_KEY = os.environ.get("API_KEY") or ""
-# api_key_prefix:BaaS 为该 key 单独分配的路径标识(非 key 前 N 位)。留空 → adapter 兜底取 API_KEY 前 10 位。
-# 若兜底触发 BaaS "API Key 不存在",说明真实 prefix 与 key 前 10 位不同,需在此/环境变量填真实值。
-API_KEY_PREFIX = os.environ.get("API_KEY_PREFIX") or ""
-BASE_URL = os.environ.get("BASE_URL") or ""
-COOKIE = 'session.cookieNameId=ALIPAYBUMNGJSESSIONID; antLoginLang=zh_CN; __TRACERT_COOKIE_bucUserId=35983; receive-cookie-deprecation=1; buservice_domain_id=KOUBEI_SALESCRM; userId=35983; antcode_user_extern_no=35983; cna=WkP4IgG/8C4BASQBsYC5wDYj; isg=BGdnAc_fwQ_QMUWDfF-yXr4e9p0x7DvO7ThfhDnUefYNKITqQbyAHhsrTii29hNG; tfstk=gdCijywKPHi7bpoUZmR_LfHrZ32LACOXjihvDIK4LH-BDEdOHjxcPHU6MOdviS-hchp9_npVmM72lOdv6K8VXMIOmZa6unSVmnBTp7Q15IO42iV8wN6mDAvfnf8auB89uyLN2KTbwIO42kUoxgvMGGLtCJJN8yYvlFlV0E7eYHTy0xS2bpoerUO20iSqL28Jzm823dlU-Ete0IRV0wzHkH-2gISV8fOq8hIVf6r-h-nUSEudTFvM4N-NWNCEGdk15Hcqg6j1n3lDxjlVtF7fEHb-_7xFBt59T1rEVB75pG8HZS0D-Tbe_FjbNfONzwW2Is2xPn6h8TphdVU6-1bliUvEYPxf6GfDC_r-OhWhOsAOplcJcKWd1L1TYfAPFNdO3MzqgnXeug-iLYR84jTUk6kjhd8B-3hk-EtGXEe8-y4nUT9wRFP8-yDjod8B-3U3-YoBQeTaw; isEnableLocale=disabled; LOCALE=zh_CN; acLoginFrom=antcloud_login; nav_original_path=iam.alipay.com; ALIPAYBUMNGJSESSIONID=GZ00Imbg7LwV3NWarlLQiUDKJs5JWJantbuserviceGZ00; IAM_TOKEN=eyJraWQiOiJkZWZhdWx0IiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYifQ.eyJjbmwiOiJCVUMiLCJzdWIiOiJqaWFuLmppYW5naiIsImF1dGhfdHAiOlsiWkZBUkIiXSwiaXNzIjoiYnVtbmcuYWxpcGF5LmNvbSIsIm5vbmNlIjoiYTczNjlkMiIsInNpZCI6IjEwMDc1MCIsImF1ZCI6IioiLCJuYmYiOjE3ODY1OTI2MjIsInNubyI6IjM1OTgzIiwidG50X2lkIjoiQUxJUFczQ04iLCJuYW1lIjoi6JSj5bu6IiwiZXhwIjoxNzg2Njc5MTQyLCJpYXQiOjE3ODY1OTI3NDIsImp0aSI6IjliNjU1YWE3YWI0ODQwODVhMTFmYTUyOTJkNTA3MTkwIn0.Rrrq8BzJeBNs44bl-oU9XgaplY8QZ9C_BDC62ILXE7UGiMfYY5VnQTj1A3bwSwzTPq25IbM-aEulXURU_iQX4A; JSESSIONID=GZ00Imbg7LwV3NWarlLQiUDKJs5JWJantbuserviceGZ00; authorization=hmac%200000112639-1%3AWU45dXBaYWI0VG1FSll1MFNGbnQ1VmpPZjV0WU0xdFI%3D~0$MYJF; authorization=hmac%200000112639-1%3AWU45dXBaYWI0VG1FSll1MFNGbnQ1VmpPZjV0WU0xdFI%3D~0$MYJF; A3_USER_COOKIE=a90a8adb7c934cf39f501a36c6ee3f08f7589a8ea6ae7e0be5cbbd3ae2eb0f4334472874cbf65e7377011c01346333af0ebbfe5ba2da318d43f2163b6d5596599dd4442afb818f288f0acf94ff62718e4210e77096280ef274643f01d5d3a7b4dd05798c7606f050fab3fa1cb680dd811e434c0dc493fb71563b10b3bf616bfb7b5b3b7abc9bbe956c7af5d1aa23641521ef16e31ce4e8abff1dc5661cae5f9965919410a118c53ba8d6d7cbb786c69aa41da5a72985942cf3fb0998c1ffb4a6a94cf2f3f6e5473ef4f06d955ef65e55402dbab9def1accb66442207610753b0123930fb33669e4e7982d5747e955fcd2f12dbb09a3f0a730cb7902b83b219772bc21022457b4720045ba34178d44253af5c15532e328170f4aeeb0057a871d54b165e69099b7a8ec754751908965d1865c922b90b9c389e06794efe84ef87ab; mustAddPartitionedTag=noNeedToAdd; bs_n_lang=zh_CN; ALIPAYDWDISSESSIONID=GZ00Q7gS0z5BOD5V7nJWknpa2CsXSRcapGZ00; 035983__project=ANT; 035983__workspace=DEFAULT_ANT; __compass_session_id=768b19c1-ab56-4fd4-b1e6-57263ba61315; ant_dp_subject=%7B%22actual_dp_subject%22%3A%7B%22subjectAbbrCode%22%3A%22ant%22%2C%22subjectCode%22%3A%22antgroup%22%7D%2C%22virtual_dp_subject%22%3A%7B%22subjectAbbrCode%22%3A%22ant%22%2C%22subjectCode%22%3A%22antgroup%22%7D%7D; dataphin-locale=zh_CN; zone=GZ00G; ALIPAYJSESSIONID=GZ00C3DD3AF57DCA4EF69049834406AFACB3kujutaGZ00; ctoken=Rg1uuVrI9wpzoQ8L; rtk=d6wLRVhAcGHCXT8OUOLjnCIOU0Ezt1tW3D1CBQJgL7JW40LDUOD; zt-id-stsq=1786675751.YshfHljY.1518698200; x-hng=lang=zh-CN; _CHIPS-x-hng=lang=zh-CN; BUSERVICE_SSO_V2=FB0796A8085F618C56A5D72D9C0DC2F2BEF6417D09B60FCA48C51FB559FF55E83D87023A0725258C1CCB13F1AD1EFED3; spanner=NCaYBxtKrIEGwxXw1SxEIVdmRT+aD8g+Xt2T4qEYgj0='
-BOT_ID = os.environ.get("BOT_ID") or ""
-MESSAGE = "帮我写一首赞美成都的古诗"
+API_KEY = os.getenv("TASK_OPENAPI_API_KEY", "")
+# When omitted, the adapter falls back to the first eight API-key characters.
+API_KEY_PREFIX = os.environ.get("TASK_OPENAPI_API_KEY_PREFIX", "")
+BASE_URL = os.environ.get("TASK_OPENAPI_BASE_URL", "")
+COOKIE = os.environ.get("TASK_OPENAPI_COOKIE", "")
+REFERER = os.environ.get("TASK_OPENAPI_REFERER", "")
+BOT_ID = os.environ.get("TASK_OPENAPI_BOT_ID", "")
+MESSAGE = os.environ.get("TASK_OPENAPI_MESSAGE", "帮我写一首赞美成都的古诗")
 
 _LIVE_ENABLED = bool(API_KEY and BASE_URL and BOT_ID)
 
 
 class _LiveKey:
-    """真实 ApiKeyProvider(读取上方配置常量;填入后生效)。"""
+    """ApiKeyProvider backed exclusively by explicit live-test configuration."""
 
     api_key = API_KEY
     api_key_prefix = API_KEY_PREFIX
     base_url = BASE_URL
     cookie = COOKIE
-    referer = ''
+    referer = REFERER
 
 
 @unittest.skipUnless(
     _LIVE_ENABLED,
-    "填入 BaaS Open API 配置(API_KEY / BASE_URL / BOT_ID)后启用 live 测试",
+    "设置 TASK_OPENAPI_API_KEY/BASE_URL/BOT_ID 后启用 live 测试",
 )
 class TestSendAndWaitLive(unittest.TestCase):
-    def test_returns_terminal_run(self):
-        adapter = OpenApiBotAdapter(_LiveKey())  # 真实 httpx.AsyncClient(base_url),非 MockTransport
-        run = adapter.send_and_wait(bot_id=BOT_ID, message=MESSAGE, timeout=180.0, poll_interval=5.0)
-        # send_and_wait 仅在终态返回(超时抛 OpenApiTimeoutError);此处断言终态并打印回答。
+    def test_returns_terminal_run(self) -> None:
+        adapter = OpenApiBotAdapter(_LiveKey())
+        run = adapter.send_and_wait(
+            bot_id=BOT_ID,
+            message=MESSAGE,
+            timeout=180.0,
+            poll_interval=5.0,
+        )
         self.assertIn(run["status"], ("COMPLETED", "FAILED"))
-        print(run)  # 查看真实回答 / 错误详情
 
 
 if __name__ == "__main__":

--- a/src/backend/tests/community/endpoints/test_task_internal_router.py
+++ b/src/backend/tests/community/endpoints/test_task_internal_router.py
@@ -1,7 +1,6 @@
 """Declarative endpoint coverage for internal collaboration task routes."""
 from __future__ import annotations
 
-from datetime import datetime
 from types import SimpleNamespace
 
 from agentclaw.community.api.task.task_service import TaskServiceProtocol
@@ -14,12 +13,7 @@ from agentclaw.community.api.task.task_grant_service import (
 )
 from agentclaw.community.core.task.domain.models import (
     NodeOpResult,
-    Status,
-    TaskExecutionGraph,
     TaskOpResult,
-)
-from agentclaw.community.core.task.repository.types import (
-    TaskInfoRecord,
 )
 from agentclaw.community.core.task.task_discovery.discovery_service import DiscoveryService
 from agentclaw.community.core.task.task_discovery.scheduler import TaskDiscoveryScheduler
@@ -68,7 +62,7 @@ class _CallbackTaskService:
         self.callback = _CallbackSink()
 
 
-def _seed_task_service(world, *, expected_owner=None) -> None:
+def _seed_task_service(world) -> None:
     async def execute(_self, _task_info):
         return TaskOpResult(
             task_id="task-endpoint-1",
@@ -76,30 +70,6 @@ def _seed_task_service(world, *, expected_owner=None) -> None:
             run_id=1,
             extend_props={"group_id": "bcs_grp_endpoint_1"},
         )
-
-    def dashboard(_self, _task_id, _node_id=None):
-        return TaskExecutionGraph(run_id=1, loop_round=0, status=Status.PENDING)
-
-    def list_tasks(_self, _status=None, owner_user_id=None):
-        assert owner_user_id == expected_owner
-        return [
-            TaskInfoRecord(
-                id=1,
-                task_id="task-endpoint-1",
-                source_type="bot",
-                owner_user_id="user-endpoint-1",
-                owner_bot_id="bot-endpoint-1",
-                execution_config={"task_type": "dynamic"},
-                task_spec=_TASK_SPEC,
-                status=Status.PENDING,
-                gmt_create=datetime(2026, 8, 22, 10, 0, 0),
-                gmt_modified=datetime(2026, 8, 22, 10, 0, 0),
-            )
-        ]
-
-    def list_tasks_page(_self, status=None, owner_user_id=None, page=1, page_size=20):
-        items = list_tasks(_self, status, owner_user_id=owner_user_id)
-        return items[:page_size], len(items)
 
     def claim(_self, task_id, _bot_id):
         return NodeOpResult(task_id=task_id, node_id="root", success=True)
@@ -115,9 +85,6 @@ def _seed_task_service(world, *, expected_owner=None) -> None:
         TaskServiceProtocol,
         {
             "execute": execute,
-            "get_task_dashboard": dashboard,
-            "list_tasks": list_tasks,
-            "list_tasks_page": list_tasks_page,
             "claim_bbs_task": claim,
             "attach_bbs_node": attach,
             "report_bbs_result": result,
@@ -187,6 +154,39 @@ def execute_happy():
     expect=ExpectError(status=422),
 )
 def execute_error():
+    pass
+
+
+# Query surfaces are public-only. Keep the unauthenticated internal mirror from
+# being reintroduced accidentally; live/singlebox readers use /openapi/v1.
+@endpoint_test(
+    method="GET",
+    path=f"{_BASE}/dashboard",
+    scenario="not_exposed",
+    input=CaseInput(query_params={"task_id": "task-endpoint-1"}),
+    expect=ExpectError(status=404),
+)
+def dashboard_not_exposed():
+    pass
+
+
+@endpoint_test(
+    method="GET",
+    path=f"{_BASE}/list",
+    scenario="not_exposed",
+    expect=ExpectError(status=404),
+)
+def list_not_exposed():
+    pass
+
+
+@endpoint_test(
+    method="GET",
+    path=f"{_BASE}/bbs/list",
+    scenario="not_exposed",
+    expect=ExpectError(status=404),
+)
+def bbs_list_not_exposed():
     pass
 
 


### PR DESCRIPTION
Title:

```text
test(task): cover task execution regressions
```

Description:

```markdown
## Problem

Recent task-system changes fixed several execution and collaboration issues, but the corresponding fast tests did not fully cover the new behavior.

The missing coverage included:

- static relay waiting for every member, including the driver, before aggregation;
- preserving Markdown formatting in relay output;
- preventing duplicate output or callback submission after HTTP 200;
- propagating the task owner through static planning and dispatch to the final OpenAPI Bot identity;
- handling non-retryable OpenAPI dispatch failures without registering invalid polling handles;
- recovering nodes when the execution backend raises an exception;
- ensuring removed internal task query routes cannot be exposed again;
- preserving optional defaults on the asynchronous OpenAPI execution API.

The live OpenAPI adapter test also contained hardcoded session credentials, which must not remain in the repository.

## Solution

Added fast unit, integration, and endpoint regression coverage for the affected task execution paths:

- verify static relay completion ordering, single aggregation, callback termination, and Markdown preservation;
- exercise the complete static-plan owner propagation path through `StaticPlanRuntime`, `TaskDispatcher`, and `TaskExecutor`;
- verify OpenAPI authentication and bad-request failures return an unsuccessful dispatch result without registering a poller;
- verify execution-backend exceptions clear the assignment, retain the node in `PENDING`, and record `start_run_failed`;
- verify the removed internal dashboard, task-list, and BBS-list routes return 404;
- verify `send_and_wait_async` retains optional metadata, timeout, and polling defaults;
- remove obsolete internal-route test stubs;
- replace hardcoded live-test credentials with explicit environment-variable configuration.

No task E2E or singlebox E2E tests were modified.

## Validation

- `579 passed, 5 skipped`
- Ruff checks passed for all changed Python files.
- `git diff --check` passed.
- Pre-push plaintext-secret scan passed.
- Pre-push backend SAST/lint gate passed.

The full pre-push CI, coverage gate, and singlebox E2E suite were not run. The push used the repository’s default lint-only pre-push mode, and E2E/singlebox changes were intentionally excluded from this iteration.

## Compatibility and risk

There is no production API, schema, persistence, or runtime behavior change.

The live OpenAPI test now reads configuration from namespaced `TASK_OPENAPI_*` environment variables instead of committed values. Developers running that test manually must provide those variables explicitly.

## Related issues

Relates to #2081, #2047, #2027, #1944, #1514, #1504, #1496, and #1443.
```