### PR TITLE
fix(baas): inject Singlebox Hermes model credential

### DIFF
--- a/src/baas/src/secbaas/community/plugins/sandbox/arca/local_proc/_process_manager.py
+++ b/src/baas/src/secbaas/community/plugins/sandbox/arca/local_proc/_process_manager.py
@@ -74,6 +74,7 @@ _OPENCLAW_CONFIG_TEMPLATE = "scripts/openclaw.json"
 
 # Path to the hermes.yaml config template (relative to project root).
 _HERMES_CONFIG_TEMPLATE = "scripts/hermes.yaml"
+_SINGLEBOX_MODEL_API_KEY_ENV = "OPENCLAW_OPENAI_API_KEY"
 _BCN_PLUGIN_REPO_PATH = (
     Path("src") / "bcs" / "crates" / "plugins" / "openclaw-channel-bcn"
 )
@@ -374,6 +375,17 @@ class LocalProcessManager:
             )
             hermes_config = {}
 
+        # Keep the shared Singlebox model credential out of the repository.
+        # ``singlebox.sh`` exports values from the ignored root ``.env.local``;
+        # the Hermes process inherits that environment from this manager.
+        model_api_key = os.environ.get(_SINGLEBOX_MODEL_API_KEY_ENV, "").strip()
+        hermes_config["api_key"] = model_api_key
+        custom_providers = hermes_config.get("custom_providers", [])
+        if isinstance(custom_providers, list):
+            for provider in custom_providers:
+                if isinstance(provider, dict):
+                    provider["api_key"] = model_api_key
+
         # Set API server port for the dashboard
         hermes_config.setdefault("platforms", {})["api_server"] = {
             "enabled": True,
@@ -384,6 +396,7 @@ class LocalProcessManager:
         # Write config file
         with open(config_file, "w") as f:
             yaml.dump(hermes_config, f, default_flow_style=False, allow_unicode=True)
+        config_file.chmod(0o600)
 
         logger.info(
             "Created hermes config: %s, port=%s, workspace=%s",

--- a/src/baas/tests/unit/plugins/sandbox/arca/test_process_manager_coverage.py
+++ b/src/baas/tests/unit/plugins/sandbox/arca/test_process_manager_coverage.py
@@ -51,6 +51,7 @@ def _clean_env(monkeypatch):
         "BCN_PLUGIN_PATH",
         "BCS_PORT",
         "LOCAL_HERMES_DIR",
+        "OPENCLAW_OPENAI_API_KEY",
         "LOCAL_ENGINE_SRC_DIR",
         "LOCAL_ENGINE_PYTHON",
     ):
@@ -1153,7 +1154,14 @@ class TestCreateHermesConfig:
 
         # Mock yaml module
         mock_yaml = MagicMock()
-        loaded_config = {"existing": "value"}
+        loaded_config = {
+            "existing": "value",
+            "api_key": "",
+            "custom_providers": [
+                {"name": "antchat-kimi", "api_key": ""},
+                {"name": "antchat-glm", "api_key": ""},
+            ],
+        }
         mock_yaml.safe_load.return_value = loaded_config
         mock_yaml.dump = MagicMock()
 
@@ -1165,6 +1173,7 @@ class TestCreateHermesConfig:
 
             template_path = tmp_path / "hermes_template.yaml"
             template_path.write_text("existing: value")
+            monkeypatch.setenv("OPENCLAW_OPENAI_API_KEY", "test-model-key")
             monkeypatch.setattr(
                 manager,
                 "_resolve_hermes_config_template_path",
@@ -1186,6 +1195,13 @@ class TestCreateHermesConfig:
         # Check subdirectories were created
         for subdir in ("sessions", "logs", "skills", "memories", "cron"):
             assert (config_dir / subdir).is_dir()
+        dumped_config = mock_yaml.dump.call_args[0][0]
+        assert dumped_config["api_key"] == "test-model-key"
+        assert all(
+            provider["api_key"] == "test-model-key"
+            for provider in dumped_config["custom_providers"]
+        )
+        assert stat.S_IMODE(config_file.stat().st_mode) == 0o600
 
     def test_create_hermes_config_no_template(self, monkeypatch, tmp_path):
         """create_hermes_config uses minimal config when template not found."""
@@ -1219,6 +1235,7 @@ class TestCreateHermesConfig:
         assert dumped_config["platforms"]["api_server"]["port"] == 18700
         assert dumped_config["platforms"]["api_server"]["host"] == "127.0.0.1"
         assert dumped_config["platforms"]["api_server"]["enabled"] is True
+        assert dumped_config["api_key"] == ""
 
     def test_create_hermes_config_with_local_env(self, monkeypatch, tmp_path):
         """create_hermes_config respects LOCAL_HERMES_DIR env var."""


### PR DESCRIPTION
## Problem

OCB's Singlebox Hermes template currently carries a shared model credential in source. Removing it from the template requires the per-bot Hermes config generator to receive that credential at runtime.

## Solution

Read `OPENCLAW_OPENAI_API_KEY` when generating each local Hermes config, apply it to the default and custom providers, and write the generated config with mode `0600`. An absent key remains an empty value so mock and non-model local flows can still start.

## Validation

- `ruff check` on the implementation and test files
- `9 passed` across the focused local process manager credential/config tests

## Compatibility and risk

The environment variable is consumed only by the local Singlebox Hermes process manager. Other engines and production ARCA delivery are unchanged.
