### PR TITLE
feat(workflow): filter run history by status and keyword

### DIFF
--- a/src/evolverun/clawweb/public/modules/workflow/docs/run-list-contract.md
+++ b/src/evolverun/clawweb/public/modules/workflow/docs/run-list-contract.md
@@ -1,0 +1,77 @@
+# Run list HTTP contract
+
+Owner: `@avernet/workflow`. Route: `GET /runs` relative to the host API mount
+(normally `GET /api/runs`). This is a read-only Service API, not an engine
+Plugin API. The optional `query` parameter is an additive, backward-compatible
+extension; the response envelope and existing filters are unchanged.
+
+## Keyword search
+
+`query` accepts a single string. Leading and trailing whitespace is removed.
+Omitted, empty, whitespace-only, repeated (array), or structured values do not
+activate keyword filtering. Clients should send one URL-encoded string.
+
+An active keyword performs a literal substring match against any of:
+
+- `flow_id` (Run ID);
+- `triggered_by` (initiator);
+- `origin_bot_id` (stored Bot identity, including the owner suffix when present).
+
+It does not search input JSON or node logs. `%`, `_`, and `!` are escaped as
+literal characters rather than LIKE patterns. Values are SQL-bound parameters.
+Case sensitivity follows the database column collation; portable clients must
+not rely on a particular case-folding behavior.
+
+## Composition with existing filters
+
+The keyword's three field matches are grouped with OR. That group is combined
+with AND against `workflowId`, `status`/`statuses`, `inputQuery`, `from`/`to`,
+the existing origin-Bot scope, and workflow view permissions.
+
+- A non-empty comma-separated `statuses` list takes precedence over `status`.
+- `inputQuery` retains its separate existing input-JSON LIKE semantics.
+- `from` and `to` retain inclusive `started_at` bounds and accept epoch seconds,
+  epoch milliseconds, or ISO timestamps. Omitting them searches all history;
+  the run list does not inherit the dashboard's metric window.
+- `botOwnerId`/`botId` retain their existing origin-scope behavior. The keyword
+  does not grant access or override the host's authorization decision.
+- Non-admin workflow visibility is applied before counts, ordering, and
+  pagination. An empty allowed-workflow scope yields no rows or counts.
+  Administrators retain their existing unrestricted view.
+
+Results are ordered by `started_at DESC`. `limit` (default 30, maximum 2000)
+and `offset` (default 0) select a page of matching, authorized records.
+Records with equal start times have no additional guaranteed order.
+
+## Response compatibility
+
+The JSON envelope remains `{ runs, total, limit, offset, statusCounts? }`.
+`total` is the number of authorized matches **before** pagination; `runs`
+contains only the requested page. A no-match result is HTTP 200 with
+`runs: []` and `total: 0`. Hidden matches must not affect either field.
+
+`statusCounts` is present only when `status`, non-empty `statuses`, non-empty
+`inputQuery`, and active `query` are all absent. When present, it observes the
+same workflow, time, origin, and permission scope as the list. Searching
+clients must not interpret an omitted `statusCounts` as real zero metrics;
+dashboard metrics use their independent unfiltered query.
+
+Examples:
+
+```http
+GET /api/runs?workflowId=example&status=failed&query=bot_123&limit=20&offset=0
+GET /api/runs?workflowId=example&statuses=cancelled,canceled&query=gateway
+GET /api/runs?workflowId=example&query=%20run-123%20
+```
+
+## Compatibility tests
+
+`server/repositories/__tests__/run-list-search.test.ts` exercises both the real
+SQLite repository and the Express HTTP route. Coverage includes normalization,
+non-scalar/omitted parameters, unchanged response shape, filter intersections,
+status-list precedence, literal wildcards, permission-scoped counts and rows,
+pagination, empty permissions, and the admin view. Run it with:
+
+```sh
+npm test --workspace @avernet/workflow -- server/repositories/__tests__/run-list-search.test.ts
+```

--- a/src/evolverun/clawweb/public/modules/workflow/server/repositories/__tests__/run-list-search.test.ts
+++ b/src/evolverun/clawweb/public/modules/workflow/server/repositories/__tests__/run-list-search.test.ts
@@ -3,6 +3,10 @@ import Database from "better-sqlite3";
 import { describe, expect, it } from "vitest";
 import { SqliteDatabase } from "@avernet/clawweb-shared/server/db";
 import { FlowRunRepository } from "../flow-run-repository.js";
+import express from "express";
+import { once } from "node:events";
+import { createRunsRouter } from "../../routes/runs.js";
+import type { BotWorkflowPermissionRepository } from "@avernet/clawweb-shared/server/repositories/bot-workflow-permission-repository";
 
 describe("run history keyword filtering", () => {
   it("searches identifiers and callers across history with consistent counts and pagination", async () => {
@@ -31,6 +35,44 @@ describe("run history keyword filtering", () => {
       expect(await repo.countRuns({ workflowId: "wf", query: "bot_one" })).toBe(1);
       expect(await repo.countRuns({ workflowId: "wf", query: "%" })).toBe(0);
       expect(await repo.countRuns({ workflowId: "wf", query: "' OR 1=1 --" })).toBe(0);
+
+      let viewableIds = new Set(["wf"]);
+      const permissions = {
+        getViewByIdsForOwner: async () => ({ restrictedIds: new Set(["wf", "other"]), viewableIds }),
+      } as unknown as BotWorkflowPermissionRepository;
+      const app = express();
+      app.use((req, _res, next) => { req.isAdmin = req.headers["x-test-admin"] === "true"; next(); });
+      app.use("/runs", createRunsRouter(repo, null, null, null, null, null, permissions));
+      const server = app.listen(0, "127.0.0.1");
+      await once(server, "listening");
+      const base = `http://127.0.0.1:${(server.address() as import("node:net").AddressInfo).port}/runs`;
+      const read = async (query: string, admin = false) => {
+        const response = await fetch(base + query, { headers: { "x-user-id": "owner", "x-test-admin": String(admin) } });
+        expect(response.status).toBe(200);
+        return response.json();
+      };
+      try {
+        for (const query of ["?query=foreign", "?workflowId=other", "?query=bot_one&workflowId=other"]) {
+          const hidden = await read(query);
+          expect(hidden.total).toBe(0);
+          expect(hidden.runs).toEqual([]);
+          if (hidden.statusCounts) expect(hidden.statusCounts).toEqual({});
+        }
+        const first = await read("?query=gateway-client&status=failed&limit=1");
+        expect(first.total).toBe(2);
+        expect(first.runs.map((r: { flow_id: string }) => r.flow_id)).toEqual(["new-match"]);
+        const second = await read("?query=gateway-client&status=failed&limit=1&offset=1");
+        expect(second.runs.map((r: { flow_id: string }) => r.flow_id)).toEqual(["old-match"]);
+        expect((await read("")).statusCounts).toEqual({ failed: 2, succeeded: 1 });
+        viewableIds = new Set();
+        expect(await read("?query=gateway-client")).toMatchObject({ total: 0, runs: [] });
+        expect(await read("")).toMatchObject({ total: 0, runs: [], statusCounts: {} });
+        expect(await read("?query=foreign", true)).toMatchObject({ total: 1 });
+        expect((await read("", true)).statusCounts).toEqual({ failed: 3, succeeded: 1 });
+      } finally {
+        server.closeAllConnections();
+        await new Promise<void>((resolve, reject) => server.close(error => error ? reject(error) : resolve()));
+      }
     } finally { await db.close(); }
   });
 });

--- a/src/evolverun/clawweb/public/modules/workflow/server/repositories/__tests__/run-list-search.test.ts
+++ b/src/evolverun/clawweb/public/modules/workflow/server/repositories/__tests__/run-list-search.test.ts
@@ -20,12 +20,13 @@ describe("run history keyword filtering", () => {
       completed_at INTEGER, identity_key TEXT, current_phase TEXT, origin_session_key TEXT,
       origin_session_id TEXT, user_id TEXT, plugin_version TEXT, engine TEXT,
       workflow_version INTEGER, workflow_deploy_number INTEGER, gmt_create INTEGER,
-      gmt_modified INTEGER, evolution_analysis_status TEXT);
+      gmt_modified INTEGER, evolution_analysis_status TEXT, input_json TEXT);
       INSERT INTO flow_runs (flow_id,workflow_id,status,triggered_by,origin_bot_id,started_at) VALUES
       ('old-match','wf','failed','gateway-client','bot_one:owner',1),
       ('new-match','wf','failed','gateway-client','bot_two:owner',2),
       ('success','wf','succeeded','gateway-client','bot_three:owner',3),
       ('foreign','other','failed','gateway-client','bot_one:owner',4);`);
+    raw.exec("UPDATE flow_runs SET input_json = 'needle' WHERE flow_id = 'new-match'");
     try {
       const filters = { workflowId: "wf", status: "failed", query: "gateway-client" };
       expect(await repo.countRuns(filters)).toBe(2);
@@ -52,6 +53,27 @@ describe("run history keyword filtering", () => {
         return response.json();
       };
       try {
+        // Public HTTP compatibility: omission, blank and non-scalar values
+        // preserve the existing unfiltered contract, including status counts.
+        const baseline = await read("?workflowId=wf");
+        expect(baseline).toMatchObject({ total: 3, limit: 30, offset: 0, statusCounts: { failed: 2, succeeded: 1 } });
+        for (const suffix of ["&query=", "&query=%20%20", "&query=old&query=new", "&query[field]=old"]) {
+          expect(await read("?workflowId=wf" + suffix)).toEqual(baseline);
+        }
+        const trimmed = await read("?workflowId=wf&query=%20new-match%20");
+        expect(trimmed.total).toBe(1);
+        expect(trimmed.runs.map((r: { flow_id: string }) => r.flow_id)).toEqual(["new-match"]);
+        expect(trimmed).not.toHaveProperty("statusCounts");
+        const combined = await read("?workflowId=wf&query=gateway&status=failed&from=2&to=2&inputQuery=needle&limit=1&offset=0");
+        expect(combined).toMatchObject({ total: 1, limit: 1, offset: 0 });
+        expect(combined.runs.map((r: { flow_id: string }) => r.flow_id)).toEqual(["new-match"]);
+        expect(await read("?workflowId=wf&query=old-match&inputQuery=needle")).toMatchObject({ total: 0, runs: [] });
+        const multiStatus = await read("?workflowId=wf&query=gateway&status=failed&statuses=succeeded,waiting");
+        expect(multiStatus.total).toBe(1);
+        expect(multiStatus.runs.map((r: { flow_id: string }) => r.flow_id)).toEqual(["success"]);
+        expect(await read("?workflowId=wf&query=bot_one&botId=bot_two")).toMatchObject({ total: 0, runs: [] });
+        expect(await read("?workflowId=wf&query=%25")).toMatchObject({ total: 0, runs: [] });
+        expect((await read("?workflowId=wf&query=bot_one")).total).toBe(1);
         for (const query of ["?query=foreign", "?workflowId=other", "?query=bot_one&workflowId=other"]) {
           const hidden = await read(query);
           expect(hidden.total).toBe(0);

--- a/src/evolverun/clawweb/public/modules/workflow/server/repositories/__tests__/run-list-search.test.ts
+++ b/src/evolverun/clawweb/public/modules/workflow/server/repositories/__tests__/run-list-search.test.ts
@@ -1,0 +1,36 @@
+// @vitest-environment node
+import Database from "better-sqlite3";
+import { describe, expect, it } from "vitest";
+import { SqliteDatabase } from "@avernet/clawweb-shared/server/db";
+import { FlowRunRepository } from "../flow-run-repository.js";
+
+describe("run history keyword filtering", () => {
+  it("searches identifiers and callers across history with consistent counts and pagination", async () => {
+    const raw = new Database(":memory:");
+    const db = new SqliteDatabase(raw);
+    const repo = new FlowRunRepository(db);
+    raw.exec(`CREATE TABLE flow_runs (
+      id INTEGER PRIMARY KEY, flow_id TEXT, workflow_id TEXT, status TEXT, triggered_by TEXT,
+      origin_bot_id TEXT, started_at INTEGER, workflow_title TEXT, node_count INTEGER,
+      succeeded_count INTEGER, failed_count INTEGER, total_duration_ms INTEGER, total_token_usage INTEGER,
+      completed_at INTEGER, identity_key TEXT, current_phase TEXT, origin_session_key TEXT,
+      origin_session_id TEXT, user_id TEXT, plugin_version TEXT, engine TEXT,
+      workflow_version INTEGER, workflow_deploy_number INTEGER, gmt_create INTEGER,
+      gmt_modified INTEGER, evolution_analysis_status TEXT);
+      INSERT INTO flow_runs (flow_id,workflow_id,status,triggered_by,origin_bot_id,started_at) VALUES
+      ('old-match','wf','failed','gateway-client','bot_one:owner',1),
+      ('new-match','wf','failed','gateway-client','bot_two:owner',2),
+      ('success','wf','succeeded','gateway-client','bot_three:owner',3),
+      ('foreign','other','failed','gateway-client','bot_one:owner',4);`);
+    try {
+      const filters = { workflowId: "wf", status: "failed", query: "gateway-client" };
+      expect(await repo.countRuns(filters)).toBe(2);
+      expect((await repo.findRuns({ ...filters, limit: 1 })).map(r => r.flow_id)).toEqual(["new-match"]);
+      expect((await repo.findRuns({ ...filters, limit: 1, offset: 1 })).map(r => r.flow_id)).toEqual(["old-match"]);
+      expect(await repo.countRuns({ workflowId: "wf", query: "old-match" })).toBe(1);
+      expect(await repo.countRuns({ workflowId: "wf", query: "bot_one" })).toBe(1);
+      expect(await repo.countRuns({ workflowId: "wf", query: "%" })).toBe(0);
+      expect(await repo.countRuns({ workflowId: "wf", query: "' OR 1=1 --" })).toBe(0);
+    } finally { await db.close(); }
+  });
+});

--- a/src/evolverun/clawweb/public/modules/workflow/server/repositories/flow-run-repository.ts
+++ b/src/evolverun/clawweb/public/modules/workflow/server/repositories/flow-run-repository.ts
@@ -89,6 +89,8 @@ export type FindFlowRunsOptions = {
   offset?: number;
   /** Fuzzy-match against input_json (LIKE %value%) */
   inputQuery?: string;
+  /** Literal substring search across run ID, initiator and origin Bot ID. */
+  query?: string;
   /** Filter by origin_bot_id owner part (format: botId:botOwnerId) */
   originBotOwnerId?: string;
   /** Filter by origin_bot_id bot part; requires originBotOwnerId */
@@ -186,6 +188,11 @@ export class FlowRunRepository {
     if (options.from) { conds.push("started_at >= ?"); params.push(options.from); }
     if (options.to) { conds.push("started_at <= ?"); params.push(options.to); }
     if (options.inputQuery) { conds.push("input_json LIKE ?"); params.push(`%${options.inputQuery}%`); }
+    if (options.query?.trim()) {
+      const pattern = `%${options.query.trim().replace(/[!%_]/g, "!$&")}%`;
+      conds.push("(flow_id LIKE ? ESCAPE '!' OR triggered_by LIKE ? ESCAPE '!' OR origin_bot_id LIKE ? ESCAPE '!')");
+      params.push(pattern, pattern, pattern);
+    }
     // origin_bot_id filtering: format is "botId:botOwnerId" (e.g. "default:461514")
     // NULL/empty origin_bot_id rows are always included (no filtering on them)
     if (options.originBotOwnerId) {

--- a/src/evolverun/clawweb/public/modules/workflow/server/repositories/flow-run-repository.ts
+++ b/src/evolverun/clawweb/public/modules/workflow/server/repositories/flow-run-repository.ts
@@ -81,6 +81,8 @@ export type FlowRunCompletion = {
 
 export type FindFlowRunsOptions = {
   workflowId?: string;
+  /** Permission scope: undefined is unrestricted; an empty list denies all. */
+  allowedWorkflowIds?: string[];
   status?: string;
   statuses?: string[];
   from?: number;
@@ -178,6 +180,14 @@ export class FlowRunRepository {
     const conds: string[] = [];
     const params: unknown[] = [];
     if (options.workflowId) { conds.push("workflow_id = ?"); params.push(options.workflowId); }
+    if (options.allowedWorkflowIds !== undefined) {
+      if (options.allowedWorkflowIds.length === 0) {
+        conds.push("1 = 0");
+      } else {
+        conds.push(`workflow_id IN (${options.allowedWorkflowIds.map(() => "?").join(",")})`);
+        params.push(...options.allowedWorkflowIds);
+      }
+    }
     if (options.statuses?.length) {
       conds.push(`status IN (${options.statuses.map(() => "?").join(",")})`);
       params.push(...options.statuses);

--- a/src/evolverun/clawweb/public/modules/workflow/server/routes/runs.ts
+++ b/src/evolverun/clawweb/public/modules/workflow/server/routes/runs.ts
@@ -156,11 +156,15 @@ export function createRunsRouter(
       const botId = (_req.query.botId as string | undefined)?.trim() || undefined;
 
       const viewPerm = _req.isAdmin ? null : await resolveViewPerm(botPermRepo, botOwnerId, botId);
+      const allowedWorkflowIds = viewPerm === null
+        ? undefined
+        : [...viewPerm.viewableIds].filter((id) => viewPerm.restrictedIds.has(id));
 
       // origin_bot_id filtering: botOwnerId/botId also filter runs by their origin bot
       const originFilter = botOwnerId ? { originBotOwnerId: botOwnerId, originBotId: botId } : {};
 
       const countOptions = {
+        allowedWorkflowIds,
         status: statuses.length === 0 ? status : undefined,
         statuses: statuses.length > 0 ? statuses : undefined,
         workflowId,
@@ -176,14 +180,11 @@ export function createRunsRouter(
       // When a status filter is active the breakdown is trivial (all runs share that status),
       // so we only query when unfiltered.
       const statusCounts = !status && statuses.length === 0 && !inputQuery && !query
-        ? await flowRunRepo.countByStatus({ workflowId, from, to, ...originFilter })
+        ? await flowRunRepo.countByStatus(countOptions)
         : undefined;
 
-      // If permission filter is active, fetch more rows to compensate for filtered-out ones
-      const fetchLimit = viewPerm !== null ? Math.min(limit * 5, 200) : limit;
-      let runs = await flowRunRepo.findRuns({ ...countOptions, limit: fetchLimit, offset });
-
-      runs = applyViewPermFilter(runs, viewPerm).slice(0, limit);
+      // Apply the same permission predicate before counting and pagination.
+      const runs = await flowRunRepo.findRuns({ ...countOptions, limit, offset });
 
       res.json({ runs: runs.map(fixDurationMs), total, limit, offset, statusCounts });
     } catch (error) {

--- a/src/evolverun/clawweb/public/modules/workflow/server/routes/runs.ts
+++ b/src/evolverun/clawweb/public/modules/workflow/server/routes/runs.ts
@@ -130,6 +130,7 @@ export function createRunsRouter(
         .slice(0, 10);
       const workflowId = _req.query.workflowId as string | undefined;
       const inputQuery = (_req.query.inputQuery as string | undefined)?.trim() || undefined;
+      const query = typeof _req.query.query === "string" ? _req.query.query.trim() || undefined : undefined;
       const limit = Math.min(parseInt(_req.query.limit as string, 10) || 30, 2000);
       const offset = parseInt(_req.query.offset as string, 10) || 0;
       // from/to accept ISO strings (e.g. "2026-07-22T08:41:14.023Z", what the frontend sends)
@@ -166,6 +167,7 @@ export function createRunsRouter(
         from,
         to,
         inputQuery,
+        query,
         ...originFilter,
       };
       const total = await flowRunRepo.countRuns(countOptions);
@@ -173,7 +175,7 @@ export function createRunsRouter(
       // Get status breakdown for accurate success-rate calculation (avoids pagination skew).
       // When a status filter is active the breakdown is trivial (all runs share that status),
       // so we only query when unfiltered.
-      const statusCounts = !status && statuses.length === 0 && !inputQuery
+      const statusCounts = !status && statuses.length === 0 && !inputQuery && !query
         ? await flowRunRepo.countByStatus({ workflowId, from, to, ...originFilter })
         : undefined;
 

--- a/src/evolverun/clawweb/public/modules/workflow/web/components/workflow-workspace/OverviewTab.tsx
+++ b/src/evolverun/clawweb/public/modules/workflow/web/components/workflow-workspace/OverviewTab.tsx
@@ -110,6 +110,10 @@ export default function OverviewTab({ workflow }: OverviewTabProps) {
   const workflowId = workflow.workflow_id
   const [days, setDays] = useState<7 | 30>(7)
   const [page, setPage] = useState(0)
+  const [statusFilter, setStatusFilter] = useState('')
+  const [searchInput, setSearchInput] = useState('')
+  const [query, setQuery] = useState('')
+  const hasFilters = Boolean(statusFilter || query)
   const [windowEnd] = useState(() => Math.floor(Date.now() / 1000))
   const [activeSubTab, setActiveSubTab] = useState<'runs' | 'nodes'>('runs')
   const [highlightNodeId, setHighlightNodeId] = useState<string | null>(null)
@@ -142,6 +146,9 @@ export default function OverviewTab({ workflow }: OverviewTabProps) {
     workflowId,
     limit: pageSize,
     offset: page * pageSize,
+    status: statusFilter && statusFilter !== 'cancelled' ? statusFilter : undefined,
+    statuses: statusFilter === 'cancelled' ? ['cancelled', 'canceled'] : undefined,
+    query: query || undefined,
   })
 
   const runs = useMemo(() => data?.runs ?? [], [data?.runs])
@@ -273,6 +280,30 @@ export default function OverviewTab({ workflow }: OverviewTabProps) {
           </button>
         </div>
 
+        {activeSubTab === 'runs' && (
+          <form
+            aria-label="运行记录筛选"
+            onSubmit={(event) => { event.preventDefault(); setQuery(searchInput.trim()); setPage(0) }}
+            className="flex flex-wrap items-center gap-2 border-b border-slate-100 px-4 py-3"
+          >
+            <select aria-label="运行状态" value={statusFilter} onChange={(event) => { setStatusFilter(event.target.value); setPage(0) }} className="rounded-md border border-slate-200 bg-white px-3 py-2 text-xs text-slate-700">
+              <option value="">全部状态</option>
+              <option value="running">运行中</option>
+              <option value="succeeded">成功</option>
+              <option value="failed">失败</option>
+              <option value="waiting">等待中</option>
+              <option value="blocked">阻塞</option>
+              <option value="queued">排队中</option>
+              <option value="cancelled">取消</option>
+              <option value="aborted">终止</option>
+            </select>
+            <input type="search" aria-label="搜索运行记录" placeholder="搜索 Run ID / 发起方 / Bot ID" value={searchInput} onChange={(event) => setSearchInput(event.target.value)} className="min-w-0 flex-1 basis-64 rounded-md border border-slate-200 px-3 py-2 text-xs text-slate-700 sm:max-w-sm" />
+            <button type="submit" className="rounded-md bg-blue-600 px-3 py-2 text-xs font-medium text-white hover:bg-blue-700">搜索</button>
+            <button type="button" disabled={!hasFilters && !searchInput} onClick={() => { setStatusFilter(''); setSearchInput(''); setQuery(''); setPage(0) }} className="rounded-md px-3 py-2 text-xs text-slate-500 hover:bg-slate-50 disabled:opacity-40">重置筛选</button>
+            {!isLoading && !isError && <span className="ml-auto text-xs text-slate-400" aria-live="polite">{hasFilters ? '匹配' : '共'} {totalCount} 条</span>}
+          </form>
+        )}
+
         {activeSubTab === 'nodes' && workflowId ? (
           <div className="p-4">
             <NodeAnalysisPanel workflowId={workflowId} highlightNodeId={highlightNodeId} />
@@ -290,7 +321,7 @@ export default function OverviewTab({ workflow }: OverviewTabProps) {
           </div>
         ) : runs.length === 0 ? (
           <div className="p-6">
-            <EmptyState title="暂无运行" description="该工作流尚未执行过" />
+            <EmptyState title={hasFilters ? '没有匹配的运行' : '暂无运行'} description={hasFilters ? '请调整筛选条件或重置筛选' : '该工作流尚未执行过'} />
           </div>
         ) : (
           <div className="overflow-x-auto">

--- a/src/evolverun/clawweb/public/modules/workflow/web/components/workflow-workspace/__tests__/OverviewTabLayout.test.tsx
+++ b/src/evolverun/clawweb/public/modules/workflow/web/components/workflow-workspace/__tests__/OverviewTabLayout.test.tsx
@@ -56,6 +56,37 @@ const workflow = {
 }
 
 describe('task escort overview layout', () => {
+  it('filters all history, resets pagination, and leaves metrics independent', async () => {
+    mockQueries()
+    render(<MemoryRouter><OverviewTab workflow={workflow} /></MemoryRouter>)
+    await userEvent.click(screen.getByRole('button', { name: '下一页' }))
+    await userEvent.selectOptions(screen.getByRole('combobox', { name: '运行状态' }), 'failed')
+    expect(mocks.useFlowRuns).toHaveBeenLastCalledWith(expect.objectContaining({ status: 'failed', offset: 0 }))
+    await userEvent.type(screen.getByRole('searchbox', { name: '搜索运行记录' }), '  gateway-client  ')
+    await userEvent.click(screen.getByRole('button', { name: '搜索', exact: true }))
+    expect(mocks.useFlowRuns).toHaveBeenLastCalledWith(expect.objectContaining({ query: 'gateway-client', status: 'failed', offset: 0 }))
+    await userEvent.click(screen.getByRole('button', { name: '下一页' }))
+    expect(mocks.useFlowRuns).toHaveBeenLastCalledWith(expect.objectContaining({ query: 'gateway-client', status: 'failed', offset: 20 }))
+    const metricCalls = mocks.useFlowRuns.mock.calls.filter(([params]) => params?.from)
+    expect(metricCalls.every(([params]) => !params.query && !params.status && !params.statuses)).toBe(true)
+    expect(screen.getByText('没有匹配的运行')).toBeInTheDocument()
+    await userEvent.click(screen.getByRole('button', { name: '重置筛选' }))
+    expect(mocks.useFlowRuns).toHaveBeenLastCalledWith(expect.objectContaining({ query: undefined, status: undefined, statuses: undefined, offset: 0 }))
+    expect(screen.getByRole('searchbox', { name: '搜索运行记录' })).toHaveValue('')
+    expect(screen.getByText('暂无运行')).toBeInTheDocument()
+  })
+
+  it('supports both cancellation spellings and submits keyword search with Enter', async () => {
+    mockQueries()
+    render(<MemoryRouter><OverviewTab workflow={workflow} /></MemoryRouter>)
+    await userEvent.selectOptions(screen.getByRole('combobox', { name: '运行状态' }), 'cancelled')
+    expect(mocks.useFlowRuns).toHaveBeenLastCalledWith(expect.objectContaining({ status: undefined, statuses: ['cancelled', 'canceled'] }))
+    await userEvent.type(screen.getByRole('searchbox', { name: '搜索运行记录' }), 'bot_123')
+    expect(mocks.useFlowRuns).toHaveBeenLastCalledWith(expect.objectContaining({ query: undefined }))
+    await userEvent.keyboard('{Enter}')
+    expect(mocks.useFlowRuns).toHaveBeenLastCalledWith(expect.objectContaining({ query: 'bot_123', offset: 0 }))
+  })
+
   it.each(['history', 'metrics'])('refreshes both queries and stays busy while %s is fetching', async (pendingQuery) => {
     mockQueries()
     const history = mocks.useFlowRuns()

--- a/src/evolverun/clawweb/public/shared/web/api/client.ts
+++ b/src/evolverun/clawweb/public/shared/web/api/client.ts
@@ -1243,6 +1243,7 @@ export const api = {
   runs: {
     list(params?: {
       status?: string
+      query?: string
       statuses?: string[]
       workflowId?: string
       limit?: number
@@ -1256,6 +1257,7 @@ export const api = {
       const sp = new URLSearchParams()
       if (params?.status) sp.set('status', params.status)
       if (params?.statuses?.length) sp.set('statuses', params.statuses.join(','))
+      if (params?.query) sp.set('query', params.query)
       if (params?.workflowId) sp.set('workflowId', params.workflowId)
       if (params?.limit) sp.set('limit', String(params.limit))
       if (params?.offset) sp.set('offset', String(params.offset))

--- a/src/evolverun/clawweb/public/shared/web/api/hooks.ts
+++ b/src/evolverun/clawweb/public/shared/web/api/hooks.ts
@@ -5,6 +5,8 @@ import type { WorkflowSpec, KnowledgeBaseCreateInput, KnowledgeBaseUpdateInput, 
 
 export function useFlowRuns(params?: {
   status?: string
+  statuses?: string[]
+  query?: string
   workflowId?: string
   limit?: number
   offset?: number


### PR DESCRIPTION
## Problem
The workflow overview run list has no status or keyword controls, making it difficult to locate failed runs or records from a particular Bot across a large history.

## Solution
- Add a compact status selector, keyword search (button or Enter), and reset control to the run list.
- Search run ID, initiator (`triggered_by`), and origin Bot ID server-side across all historical records.
- Combine keyword and status filters before counting and pagination; reset to the first page when filters change.
- Support both `cancelled` and `canceled` for the cancellation filter.
- Preserve the independent 7/30-day metric queries and show a distinct no-match empty state.
- Bind SQL parameters and escape LIKE wildcard characters for literal substring matching.

## Validation
- Confirmed new UI and repository regression tests failed before implementation.
- Focused workflow tests: 11 passed (overview behavior and SQLite repository filtering/pagination).
- Shared package build: passed.
- Workflow type check and build: passed.
- `git diff --check` and pre-push gate: passed.
- Live browser verification and production deployment were not performed.

## Compatibility and risk
The optional `query` parameter extends the existing run-list API; existing callers remain unchanged. No database migration or independent time filter is added. Substring search can increase query cost on large histories. This PR is independent of the automatic-analysis Bot-owner fix in #2116.