### PR TITLE
fix(bcs): make participant add/remove CAS immune to serialization drift

### DIFF
--- a/src/bcs/crates/services/bcs-session-store/src/mysql.rs
+++ b/src/bcs/crates/services/bcs-session-store/src/mysql.rs
@@ -1461,9 +1461,9 @@ impl SessionRepoPort for MySqlSessionStore {
         &self,
         command: AddSessionParticipantWithEvent,
     ) -> ServiceResult<Session> {
-        let mut candidate = self
-            .get(&command.session_id)
-            .await
+        let (mut candidate, stored_participants_json) = self
+            .load_with_raw_participants(&command.session_id)
+            .await?
             .ok_or_else(|| ServiceError::SessionNotFound(command.session_id.clone()))?;
         if candidate
             .participants
@@ -1481,8 +1481,6 @@ impl SessionRepoPort for MySqlSessionStore {
             )));
         }
 
-        let expected_json = serde_json::to_string(&command.expected_participants)
-            .map_err(|error| ServiceError::SessionInvalidParams(error.to_string()))?;
         let bot_uuid = command.participant.bot_uuid.clone();
         let role = participant_role_to_str(command.participant.role);
         let mut join_map = candidate
@@ -1528,7 +1526,7 @@ impl SessionRepoPort for MySqlSessionStore {
                 vec![
                     DbValue::from(self.env.as_str()),
                     DbValue::from(command.session_id.as_str()),
-                    DbValue::from(expected_json.as_str()),
+                    DbValue::from(stored_participants_json.as_str()),
                 ],
             )),
             DbTransactionStep::Execute(DbStatement::with_transaction_params(
@@ -1538,7 +1536,7 @@ impl SessionRepoPort for MySqlSessionStore {
                     DbTransactionParam::value(join_seq_json.to_string()),
                     DbTransactionParam::value(self.env.as_str()),
                     DbTransactionParam::query_result(0, 0, "session_id"),
-                    DbTransactionParam::value(expected_json.as_str()),
+                    DbTransactionParam::value(stored_participants_json.as_str()),
                 ],
             )),
             DbTransactionStep::Execute(DbStatement::with_params(
@@ -1562,10 +1560,16 @@ impl SessionRepoPort for MySqlSessionStore {
         })?;
         steps.extend(event_plan.steps);
         self.db.transaction(steps).await.map_err(|error| {
-            ServiceError::Conflict(format!(
-                "Session '{}' changed during participant addition: {error}",
-                command.session_id
-            ))
+            if transaction_lock_row_is_missing(&error) {
+                // The CAS lock row vanished: a concurrent writer changed or
+                // deleted the session between the pre-check read and the lock.
+                ServiceError::Conflict(format!(
+                    "Session '{}' changed during participant addition",
+                    command.session_id
+                ))
+            } else {
+                ServiceError::InternalError(format!("session db: {error}"))
+            }
         })?;
         Ok(candidate)
     }
@@ -1640,9 +1644,9 @@ impl SessionRepoPort for MySqlSessionStore {
         &self,
         command: RemoveSessionParticipantWithEvent,
     ) -> ServiceResult<Session> {
-        let mut candidate = self
-            .get(&command.session_id)
-            .await
+        let (mut candidate, stored_participants_json) = self
+            .load_with_raw_participants(&command.session_id)
+            .await?
             .ok_or_else(|| ServiceError::SessionNotFound(command.session_id.clone()))?;
         if serde_json::to_value(&candidate.participants).ok()
             != serde_json::to_value(&command.expected_participants).ok()
@@ -1665,8 +1669,6 @@ impl SessionRepoPort for MySqlSessionStore {
         candidate.updated_at = current_millis();
         validate_session_event_scope(&candidate, &command.event)?;
 
-        let expected_json = serde_json::to_string(&command.expected_participants)
-            .map_err(|error| ServiceError::SessionInvalidParams(error.to_string()))?;
         let participants_json = serde_json::to_string(&candidate.participants)
             .map_err(|error| ServiceError::SessionInvalidParams(error.to_string()))?;
         let lock_sql = format!(
@@ -1685,7 +1687,7 @@ impl SessionRepoPort for MySqlSessionStore {
                 vec![
                     DbValue::from(self.env.as_str()),
                     DbValue::from(command.session_id.as_str()),
-                    DbValue::from(expected_json.as_str()),
+                    DbValue::from(stored_participants_json.as_str()),
                 ],
             )),
             DbTransactionStep::Execute(DbStatement::with_transaction_params(
@@ -1694,7 +1696,7 @@ impl SessionRepoPort for MySqlSessionStore {
                     DbTransactionParam::value(participants_json.as_str()),
                     DbTransactionParam::value(self.env.as_str()),
                     DbTransactionParam::query_result(0, 0, "session_id"),
-                    DbTransactionParam::value(expected_json.as_str()),
+                    DbTransactionParam::value(stored_participants_json.as_str()),
                 ],
             )),
             DbTransactionStep::Execute(DbStatement::with_params(
@@ -1717,10 +1719,16 @@ impl SessionRepoPort for MySqlSessionStore {
         })?;
         steps.extend(event_plan.steps);
         self.db.transaction(steps).await.map_err(|error| {
-            ServiceError::Conflict(format!(
-                "Session '{}' changed during participant removal: {error}",
-                command.session_id
-            ))
+            if transaction_lock_row_is_missing(&error) {
+                // The CAS lock row vanished: a concurrent writer changed or
+                // deleted the session between the pre-check read and the lock.
+                ServiceError::Conflict(format!(
+                    "Session '{}' changed during participant removal",
+                    command.session_id
+                ))
+            } else {
+                ServiceError::InternalError(format!("session db: {error}"))
+            }
         })?;
         Ok(candidate)
     }

--- a/src/bcs/crates/services/bcs-session-store/tests/conformance_session_repo.rs
+++ b/src/bcs/crates/services/bcs-session-store/tests/conformance_session_repo.rs
@@ -10,7 +10,8 @@ use bcs_db_api::{
 use bcs_db_local::LocalSqliteDbPlugin;
 use bcs_service_api::port::NewEvent;
 use bcs_service_api::port::repo::{
-    AppendEventRecord, NewSessionParams, SessionRepoPort,
+    AddSessionParticipantWithEvent, AppendEventRecord, NewSessionParams,
+    RemoveSessionParticipantWithEvent, SessionRepoPort,
     UpdateSessionParticipantMessageViewScopeWithEvent,
 };
 use bcs_service_api::types::{
@@ -525,4 +526,68 @@ async fn sqlite_scope_update_race_reports_clean_conflict() {
         }
         other => panic!("expected Conflict, got {other:?}"),
     }
+}
+
+#[tokio::test]
+async fn sqlite_add_participant_with_event_succeeds_on_legacy_participants_bytes() {
+    let db = sqlite_db().await;
+    let repo = MySqlSessionStore::sqlite(db.clone(), "dev".to_string());
+    let session = create_legacy_scope_session(&repo, &db).await;
+
+    let stored = repo.get(&session.id).await.expect("stored session");
+    let updated = repo
+        .add_participant_with_event(AddSessionParticipantWithEvent {
+            session_id: session.id.clone(),
+            expected_participants: stored.participants.clone(),
+            participant: Participant::bot("bot-2", ParticipantRole::Consultant),
+            event: scope_change_event(&session.id, &session.group_id),
+        })
+        .await
+        .expect("legacy participants bytes must not break the addition CAS");
+
+    assert!(
+        updated
+            .participants
+            .iter()
+            .any(|participant| participant.bot_uuid == "bot-2")
+    );
+    let reloaded = repo.get(&session.id).await.expect("reload session");
+    assert!(
+        reloaded
+            .participants
+            .iter()
+            .any(|participant| participant.bot_uuid == "bot-2")
+    );
+}
+
+#[tokio::test]
+async fn sqlite_remove_participant_with_event_succeeds_on_legacy_participants_bytes() {
+    let db = sqlite_db().await;
+    let repo = MySqlSessionStore::sqlite(db.clone(), "dev".to_string());
+    let session = create_legacy_scope_session(&repo, &db).await;
+
+    let stored = repo.get(&session.id).await.expect("stored session");
+    let updated = repo
+        .remove_participant_with_event(RemoveSessionParticipantWithEvent {
+            session_id: session.id.clone(),
+            expected_participants: stored.participants.clone(),
+            bot_uuid: "human-1".to_string(),
+            event: scope_change_event(&session.id, &session.group_id),
+        })
+        .await
+        .expect("legacy participants bytes must not break the removal CAS");
+
+    assert!(
+        !updated
+            .participants
+            .iter()
+            .any(|participant| participant.bot_uuid == "human-1")
+    );
+    let reloaded = repo.get(&session.id).await.expect("reload session");
+    assert!(
+        !reloaded
+            .participants
+            .iter()
+            .any(|participant| participant.bot_uuid == "human-1")
+    );
 }

--- a/src/bcs/crates/services/bcs-session-store/tests/conformance_session_repo.rs
+++ b/src/bcs/crates/services/bcs-session-store/tests/conformance_session_repo.rs
@@ -441,6 +441,7 @@ async fn sqlite_mode_and_scope_update_succeeds_on_legacy_participants_bytes() {
 struct ScopeRaceDb {
     inner: Arc<dyn DbPlugin>,
     sabotage: AtomicBool,
+    fail_transaction: AtomicBool,
 }
 
 #[async_trait]
@@ -457,6 +458,9 @@ impl DbPlugin for ScopeRaceDb {
         &self,
         steps: Vec<DbTransactionStep>,
     ) -> DbResult<Vec<DbTransactionStepResult>> {
+        if self.fail_transaction.swap(false, Ordering::SeqCst) {
+            return Err(DbError::Backend("forced transaction failure".to_string()));
+        }
         if self.sabotage.swap(false, Ordering::SeqCst) {
             self.inner
                 .execute(DbStatement::with_params(
@@ -479,6 +483,7 @@ async fn sqlite_scope_update_race_reports_clean_conflict() {
     let db = Arc::new(ScopeRaceDb {
         inner,
         sabotage: AtomicBool::new(false),
+        fail_transaction: AtomicBool::new(false),
     });
     let repo = MySqlSessionStore::sqlite(db.clone() as Arc<dyn DbPlugin>, "dev".to_string());
     let session = repo
@@ -590,4 +595,193 @@ async fn sqlite_remove_participant_with_event_succeeds_on_legacy_participants_by
             .iter()
             .any(|participant| participant.bot_uuid == "human-1")
     );
+}
+
+#[tokio::test]
+async fn sqlite_add_participant_with_event_race_reports_clean_conflict() {
+    let inner = sqlite_db().await;
+    let db = Arc::new(ScopeRaceDb {
+        inner,
+        sabotage: AtomicBool::new(false),
+        fail_transaction: AtomicBool::new(false),
+    });
+    let repo = MySqlSessionStore::sqlite(db.clone() as Arc<dyn DbPlugin>, "dev".to_string());
+    let session = repo
+        .create(
+            "group-race",
+            NewSessionParams {
+                participants: vec![Participant::bot("bot-1", ParticipantRole::Driver)],
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("create session");
+
+    let stored = repo.get(&session.id).await.expect("stored session");
+    db.sabotage.store(true, Ordering::SeqCst);
+
+    let error = repo
+        .add_participant_with_event(AddSessionParticipantWithEvent {
+            session_id: session.id.clone(),
+            expected_participants: stored.participants.clone(),
+            participant: Participant::bot("bot-2", ParticipantRole::Consultant),
+            event: scope_change_event(&session.id, &session.group_id),
+        })
+        .await
+        .expect_err("concurrent writer must produce a conflict");
+
+    match &error {
+        ServiceError::Conflict(message) => {
+            assert!(
+                !message.contains("references missing row"),
+                "conflict must not leak transaction binding internals: {message}"
+            );
+            assert!(
+                !message.contains("transaction parameter"),
+                "conflict must not leak transaction binding internals: {message}"
+            );
+            assert!(
+                message.contains(&session.id),
+                "conflict should identify the session: {message}"
+            );
+        }
+        other => panic!("expected Conflict, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn sqlite_remove_participant_with_event_race_reports_clean_conflict() {
+    let inner = sqlite_db().await;
+    let db = Arc::new(ScopeRaceDb {
+        inner,
+        sabotage: AtomicBool::new(false),
+        fail_transaction: AtomicBool::new(false),
+    });
+    let repo = MySqlSessionStore::sqlite(db.clone() as Arc<dyn DbPlugin>, "dev".to_string());
+    let session = repo
+        .create(
+            "group-race",
+            NewSessionParams {
+                participants: vec![
+                    Participant::bot("bot-1", ParticipantRole::Driver),
+                    Participant::human("human-1", ParticipantRole::Observer),
+                ],
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("create session");
+
+    let stored = repo.get(&session.id).await.expect("stored session");
+    db.sabotage.store(true, Ordering::SeqCst);
+
+    let error = repo
+        .remove_participant_with_event(RemoveSessionParticipantWithEvent {
+            session_id: session.id.clone(),
+            expected_participants: stored.participants.clone(),
+            bot_uuid: "human-1".to_string(),
+            event: scope_change_event(&session.id, &session.group_id),
+        })
+        .await
+        .expect_err("concurrent writer must produce a conflict");
+
+    match &error {
+        ServiceError::Conflict(message) => {
+            assert!(
+                !message.contains("references missing row"),
+                "conflict must not leak transaction binding internals: {message}"
+            );
+            assert!(
+                !message.contains("transaction parameter"),
+                "conflict must not leak transaction binding internals: {message}"
+            );
+            assert!(
+                message.contains(&session.id),
+                "conflict should identify the session: {message}"
+            );
+        }
+        other => panic!("expected Conflict, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn sqlite_add_participant_with_event_db_failure_maps_to_internal_error() {
+    let inner = sqlite_db().await;
+    let db = Arc::new(ScopeRaceDb {
+        inner,
+        sabotage: AtomicBool::new(false),
+        fail_transaction: AtomicBool::new(false),
+    });
+    let repo = MySqlSessionStore::sqlite(db.clone() as Arc<dyn DbPlugin>, "dev".to_string());
+    let session = repo
+        .create("group-db-fail", NewSessionParams::default())
+        .await
+        .expect("create session");
+
+    let stored = repo.get(&session.id).await.expect("stored session");
+    db.fail_transaction.store(true, Ordering::SeqCst);
+
+    let error = repo
+        .add_participant_with_event(AddSessionParticipantWithEvent {
+            session_id: session.id.clone(),
+            expected_participants: stored.participants.clone(),
+            participant: Participant::bot("bot-2", ParticipantRole::Consultant),
+            event: scope_change_event(&session.id, &session.group_id),
+        })
+        .await
+        .expect_err("db failure must propagate");
+
+    match &error {
+        ServiceError::InternalError(message) => {
+            assert!(
+                message.contains("forced transaction failure"),
+                "internal error should carry the db failure: {message}"
+            );
+        }
+        other => panic!("expected InternalError, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn sqlite_remove_participant_with_event_db_failure_maps_to_internal_error() {
+    let inner = sqlite_db().await;
+    let db = Arc::new(ScopeRaceDb {
+        inner,
+        sabotage: AtomicBool::new(false),
+        fail_transaction: AtomicBool::new(false),
+    });
+    let repo = MySqlSessionStore::sqlite(db.clone() as Arc<dyn DbPlugin>, "dev".to_string());
+    let session = repo
+        .create(
+            "group-db-fail",
+            NewSessionParams {
+                participants: vec![Participant::human("human-1", ParticipantRole::Observer)],
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("create session");
+
+    let stored = repo.get(&session.id).await.expect("stored session");
+    db.fail_transaction.store(true, Ordering::SeqCst);
+
+    let error = repo
+        .remove_participant_with_event(RemoveSessionParticipantWithEvent {
+            session_id: session.id.clone(),
+            expected_participants: stored.participants.clone(),
+            bot_uuid: "human-1".to_string(),
+            event: scope_change_event(&session.id, &session.group_id),
+        })
+        .await
+        .expect_err("db failure must propagate");
+
+    match &error {
+        ServiceError::InternalError(message) => {
+            assert!(
+                message.contains("forced transaction failure"),
+                "internal error should carry the db failure: {message}"
+            );
+        }
+        other => panic!("expected InternalError, got {other:?}"),
+    }
 }


### PR DESCRIPTION
## Problem

`POST /sessions/join/{token}` failed on sessions whose `participants` TEXT predates the `message_view_scope` field with a 409 leaking internals:

```
Session '...' changed during participant addition:
invalid database input: transaction parameter 3 references missing row 0 from step 0
```

#2103 fixed the two scope-update CAS sites in `MySqlSessionStore`, but `add_participant_with_event` and `remove_participant_with_event` carried the same pattern: the optimistic lock compared raw stored TEXT against a **re-serialization** of the parsed struct. Legacy rows parse equal (serde defaults `message_view_scope` to `full`) but serialize differently, so the CAS predicate could never match — the lock query returned zero rows and the transaction binding surfaced the miss as a leaked db-api error wrapped in Conflict. Any join/add/remove on a pre-#1986 session failed deterministically.

## Solution

Same pattern as #2103, applied to the remaining two sites:

- Both methods now use `load_with_raw_participants` and take the **stored raw bytes** as the CAS predicate (stored-bytes vs stored-bytes, immune to schema evolution). The structural pre-check against the caller's snapshot is unchanged; a successful write rewrites the column canonically, so legacy rows self-heal on first add/remove.
- Transaction error mapping via `transaction_lock_row_is_missing`: a missing CAS lock row (genuine concurrent writer between pre-check and lock) becomes a clean retryable 409 Conflict without leaking transaction binding internals; other transaction failures map to InternalError instead of being misreported as conflicts.

## Validation

- New tests (bcs-session-store, sqlite flavor): add-participant-with-event and remove-participant-with-event succeed on legacy participants bytes. Both were verified to fail before the fix, reproducing the production errors verbatim (`transaction parameter 3/2 references missing row 0 from step 0`).
- `cargo test --package bcs-session-store --package bcs-session --package bcs-app-session --package bcs-app-group`: all pass (40 + 79 + 85 + sub-suites).
- `cargo check --workspace --all-targets`: clean.
- Not run: real MySQL E2E (no deployment available here); the sqlite flavor exercises the same store code path, and byte equality on TEXT (`WHERE participants = ?`) has identical semantics on both backends.