### PR TITLE
feat(engine): wire DeepSeek Harness through community stack

### DIFF
--- a/src/baas/src/secbaas/community/core/service/bot_run/_baas_service.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_baas_service.py
@@ -1226,7 +1226,7 @@ class BaasBotService(BotService):
         if engine_type == "openclaw":
             # Fixed prefix 'agent:main:'
             return f"agent:main:session:{session_key}:user:{user_id}"
-        elif engine_type == "claude_code":
+        elif engine_type in {"claude_code", "deepseek_harness"}:
             return f"agent:{tc_bot_id}:session:{session_key}:user:{user_id}"
         elif engine_type == "teclaw":
             # 仅评测流量（eval_id 存在）时构造结构化 key，

--- a/src/baas/src/secbaas/community/core/service/bot_run/_bot_run_utils.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_bot_run_utils.py
@@ -14,7 +14,14 @@ if TYPE_CHECKING:
 logger = get_logger("core-bot-run")
 
 _SUPPORTED_ENGINES = frozenset(
-    {"openclaw", "teclaw", "aicoding", "hermes", "claude_code"}
+    {
+        "openclaw",
+        "teclaw",
+        "aicoding",
+        "hermes",
+        "claude_code",
+        "deepseek_harness",
+    }
 )
 
 

--- a/src/baas/src/secbaas/community/plugins/bot_service/real/_plugin.py
+++ b/src/baas/src/secbaas/community/plugins/bot_service/real/_plugin.py
@@ -30,7 +30,14 @@ from secbaas.community.spi.bot_service import (
 logger = get_logger("plugin-bot-service")
 
 _SUPPORTED_RUNTIME_ENGINE_TYPES = frozenset(
-    {"openclaw", "teclaw", "aicoding", "hermes", "claude_code"}
+    {
+        "openclaw",
+        "teclaw",
+        "aicoding",
+        "hermes",
+        "claude_code",
+        "deepseek_harness",
+    }
 )
 _CLAUDE_CODE_NORMAL_TEMPLATE = "normalCC"
 _BINDING_MAX_ATTEMPTS = 2

--- a/src/baas/tests/unit/core/service/bot_run/test_baas_service.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_baas_service.py
@@ -280,6 +280,20 @@ class TestSessionRoutingAffinityPrefix:
             == f"agent:{BOT_UUID}:session:run-1:user:u-1"
         )
 
+    @pytest.mark.parametrize("eval_id", [None, "eval-abc123"])
+    def test_deepseek_harness_uses_structured_affinity_key(
+        self, service, eval_id
+    ):
+        session_key = eval_id or "run-1"
+        assert service._create_session_consistency_key(
+            engine_type="deepseek_harness",
+            tc_bot_id=BOT_UUID,
+            user_id="u-1",
+            run_id="run-1",
+            session_id=None,
+            eval_id=eval_id,
+        ) == f"agent:{BOT_UUID}:session:{session_key}:user:u-1"
+
     def test_eval_id_ignored_when_session_id_provided(self, service):
         """session_id 已传入时直接返回，eval_id 不生效。"""
         assert (

--- a/src/baas/tests/unit/core/service/bot_run/test_bot_run_utils.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_bot_run_utils.py
@@ -565,6 +565,7 @@ class TestBindingDataToInfoEngineNormalization:
             # 其他已知引擎以 active_engine 为准,不受 template_type 影响
             ("hermes", "applicationCoding", "hermes"),
             ("openclaw", None, "openclaw"),
+            ("deepseek_harness", None, "deepseek_harness"),
             # 空 / 未知 active_engine 兜底 openclaw(与旧行为等价)
             ("", None, "openclaw"),
             ("unknown_engine", None, "openclaw"),

--- a/src/baas/tests/unit/core/service/bot_run/test_engine_dispatch_integration.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_engine_dispatch_integration.py
@@ -110,6 +110,13 @@ _CASES = [
         "agent:main:sess-oc",
     ),
     ("teclaw", "sess-tc", "/api/teclaw/ws", None, "sess-tc"),
+    (
+        "deepseek_harness",
+        "sess-dsh",
+        "/api/deepseek_harness/ws",
+        _AGENT_KEY,
+        "sess-dsh",
+    ),
 ]
 
 

--- a/src/baas/tests/unit/plugins/bot_service/test_bot_service_plugin.py
+++ b/src/baas/tests/unit/plugins/bot_service/test_bot_service_plugin.py
@@ -960,7 +960,14 @@ class TestAiohttpBotServicePluginRuntimeEngineSelection:
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "runtime_engine_type",
-        ["openclaw", "teclaw", "aicoding", "hermes", "claude_code"],
+        [
+            "openclaw",
+            "teclaw",
+            "aicoding",
+            "hermes",
+            "claude_code",
+            "deepseek_harness",
+        ],
     )
     async def test_supported_runtime_engine_overrides_original_engine(
         self, runtime_engine_type

--- a/src/backend/src/agentclaw/community/core/workspace/constants.py
+++ b/src/backend/src/agentclaw/community/core/workspace/constants.py
@@ -11,6 +11,7 @@ SUPPORTED_ENGINE_TYPES = [
     "moltis",
     "openclaw",
     "hermes",
+    "deepseek_harness",
     "aicoding",
     "claude_code",
     "teclaw",
@@ -36,7 +37,7 @@ def _get_engine_types() -> list[str]:
     2. SUPPORTED_ENGINE_TYPES 默认列表
 
     Returns:
-        list[str]: 引擎类型列表，如 ["moltis", "openclaw", "hermes", "aicoding", "teclaw"]
+        list[str]: 引擎类型列表，如 ["moltis", "openclaw", "deepseek_harness"]
     """
     env_engines = os.getenv("ENGINE_TYPES", "")
     if env_engines:

--- a/src/backend/src/agentclaw/community/core/workspace/engines/__init__.py
+++ b/src/backend/src/agentclaw/community/core/workspace/engines/__init__.py
@@ -5,6 +5,9 @@ from typing import Any
 from agentclaw.community.core.workspace.engine_sandbox import EngineSandboxRegistry
 from agentclaw.community.core.workspace.engines.aicoding import AICodingSandboxProvider
 from agentclaw.community.core.workspace.engines.claude_code import ClaudeCodeSandboxProvider
+from agentclaw.community.core.workspace.engines.deepseek_harness import (
+    DeepSeekHarnessSandboxProvider,
+)
 from agentclaw.community.core.workspace.engines.openclaw import OpenClawSandboxProvider
 from agentclaw.community.core.workspace.engines.hermes import HermesSandboxProvider
 from agentclaw.community.di import config as cfg
@@ -50,4 +53,5 @@ def create_engine_sandbox_registry(
     registry.register(ClaudeCodeSandboxProvider(workspace=workspace))
     registry.register(AICodingSandboxProvider(workspace=workspace))
     registry.register(HermesSandboxProvider(workspace=workspace))
+    registry.register(DeepSeekHarnessSandboxProvider(workspace=workspace))
     return registry

--- a/src/backend/src/agentclaw/community/core/workspace/engines/deepseek_harness.py
+++ b/src/backend/src/agentclaw/community/core/workspace/engines/deepseek_harness.py
@@ -1,0 +1,118 @@
+"""DeepSeek Harness sandbox filesystem adapter."""
+
+from __future__ import annotations
+
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from agentclaw.community.core.workspace.engine_sandbox import (
+    DirectoryItem,
+    EngineBuildPlan,
+    ReadOnlyRule,
+)
+from agentclaw.community.di import config as cfg
+from agentclaw.community.log import get_logger
+
+logger = get_logger()
+
+
+class DeepSeekHarnessSandboxProvider:
+    """Describe the DSH workspace and session layout used in an ARCA sandbox."""
+
+    def __init__(self, workspace: cfg.WorkspaceConfig) -> None:
+        self._workspace = workspace
+
+    @property
+    def engine_type(self) -> str:
+        return "deepseek_harness"
+
+    def get_base_path(self) -> str:
+        # 以下为安全注释COSEC：资源与只读目录接口仅暴露 workspace，禁止读取同级凭证文件。
+        return f"{self._workspace.deepseek_harness_root}/workspace"
+
+    def get_sessions_dir(self) -> str:
+        return f"{self._workspace.deepseek_harness_root}/sessions"
+
+    def get_default_read_only_rules(self) -> list[ReadOnlyRule]:
+        return []
+
+    def get_build_plan(
+        self,
+        build_rsync_excludes_append: list[str] | None = None,
+        bot: dict[str, Any] | None = None,
+    ) -> EngineBuildPlan:
+        del build_rsync_excludes_append, bot
+        raise ValueError("DeepSeek Harness service bot builds are not supported yet")
+
+    @staticmethod
+    def _normalize_sub_path(sub_path: str) -> str:
+        if not sub_path:
+            return ""
+        if "\x00" in sub_path:
+            raise ValueError(f"Invalid sub_path: {sub_path!r}")
+        path = PurePosixPath(sub_path)
+        if path.is_absolute() or ".." in path.parts:
+            raise ValueError(f"Invalid sub_path: {sub_path}")
+        normalized = str(path)
+        return "" if normalized == "." else normalized
+
+    async def list_directory(
+        self,
+        sub_path: str = "",
+        recursive: bool = False,
+        *,
+        device_fs=None,
+    ) -> list[DirectoryItem]:
+        sub_path = self._normalize_sub_path(sub_path)
+        items: list[DirectoryItem] = []
+        base_path = self.get_base_path()
+
+        if device_fs is not None:
+
+            async def walk(current_sub_path: str) -> None:
+                target = (
+                    f"{base_path}/{current_sub_path}" if current_sub_path else base_path
+                )
+                for item in await device_fs.list_dir(target, recursive=False) or ():
+                    name = item.get("name", "")
+                    if not name:
+                        continue
+                    relative_path = (
+                        f"{current_sub_path}/{name}" if current_sub_path else name
+                    )
+                    is_dir = item.get("is_dir", False)
+                    items.append(
+                        DirectoryItem(
+                            name=name,
+                            path=relative_path,
+                            is_dir=is_dir,
+                        )
+                    )
+                    if recursive and is_dir:
+                        await walk(relative_path)
+
+            await walk(sub_path)
+            return items
+
+        root = Path(base_path)
+        target = root / sub_path if sub_path else root
+        if target.exists() and target.is_dir():
+            entries = target.rglob("*") if recursive else target.iterdir()
+            for entry in entries:
+                items.append(
+                    DirectoryItem(
+                        name=entry.name,
+                        path=str(entry.relative_to(root)),
+                        is_dir=entry.is_dir(),
+                    )
+                )
+        else:
+            logger.info(
+                "[DeepSeekHarnessSandboxProvider.list_directory] local root %s "
+                "is absent",
+                root,
+            )
+        return items
+
+
+__all__ = ["DeepSeekHarnessSandboxProvider"]

--- a/src/backend/src/agentclaw/community/di/config.py
+++ b/src/backend/src/agentclaw/community/di/config.py
@@ -669,6 +669,7 @@ class WorkspaceConfig:
         claude_code_root: Same shape, for Claude Code bots.
         aicoding_root: Same shape, for AICoding bots.
         hermes_root: Same shape, for Hermes bots.
+        deepseek_harness_root: Same shape, for DeepSeek Harness bots.
     """
 
     openclaw_root: str = "/home/admin/.openclaw"
@@ -676,6 +677,7 @@ class WorkspaceConfig:
     claude_code_session_root: str = "/home/admin/.claude"
     aicoding_root: str = "/home/admin/.aicoding"
     hermes_root: str = "/home/admin/.hermes"
+    deepseek_harness_root: str = "/home/admin/.dsh"
 
 
 # ── Creating a bot with its configuration manifest (W13) ─────────────────

--- a/src/backend/src/agentclaw/community/di/modules/config_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/config_module.py
@@ -276,6 +276,10 @@ class ConfigModule(Module):
                 block.get("aicoding_root"), defaults.aicoding_root
             ),
             hermes_root=_expand(block.get("hermes_root"), defaults.hermes_root),
+            deepseek_harness_root=_expand(
+                block.get("deepseek_harness_root"),
+                defaults.deepseek_harness_root,
+            ),
         )
 
     # ── Access policy ───────────────────────────────────────────────

--- a/src/backend/src/agentclaw/community/di/modules/config_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/config_module.py
@@ -277,8 +277,7 @@ class ConfigModule(Module):
             ),
             hermes_root=_expand(block.get("hermes_root"), defaults.hermes_root),
             deepseek_harness_root=_expand(
-                block.get("deepseek_harness_root"),
-                defaults.deepseek_harness_root,
+                block.get("deepseek_harness_root"), defaults.deepseek_harness_root
             ),
         )
 

--- a/src/backend/src/agentclaw/community/di/modules/infrastructure/singlebox/template_config.py
+++ b/src/backend/src/agentclaw/community/di/modules/infrastructure/singlebox/template_config.py
@@ -16,7 +16,14 @@ logger = get_logger()
 
 _LOCAL_TEMPLATE_UID = "local_default"
 _TEMPLATE_UID_ALIASES = (_LOCAL_TEMPLATE_UID, "aicoding")
-_SUPPORTED_ENGINES = ("openclaw", "moltis", "hermes", "aicoding", "claude_code")
+_SUPPORTED_ENGINES = (
+    "openclaw",
+    "moltis",
+    "hermes",
+    "aicoding",
+    "claude_code",
+    "deepseek_harness",
+)
 
 
 class SingleboxBaasTemplateConfigLifecycle(LifecycleBase):

--- a/src/backend/tests/community/config/golden/community.json
+++ b/src/backend/tests/community/config/golden/community.json
@@ -327,6 +327,7 @@
       "aicoding_root": "<CWD>/data/workspace/aicoding",
       "claude_code_root": "<CWD>/data/workspace/claude_code",
       "claude_code_session_root": "/home/admin/.claude",
+      "deepseek_harness_root": "/home/admin/.dsh",
       "hermes_root": "<CWD>/data/workspace/hermes",
       "openclaw_root": "<CWD>/data/workspace/openclaw"
     },

--- a/src/backend/tests/community/config/golden/singlebox.json
+++ b/src/backend/tests/community/config/golden/singlebox.json
@@ -393,6 +393,7 @@
       "aicoding_root": "~/.aicoding",
       "claude_code_root": "~/.claude_code",
       "claude_code_session_root": "/home/admin/.claude",
+      "deepseek_harness_root": "/home/admin/.dsh",
       "hermes_root": "~/.hermes",
       "openclaw_root": "~/.openclaw"
     },

--- a/src/backend/tests/community/config/golden/test.json
+++ b/src/backend/tests/community/config/golden/test.json
@@ -253,6 +253,7 @@
       "aicoding_root": "~/.aicoding",
       "claude_code_root": "~/.claude_code",
       "claude_code_session_root": "/home/admin/.claude",
+      "deepseek_harness_root": "/home/admin/.dsh",
       "hermes_root": "~/.hermes",
       "openclaw_root": "~/.openclaw"
     },

--- a/src/backend/tests/community/core/bot_inventory/policies/test_combo_policy.py
+++ b/src/backend/tests/community/core/bot_inventory/policies/test_combo_policy.py
@@ -20,6 +20,7 @@ from agentclaw.community.core.bot_inventory.types import DeployMode
 @pytest.mark.unit
 def test_personal_cloud_supported_engine_matrix_includes_teclaw() -> None:
     assert "teclaw" in PERSONAL_CLOUD_CAPABLE_ENGINES
+    assert "deepseek_harness" in PERSONAL_CLOUD_CAPABLE_ENGINES
     for engine in PERSONAL_CLOUD_CAPABLE_ENGINES:
         assert assert_personal_cloud_create(engine, "personal").ok
         assert assert_personal_cloud_create(engine, "team").ok
@@ -67,10 +68,22 @@ def test_local_rejects_teclaw_cloud_only_engine() -> None:
 
 
 @pytest.mark.unit
+def test_local_rejects_deepseek_harness_cloud_only_engine() -> None:
+    rejected = assert_local_create("deepseek_harness", "personal")
+    assert not rejected.ok
+    assert rejected.reason == ("local bot does not support engine: deepseek_harness")
+    assert assert_personal_cloud_create("deepseek_harness", "personal").ok
+
+
+@pytest.mark.unit
 def test_service_upgrade_engine_matrix() -> None:
     assert SERVICE_CAPABLE_ENGINES == frozenset({"openclaw", "claude_code", "teclaw"})
     for engine in SERVICE_CAPABLE_ENGINES:
         assert assert_service_upgrade(engine).ok
+
+    rejected = assert_service_upgrade("deepseek_harness")
+    assert not rejected.ok
+    assert rejected.reason == "engine cannot be serviced: deepseek_harness"
 
     rejected = assert_service_upgrade("hermes")
     assert not rejected.ok

--- a/src/backend/tests/community/core/service_bot/services/test_baas_service_engine_aware_mounts.py
+++ b/src/backend/tests/community/core/service_bot/services/test_baas_service_engine_aware_mounts.py
@@ -15,6 +15,9 @@ from agentclaw.community.core.service_bot.services.baas_service import BaasServi
 from agentclaw.community.core.workspace.engine_sandbox import EngineSandboxRegistry
 from agentclaw.community.core.workspace.engines.aicoding import AICodingSandboxProvider
 from agentclaw.community.core.workspace.engines.claude_code import ClaudeCodeSandboxProvider
+from agentclaw.community.core.workspace.engines.deepseek_harness import (
+    DeepSeekHarnessSandboxProvider,
+)
 from agentclaw.community.core.workspace.engines.openclaw import OpenClawSandboxProvider
 from agentclaw.community.core.workspace.engines.hermes import HermesSandboxProvider
 from agentclaw.community.di import config as cfg
@@ -32,6 +35,7 @@ def _make_registry() -> EngineSandboxRegistry:
     registry.register(ClaudeCodeSandboxProvider(workspace=workspace))
     registry.register(AICodingSandboxProvider(workspace=workspace))
     registry.register(HermesSandboxProvider(workspace=workspace))
+    registry.register(DeepSeekHarnessSandboxProvider(workspace=workspace))
     return registry
 
 
@@ -282,6 +286,18 @@ class TestSetupSessionsDirEngineAware:
         )
 
         assert storage.path == "/home/admin/.claude/projects"
+
+    def test_deepseek_harness_sessions_path_uses_dsh_home(self):
+        composer = _make_composer()
+
+        storage = composer._setup_sessions_dir(
+            entity_id="u1",
+            entity_type="staff",
+            bot_id="b1",
+            engine_type="deepseek_harness",
+        )
+
+        assert storage.path == "/home/admin/.dsh/sessions"
 
     def test_empty_engine_type_falls_back_to_openclaw(self):
         bot_repo = MagicMock()

--- a/src/backend/tests/community/core/workspace/test_constants.py
+++ b/src/backend/tests/community/core/workspace/test_constants.py
@@ -14,6 +14,7 @@ def test_supported_engine_types():
     assert "moltis" in SUPPORTED_ENGINE_TYPES
     assert "aicoding" in SUPPORTED_ENGINE_TYPES
     assert "hermes" in SUPPORTED_ENGINE_TYPES
+    assert "deepseek_harness" in SUPPORTED_ENGINE_TYPES
     assert "teclaw" in SUPPORTED_ENGINE_TYPES
 
 

--- a/src/backend/tests/community/core/workspace/test_engine_sandbox_providers.py
+++ b/src/backend/tests/community/core/workspace/test_engine_sandbox_providers.py
@@ -15,6 +15,9 @@ import pytest
 
 from agentclaw.community.core.workspace.engines.aicoding import AICodingSandboxProvider
 from agentclaw.community.core.workspace.engines.claude_code import ClaudeCodeSandboxProvider
+from agentclaw.community.core.workspace.engines.deepseek_harness import (
+    DeepSeekHarnessSandboxProvider,
+)
 from agentclaw.community.core.workspace.engines.openclaw import OpenClawSandboxProvider
 from agentclaw.community.core.workspace.engines.hermes import HermesSandboxProvider
 from agentclaw.community.core.workspace.engines import create_engine_sandbox_registry
@@ -48,6 +51,7 @@ def _device_fs(mapping: dict[str, list[dict]]):
         ClaudeCodeSandboxProvider,
         AICodingSandboxProvider,
         HermesSandboxProvider,
+        DeepSeekHarnessSandboxProvider,
     ),
 )
 def test_list_directory_provider_signature_matches_runtime_contract(
@@ -353,6 +357,105 @@ class TestHermesProvider:
         assert contract["pool_repo"].removeprefix(
             f"{provider.get_base_path()}/"
         ) in plan.rsync_excludes
+
+
+@pytest.mark.unit
+class TestDeepSeekHarnessProvider:
+    def test_uses_dsh_home_and_session_layout(self):
+        provider = DeepSeekHarnessSandboxProvider(workspace=_workspace())
+
+        assert provider.get_base_path() == "/home/admin/.dsh/workspace"
+        assert provider.get_sessions_dir() == "/home/admin/.dsh/sessions"
+        assert provider.get_default_read_only_rules() == []
+
+    def test_composition_registry_resolves_provider_without_fallback(self):
+        provider = create_engine_sandbox_registry(_workspace()).resolve(
+            "deepseek_harness"
+        )
+
+        assert isinstance(provider, DeepSeekHarnessSandboxProvider)
+
+    def test_service_build_plan_is_explicitly_unsupported(self):
+        provider = DeepSeekHarnessSandboxProvider(workspace=_workspace())
+
+        with pytest.raises(ValueError, match="service bot builds"):
+            provider.get_build_plan(["custom"], bot={"bot_id": "b1"})
+
+    @pytest.mark.parametrize("sub_path", ("../escape", "/etc/passwd", "bad\x00path"))
+    def test_invalid_sub_path_is_rejected(self, sub_path):
+        provider = DeepSeekHarnessSandboxProvider(workspace=_workspace())
+
+        with pytest.raises(ValueError):
+            provider._normalize_sub_path(sub_path)
+
+    @pytest.mark.parametrize("sub_path", ("", ".", "./"))
+    def test_empty_sub_path_is_normalized(self, sub_path):
+        provider = DeepSeekHarnessSandboxProvider(workspace=_workspace())
+
+        assert provider._normalize_sub_path(sub_path) == ""
+
+    @pytest.mark.asyncio
+    async def test_list_directory_with_device_fs_walks_recursively(self):
+        base = f"{cfg.WorkspaceConfig().deepseek_harness_root}/workspace"
+        provider = DeepSeekHarnessSandboxProvider(workspace=_workspace())
+
+        items = await provider.list_directory(
+            recursive=True,
+            device_fs=_device_fs({
+                base: [
+                    {"name": "skills", "is_dir": True},
+                    {"name": "AGENTS.md", "is_dir": False},
+                    {"name": "", "is_dir": False},
+                ],
+                f"{base}/skills": [
+                    {"name": "local-skill", "is_dir": True},
+                ],
+                f"{base}/skills/local-skill": [],
+            }),
+        )
+
+        assert {item.path for item in items} == {
+            "skills",
+            "skills/local-skill",
+            "AGENTS.md",
+        }
+
+    @pytest.mark.asyncio
+    async def test_list_directory_walks_local_filesystem(self, tmp_path):
+        root = tmp_path / ".dsh"
+        workspace = root / "workspace"
+        workspace.mkdir(parents=True)
+        (workspace / "AGENTS.md").write_text("instructions", encoding="utf-8")
+        provider = DeepSeekHarnessSandboxProvider(
+            workspace=cfg.WorkspaceConfig(deepseek_harness_root=str(root)),
+        )
+
+        top_level = await provider.list_directory()
+        recursive = await provider.list_directory(recursive=True)
+
+        assert [item.path for item in top_level] == ["AGENTS.md"]
+        assert {item.path for item in recursive} == {"AGENTS.md"}
+
+    @pytest.mark.asyncio
+    async def test_list_directory_does_not_expose_dsh_credentials(self, tmp_path):
+        root = tmp_path / ".dsh"
+        (root / "workspace").mkdir(parents=True)
+        (root / ".credentials.yaml").write_text("secret", encoding="utf-8")
+        provider = DeepSeekHarnessSandboxProvider(
+            workspace=cfg.WorkspaceConfig(deepseek_harness_root=str(root)),
+        )
+
+        assert await provider.list_directory() == []
+
+    @pytest.mark.asyncio
+    async def test_list_directory_missing_local_root_returns_empty(self, tmp_path):
+        provider = DeepSeekHarnessSandboxProvider(
+            workspace=cfg.WorkspaceConfig(
+                deepseek_harness_root=str(tmp_path / "missing")
+            ),
+        )
+
+        assert await provider.list_directory() == []
 
 _OPENCLAW_ROOT = cfg.WorkspaceConfig().openclaw_root
 _CLAUDE_CODE_ROOT = cfg.WorkspaceConfig().claude_code_root

--- a/src/backend/tests/community/di/test_singlebox_baas_template_config.py
+++ b/src/backend/tests/community/di/test_singlebox_baas_template_config.py
@@ -32,6 +32,7 @@ async def test_seeds_singlebox_baas_template_mapping():
         "hermes",
         "aicoding",
         "claude_code",
+        "deepseek_harness",
     }
     assert config_service.set_config.call_args.kwargs["env"] == "dev"
 

--- a/src/backend/tests/community/di/test_workspace_config_provider.py
+++ b/src/backend/tests/community/di/test_workspace_config_provider.py
@@ -21,6 +21,7 @@ def test_workspace_resolves_relative_roots_before_engine_injection(
                 "claude_code_root": "./data/workspace/claude_code",
                 "aicoding_root": "./data/workspace/aicoding",
                 "hermes_root": "./data/workspace/hermes",
+                "deepseek_harness_root": "./data/workspace/dsh",
             }
         },
     )
@@ -31,6 +32,7 @@ def test_workspace_resolves_relative_roots_before_engine_injection(
     assert workspace.claude_code_root == str(tmp_path / "data/workspace/claude_code")
     assert workspace.aicoding_root == str(tmp_path / "data/workspace/aicoding")
     assert workspace.hermes_root == str(tmp_path / "data/workspace/hermes")
+    assert workspace.deepseek_harness_root == str(tmp_path / "data/workspace/dsh")
 
 
 def test_workspace_keeps_absolute_sandbox_roots_stable(monkeypatch) -> None:
@@ -43,3 +45,4 @@ def test_workspace_keeps_absolute_sandbox_roots_stable(monkeypatch) -> None:
     assert workspace.claude_code_root == defaults.claude_code_root
     assert workspace.aicoding_root == defaults.aicoding_root
     assert workspace.hermes_root == defaults.hermes_root
+    assert workspace.deepseek_harness_root == defaults.deepseek_harness_root

--- a/src/engine/src/engine/community/engine.json
+++ b/src/engine/src/engine/community/engine.json
@@ -175,6 +175,28 @@
       },
       "relay_url": "ws://localhost:18900",
       "connection_timeout": 15.0
+    },
+    "deepseek_harness": {
+      "process": {
+        "start_cmd": [],
+        "stop_cmd": [],
+        "restart_cmd": [],
+        "startup_timeout_sec": 30,
+        "graceful_timeout_sec": 5
+      },
+      "sandbox_setup": {
+        "engine_dirs": ["dsh"],
+        "rsync_pairs": [
+          {
+            "name": "user",
+            "source": "/home/admin/.dsh",
+            "target": "/home/admin/nfs/bot-data/dsh",
+            "mode": "two-way",
+            "interval": 300,
+            "exclude": ["node_modules/", ".cache/", "*.tmp"]
+          }
+        ]
+      }
     }
   },
   "mcp_token_header_name": "x-moltis-mcp-token",

--- a/src/engine/src/engine/community/engines/__init__.py
+++ b/src/engine/src/engine/community/engines/__init__.py
@@ -8,9 +8,10 @@ Profile-driven engine set (mutual exclusion on the ``claude_code`` name):
     18900 relay). The community claude_code engine lives in
     ``community/engines/claude_code/`` and self-registers on import. GitHub
     export ships this set.
-  - **corp**: OpenClaw + aicoding + hermes + claude_code (corp impl). The corp
-    ``engines/`` packages live under ``corp/engines/`` and are present only in
-    the OCB internal checkout (excluded from GitHub export).
+  - **corp**: OpenClaw + aicoding + hermes + deepseek_harness + claude_code
+    (corp impl). The corp ``engines/`` packages live under ``corp/engines/``
+    and are present only in the OCB internal checkout (excluded from GitHub
+    export).
 
 Loading claude_code by profile avoids a same-name registration conflict: both
 ``ClaudeCodeEngine`` (corp) and ``ClaudeCodeCommunityEngine`` (community)
@@ -53,7 +54,7 @@ _profile = EngineProfile.detect()
 if _profile is EngineProfile.CORP:
     _optional_import_module("engine.corp.engines.claude_code", label="claude_code (corp)")
     # Other internal legacy engines: present in OCB, excluded from GitHub export.
-    for _name in ("aicoding", "hermes"):
+    for _name in ("aicoding", "hermes", "deepseek_harness"):
         _optional_import_module(f"engine.corp.engines.{_name}", label=_name)
 else:  # community / test
     # Community claude_code engine: composition root under

--- a/src/engine/src/engine/community/engines/tests/test_loader.py
+++ b/src/engine/src/engine/community/engines/tests/test_loader.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import importlib
+import runpy
+from pathlib import Path
+
+import pytest
+
+
+def test_corp_profile_loads_every_internal_engine(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    imported: list[str] = []
+    loader_path = Path(__file__).parents[1] / "__init__.py"
+    monkeypatch.setenv("ENGINE_PROFILE", "corp")
+    monkeypatch.setattr(
+        importlib,
+        "import_module",
+        lambda module_name: imported.append(module_name),
+    )
+
+    runpy.run_path(str(loader_path))
+
+    assert imported == [
+        "engine.community.engines.openclaw",
+        "engine.corp.engines.claude_code",
+        "engine.corp.engines.aicoding",
+        "engine.corp.engines.hermes",
+        "engine.corp.engines.deepseek_harness",
+    ]

--- a/src/engine/src/engine/community/tests/test_process_factory.py
+++ b/src/engine/src/engine/community/tests/test_process_factory.py
@@ -216,3 +216,24 @@ class TestFactoryFromEngineJson:
         settings = load_engine_process_settings("claude-code", path=cfg)
         proc = create_engine_process("claude-code", settings=settings)
         assert isinstance(proc, NoOpEngineProcess)
+
+    def test_dsh_with_empty_start_command_yields_noop(self, tmp_path):
+        cfg = _write_json(
+            tmp_path,
+            {
+                "engines": {
+                    "deepseek_harness": {
+                        "process": {
+                            "start_cmd": [],
+                            "stop_cmd": [],
+                            "restart_cmd": [],
+                        }
+                    }
+                }
+            },
+        )
+        settings = load_engine_process_settings("deepseek_harness", path=cfg)
+
+        proc = create_engine_process("deepseek_harness", settings=settings)
+
+        assert isinstance(proc, NoOpEngineProcess)


### PR DESCRIPTION
Add DeepSeek Harness engine recognition, sandbox workspace configuration, BaaS routing and session-key support, and corp-profile adapter registration. Existing engine dispatch conditions remain unchanged; DSH service/local Bot creation is not enabled.

The DSH runtime implementation is supplied by the companion internal OCB change. Merge this PR first, wait for the internal mirror, then update OCB's ocb-public gitlink before deploying DSH.

Validation: backend 139 tests, BaaS 279 tests, engine loader/process factory 17 tests passed before the latest conflict-free rebase. Pre-push secret scan and Python SAST passed on the rebased commit. Full CI remains required.