### PR TITLE
feat(frontend): refine workspace and bot workshop UX

### DIFF
--- a/src/frontend-nextgen/OPEN_CORE_MANIFEST.json
+++ b/src/frontend-nextgen/OPEN_CORE_MANIFEST.json
@@ -1,6 +1,6 @@
 {
   "sourceRepository": "teamclaw",
-  "sourceCommit": "3414cb6b39ea6780e76fb79926e58be3a2c99ae9",
+  "sourceCommit": "261f7741ad760b3887ad7812fc9b9a484aff6c8d",
   "sourceDirty": false,
   "exportSchemaVersion": 1,
   "target": "src/frontend-nextgen",

--- a/src/frontend-nextgen/src/components/BotWorkshop/CreateBotModal/AuthorizationPanel.tsx
+++ b/src/frontend-nextgen/src/components/BotWorkshop/CreateBotModal/AuthorizationPanel.tsx
@@ -1,70 +1,25 @@
-import { Button } from '@/components/ui/Button';
-import { ModalDescription, ModalFooter, ModalHeader, ModalTitle } from '@/components/ui/Modal';
 import type { BotCreateAuthorization } from '@/services/botWorkshop';
-import { ExternalLink, ShieldCheck } from 'lucide-react';
+import { createPortal } from 'react-dom';
 
+/** 老版 AgentPass 交互：授权页面直接覆盖视口，不嵌套在创建弹窗的内容框中。 */
 export function AuthorizationPanel({
   authorization,
-  creating,
-  onClose,
 }: {
   authorization: BotCreateAuthorization & { message?: string; error?: string };
-  creating: boolean;
-  onClose: () => void;
 }) {
-  return (
-    <>
-      <ModalHeader>
-        <div className="mb-2 flex size-10 items-center justify-center rounded-lg bg-primary text-primary-foreground">
-          <ShieldCheck aria-hidden className="size-5" />
-        </div>
-        <ModalTitle>完成 AgentPass 授权</ModalTitle>
-        <ModalDescription id="create-bot-description">
-          请在下方完成授权。授权成功后系统会自动确认并完成 Bot 创建，请勿重复提交。
-        </ModalDescription>
-      </ModalHeader>
-      {authorization.iframeUrl ? (
-        <iframe
-          title="AgentPass 授权"
-          src={authorization.iframeUrl}
-          className="h-[520px] w-full rounded-lg border border-border bg-background"
-          referrerPolicy="strict-origin-when-cross-origin"
-        />
-      ) : (
-        <div className="flex min-h-64 flex-col items-center justify-center rounded-lg border border-border bg-muted/30 p-6 text-center">
-          <p className="m-0 text-xs text-muted-foreground">授权服务要求在新窗口中继续。</p>
-          <Button
-            className="mt-4"
-            leftIcon={<ExternalLink className="size-4" />}
-            onClick={() => window.open(authorization.redirectUrl, '_blank', 'noopener,noreferrer')}
-          >
-            打开授权页面
-          </Button>
-        </div>
-      )}
-      <div aria-live="polite" className="rounded-lg border border-border bg-muted/30 px-4 py-3 text-xs">
-        {authorization.error ? (
-          <span className="text-destructive">{authorization.error}</span>
-        ) : (
-          <span className="text-muted-foreground">
-            {authorization.message || '正在等待授权结果，完成后将自动关闭此窗口…'}
-          </span>
-        )}
-      </div>
-      <ModalFooter>
-        <Button variant="secondary" disabled={creating} onClick={onClose}>
-          取消创建
-        </Button>
-        {authorization.redirectUrl && authorization.iframeUrl ? (
-          <Button
-            variant="secondary"
-            leftIcon={<ExternalLink className="size-4" />}
-            onClick={() => window.open(authorization.redirectUrl, '_blank', 'noopener,noreferrer')}
-          >
-            新窗口打开
-          </Button>
-        ) : null}
-      </ModalFooter>
-    </>
+  const authorizationUrl = authorization.iframeUrl || authorization.redirectUrl;
+
+  if (typeof document === 'undefined') return null;
+
+  return createPortal(
+    <div className="fixed inset-0 z-[200] h-dvh w-screen bg-background">
+      <iframe
+        title="Bot 授权"
+        src={authorizationUrl}
+        className="h-full w-full border-none"
+        referrerPolicy="strict-origin-when-cross-origin"
+      />
+    </div>,
+    document.body,
   );
 }

--- a/src/frontend-nextgen/src/components/BotWorkshop/CreateBotModal/index.tsx
+++ b/src/frontend-nextgen/src/components/BotWorkshop/CreateBotModal/index.tsx
@@ -100,7 +100,7 @@ const CreateBotModal: React.FC<CreateBotModalProps> = ({
         className="overlay-scrollbar max-h-[calc(100vh-3rem)] max-w-[710px] p-4"
       >
         {authorization ? (
-          <AuthorizationPanel authorization={authorization} creating={creating} onClose={onClose} />
+          <AuthorizationPanel authorization={authorization} />
         ) : (
           <>
             <ModalHeader className="flex-row items-center gap-2.5 space-y-0">

--- a/src/frontend-nextgen/src/components/BotWorkshop/Editor/CapabilityMembers.tsx
+++ b/src/frontend-nextgen/src/components/BotWorkshop/Editor/CapabilityMembers.tsx
@@ -1,6 +1,7 @@
 import { Badge } from '@/components/ui/Badge';
 import { Button } from '@/components/ui/Button';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/Popover';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/Tooltip';
 import type { BotEditorCli, BotEditorMcp, BotEditorSkill } from '@/domain/botEditor';
 import { FileCheck, FileText, Loader2, Plus, Terminal, Trash2, User } from 'lucide-react';
 import { useState } from 'react';
@@ -11,6 +12,7 @@ interface CapabilityMembersProps {
   editable: boolean;
   identities?: Record<string, 'caller' | 'owner'>;
   identityEditable?: boolean;
+  identityDisabledReason?: string;
   updatingIdentityId?: string;
   onIdentity?: (id: string, identity: 'caller' | 'owner') => Promise<void>;
   onAdd?: () => void;
@@ -24,6 +26,7 @@ export function CapabilityMembers({
   identities = {},
   onIdentity,
   identityEditable = false,
+  identityDisabledReason,
   updatingIdentityId,
   onAdd,
   onRemove,
@@ -66,7 +69,7 @@ export function CapabilityMembers({
               )}
               <span className="min-w-0 flex-1 truncate text-xs">{item.name}</span>
               {'version' in item && item.version ? <Badge>{item.version}</Badge> : null}
-              {kind === 'mcp' ? (
+              {kind === 'mcp' && identityEditable ? (
                 <Popover>
                   <PopoverTrigger asChild>
                     <Button
@@ -119,6 +122,25 @@ export function CapabilityMembers({
                     </Button>
                   </PopoverContent>
                 </Popover>
+              ) : kind === 'mcp' ? (
+                <TooltipProvider delayDuration={0}>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span data-testid={`mcp-identity-disabled-${id}`} className="inline-flex" tabIndex={0}>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          disabled
+                          aria-label={`${item.name}访问方式不可切换`}
+                          leftIcon={<User className="size-3.5" />}
+                        >
+                          Owner
+                        </Button>
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent>{identityDisabledReason || '当前 Bot 不支持切换 MCP 访问方式'}</TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
               ) : null}
               {kind !== 'cli' ? (
                 <Button

--- a/src/frontend-nextgen/src/components/BotWorkshop/Editor/CapabilitySetManager.tsx
+++ b/src/frontend-nextgen/src/components/BotWorkshop/Editor/CapabilitySetManager.tsx
@@ -34,6 +34,7 @@ export interface CapabilitySetManagerProps {
   candidatesLoading?: boolean;
   mcpCallTypes?: Record<string, 'caller' | 'owner'>;
   callerContextEditable?: boolean;
+  mcpIdentityDisabledReason?: string;
   updatingCallType?: string;
   onMcpCallType?: (serverCode: string, callType: 'caller' | 'owner') => Promise<void>;
 }
@@ -154,6 +155,7 @@ export function CapabilitySetManager(props: CapabilitySetManagerProps) {
                       editable={editable}
                       identities={props.mcpCallTypes}
                       identityEditable={props.callerContextEditable}
+                      identityDisabledReason={props.mcpIdentityDisabledReason}
                       updatingIdentityId={props.updatingCallType}
                       onIdentity={props.onMcpCallType}
                       onAdd={set.isDefault || !canAddMcp ? undefined : () => openPicker(set, 'mcp')}

--- a/src/frontend-nextgen/src/components/BotWorkshop/Editor/ChannelConfigPanel.tsx
+++ b/src/frontend-nextgen/src/components/BotWorkshop/Editor/ChannelConfigPanel.tsx
@@ -2,6 +2,7 @@ import { Badge } from '@/components/ui/Badge';
 import { Button } from '@/components/ui/Button';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import { Empty } from '@/components/ui/Empty';
+import { Switch } from '@/components/ui/Switch';
 import type { BotChannel, BotChannelInput, ChannelBindingMode } from '@/domain/botAdvancedConfig';
 import { CircleHelp, Pencil, Plus, Trash2 } from 'lucide-react';
 import { useState } from 'react';
@@ -74,52 +75,73 @@ export function ChannelConfigPanel({
           <Badge tone="neutral">{modeLabel}</Badge>
         </div>
         {visibleChannels.length ? (
-          visibleChannels.map((channel) => (
-            <div key={channel.id} className="flex items-center gap-4 rounded-lg border border-border p-3">
-              <div className="min-w-0 flex-1">
-                <p className="m-0 font-medium">钉钉 · {channel.description || channel.clientId}</p>
-                <p className="m-0 mt-1 text-xs text-muted-foreground">
-                  {bindingMode === 'bcn_gateway' ? `Robot Code：${channel.robotCode || '未配置'} · ` : ''}
-                  Client ID：{channel.clientId} · Secret {channel.hasSecret ? '已配置' : '未配置'}
-                </p>
-                <p className="m-0 mt-1 text-xs text-muted-foreground">
-                  流式输出：{channel.enableStreamingCards ? '已开启' : '已关闭'}
-                  {bindingMode === 'plugin'
-                    ? ` · 私聊：${channel.dmPolicy === 'open' ? '允许' : '禁止'}`
-                    : ` · 会话：${channel.groupChatScope === 'conversation_shared' ? '群内共享' : '按发送者隔离'}`}
-                  {channel.createdAt
-                    ? ` · 创建于 ${new Date(channel.createdAt).toLocaleString('zh-CN', { hour12: false })}`
-                    : ''}
-                </p>
-              </div>
-              <Badge tone={channel.status === 'active' ? 'success' : 'neutral'}>
-                {channel.status === 'active' ? '已启用' : '已停用'}
-              </Badge>
-              <Button variant="secondary" size="sm" disabled={!editable} onClick={() => void onToggle(channel)}>
-                {channel.status === 'active' ? '停用' : '启用'}
-              </Button>
-              <Button
-                variant="ghost"
-                size="icon"
-                disabled={!editable}
-                aria-label={`编辑${channel.description || channel.clientId}`}
-                leftIcon={<Pencil className="size-4" />}
-                onClick={() => {
-                  setEditing(channel);
-                  setOpen(true);
-                }}
-              />
-              <ConfirmDialog
-                title="删除渠道"
-                description="删除后需重新配置凭证。"
-                confirmVariant="destructive"
-                disabled={!editable}
-                onConfirm={() => onDelete(channel.id)}
-              >
-                <Button variant="ghost" size="icon" aria-label="删除渠道" leftIcon={<Trash2 className="size-4" />} />
-              </ConfirmDialog>
+          <div className="overflow-x-auto rounded-lg border border-border">
+            <div className="grid min-w-[780px] grid-cols-[minmax(150px,1.4fr)_90px_minmax(150px,1.2fr)_100px_150px_100px] gap-3 border-b border-border bg-muted px-4 py-2 text-xs font-medium text-muted-foreground">
+              <span>场景描述</span>
+              <span>绑定环境</span>
+              <span>{bindingMode === 'plugin' ? '机器人 ID' : 'Robot Code'}</span>
+              <span>状态</span>
+              <span>创建时间</span>
+              <span className="text-right">操作</span>
             </div>
-          ))
+            {visibleChannels.map((channel) => (
+              <div
+                key={channel.id}
+                className="grid min-w-[780px] grid-cols-[minmax(150px,1.4fr)_90px_minmax(150px,1.2fr)_100px_150px_100px] items-center gap-3 border-b border-border px-4 py-3 text-xs last:border-b-0"
+              >
+                <div className="min-w-0">
+                  <p className="m-0 truncate font-medium">{channel.description || '未命名场景'}</p>
+                  <p className="m-0 mt-1 truncate text-muted-foreground">
+                    流式输出：{channel.enableStreamingCards ? '已开启' : '已关闭'}
+                  </p>
+                </div>
+                <Badge tone="neutral">草稿态</Badge>
+                <span className="truncate">
+                  {bindingMode === 'plugin' ? channel.clientId : channel.robotCode || '未配置'}
+                </span>
+                <span className="flex items-center gap-2">
+                  <Switch
+                    size="sm"
+                    checked={channel.status === 'active'}
+                    disabled={!editable}
+                    aria-label={`${channel.description || channel.clientId}渠道状态`}
+                    onCheckedChange={() => void onToggle(channel)}
+                  />
+                  {channel.status === 'active' ? '启用' : '停用'}
+                </span>
+                <span className="text-muted-foreground">
+                  {channel.createdAt ? new Date(channel.createdAt).toLocaleString('zh-CN', { hour12: false }) : '--'}
+                </span>
+                <span className="flex justify-end gap-1">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    disabled={!editable}
+                    aria-label={`编辑${channel.description || channel.clientId}`}
+                    leftIcon={<Pencil className="size-4" />}
+                    onClick={() => {
+                      setEditing(channel);
+                      setOpen(true);
+                    }}
+                  />
+                  <ConfirmDialog
+                    title="删除渠道"
+                    description="删除后需重新配置凭证。"
+                    confirmVariant="destructive"
+                    disabled={!editable}
+                    onConfirm={() => onDelete(channel.id)}
+                  >
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      aria-label={`删除${channel.description || channel.clientId}`}
+                      leftIcon={<Trash2 className="size-4" />}
+                    />
+                  </ConfirmDialog>
+                </span>
+              </div>
+            ))}
+          </div>
         ) : (
           <Empty title={`暂无${modeLabel}配置`} description="点击“新建配置”绑定钉钉机器人。" />
         )}

--- a/src/frontend-nextgen/src/components/BotWorkshop/Editor/DebugChatPanel.tsx
+++ b/src/frontend-nextgen/src/components/BotWorkshop/Editor/DebugChatPanel.tsx
@@ -50,6 +50,7 @@ export function DebugChatPanel({ bot, runtimeStage }: { bot: BotDomain; runtimeS
   const [session, setSession] = useState<BotChatSessionView | null>(null);
   const [draft, setDraft] = useState('');
   const [loading, setLoading] = useState(true);
+  const [creatingSession, setCreatingSession] = useState(false);
   const chatBot = useMemo<ChatBotView>(
     () => ({
       botId: bot.id,
@@ -85,13 +86,18 @@ export function DebugChatPanel({ bot, runtimeStage }: { bot: BotDomain; runtimeS
   }, [loadSessions]);
   const create = async () => {
     if (!identityId) return;
-    const result = await botSessionService.createSession(chatBot, identityId, 'Bot 工坊调试');
-    if (!result.ok) {
-      toast.error(result.error.friendlyMessage);
-      return;
+    setCreatingSession(true);
+    try {
+      const result = await botSessionService.createSession(chatBot, identityId, 'Bot 工坊调试');
+      if (!result.ok) {
+        toast.error(result.error.friendlyMessage);
+        return;
+      }
+      setSessions((items) => [result.data, ...items]);
+      setSession(result.data);
+    } finally {
+      setCreatingSession(false);
     }
-    setSessions((items) => [result.data, ...items]);
-    setSession(result.data);
   };
   const send = () => {
     if (!draft.trim()) return;
@@ -126,16 +132,17 @@ export function DebugChatPanel({ bot, runtimeStage }: { bot: BotDomain; runtimeS
           leftIcon={<RefreshCw className="size-4" />}
           onClick={() => void loadSessions()}
         />
-        <Button variant="secondary" size="sm" leftIcon={<Plus className="size-4" />} onClick={() => void create()}>
-          新建会话
-        </Button>
-      </div>
-      <div className="border-b border-border p-3">
         <Select
           value={session?.sessionId ?? ''}
-          onValueChange={(id) => setSession(sessions.find((item) => item.sessionId === id) ?? null)}
+          onValueChange={(id) => {
+            if (id === '__create_session__') {
+              void create();
+              return;
+            }
+            setSession(sessions.find((item) => item.sessionId === id) ?? null);
+          }}
         >
-          <SelectTrigger aria-label="调试会话">
+          <SelectTrigger className="w-44" aria-label="新建或切换调试会话" disabled={creatingSession}>
             <SelectValue placeholder="请选择或新建会话" />
           </SelectTrigger>
           <SelectContent>
@@ -144,6 +151,12 @@ export function DebugChatPanel({ bot, runtimeStage }: { bot: BotDomain; runtimeS
                 {item.title}
               </SelectItem>
             ))}
+            <SelectItem value="__create_session__">
+              <span className="inline-flex items-center gap-2 text-primary">
+                {creatingSession ? <Loader2 className="size-3.5 animate-spin" /> : <Plus className="size-3.5" />}
+                新建会话
+              </span>
+            </SelectItem>
           </SelectContent>
         </Select>
       </div>

--- a/src/frontend-nextgen/src/components/MessageViewScope/MessageViewScopeField.tsx
+++ b/src/frontend-nextgen/src/components/MessageViewScope/MessageViewScopeField.tsx
@@ -14,7 +14,7 @@ export function MessageViewScopeField({ value, onChange, disabled, label = 'æ¶ˆæ
   const name = useId();
   return (
     <fieldset className="space-y-2 text-left" disabled={disabled}>
-      <legend className="mb-2 text-xs font-medium text-foreground">{label}</legend>
+      <legend className="mb-2 text-xs font-semibold text-muted-foreground">{label}</legend>
       <div className="space-y-2" role="radiogroup" aria-label={label}>
         {MESSAGE_VIEW_SCOPE_OPTIONS.map((option) => (
           <label
@@ -30,8 +30,8 @@ export function MessageViewScopeField({ value, onChange, disabled, label = 'æ¶ˆæ
               onChange={() => onChange(option.value)}
             />
             <span className="min-w-0">
-              <span className="block text-sm text-foreground">{option.label}</span>
-              <span className="mt-0.5 block text-xs text-muted-foreground">{option.description}</span>
+              <span className="block text-xs text-foreground">{option.label}</span>
+              <span className="mt-0.5 block text-[11px] leading-4 text-muted-foreground">{option.description}</span>
             </span>
           </label>
         ))}

--- a/src/frontend-nextgen/src/components/MessageViewScope/MessageViewScopeMenuButton.tsx
+++ b/src/frontend-nextgen/src/components/MessageViewScope/MessageViewScopeMenuButton.tsx
@@ -27,10 +27,10 @@ export function MessageViewScopeMenuButton({ onSelect, selected, disabled }: Mes
         <IconButton
           label="新建会话"
           size="sm"
-          icon={<Plus className="h-4 w-4" />}
+          icon={<Plus className="h-3.5 w-3.5" />}
           disabled={disabled}
           onClick={(event) => event.stopPropagation()}
-          className="rounded-md text-muted-foreground hover:bg-primary/10 hover:text-primary"
+          className="h-6 w-6 rounded-md text-muted-foreground hover:bg-primary/10 hover:text-primary"
         />
       </PopoverTrigger>
       <PopoverContent align="end" className="w-64 p-1">
@@ -52,8 +52,8 @@ export function MessageViewScopeMenuButton({ onSelect, selected, disabled }: Mes
               aria-hidden="true"
             />
             <span className="min-w-0">
-              <span className="block text-sm font-medium text-foreground">{option.label}</span>
-              <span className="mt-0.5 block text-xs text-muted-foreground">{option.description}</span>
+              <span className="block text-xs font-medium text-foreground">{option.label}</span>
+              <span className="mt-0.5 block text-[11px] leading-4 text-muted-foreground">{option.description}</span>
             </span>
           </Button>
         ))}

--- a/src/frontend-nextgen/src/components/Workspace/ChatPanel/chatPanelPresentation.tsx
+++ b/src/frontend-nextgen/src/components/Workspace/ChatPanel/chatPanelPresentation.tsx
@@ -26,7 +26,7 @@ function renderAvatar(name: string, avatarUrl?: string, fallbackAvatar?: string)
     return <img src={avatarUrl} alt={name} className="h-8 w-8 shrink-0 rounded-full object-cover" />;
   }
   return (
-    <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-foreground text-xs font-semibold text-background">
+    <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary/10 text-xs font-semibold text-primary">
       {fallbackAvatar || name.charAt(0)}
     </span>
   );
@@ -45,8 +45,7 @@ export function resolveSingleSender(
   }
   const senderId = typeof message.extra?.senderId === 'string' ? message.extra.senderId : undefined;
   const senderName = typeof message.extra?.senderName === 'string' ? message.extra.senderName.trim() : '';
-  const isCurrentUser =
-    !senderId || isSameHumanIdentity(senderId, authenticatedUserId, 'human');
+  const isCurrentUser = !senderId || isSameHumanIdentity(senderId, authenticatedUserId, 'human');
   const name = isCurrentUser
     ? authenticatedUserName?.trim() || (viewer?.kind === 'user' ? viewer.displayName : '') || senderName || '未命名成员'
     : senderName || senderId || '未命名成员';

--- a/src/frontend-nextgen/src/components/Workspace/ChatPanel/index.tsx
+++ b/src/frontend-nextgen/src/components/Workspace/ChatPanel/index.tsx
@@ -197,7 +197,7 @@ export function ChatPanel({
           className="flex h-16 border-b border-border bg-card px-3 sm:px-5"
           slotLeft={
             <div className="flex min-w-0 items-center gap-3">
-              <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-primary text-sm font-semibold text-primary-foreground">
+              <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-primary/10 text-sm font-semibold text-primary">
                 {target.avatar}
               </span>
               <div className="min-w-0">

--- a/src/frontend-nextgen/src/pages/BotWorkshop/Detail/index.tsx
+++ b/src/frontend-nextgen/src/pages/BotWorkshop/Detail/index.tsx
@@ -220,6 +220,9 @@ const BotWorkshopDetailPage: React.FC = () => {
               onMcp={editor.setSkillSetMcp}
               mcpCallTypes={editor.mcpCallTypes}
               callerContextEditable={editor.callerContextEditable}
+              mcpIdentityDisabledReason={
+                bot.serviceMode === 'service' ? undefined : '个人 Bot 固定使用 Owner 模式，不支持切换 MCP 访问方式'
+              }
               updatingCallType={editor.updatingCallType}
               onMcpCallType={editor.updateMcpCallType}
             />

--- a/src/frontend-nextgen/src/pages/Workspace/components/BotSessionSidebar/BotItem.tsx
+++ b/src/frontend-nextgen/src/pages/Workspace/components/BotSessionSidebar/BotItem.tsx
@@ -1,4 +1,4 @@
-import { Button, IconButton, Skeleton } from '@/components/ui';
+import { Badge, Button, IconButton, Skeleton } from '@/components/ui';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/Tooltip';
 import { getBotEngineLabel } from '@/domain/botEngine';
 import { getBotTypeLabel } from '@/domain/botType';
@@ -8,6 +8,7 @@ import { ChevronDown, ChevronRight, Plus } from 'lucide-react';
 import React, { useEffect, useRef, useState } from 'react';
 import type { BotSessionPageMeta } from '../../hooks/useBotSessionMap';
 import { AvatarTile } from '../AvatarTile';
+import { SIDEBAR_TAG_CLASS } from '../GroupSidebar/GroupItem.types';
 import { ListErrorState } from '../ListErrorState';
 import { SessionScopeFilter } from '../SessionScopeFilter';
 import { BotSessionItem } from './BotSessionItem';
@@ -124,28 +125,16 @@ export const BotItem = React.memo(function BotItem({
             </TooltipProvider>
             <div className="mt-1 flex min-w-0 items-center gap-1 truncate text-xs leading-4 text-muted-foreground">
               {(bot.isAgentCodingBot ? bot.templateName || 'AgentCoding' : botEngineLabel) && (
-                <span className="shrink-0">
+                <Badge tone="primary" className={SIDEBAR_TAG_CLASS}>
                   {bot.isAgentCodingBot ? bot.templateName || 'AgentCoding' : botEngineLabel}
-                </span>
+                </Badge>
               )}
               {(bot.isAgentCodingBot ? bot.templateName || 'AgentCoding' : botEngineLabel) && botTypeLabel && (
-                <>
-                  <span aria-hidden="true" className="text-muted-foreground/50">
-                    ·
-                  </span>
-                  <span className="shrink-0">{botTypeLabel}</span>
-                </>
+                <Badge tone="primary" className={SIDEBAR_TAG_CLASS}>
+                  {botTypeLabel}
+                </Badge>
               )}
-              {isUnavailable && (
-                <>
-                  {(botEngineLabel || botTypeLabel) && (
-                    <span aria-hidden="true" className="text-muted-foreground/50">
-                      ·
-                    </span>
-                  )}
-                  <span className="shrink-0">暂不支持单聊</span>
-                </>
-              )}
+              {isUnavailable && <span className="shrink-0">暂不支持单聊</span>}
             </div>
           </div>
           {bot.chatable &&
@@ -157,24 +146,25 @@ export const BotItem = React.memo(function BotItem({
             ))}
         </Button>
         {bot.chatable && !bot.isAgentCodingBot && (
-          <>
+          <div className="flex shrink-0 items-center gap-0.5" onClick={(event) => event.stopPropagation()}>
             <IconButton
               label="新建会话"
               size="sm"
-              icon={<Plus className="h-4 w-4" />}
-              className="rounded-md text-muted-foreground hover:bg-primary/10 hover:text-primary"
+              icon={<Plus className="h-3.5 w-3.5" />}
+              className="h-6 w-6 rounded-md text-muted-foreground hover:bg-primary/10 hover:text-primary"
               onClick={(event) => {
                 event.stopPropagation();
                 onCreateSession(bot.botId);
               }}
             />
             <SessionScopeFilter
+              compact
               value={sessionTab}
               onChange={handleSessionScopeChange}
               allCount={allSessionMeta?.total}
               favoriteCount={favoriteSessionMeta?.total}
             />
-          </>
+          </div>
         )}
       </div>
 

--- a/src/frontend-nextgen/src/pages/Workspace/components/GroupChatPane/SessionFilesModal.tsx
+++ b/src/frontend-nextgen/src/pages/Workspace/components/GroupChatPane/SessionFilesModal.tsx
@@ -97,14 +97,14 @@ export function SessionFilesModal({
           'border border-border bg-card text-foreground shadow-2xl',
         )}
       >
-        <ModalTitle className="sr-only">资源管理 · {sessionName}</ModalTitle>
+        <ModalTitle className="sr-only">文件管理 · {sessionName}</ModalTitle>
         <ModalDescription className="sr-only">查看、预览、下载本会话中已上传的文件。</ModalDescription>
 
         <header className="flex items-start justify-between gap-3 border-b border-border px-3 py-4 sm:px-6 sm:py-5">
           <div className="min-w-0 flex-1 pr-2">
             <div className="flex items-center gap-2">
               <FolderOpen className="h-5 w-5 shrink-0 text-primary" aria-hidden />
-              <h2 className="m-0 truncate text-base font-semibold text-foreground">资源管理 · {sessionName}</h2>
+              <h2 className="m-0 truncate text-base font-semibold text-foreground">文件管理</h2>
             </div>
             <p className="mt-1.5 text-sm leading-5 text-muted-foreground">
               已添加的资源仅对当前会话生效，协作群内所有成员均可查看与管理。
@@ -119,7 +119,6 @@ export function SessionFilesModal({
 
         <div className="flex items-center justify-between gap-4 border-b border-border px-3 pt-3 sm:px-6">
           <div className="rounded-t-lg bg-primary/10 px-4 py-2.5 text-[13px] font-medium text-primary">文件</div>
-          <span className="pb-2 text-xs text-muted-foreground">仅可访问当前协作群会话文件</span>
         </div>
 
         <div className="flex min-h-0 flex-1">
@@ -153,21 +152,24 @@ export function SessionFilesModal({
                 />
               ) : (
                 <TooltipProvider>
-                  <ul className="m-0 list-none p-0">
+                  <ul className="m-0 list-none space-y-1 p-0">
                     {readyFiles.map((file) => {
                       const isActive = file.fileId === selectedFile?.fileId;
                       return (
                         <li
                           key={file.fileId}
-                          className="group flex items-center gap-1 rounded-lg px-1.5 py-1 transition-colors hover:bg-muted/50"
+                          className={cn(
+                            'group flex items-center gap-1 rounded-lg px-2.5 py-2 transition-colors',
+                            isActive ? 'bg-primary/10' : 'hover:bg-muted/50',
+                          )}
                         >
                           <Button
                             type="button"
                             variant="ghost"
                             onClick={() => setSelectedId(file.fileId)}
                             className={cn(
-                              'min-w-0 flex-1 shrink justify-start gap-2 rounded-md px-2 py-1.5 text-left text-[13px] transition-colors',
-                              isActive ? 'bg-primary/10 text-primary' : 'text-foreground hover:text-primary',
+                              'min-w-0 flex-1 shrink justify-start gap-2 rounded-md px-1.5 py-0.5 text-left text-[13px] transition-colors hover:bg-transparent',
+                              isActive ? 'text-primary' : 'text-foreground hover:text-primary',
                             )}
                           >
                             <FileText
@@ -181,7 +183,7 @@ export function SessionFilesModal({
                                 </TooltipTrigger>
                                 <TooltipContent>{file.name}</TooltipContent>
                               </Tooltip>
-                              <span className="block truncate text-[11px] text-muted-foreground">
+                              <span className="mt-1 block truncate text-[11px] leading-4 text-muted-foreground">
                                 {file.ownerName} · {formatMonthDayTime(file.createdAt * 1000)}
                               </span>
                             </div>

--- a/src/frontend-nextgen/src/pages/Workspace/components/GroupChatPane/messageHelpers.tsx
+++ b/src/frontend-nextgen/src/pages/Workspace/components/GroupChatPane/messageHelpers.tsx
@@ -40,7 +40,7 @@ function renderBotAvatar(name: string, avatarUrl?: string, fallbackAvatar?: stri
     return <img src={avatarUrl} alt={name} className="h-8 w-8 shrink-0 rounded-full object-cover" />;
   }
   return (
-    <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-foreground text-xs font-semibold text-background">
+    <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary/10 text-xs font-semibold text-primary">
       {fallbackAvatar || name.charAt(0)}
     </span>
   );

--- a/src/frontend-nextgen/src/pages/Workspace/components/GroupHeader.tsx
+++ b/src/frontend-nextgen/src/pages/Workspace/components/GroupHeader.tsx
@@ -6,6 +6,7 @@ import type { DomainResult } from '@/services/workspace/identityService';
 import type { ProviderConnectionStatus } from '@tc-chat/adapters';
 import { FolderOpen, RefreshCw, Settings2, Share2 } from 'lucide-react';
 import { useState } from 'react';
+import { KIND_LABEL } from './GroupSidebar/GroupItem.types';
 import { ShareDialog } from './ManagePanel/ShareDialog';
 
 export type GroupPanelKind = 'none' | 'members' | 'manage' | 'sessionManage' | 'resources';
@@ -30,7 +31,7 @@ function connectionCopy(status: ProviderConnectionStatus, support: GroupChatStat
   if (support.phase === 'error') return { label: '连接失败', tone: 'error' as const };
   switch (status) {
     case 'connected':
-      return { label: '在线', tone: 'success' as const };
+      return { label: '已连接', tone: 'success' as const };
     case 'connecting':
       return { label: '连接中', tone: 'warning' as const };
     case 'reconnecting':
@@ -40,7 +41,7 @@ function connectionCopy(status: ProviderConnectionStatus, support: GroupChatStat
     case 'error':
       return { label: '连接失败', tone: 'error' as const };
     default:
-      return { label: '离线', tone: 'neutral' as const };
+      return { label: '已断开', tone: 'neutral' as const };
   }
 }
 
@@ -62,7 +63,14 @@ export function GroupHeader({
   const copy = connectionCopy(connectionStatus, supportState);
   const showReconnect =
     connectionStatus === 'disconnected' || connectionStatus === 'error' || connectionStatus === 'reconnecting';
-  const memberCount = selectedGroup?.participants?.length ?? 0;
+  const memberCount = selectedGroup?.participants?.length || selectedGroup?.participantCount || 0;
+  const subtitleLabel = [
+    selectedSession && selectedGroup ? selectedGroup.name : null,
+    memberCount > 0 ? `${memberCount} 个成员` : null,
+    selectedGroup ? KIND_LABEL[selectedGroup.kind] : null,
+  ]
+    .filter(Boolean)
+    .join(' · ');
 
   const handleShare = async (title: string, request: () => Promise<DomainResult<{ invitationUrl: string }>>) => {
     setShareOpen(true);
@@ -83,16 +91,11 @@ export function GroupHeader({
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2">
             <h2 className="m-0 truncate text-sm font-semibold text-foreground">
-              {selectedGroup?.name ?? '未选择协作群'}
+              {selectedSession?.title ?? selectedGroup?.name ?? '未选择协作群'}
             </h2>
             <Badge tone={copy.tone}>{copy.label}</Badge>
-            {selectedSession && (
-              <span className="truncate text-xs text-muted-foreground"># {selectedSession.title}</span>
-            )}
           </div>
-          <p className="m-0 mt-0.5 truncate text-xs text-muted-foreground">
-            {memberCount > 0 ? `${memberCount} 个成员` : '协作群 · 群组对话'}
-          </p>
+          <p className="m-0 mt-0.5 truncate text-xs text-muted-foreground">{subtitleLabel}</p>
         </div>
 
         <div className="flex items-center gap-1">
@@ -132,6 +135,7 @@ export function GroupHeader({
               icon={<Settings2 className="h-4 w-4" aria-hidden />}
               size="sm"
               variant={activePanel === 'sessionManage' ? 'primary' : 'ghost'}
+              data-manage-panel-trigger
               onClick={() => onTogglePanel(activePanel === 'sessionManage' ? 'none' : 'sessionManage')}
             />
           ) : selectedGroup ? (
@@ -140,6 +144,7 @@ export function GroupHeader({
               icon={<Settings2 className="h-4 w-4" aria-hidden />}
               size="sm"
               variant={activePanel === 'manage' ? 'primary' : 'ghost'}
+              data-manage-panel-trigger
               onClick={() => onTogglePanel(activePanel === 'manage' ? 'none' : 'manage')}
             />
           ) : null}

--- a/src/frontend-nextgen/src/pages/Workspace/components/GroupSidebar/GroupItem.tsx
+++ b/src/frontend-nextgen/src/pages/Workspace/components/GroupSidebar/GroupItem.tsx
@@ -1,5 +1,5 @@
 import { MessageViewScopeMenuButton } from '@/components/MessageViewScope';
-import { Button, IconButton } from '@/components/ui';
+import { Badge, Button, IconButton } from '@/components/ui';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -19,10 +19,17 @@ import { AvatarTile } from '../AvatarTile';
 import { ShareDialog } from '../ManagePanel/ShareDialog';
 import { SessionScopeFilter } from '../SessionScopeFilter';
 import type { GroupItemProps, SessionTab } from './GroupItem.types';
-import { KIND_LABEL, MEMBERSHIP_LABEL } from './GroupItem.types';
+import { KIND_LABEL, MEMBERSHIP_LABEL, SIDEBAR_TAG_CLASS } from './GroupItem.types';
 import { GroupSessionsList } from './GroupSessionsList';
 
 export type { SessionTab } from './GroupItem.types';
+
+/** 群类型标签配色：自由聊天=蓝、自定义协同=绿、任务协作=橙。 */
+const KIND_TONE: Record<GroupItemProps['group']['kind'], 'primary' | 'success' | 'warning'> = {
+  free_chat: 'primary',
+  task_dag: 'success',
+  task_master_slave: 'warning',
+};
 
 export const GroupItem = React.memo(function GroupItem({
   group,
@@ -129,21 +136,19 @@ export const GroupItem = React.memo(function GroupItem({
                 <TooltipTrigger asChild>
                   <div
                     aria-label={`协作群标签：${metadataLabel}`}
-                    className="mt-1 flex min-w-0 items-center gap-1 truncate text-xs leading-4 text-muted-foreground"
+                    className="mt-1 flex min-w-0 items-center gap-1 truncate text-xs leading-4"
                   >
                     {group.isPublic && (
-                      <>
-                        <span className="shrink-0 text-primary">公开</span>
-                        <span aria-hidden="true" className="text-muted-foreground/50">
-                          ·
-                        </span>
-                      </>
+                      <Badge tone="success" className={SIDEBAR_TAG_CLASS}>
+                        公开
+                      </Badge>
                     )}
-                    <span className="shrink-0">{KIND_LABEL[group.kind]}</span>
-                    <span aria-hidden="true" className="text-muted-foreground/50">
-                      ·
-                    </span>
-                    <span className="shrink-0">{membershipLabel}</span>
+                    <Badge tone={KIND_TONE[group.kind]} className={SIDEBAR_TAG_CLASS}>
+                      {KIND_LABEL[group.kind]}
+                    </Badge>
+                    <Badge tone="primary" className={SIDEBAR_TAG_CLASS}>
+                      {membershipLabel}
+                    </Badge>
                   </div>
                 </TooltipTrigger>
                 <TooltipContent>{metadataLabel}</TooltipContent>
@@ -151,66 +156,69 @@ export const GroupItem = React.memo(function GroupItem({
             </TooltipProvider>
           </div>
         </Button>
-        {viewerKind === 'user' ? (
-          <MessageViewScopeMenuButton onSelect={(scope) => onCreateSession(group.groupId, scope)} />
-        ) : (
-          <IconButton
-            label="新建会话"
-            size="sm"
-            icon={<Plus className="h-4 w-4" />}
-            className="rounded-md text-muted-foreground hover:bg-primary/10 hover:text-primary"
-            onClick={(event) => {
-              event.stopPropagation();
-              onCreateSession(group.groupId);
-            }}
-          />
-        )}
-        <SessionScopeFilter
-          value={sessionTab}
-          onChange={handleSessionScopeChange}
-          allCount={totalSessionCount}
-          favoriteCount={favoriteCount}
-        />
-        <Popover open={actionsOpen} onOpenChange={setActionsOpen}>
-          <PopoverTrigger asChild>
+        <div className="flex shrink-0 items-center gap-0.5" onClick={(event) => event.stopPropagation()}>
+          {viewerKind === 'user' ? (
+            <MessageViewScopeMenuButton onSelect={(scope) => onCreateSession(group.groupId, scope)} />
+          ) : (
             <IconButton
-              label="协作群操作"
+              label="新建会话"
               size="sm"
-              icon={<MoreHorizontal className="h-4 w-4" />}
-              className="rounded-md text-muted-foreground hover:bg-primary/10 hover:text-primary"
-              onClick={(event) => event.stopPropagation()}
-            />
-          </PopoverTrigger>
-          <PopoverContent align="end" className="w-44 p-1">
-            <Button
-              variant="ghost"
-              className="h-auto w-full justify-start gap-2 px-2 py-2 text-xs"
-              onClick={() => {
-                setActionsOpen(false);
-                onManageGroup(group.groupId);
+              icon={<Plus className="h-3.5 w-3.5" />}
+              className="h-6 w-6 rounded-md text-muted-foreground hover:bg-primary/10 hover:text-primary"
+              onClick={(event) => {
+                event.stopPropagation();
+                onCreateSession(group.groupId);
               }}
-            >
-              <Settings2 className="h-3.5 w-3.5" aria-hidden="true" />
-              管理协作群
-            </Button>
-            <Button
-              variant="ghost"
-              className="h-auto w-full justify-start gap-2 px-2 py-2 text-xs"
-              onClick={() => void handleShare()}
-            >
-              <Share2 className="h-3.5 w-3.5" aria-hidden="true" />
-              分享协作群
-            </Button>
-            <Button
-              variant="ghost"
-              className="h-auto w-full justify-start gap-2 px-2 py-2 text-xs text-destructive"
-              onClick={openDissolveConfirm}
-            >
-              <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
-              解散协作群
-            </Button>
-          </PopoverContent>
-        </Popover>
+            />
+          )}
+          <SessionScopeFilter
+            compact
+            value={sessionTab}
+            onChange={handleSessionScopeChange}
+            allCount={totalSessionCount}
+            favoriteCount={favoriteCount}
+          />
+          <Popover open={actionsOpen} onOpenChange={setActionsOpen}>
+            <PopoverTrigger asChild>
+              <IconButton
+                label="协作群操作"
+                size="sm"
+                icon={<MoreHorizontal className="h-3.5 w-3.5" />}
+                className="h-6 w-6 rounded-md text-muted-foreground hover:bg-primary/10 hover:text-primary"
+                onClick={(event) => event.stopPropagation()}
+              />
+            </PopoverTrigger>
+            <PopoverContent align="end" className="w-44 p-1">
+              <Button
+                variant="ghost"
+                className="h-auto w-full justify-start gap-2 px-2 py-2 text-xs"
+                onClick={() => {
+                  setActionsOpen(false);
+                  onManageGroup(group.groupId);
+                }}
+              >
+                <Settings2 className="h-3.5 w-3.5" aria-hidden="true" />
+                管理协作群
+              </Button>
+              <Button
+                variant="ghost"
+                className="h-auto w-full justify-start gap-2 px-2 py-2 text-xs"
+                onClick={() => void handleShare()}
+              >
+                <Share2 className="h-3.5 w-3.5" aria-hidden="true" />
+                分享协作群
+              </Button>
+              <Button
+                variant="ghost"
+                className="h-auto w-full justify-start gap-2 px-2 py-2 text-xs text-destructive"
+                onClick={openDissolveConfirm}
+              >
+                <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
+                解散协作群
+              </Button>
+            </PopoverContent>
+          </Popover>
+        </div>
       </div>
 
       {expanded && (

--- a/src/frontend-nextgen/src/pages/Workspace/components/GroupSidebar/GroupItem.types.ts
+++ b/src/frontend-nextgen/src/pages/Workspace/components/GroupSidebar/GroupItem.types.ts
@@ -42,3 +42,6 @@ export const MEMBERSHIP_LABEL: Record<NonNullable<GroupView['membership']>, stri
   direct: '固定群成员',
   session_only: '仅参与临时会话',
 };
+
+/** 侧栏条目元信息标签统一样式（群 tab / bot tab 共用）。 */
+export const SIDEBAR_TAG_CLASS = 'shrink-0 rounded px-1.5 py-0 text-[10px] leading-4';

--- a/src/frontend-nextgen/src/pages/Workspace/components/Modals/CreateGroupHeader.tsx
+++ b/src/frontend-nextgen/src/pages/Workspace/components/Modals/CreateGroupHeader.tsx
@@ -1,28 +1,9 @@
 import { ModalHeader, ModalTitle } from '@/components/ui/Modal';
-import type { IdentityView } from '@/domain/collaboration';
 
-interface Props {
-  activeIdentity?: IdentityView | null;
-  activeIdentityDisplayName: string;
-}
-
-export function CreateGroupHeader({ activeIdentity, activeIdentityDisplayName }: Props) {
+export function CreateGroupHeader() {
   return (
     <ModalHeader className="border-b border-border px-6 pb-4 pt-5">
-      <div className="flex min-w-0 items-center gap-2">
-        <ModalTitle className="m-0 shrink-0 text-base font-semibold text-foreground">发起协作</ModalTitle>
-        {activeIdentity && (
-          <>
-            <span className="text-xs text-muted-foreground">为</span>
-            <span className="shrink-0 rounded-full border border-primary/20 bg-primary/10 px-2 py-0.5 text-[11px] text-primary">
-              {activeIdentity.kind === 'bot' ? 'Bot' : '用户'}
-            </span>
-            <span className="max-w-44 truncate rounded-full bg-muted px-2 py-0.5 text-[11px] text-muted-foreground">
-              {activeIdentityDisplayName}
-            </span>
-          </>
-        )}
-      </div>
+      <ModalTitle className="m-0 shrink-0 text-base font-semibold text-foreground">发起协作</ModalTitle>
     </ModalHeader>
   );
 }

--- a/src/frontend-nextgen/src/pages/Workspace/components/Modals/CreateGroupModal.tsx
+++ b/src/frontend-nextgen/src/pages/Workspace/components/Modals/CreateGroupModal.tsx
@@ -214,7 +214,7 @@ export function CreateGroupModal({
         closeLabel="关闭发起协作弹窗"
         className="min-w-0 gap-0 overflow-hidden p-0"
       >
-        <CreateGroupHeader activeIdentity={activeIdentity} activeIdentityDisplayName={activeIdentityDisplayName} />
+        <CreateGroupHeader />
 
         <div className="flex min-h-0 min-w-0 max-w-full overflow-x-hidden">
           <div

--- a/src/frontend-nextgen/src/pages/Workspace/components/Modals/GroupConfigFields.tsx
+++ b/src/frontend-nextgen/src/pages/Workspace/components/Modals/GroupConfigFields.tsx
@@ -225,13 +225,11 @@ export function GroupConfigFields(props: GroupConfigFieldsProps) {
             协作定义 YAML
           </label>
           <YamlCodeEditor value={definitionYaml} onChange={onYamlChange} className="text-sm" />
-          <div className="mt-2 min-h-5 text-xs text-muted-foreground">
-            {yamlSummary.length > 0 ? (
-              <span>已识别顶层 key：{yamlSummary.join(' / ')}</span>
-            ) : (
+          {yamlSummary.length === 0 && (
+            <div className="mt-2 min-h-5 text-xs text-muted-foreground">
               <span>等待输入有效 YAML</span>
-            )}
-          </div>
+            </div>
+          )}
           {bindingSlot}
         </div>
       )}

--- a/src/frontend-nextgen/src/pages/Workspace/components/Modals/GroupLeaderSelect.tsx
+++ b/src/frontend-nextgen/src/pages/Workspace/components/Modals/GroupLeaderSelect.tsx
@@ -47,13 +47,13 @@ export function GroupLeaderSelect({
             <span className={cn('flex min-w-0 flex-1 items-center gap-2', !selected && 'text-muted-foreground')}>
               {selected ? (
                 <>
-                  <span className="max-w-44 truncate text-sm text-foreground">{selected.name}</span>
+                  <span className="max-w-44 truncate text-xs text-foreground">{selected.name}</span>
                   {selected.current && (
                     <span className="rounded-full bg-primary/10 px-1.5 py-0.5 text-[10px] text-primary">当前</span>
                   )}
                 </>
               ) : (
-                <span className="truncate text-sm">{placeholder}</span>
+                <span className="truncate text-xs">{placeholder}</span>
               )}
             </span>
             <ChevronDown

--- a/src/frontend-nextgen/src/pages/Workspace/components/Modals/GroupParticipantPicker.tsx
+++ b/src/frontend-nextgen/src/pages/Workspace/components/Modals/GroupParticipantPicker.tsx
@@ -65,7 +65,7 @@ export function GroupParticipantPicker({
   return (
     <div data-testid="group-participant-picker" className="w-full min-w-0 max-w-full">
       <div className="mb-2 flex items-center justify-between">
-        <span className="text-sm font-semibold text-foreground">
+        <span className="text-xs font-semibold text-muted-foreground">
           成员 Bot <span className="text-destructive">*</span>
         </span>
         <span className="rounded-lg border border-primary/20 bg-primary/10 px-2 py-0.5 text-xs font-semibold text-primary">

--- a/src/frontend-nextgen/src/pages/Workspace/components/SessionScopeFilter.tsx
+++ b/src/frontend-nextgen/src/pages/Workspace/components/SessionScopeFilter.tsx
@@ -11,6 +11,8 @@ interface SessionScopeFilterProps {
   onChange: (value: SessionScope) => void;
   allCount?: number;
   favoriteCount?: number;
+  /** 紧凑形态：按钮与图标调小，用于协作群条目行内按钮组。 */
+  compact?: boolean;
 }
 
 const SCOPE_OPTIONS: Array<{ value: SessionScope; label: string }> = [
@@ -18,9 +20,10 @@ const SCOPE_OPTIONS: Array<{ value: SessionScope; label: string }> = [
   { value: 'favorite', label: '已收藏会话' },
 ];
 
-export function SessionScopeFilter({ value, onChange, allCount, favoriteCount }: SessionScopeFilterProps) {
+export function SessionScopeFilter({ value, onChange, allCount, favoriteCount, compact }: SessionScopeFilterProps) {
   const [open, setOpen] = useState(false);
   const activeLabel = value === 'favorite' ? '已收藏会话' : '全部会话';
+  const iconSize = compact ? 'h-3.5 w-3.5' : 'h-4 w-4';
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -30,8 +33,8 @@ export function SessionScopeFilter({ value, onChange, allCount, favoriteCount }:
           size="sm"
           aria-pressed={value === 'favorite'}
           icon={
-            <span className="relative flex h-4 w-4 items-center justify-center">
-              <ListFilter className="h-4 w-4" aria-hidden="true" />
+            <span className={cn('relative flex items-center justify-center', iconSize)}>
+              <ListFilter className={iconSize} aria-hidden="true" />
               {value === 'favorite' && (
                 <span className="absolute -right-0.5 -top-0.5 h-1.5 w-1.5 rounded-full bg-primary" aria-hidden="true" />
               )}
@@ -39,6 +42,7 @@ export function SessionScopeFilter({ value, onChange, allCount, favoriteCount }:
           }
           className={cn(
             'rounded-md text-muted-foreground hover:bg-primary/10 hover:text-primary',
+            compact && 'h-6 w-6',
             value === 'favorite' && 'bg-primary/10 text-primary hover:bg-primary/15 hover:text-primary',
           )}
           onClick={(event) => event.stopPropagation()}

--- a/src/frontend-nextgen/src/pages/Workspace/components/WorkspaceManagePanels.tsx
+++ b/src/frontend-nextgen/src/pages/Workspace/components/WorkspaceManagePanels.tsx
@@ -2,6 +2,7 @@ import type { DeliveryPolicy, GroupView, IdentityView, SessionView } from '@/dom
 import type { DingTalkBindingState } from '@/services/workspace/channelBindingService';
 import type { PolicyResult } from '@/services/workspace/groupService';
 import type { DomainResult } from '@/services/workspace/identityService';
+import { useEffect } from 'react';
 import type { GroupPanelKind } from './GroupHeader';
 import type { GroupDingTalkConfig } from './ManagePanel/DingTalkConfigPanel';
 import { GroupManagePanel } from './ManagePanel/GroupManagePanel';
@@ -55,15 +56,38 @@ export function WorkspaceManagePanels(props: WorkspaceManagePanelsProps) {
     onClose,
   } = props;
 
+  // 点击面板外部自动收起：监听 pointerdown，命中面板本体、面板开关按钮（data-manage-panel-trigger）
+  // 或浮层（菜单/弹窗，避免侧栏「…」菜单打开面板时误关）之外的区域即关闭。
+  useEffect(() => {
+    if (activePanel !== 'manage' && activePanel !== 'sessionManage') return;
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target as Element | null;
+      if (!target?.closest) return;
+      if (
+        target.closest('[data-manage-panel="true"]') ||
+        target.closest('[data-manage-panel-trigger]') ||
+        target.closest('[role="dialog"], [role="menu"], [role="alertdialog"]')
+      ) {
+        return;
+      }
+      onClose();
+    };
+    document.addEventListener('pointerdown', handlePointerDown);
+    return () => document.removeEventListener('pointerdown', handlePointerDown);
+  }, [activePanel, onClose]);
+
   if (!group) return null;
 
   // 不再渲染全屏点击层:fixed inset-0 的 backdrop 会盖在侧栏与聊天区之上,拦截 pointer/touch,
   // 导致群列表与会话框无法上下滚动。面板改为与 members 面板一致的纯 inline 侧栏,
-  // 关闭由 ManagePanelHeader 的 X 按钮 / GroupHeader 齿轮 toggle 承担。
+  // 关闭由 ManagePanelHeader 的 X 按钮 / GroupHeader 齿轮 toggle / 点击面板外部（上方 effect）承担。
   return (
     <>
       {activePanel === 'manage' ? (
-        <div className="relative z-30 flex w-[min(380px,36vw)] max-w-[36vw] shrink-0 border-l border-border">
+        <div
+          data-manage-panel="true"
+          className="relative z-30 flex w-[min(380px,36vw)] max-w-[36vw] shrink-0 border-l border-border"
+        >
           <GroupManagePanel
             key={group.groupId}
             group={group}
@@ -90,7 +114,10 @@ export function WorkspaceManagePanels(props: WorkspaceManagePanelsProps) {
       ) : null}
 
       {activePanel === 'sessionManage' && session ? (
-        <div className="relative z-30 flex w-[min(380px,36vw)] max-w-[36vw] shrink-0 border-l border-border">
+        <div
+          data-manage-panel="true"
+          className="relative z-30 flex w-[min(380px,36vw)] max-w-[36vw] shrink-0 border-l border-border"
+        >
           <SessionManagePanel
             key={session.sessionId}
             session={session}

--- a/src/frontend-nextgen/test/components/BotWorkshop/AuthorizationPanel.test.tsx
+++ b/src/frontend-nextgen/test/components/BotWorkshop/AuthorizationPanel.test.tsx
@@ -1,0 +1,37 @@
+/** @jest-environment jsdom */
+
+import { AuthorizationPanel } from '@/components/BotWorkshop/CreateBotModal/AuthorizationPanel';
+import { Modal, ModalContent } from '@/components/ui/Modal';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+
+test('AgentPass 授权按老版交互使用无外框的全屏 iframe', () => {
+  render(
+    <Modal open>
+      <ModalContent>
+        <AuthorizationPanel
+          authorization={{
+            type: 'authorization_required',
+            botId: 'bot-1',
+            iframeUrl: 'https://agentpass.example/authorize',
+            redirectUrl: '',
+            request: {
+              bot_name: '测试 Bot',
+              bot_desc: '等待 AgentPass 授权',
+              engine: 'openclaw',
+              cluster_name: 'ACRA',
+              bot_type: 'personal',
+            },
+          }}
+        />
+      </ModalContent>
+    </Modal>,
+  );
+
+  const iframe = screen.getByTitle('Bot 授权');
+  expect(iframe).toHaveAttribute('src', 'https://agentpass.example/authorize');
+  expect(iframe).toHaveClass('h-full', 'w-full', 'border-none');
+  expect(iframe.parentElement).toHaveClass('fixed', 'inset-0', 'z-[200]');
+  expect(iframe.parentElement?.parentElement).toBe(document.body);
+  expect(screen.queryByRole('button', { name: '打开授权页面' })).not.toBeInTheDocument();
+});

--- a/src/frontend-nextgen/test/components/BotWorkshop/CapabilityMembers.test.tsx
+++ b/src/frontend-nextgen/test/components/BotWorkshop/CapabilityMembers.test.tsx
@@ -30,3 +30,17 @@ test('MCP 调用身份点击后展示说明并由用户明确选择', () => {
   fireEvent.click(screen.getByRole('button', { name: /Caller 模式/ }));
   expect(onIdentity).toHaveBeenCalledWith('mcp-1', 'caller');
 });
+
+test('个人 Bot 的 MCP 访问方式不可切换时展示原因', async () => {
+  render(
+    <CapabilityMembers
+      kind="mcp"
+      items={[{ serverCode: 'mcp-1', name: '知识检索', active: true }]}
+      editable
+      identityDisabledReason="个人 Bot 固定使用 Owner 模式，不支持切换访问方式"
+    />,
+  );
+
+  fireEvent.focus(screen.getByTestId('mcp-identity-disabled-mcp-1'));
+  expect(await screen.findByText('个人 Bot 固定使用 Owner 模式，不支持切换访问方式')).toBeInTheDocument();
+});

--- a/src/frontend-nextgen/test/components/BotWorkshop/ChannelConfigPanel.test.tsx
+++ b/src/frontend-nextgen/test/components/BotWorkshop/ChannelConfigPanel.test.tsx
@@ -85,3 +85,39 @@ test('按绑定方式分栏展示渠道，并在 BCN 表单回显对应配置', 
   expect(screen.getByDisplayValue('robot-2')).toBeInTheDocument();
   expect(screen.getByText('群内共享会话')).toBeInTheDocument();
 });
+
+test('按老版渠道表格展示草稿环境、机器人标识、状态和操作', () => {
+  render(
+    <ChannelConfigPanel
+      editable
+      channels={[
+        {
+          id: 3,
+          type: 'dingding',
+          bindingMode: 'plugin',
+          description: '发布通知群',
+          status: 'active',
+          clientId: 'ding-app-3',
+          hasSecret: true,
+          enableStreamingCards: false,
+          dmPolicy: 'open',
+          allowlist: ['*'],
+          replyToMessage: true,
+          aixEnable: true,
+          includeSenderName: true,
+          createdAt: '2026-09-10T08:00:00Z',
+        },
+      ]}
+      onCreate={jest.fn()}
+      onUpdate={jest.fn()}
+      onToggle={jest.fn()}
+      onDelete={jest.fn()}
+    />,
+  );
+
+  expect(screen.getByText('场景描述')).toBeInTheDocument();
+  expect(screen.getByText('绑定环境')).toBeInTheDocument();
+  expect(screen.getByText('机器人 ID')).toBeInTheDocument();
+  expect(screen.getByText('草稿态')).toBeInTheDocument();
+  expect(screen.getByText('ding-app-3')).toBeInTheDocument();
+});

--- a/src/frontend-nextgen/test/pages/Workspace/components/BotSessionSidebar/BotSessionSidebar.test.tsx
+++ b/src/frontend-nextgen/test/pages/Workspace/components/BotSessionSidebar/BotSessionSidebar.test.tsx
@@ -441,15 +441,15 @@ describe('BotSessionSidebar', () => {
     const createSessionButton = screen.getByRole('button', { name: '新建会话' });
     expect(createSessionButton).toBeInTheDocument();
     expect(createSessionButton).toHaveClass(
-      'h-7',
-      'w-7',
+      'h-6',
+      'w-6',
       'rounded-md',
       'text-muted-foreground',
       'hover:bg-primary/10',
       'hover:text-primary',
     );
     const scopeButton = screen.getByRole('button', { name: '会话范围：全部会话' });
-    expect(scopeButton).toHaveClass('h-7', 'w-7');
+    expect(scopeButton).toHaveClass('h-6', 'w-6');
     expect(scopeButton.querySelector('svg.lucide-list-filter')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Bot操作' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: '管理 Bot' })).not.toBeInTheDocument();

--- a/src/frontend-nextgen/test/pages/Workspace/components/GroupHeader.test.tsx
+++ b/src/frontend-nextgen/test/pages/Workspace/components/GroupHeader.test.tsx
@@ -1,0 +1,78 @@
+/** @jest-environment jsdom */
+import type { GroupView, SessionView } from '@/domain/collaboration';
+import { GroupHeader, type GroupHeaderProps } from '@/pages/Workspace/components/GroupHeader';
+import { expect, it, jest } from '@jest/globals';
+import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/jest-globals';
+import { render, screen } from '@testing-library/react';
+
+const group: GroupView = {
+  groupId: 'g1',
+  name: '主站群',
+  kind: 'task_dag',
+  status: 'active',
+  participants: [
+    { actorId: 'me', kind: 'human', name: '我', role: 'owner', mode: 'present' },
+    { actorId: 'bot1', kind: 'bot', name: '协作 Bot', role: 'driver', mode: 'auto' },
+  ],
+  participantCount: 2,
+  sessions: [],
+  lastMessageAt: 0,
+  createdAt: 0,
+  isPublic: false,
+  deliveryPolicy: 'send_to_driver',
+};
+
+const session: SessionView = {
+  sessionId: 's1',
+  groupId: 'g1',
+  title: '发布排期讨论',
+  kind: 'chat',
+  status: 'running',
+  participants: [],
+  lastMessageAt: 0,
+  createdAt: 0,
+  favorite: false,
+};
+
+const buildProps = (partial: Partial<GroupHeaderProps> = {}): GroupHeaderProps => ({
+  selectedGroup: group,
+  selectedSession: session,
+  supportState: { phase: 'ready', error: null },
+  connectionStatus: 'connected',
+  onReconnect: jest.fn(),
+  canManageGroup: { allowed: true },
+  activePanel: 'none',
+  onTogglePanel: jest.fn(),
+  onRequestDissolve: jest.fn(),
+  onRequestShareGroup: jest.fn(async () => ({ ok: true as const, data: { invitationUrl: 'http://example.com' } })),
+  onRequestShareSession: jest.fn(async () => ({ ok: true as const, data: { invitationUrl: 'http://example.com' } })),
+  ...partial,
+});
+
+it('选中会话时标题用会话名称，副标题展示群名/成员数/群类型', () => {
+  render(<GroupHeader {...buildProps()} />);
+  expect(screen.getByRole('heading', { name: '发布排期讨论' })).toBeInTheDocument();
+  expect(screen.getByText('主站群 · 2 个成员 · 自定义协同')).toBeInTheDocument();
+  expect(screen.queryByText('协作群 · 群组对话')).not.toBeInTheDocument();
+});
+
+it('未选会话时标题用群名称，副标题展示成员数与群类型', () => {
+  render(<GroupHeader {...buildProps({ selectedSession: null })} />);
+  expect(screen.getByRole('heading', { name: '主站群' })).toBeInTheDocument();
+  expect(screen.getByText('2 个成员 · 自定义协同')).toBeInTheDocument();
+});
+
+it('participants 为空时回退 participantCount', () => {
+  render(<GroupHeader {...buildProps({ selectedGroup: { ...group, participants: [] } })} />);
+  expect(screen.getByText('主站群 · 2 个成员 · 自定义协同')).toBeInTheDocument();
+});
+
+it('群聊连接状态文案：connected=已连接、disconnected=已断开', () => {
+  const { rerender } = render(<GroupHeader {...buildProps({ connectionStatus: 'connected' })} />);
+  expect(screen.getByText('已连接')).toBeInTheDocument();
+  expect(screen.queryByText('在线')).not.toBeInTheDocument();
+  rerender(<GroupHeader {...buildProps({ connectionStatus: 'disconnected' })} />);
+  expect(screen.getByText('已断开')).toBeInTheDocument();
+  expect(screen.queryByText('离线')).not.toBeInTheDocument();
+});

--- a/src/frontend-nextgen/test/pages/Workspace/components/GroupSidebar/GroupSidebar.test.tsx
+++ b/src/frontend-nextgen/test/pages/Workspace/components/GroupSidebar/GroupSidebar.test.tsx
@@ -256,7 +256,7 @@ describe('GroupSidebar', () => {
     expect(onToggleGroupExpanded).not.toHaveBeenCalled();
     const createSessionButton = screen.getByRole('button', { name: '新建会话' });
     const scopeButton = screen.getByRole('button', { name: '会话范围：全部会话' });
-    expect(scopeButton).toHaveClass('h-7', 'w-7');
+    expect(scopeButton).toHaveClass('h-6', 'w-6');
     expect(scopeButton.querySelector('svg.lucide-list-filter')).toBeInTheDocument();
     fireEvent.click(createSessionButton);
     fireEvent.click(screen.getByText('参与者视角'));
@@ -315,9 +315,8 @@ describe('GroupSidebar', () => {
       'shadow-md',
     );
     expect(filterPanel).not.toHaveClass('mx-[18px]', 'mt-2');
-    const sidebarScrollArea = screen
-      .getByLabelText('协作群会话列表：主站群')
-      .parentElement?.parentElement?.parentElement;
+    const sidebarScrollArea =
+      screen.getByLabelText('协作群会话列表：主站群').parentElement?.parentElement?.parentElement;
     expect(sidebarScrollArea).not.toContainElement(filterPanel);
     expect(screen.getByRole('radiogroup', { name: '协作群类型' })).toHaveClass('min-w-0');
     expect(screen.getByRole('radiogroup', { name: '协作群类型' }).querySelector('.flex')).toHaveClass(

--- a/src/frontend-nextgen/test/pages/Workspace/components/ManagePanel/ManagePanel.test.tsx
+++ b/src/frontend-nextgen/test/pages/Workspace/components/ManagePanel/ManagePanel.test.tsx
@@ -16,7 +16,7 @@ import type { PolicyResult } from '@/services/workspace/groupService';
 import { expect, it, jest } from '@jest/globals';
 import '@testing-library/jest-dom';
 import '@testing-library/jest-dom/jest-globals';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 
 const allowed: PolicyResult = { allowed: true };
 
@@ -257,4 +257,100 @@ it.each(['manage', 'sessionManage'] as const)('%s 入口将认证名称传递到
   expect(screen.getByText('其他成员')).toBeInTheDocument();
   expect(screen.getByText('协作 Bot')).toBeInTheDocument();
   expect(screen.queryByText('旧用户名称')).not.toBeInTheDocument();
+});
+
+// 点击面板外部自动收起：pointerdown 命中面板本体 / 齿轮开关（data-manage-panel-trigger）/
+// 浮层（role=dialog|menu|alertdialog）之外的区域时触发 onClose；命中面板本体或开关时不关闭。
+describe('WorkspaceManagePanels 点击外部自动收起', () => {
+  const buildProps = (activePanel: 'manage' | 'sessionManage', onClose: () => void): WorkspaceManagePanelsProps => {
+    const groupHandlers = groupProps();
+    const sessionHandlers = sessionProps();
+    return {
+      activePanel,
+      group,
+      session,
+      groupAdvancedConfigEnabled: true,
+      canManage: allowed,
+      identities: [],
+      activeIdentity: identity,
+      onClose,
+      onUpdateGroup: groupHandlers.onUpdate,
+      onDissolveGroup: groupHandlers.onDissolve,
+      onLeaveGroup: groupHandlers.onLeaveGroup,
+      onAddGroupMember: groupHandlers.onAddMember,
+      onRemoveGroupMember: groupHandlers.onRemoveMember,
+      onShareGroup: groupHandlers.onShare,
+      onSaveDingTalk: groupHandlers.onSaveDingTalk,
+      onToggleDingTalkActive: groupHandlers.onToggleDingTalkActive,
+      onDeleteDingTalk: groupHandlers.onDeleteDingTalk,
+      dingTalkBinding: null,
+      dingTalkLoading: false,
+      onRenameSession: sessionHandlers.onRename,
+      onDeleteSession: sessionHandlers.onDelete,
+      onLeaveSession: sessionHandlers.onLeaveSession,
+      onAddSessionMember: sessionHandlers.onAddMember,
+      onRemoveSessionMember: sessionHandlers.onRemoveMember,
+      onShareSession: sessionHandlers.onShare,
+    };
+  };
+
+  it('点击面板外部区域时关闭管理面板', () => {
+    const onClose = jest.fn();
+    render(
+      <div>
+        <div data-testid="outside">外部区域</div>
+        <WorkspaceManagePanels {...buildProps('manage', onClose)} />
+      </div>,
+    );
+    fireEvent.pointerDown(screen.getByTestId('outside'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('点击面板本体时不关闭', () => {
+    const onClose = jest.fn();
+    render(<WorkspaceManagePanels {...buildProps('manage', onClose)} />);
+    const panel = document.querySelector('[data-manage-panel="true"]');
+    expect(panel).not.toBeNull();
+    fireEvent.pointerDown(panel as Element);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('点击面板开关（data-manage-panel-trigger）时不由外部收起逻辑关闭', () => {
+    const onClose = jest.fn();
+    render(
+      <div>
+        <button type="button" data-manage-panel-trigger>
+          齿轮
+        </button>
+        <WorkspaceManagePanels {...buildProps('sessionManage', onClose)} />
+      </div>,
+    );
+    fireEvent.pointerDown(screen.getByRole('button', { name: '齿轮' }));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('点击浮层（role=dialog）内部时不关闭', () => {
+    const onClose = jest.fn();
+    render(
+      <div>
+        <div role="dialog">浮层内容</div>
+        <WorkspaceManagePanels {...buildProps('manage', onClose)} />
+      </div>,
+    );
+    fireEvent.pointerDown(screen.getByRole('dialog'));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('activePanel=none 时不监听外部点击', () => {
+    const onClose = jest.fn();
+    const props = { ...buildProps('manage', onClose), activePanel: 'none' as const };
+    render(
+      <div>
+        <div data-testid="outside">外部区域</div>
+        <WorkspaceManagePanels {...props} />
+      </div>,
+    );
+    fireEvent.pointerDown(screen.getByTestId('outside'));
+    expect(onClose).not.toHaveBeenCalled();
+  });
 });

--- a/src/frontend-nextgen/test/pages/Workspace/components/Modals/CreateGroupModal.test.tsx
+++ b/src/frontend-nextgen/test/pages/Workspace/components/Modals/CreateGroupModal.test.tsx
@@ -97,8 +97,8 @@ beforeEach(() => {
   });
 });
 
-it('发起协作顶栏只在当前 human ID 匹配时使用认证用户名，Bot 保留自身名称', () => {
-  const { rerender } = render(
+it('发起协作顶栏不再展示身份 chip，仅保留标题', () => {
+  render(
     <CreateGroupModal
       open
       activeIdentity={{ id: 'human_900004', kind: 'user', displayName: '900004', online: true }}
@@ -108,10 +108,15 @@ it('发起协作顶栏只在当前 human ID 匹配时使用认证用户名，Bot
       onCreated={jest.fn()}
     />,
   );
-  expect(screen.getByText('示例用户')).toBeInTheDocument();
-  expect(screen.queryByText('900004')).not.toBeInTheDocument();
+  expect(screen.getByRole('heading', { name: '发起协作' })).toBeInTheDocument();
+  // 「为 xxx」身份 chip 已移除：顶栏不再展示认证用户名 / 身份类型徽标。
+  expect(screen.queryByText('示例用户')).not.toBeInTheDocument();
+  expect(screen.queryByText('为')).not.toBeInTheDocument();
+});
 
-  rerender(
+it('Bot 身份未命名时自动群名保留自身名称而非认证用户名', async () => {
+  gs.createGroup.mockResolvedValue({ ok: true, data: { groupId: 'g9' } });
+  render(
     <CreateGroupModal
       open
       activeIdentity={{ id: 'bot_xxx:900004', kind: 'bot', displayName: '协作 Bot', online: true }}
@@ -121,8 +126,13 @@ it('发起协作顶栏只在当前 human ID 匹配时使用认证用户名，Bot
       onCreated={jest.fn()}
     />,
   );
-  expect(screen.getByText('协作 Bot')).toBeInTheDocument();
-  expect(screen.queryByText('示例用户')).not.toBeInTheDocument();
+  fireEvent.click(await screen.findByRole('button', { name: '确认创建' }));
+  await waitFor(() =>
+    expect(gs.createGroup).toHaveBeenCalledWith(expect.objectContaining({ name: expect.stringContaining('协作 Bot') })),
+  );
+  expect(gs.createGroup).not.toHaveBeenCalledWith(
+    expect.objectContaining({ name: expect.stringContaining('示例用户') }),
+  );
 });
 
 it('free_chat strategy posts delivery_policy on confirm', async () => {


### PR DESCRIPTION
## Problem
The nextgen open core export was behind the latest TeamClaw workspace and bot workshop UX refinements: the AgentPass authorization page was nested inside the create-bot modal frame (constraining the third-party page), bot channel configuration used card rows that scaled poorly, and collaboration group sidebar items needed cleaner tag and action affordances.

## Solution
- Synced the open core export to TeamClaw source commit `261f7741` and updated `OPEN_CORE_MANIFEST.json`.
- Bot authorization: the AgentPass iframe now renders as a full-viewport portal overlay instead of being nested in the create-bot modal content frame.
- Channel configuration: replaced card rows with a scrollable column layout (description, binding environment, robot ID, status, created time, actions) and added switch-based enable/disable.
- Group sidebar: group tag metadata (public/group kind/membership) now uses semantic `Badge` tones, actions are grouped with compact sizing, and event propagation is contained to the action area.
- Refined debug chat, capability members, message view scope, manage panels, create-group modal, and session files modal UX.
- Added and updated unit tests covering the authorization panel, channel config, capability members, group header/sidebar, and manage panels.

## Validation
- Mechanical export from TeamClaw source commit `261f7741` (`sourceDirty: false`); no manual code changes beyond the export.
- Diff scope: `src/frontend-nextgen` (33 files, +602/-298).
- Did not run frontend unit tests locally; CI will run the frontend gate on this PR.

## Compatibility and risk
- No public API contract changes; all updates are frontend-internal UI/UX.
- AgentPass authorization now takes over the full viewport during bot creation; the overlay closes automatically once authorization completes.
- Rollback path: revert this PR to restore the previous export.

## Spec
- Open Core export schema: `src/frontend-nextgen/OPEN_CORE_MANIFEST.json` (exportSchemaVersion 1)