### PR TITLE
feat(evolution): synthesize evidence-linked issue conclusions across runs

### DIFF
--- a/docs/superpowers/plans/2026-09-10-issue-cause-aggregation.md
+++ b/docs/superpowers/plans/2026-09-10-issue-cause-aggregation.md
@@ -1,0 +1,17 @@
+# Issue cause aggregation implementation plan
+
+Goal: summarize latest per-run diagnoses within deterministic workflow/signature groups while preserving distinct causes and source references.
+
+Approved design: the conversation's two-stage grouping and model synthesis design. Execute inline; do not dispatch subagents.
+
+Constraints: Avernet owns public API/storage/UI; ClawMind owns the Bot model invocation. Preserve existing diagnostics and application states. No automatic remediation. Tests must not contact production.
+
+- [x] Add latest-per-run grouping and strict source-bound aggregation contracts; test replacement, multiple causes, invalid citations and empty latest analyses.
+- [x] Persist aggregation snapshots using the existing analysis storage with a separate scope/version; expose authenticated input/result and view endpoints. Verify idempotency and stale-input handling through SQLite/API tests.
+- [x] Invoke the model in a second phase using the same analysis Bot; preserve single-run success on aggregation failure; retain same-signature diagnoses.
+- [x] Render server groups and model causes with source runs; show unique affected-run counts and collapsible single-run diagnoses. Existing suggestion actions remain separate.
+- [x] Document contracts, run affected checks/builds and focused regression suites; inspect the final diff. Do not claim deployment or push without evidence.
+
+Verification: Workflow 194 tests, ClawEvolve 276 tests, ClawMind 23 focused tests passed. Shared, Workflow, ClawEvolve and ClawMind builds/checks passed. No live Bot or browser visual validation; no commit, push or deployment.
+
+Implementation boundary discovered: the existing suggestion table is unique on workflow/signature. Competing proposals are retained as source candidates, not published over one another. Multiple independently executable cause suggestions remain a separate schema/lifecycle migration; see the module contract. No standalone manual aggregation dispatch or hierarchical large-input synthesis is included.

--- a/src/evolverun/clawweb/public/modules/clawevolve/docs/issue-aggregation-contract.md
+++ b/src/evolverun/clawweb/public/modules/clawevolve/docs/issue-aggregation-contract.md
@@ -72,6 +72,9 @@ Groups exceeding 500 source diagnoses or 180,000 UTF-8 input bytes report
 Historical groups are not automatically backfilled merely by opening a page.
 Run analysis triggers affected groups; reanalyzing an associated run refreshes
 them. There is no separate browser model-dispatch or bulk backfill endpoint in v1.
+Refresh selection includes every declared `scope.flowIds` entry, even when a
+completed run-set result contains no diagnosis for that flow. Existing summaries
+that reference removed flows are regenerated if other runs keep the group alive.
 
 ## Suggestions
 
@@ -84,6 +87,10 @@ suggestions, not executable group actions. Existing suggestion lifecycle remains
 independent and does not mark all aggregate causes resolved. Supporting multiple
 independently executable suggestions for a signature requires a separate schema
 and lifecycle migration; this change does not perform that migration.
+If a signature no longer has a current diagnosis group, its independently stored
+suggestion remains visible in a separate lifecycle section with the existing
+apply/verify controls and task progress. It is not counted as a current issue or
+treated as verified merely because the latest analysis removed its diagnosis.
 
 ## Verification
 

--- a/src/evolverun/clawweb/public/modules/clawevolve/docs/issue-aggregation-contract.md
+++ b/src/evolverun/clawweb/public/modules/clawevolve/docs/issue-aggregation-contract.md
@@ -1,0 +1,96 @@
+# Workflow issue aggregation v1
+
+## Ownership and compatibility
+
+ClawEvolve owns snapshots, selection and validation; Workflow owns presentation;
+ClawMind invokes the existing analysis Bot in a separate synthesis phase after
+single-run completion. No OCB-specific dependency or new model credential is used.
+Deploy Avernet before ClawMind: `/analysis-runs/:id/input` advertises the optional
+`issueAggregationSupported: true` capability. Older Bot versions ignore it;
+new Bots skip synthesis against servers without it.
+
+## Input selection
+
+Only completed run analyses participate. Select the latest completed analysis
+per flow (completion time, then analysis ID tie-break), including empty results,
+before grouping by workflow ID and canonical failure signature. Every diagnosis
+in that selected analysis is retained, including multiple diagnoses with the same
+signature. Run-set scopes include their declared flow IDs even for empty results.
+Legacy diagnoses are fallback only for runs without completed managed analyses.
+History is scanned with database pagination, not a frontend 100-record sample.
+
+A source binds an analysis ID, diagnosis ID, flow ID, diagnosis text, proposal and
+evidence event IDs. Its deterministic source ID is a SHA-256 identity. Group input
+digests include the full ordered source snapshot. Affected-run counts are distinct
+flow counts, never model-produced or analysis-attempt counts.
+
+## Service API (browser → ClawEvolve)
+
+`GET /api/evolve/issue-groups?workflowId=...` requires view permission using the
+same workflow access boundary as diagnoses. Missing workflow is 400; missing
+identity is 401, forbidden workflow is 403. A load failure is 500, not empty data.
+The response is `{groups: [...]}`. Each group has `workflowId`, `signature`,
+`inputDigest`, `flowIds`, `sources`, `summarySources`, `summary`, `stale`,
+`aggregationStatus` and `aggregationId`.
+
+`summary` is either null or `{summary, causes, unknowns}`; each cause has `title`,
+`conclusion`, `certainty` (`supported|hypothesis|unknown`) and `sourceIds`.
+Every source must be covered; only IDs in the frozen input are accepted. Counts,
+source run mappings and evidence references are server-derived, not model claims.
+Model prose is a diagnosis, not proof of root cause or successful remediation.
+
+## Signed Bot API (ClawMind → ClawEvolve)
+
+These relative routes live under the existing signed internal Evolve router,
+not the browser router. Existing linked-task Bot validation applies to both.
+
+- `POST /analysis-runs/:id/aggregations`, body `{botId}`: requires a completed
+  non-aggregation parent. Returns `{jobs:[{id,input}]}` for changed affected groups.
+- `POST /analysis-runs/:id/aggregations/:aggregationId`, body `{botId,result}`
+  or `{botId,failed:true}`: validates parent binding, references, coverage and CAS.
+  Returns `{ok:true}`. Identical completed writes are idempotent; invalid writes
+  are rejected. Bot mismatch is 403; missing parent is 404; rejected input is 400.
+
+## Persistence and recovery
+
+Snapshots reuse `workflow_evolution_analysis_runs` under the separate scope
+`issue_aggregate` and analysis version `workflow-issue-summary/v1`. They have no
+flow/task binding of their own and are excluded from run diagnosis/history
+projection. No database schema change is required.
+
+Input is frozen in `scope_json`; model results are separately stored in
+`result_json`. Unique request keys deduplicate concurrent preparation. Completed
+inputs are reused. An old completion cannot replace a newer snapshot: the browser
+compares input digests and explicitly labels retained old results stale.
+Abandoned jobs expire after ten minutes and can be retried on subsequent analysis.
+Each Bot model call is bounded to 120 seconds; new group calls stop after a
+180-second batch budget (an in-flight call can extend the batch up to 300 seconds).
+Failure to synthesize never rolls back an already saved single-run diagnosis.
+
+Groups exceeding 500 source diagnoses or 180,000 UTF-8 input bytes report
+`too_large`; they are never silently sampled. Hierarchical synthesis is not in v1.
+Historical groups are not automatically backfilled merely by opening a page.
+Run analysis triggers affected groups; reanalyzing an associated run refreshes
+them. There is no separate browser model-dispatch or bulk backfill endpoint in v1.
+
+## Suggestions
+
+Aggregation never creates, applies or verifies a suggestion. Source proposals
+remain linked to their source diagnoses. The existing executable-suggestion table
+has one entry per workflow/signature; if a single result contains distinct
+proposals for one signature, preserve them in the immutable diagnosis result but
+do not overwrite an executable suggestion with either one. UI calls them candidate
+suggestions, not executable group actions. Existing suggestion lifecycle remains
+independent and does not mark all aggregate causes resolved. Supporting multiple
+independently executable suggestions for a signature requires a separate schema
+and lifecycle migration; this change does not perform that migration.
+
+## Verification
+
+`issue-aggregation.test.ts`: latest replacement (including empty run sets),
+distinct causes, stable inputs and invalid/missing references.
+`evolve-knowledge.test.ts`: real SQLite persistence, HTTP permission isolation,
+Bot binding, cached results, stale snapshots and expired-job recovery.
+Workflow `IssueSummary` and `EvolutionIssueFlow` tests: cause/source display,
+failure states and existing run navigation/actions.
+ClawMind routing/helper tests: two model phases and single-analysis preservation.

--- a/src/evolverun/clawweb/public/modules/clawevolve/server/repositories/issue-aggregation-repository.ts
+++ b/src/evolverun/clawweb/public/modules/clawevolve/server/repositories/issue-aggregation-repository.ts
@@ -1,0 +1,115 @@
+import type { IDatabase } from '@avernet/clawweb-shared/server/db';
+import { canonicalJson, digestCanonicalJson, validateWorkflowEvolutionAnalysisResult } from '../services/evolution/contracts.js';
+import { buildIssueGroups, validateIssueSummary, type IssueAnalysis, type IssueGroup, type IssueSummary } from '../services/evolution/issue-aggregation.js';
+import type { WorkflowEvolutionAnalysisRow } from './workflow-evolution-repository.js';
+
+const SCOPE = 'issue_aggregate';
+type Snapshot = { parentAnalysisId: string; input: IssueGroup };
+export type PresentedIssueGroup = IssueGroup & { summary: IssueSummary | null; summarySources: IssueGroup['sources']; stale: boolean; aggregationStatus: string; aggregationId: string | null };
+
+/** Aggregations are immutable versioned analysis snapshots, not diagnoses or suggestion states. */
+export class IssueAggregationRepository {
+  constructor(private readonly db: IDatabase) {}
+
+  private async groups(workflowId: string): Promise<IssueGroup[]> {
+    const analyses: IssueAnalysis[] = [];
+    let afterId = 0;
+    for (;;) {
+      const rows = await this.db.query<WorkflowEvolutionAnalysisRow>(
+        `SELECT * FROM workflow_evolution_analysis_runs WHERE workflow_id = ? AND status = 'completed'
+         AND scope_type <> ? AND id > ? ORDER BY id ASC LIMIT 200`, [workflowId, SCOPE, afterId]);
+      if (!rows.length) break;
+      for (const row of rows) {
+        const result = validateWorkflowEvolutionAnalysisResult(JSON.parse(row.result_json ?? 'null'));
+        const scope = JSON.parse(row.scope_json) as { flowIds?: unknown };
+        analyses.push({ analysisId: row.analysis_id, flowId: row.flow_id, flowIds: Array.isArray(scope.flowIds) ? scope.flowIds.map(String) : [], completedAtMs: row.completed_at_ms ?? row.requested_at_ms, diagnoses: result.diagnoses });
+      }
+      afterId = rows.at(-1)!.id;
+    }
+    const coveredRuns = new Set(analyses.flatMap(a => [...(a.flowIds ?? []), ...(a.flowId ? [a.flowId] : []), ...a.diagnoses.flatMap(d => d.flowIds)]));
+    const legacy = await this.db.query<{
+      diagnosis_id: string; flow_id: string; failure_signature: string; failure_mode: string; node_id: string | null;
+      weak_node_id: string | null; error_text: string | null; gmt_modified: string | number;
+    }>('SELECT diagnosis_id, flow_id, failure_signature, failure_mode, node_id, weak_node_id, error_text, gmt_modified FROM workflow_healing_diagnoses WHERE workflow_id = ?', [workflowId]);
+    const legacyByRun = new Map<string, IssueAnalysis>();
+    for (const row of legacy) {
+      if (coveredRuns.has(row.flow_id)) continue;
+      const numeric = Number(row.gmt_modified);
+      const time = Number.isFinite(numeric) ? (numeric < 1e12 ? numeric * 1000 : numeric) : Date.parse(String(row.gmt_modified)) || 0;
+      const entry = legacyByRun.get(row.flow_id) ?? { analysisId: 'legacy', flowId: row.flow_id, completedAtMs: time, diagnoses: [] };
+      entry.completedAtMs = Math.max(entry.completedAtMs, time);
+      entry.diagnoses.push({ diagnosisId: row.diagnosis_id, flowIds: [row.flow_id], nodeId: row.weak_node_id ?? row.node_id,
+        failureSignature: row.failure_signature, failureMode: row.failure_mode, severity: 'medium',
+        reasoning: row.error_text || row.failure_signature, evidenceEventIds: [] });
+      legacyByRun.set(row.flow_id, entry);
+    }
+    return buildIssueGroups(workflowId, [...analyses, ...legacyByRun.values()]);
+  }
+
+  async list(workflowId: string): Promise<PresentedIssueGroup[]> {
+    const [groups, rows] = await Promise.all([this.groups(workflowId), this.db.query<WorkflowEvolutionAnalysisRow>(
+      `SELECT * FROM workflow_evolution_analysis_runs WHERE workflow_id = ? AND scope_type = ? ORDER BY id DESC`, [workflowId, SCOPE])]);
+    return groups.map(group => {
+      const matches = rows.filter(row => (JSON.parse(row.scope_json) as Snapshot).input.signature === group.signature);
+      const current = matches.find(row => (JSON.parse(row.scope_json) as Snapshot).input.inputDigest === group.inputDigest);
+      const completed = (current?.status === 'completed' ? current : matches.find(row => row.status === 'completed'));
+      const frozen = completed ? (JSON.parse(completed.scope_json) as Snapshot).input : null;
+      const tooLarge = Buffer.byteLength(canonicalJson(group), 'utf8') > 180_000 || group.sources.length > 500;
+      return { ...group, summary: completed && frozen ? validateIssueSummary(JSON.parse(completed.result_json!), frozen) : null,
+        summarySources: frozen?.sources ?? [],
+        stale: !!completed && frozen?.inputDigest !== group.inputDigest,
+        aggregationStatus: tooLarge ? 'too_large' : current?.status === 'queued' && Date.now() - current.requested_at_ms > 600_000 ? 'failed' : current?.status ?? 'not_generated', aggregationId: current?.analysis_id ?? null,
+      };
+    });
+  }
+
+  async prepare(parentAnalysisId: string): Promise<Array<{ id: string; input: IssueGroup }>> {
+    const parent = (await this.db.query<WorkflowEvolutionAnalysisRow>(
+      'SELECT * FROM workflow_evolution_analysis_runs WHERE analysis_id = ?', [parentAnalysisId]))[0];
+    if (!parent || parent.status !== 'completed' || parent.scope_type === SCOPE || !parent.workflow_id) throw new Error('completed run analysis required');
+    await this.db.exec(`UPDATE workflow_evolution_analysis_runs SET status = 'failed', error_code = 'aggregation_timeout', state_version = state_version + 1
+      WHERE workflow_id = ? AND scope_type = ? AND status = 'queued' AND requested_at_ms < ?`, [parent.workflow_id, SCOPE, Date.now() - 600_000]);
+    const groups = await this.list(parent.workflow_id);
+    const parentResult = validateWorkflowEvolutionAnalysisResult(JSON.parse(parent.result_json!));
+    const affectedFlows = new Set([...(parent.flow_id ? [parent.flow_id] : []), ...parentResult.diagnoses.flatMap(d => d.flowIds)]);
+    const affectedSignatures = new Set(parentResult.diagnoses.map(d => d.failureSignature));
+    const jobs: Array<{ id: string; input: IssueGroup }> = [];
+    for (const { summary: _summary, summarySources: _sources, stale: _stale, aggregationStatus, aggregationId: previousId, ...input } of groups) {
+      if (!affectedSignatures.has(input.signature) && !_sources.some(source => affectedFlows.has(source.flowId))) continue;
+      if (aggregationStatus === 'completed' || aggregationStatus === 'queued') continue;
+      // Fail explicitly rather than silently summarizing a truncated sample.
+      if (Buffer.byteLength(canonicalJson(input), 'utf8') > 180_000 || input.sources.length > 500) continue;
+      const requestKey = digestCanonicalJson([SCOPE, input.inputDigest, previousId]);
+      const id = `AG-${requestKey.slice(0, 40)}`;
+      const now = Date.now();
+      try {
+        await this.db.exec(`INSERT INTO workflow_evolution_analysis_runs
+          (analysis_id, request_key, scope_type, scope_json, workflow_id, status, analysis_version,
+           requested_by, requested_at_ms, state_version, gmt_create, gmt_modified)
+          VALUES (?, ?, ?, ?, ?, 'queued', 'workflow-issue-summary/v1', ?, ?, 0, ?, ?)`,
+        [id, requestKey, SCOPE, canonicalJson({ parentAnalysisId, input }), parent.workflow_id, parent.requested_by, now, this.db.dialect.now(), this.db.dialect.now()]);
+        jobs.push({ id, input });
+      } catch (error) {
+        const existing = (await this.db.query<{ analysis_id: string }>('SELECT analysis_id FROM workflow_evolution_analysis_runs WHERE request_key = ?', [requestKey]))[0];
+        if (!existing) throw error;
+      }
+    }
+    return jobs;
+  }
+
+  async complete(parentAnalysisId: string, id: string, raw: unknown, failed = false): Promise<void> {
+    const row = (await this.db.query<WorkflowEvolutionAnalysisRow>(
+      'SELECT * FROM workflow_evolution_analysis_runs WHERE analysis_id = ? AND scope_type = ?', [id, SCOPE]))[0];
+    if (!row) throw new Error('aggregation not found');
+    const snapshot = JSON.parse(row.scope_json) as Snapshot;
+    if (snapshot.parentAnalysisId !== parentAnalysisId) throw new Error('aggregation parent mismatch');
+    const result = failed ? null : validateIssueSummary(raw, snapshot.input);
+    if (row.status === 'completed' && result && row.result_digest === digestCanonicalJson(result)) return;
+    if (row.status !== 'queued') throw new Error('aggregation state conflict');
+    const updated = await this.db.exec(`UPDATE workflow_evolution_analysis_runs SET status = ?, result_json = ?, result_digest = ?,
+      completed_at_ms = ?, error_code = ?, state_version = state_version + 1 WHERE analysis_id = ? AND status = 'queued' AND state_version = ?`,
+    [failed ? 'failed' : 'completed', result ? canonicalJson(result) : null, result ? digestCanonicalJson(result) : null,
+      Date.now(), failed ? 'aggregation_failed' : null, id, row.state_version]);
+    if (!updated.affectedRows) throw new Error('aggregation state conflict');
+  }
+}

--- a/src/evolverun/clawweb/public/modules/clawevolve/server/repositories/issue-aggregation-repository.ts
+++ b/src/evolverun/clawweb/public/modules/clawevolve/server/repositories/issue-aggregation-repository.ts
@@ -71,7 +71,9 @@ export class IssueAggregationRepository {
       WHERE workflow_id = ? AND scope_type = ? AND status = 'queued' AND requested_at_ms < ?`, [parent.workflow_id, SCOPE, Date.now() - 600_000]);
     const groups = await this.list(parent.workflow_id);
     const parentResult = validateWorkflowEvolutionAnalysisResult(JSON.parse(parent.result_json!));
-    const affectedFlows = new Set([...(parent.flow_id ? [parent.flow_id] : []), ...parentResult.diagnoses.flatMap(d => d.flowIds)]);
+    const parentScope = JSON.parse(parent.scope_json) as { flowIds?: unknown };
+    const declaredFlows = Array.isArray(parentScope.flowIds) ? parentScope.flowIds.map(String) : [];
+    const affectedFlows = new Set([...declaredFlows, ...(parent.flow_id ? [parent.flow_id] : []), ...parentResult.diagnoses.flatMap(d => d.flowIds)]);
     const affectedSignatures = new Set(parentResult.diagnoses.map(d => d.failureSignature));
     const jobs: Array<{ id: string; input: IssueGroup }> = [];
     for (const { summary: _summary, summarySources: _sources, stale: _stale, aggregationStatus, aggregationId: previousId, ...input } of groups) {

--- a/src/evolverun/clawweb/public/modules/clawevolve/server/repositories/workflow-evolution-repository.ts
+++ b/src/evolverun/clawweb/public/modules/clawevolve/server/repositories/workflow-evolution-repository.ts
@@ -316,7 +316,7 @@ export class WorkflowEvolutionRepository {
     if (analysis.workflow_id) {
       const prior = await this.db.query<WorkflowEvolutionAnalysisRow>(
         `SELECT * FROM workflow_evolution_analysis_runs
-         WHERE workflow_id = ? AND analysis_id <> ? AND status = 'completed' AND result_json IS NOT NULL
+         WHERE workflow_id = ? AND analysis_id <> ? AND scope_type <> 'issue_aggregate' AND status = 'completed' AND result_json IS NOT NULL
          ORDER BY id DESC LIMIT 20`,
         [analysis.workflow_id, analysis.analysis_id],
       );
@@ -418,6 +418,10 @@ export class WorkflowEvolutionRepository {
       ))[0]!;
       for (const diagnosis of result.diagnoses) {
         if (!diagnosis.proposal) continue;
+        // One executable suggestion per signature: retain competing proposals in
+        // result_json instead of silently overwriting one cause's fix with another.
+        const competing = result.diagnoses.filter(item => item.failureSignature === diagnosis.failureSignature && item.proposal);
+        if (new Set(competing.map(item => digestCanonicalJson(item.proposal))).size > 1) continue;
         const existing = (await tx.query<{
           id: number;
           source_diagnosis_ids: string | null;
@@ -498,7 +502,7 @@ export class WorkflowEvolutionRepository {
   }
 
   async listProjectedDiagnoses(options: { workflowId?: string; flowId?: string; analysisId?: string; query?: string; limit?: number; offset?: number } = {}): Promise<{ rows: Array<Record<string, unknown>>; total: number }> {
-    const clauses = ["status = 'completed'", "result_json IS NOT NULL"];
+    const clauses = ["status = 'completed'", "result_json IS NOT NULL", "scope_type <> 'issue_aggregate'"];
     const params: unknown[] = [];
     if (options.workflowId) { clauses.push("workflow_id = ?"); params.push(options.workflowId); }
     if (options.flowId) { clauses.push("flow_id = ?"); params.push(options.flowId); }

--- a/src/evolverun/clawweb/public/modules/clawevolve/server/routes/__tests__/evolve-knowledge.test.ts
+++ b/src/evolverun/clawweb/public/modules/clawevolve/server/routes/__tests__/evolve-knowledge.test.ts
@@ -5,6 +5,9 @@ import { SqliteDatabase, runMigrations } from "@avernet/clawweb-shared/server/db
 import { EvolveRepository } from "../../repositories/evolve-repository.js";
 import { WorkflowEvolutionRepository } from "../../repositories/workflow-evolution-repository.js";
 import { createEvolveRouter } from "../evolve.js";
+import { IssueAggregationRepository } from '../../repositories/issue-aggregation-repository.js';
+import { createInternalEvolveRouter } from '../internal/evolve.js';
+import { createEvolveKnowledgeRouter } from '../evolve-knowledge.js';
 
 let db: SqliteDatabase;
 let repo: EvolveRepository;
@@ -38,6 +41,10 @@ beforeEach(async () => {
   cancelExecution.mockReset();
   const app = express();
   app.use(express.json());
+  app.use('/internal', createInternalEvolveRouter({ db, evolveRepo: repo }));
+  app.use('/restricted', createEvolveKnowledgeRouter(db, repo, {
+    getViewByIdsForOwner: async (owner: string) => ({ viewableIds: new Set(owner === 'owner' ? ['wf'] : []) }),
+  } as never));
   const createSignedUrl = vi.fn();
   createSignedUrl.mockResolvedValue("https://oss.example.test/signed");
   app.use("/api/evolve", createEvolveRouter(repo, {
@@ -52,6 +59,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  vi.restoreAllMocks();
   const activeServer = server;
   server = null;
   if (activeServer) await new Promise<void>((resolve) => activeServer.close(() => resolve()));
@@ -59,6 +67,67 @@ afterEach(async () => {
 });
 
 describe("evolve knowledge endpoints", () => {
+  it('retains competing cause proposals without overwriting a single executable suggestion', async () => {
+    const analyses = new WorkflowEvolutionRepository(db);
+    await analyses.createAnalysisRun({ analysisId: 'multi', requestKey: 'multi', workflowId: 'wf', flowId: 'run', scopeType: 'single_run', scope: { flowIds: ['run'] }, analysisVersion: 'v1', requestedAtMs: 1 });
+    await analyses.completeAnalysisRun('multi', { schemaVersion: 'workflow-evolution-analysis/v1', analysisId: 'multi', facts: [], inferences: [], unknowns: [],
+      diagnoses: [100, 200].map(value => ({ diagnosisId: `d${value}`, flowIds: ['run'], nodeId: 'fetch', failureSignature: 'timeout', failureMode: 'timeout', severity: 'high', reasoning: String(value), evidenceEventIds: [],
+        proposal: { schemaVersion: 'workflow-patch/v1', workflowId: 'wf', baseSpecDigest: 'a'.repeat(64), summary: `timeout ${value}`,
+          operations: [{ op: 'replace', nodeId: 'fetch', path: '/executor/timeoutMs', value }] } })) }, 2);
+    expect((await db.query('SELECT * FROM workflow_healing_suggestions'))).toHaveLength(0);
+    const groups = await new IssueAggregationRepository(db).list('wf');
+    expect(groups[0].sources.map(s => s.proposal?.summary)).toEqual(expect.arrayContaining(['timeout 100', 'timeout 200']));
+    const response = await fetch(`${baseUrl}/api/evolve/issue-groups?workflowId=wf`);
+    expect(response.status).toBe(200);
+    expect((await response.json() as { groups: unknown[] }).groups).toHaveLength(1);
+    expect((await fetch(`${baseUrl}/api/evolve/issue-groups`)).status).toBe(400);
+  });
+  it('freezes latest-run aggregation input, caches completed results and rejects stale or invented references', async () => {
+    const insert = async (id: string, run: string, time: number, findings = true) => {
+      const result = { schemaVersion: 'workflow-evolution-analysis/v1', analysisId: id, facts: [], inferences: [], unknowns: [],
+        diagnoses: findings ? [{ diagnosisId: 'd', flowIds: [run], nodeId: 'fetch', failureSignature: 'timeout · cli · fetch',
+          failureMode: 'timeout', severity: 'high', reasoning: 'network delay', evidenceEventIds: [] }] : [] };
+      await db.exec(`INSERT INTO workflow_evolution_analysis_runs
+        (analysis_id, request_key, scope_type, scope_json, flow_id, workflow_id, status, analysis_version, result_json, requested_at_ms, completed_at_ms)
+        VALUES (?, ?, 'single_run', '{}', ?, 'wf', 'completed', 'v1', ?, ?, ?)`, [id, id, run, JSON.stringify(result), time, time]);
+    };
+    await insert('a', 'run-a', 1);
+    await insert('b', 'run-b', 2);
+    const aggregates = new IssueAggregationRepository(db);
+    const jobs = await aggregates.prepare('b');
+    expect(jobs).toHaveLength(1);
+    expect(jobs[0].input.flowIds).toEqual(['run-a', 'run-b']);
+    expect((await fetch(`${baseUrl}/restricted/issue-groups?workflowId=wf`)).status).toBe(401);
+    expect((await fetch(`${baseUrl}/restricted/issue-groups?workflowId=wf`, { headers: { 'X-User-Id': 'other' } })).status).toBe(403);
+    expect((await fetch(`${baseUrl}/restricted/issue-groups?workflowId=wf`, { headers: { 'X-User-Id': 'owner' } })).status).toBe(200);
+    await db.exec("UPDATE workflow_evolution_analysis_runs SET task_id = 'task', step_id = 'step' WHERE analysis_id = 'b'");
+    vi.spyOn(repo, 'findTask').mockResolvedValue({ bot_id: 'assigned' } as never);
+    vi.spyOn(repo, 'findStep').mockResolvedValue({ task_id: 'task', step_type: 'run_analysis' } as never);
+    const post = (path: string, body: unknown) => fetch(`${baseUrl}/internal${path}`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
+    expect((await post('/analysis-runs/b/aggregations', { botId: 'wrong' })).status).toBe(403);
+    expect((await post('/analysis-runs/b/aggregations', { botId: 'assigned' })).status).toBe(200);
+    const summary = { summary: 'Network delays', causes: [{ title: 'Network', conclusion: 'Slow upstream', certainty: 'hypothesis',
+      sourceIds: jobs[0].input.sources.map(s => s.sourceId) }], unknowns: [] };
+    await expect(aggregates.complete('b', jobs[0].id, { ...summary, causes: [{ ...summary.causes[0], sourceIds: ['invented'] }] })).rejects.toThrow();
+    expect((await post(`/analysis-runs/b/aggregations/${jobs[0].id}`, { botId: 'wrong', result: summary })).status).toBe(403);
+    expect((await post(`/analysis-runs/b/aggregations/${jobs[0].id}`, { botId: 'assigned', result: summary })).status).toBe(200);
+    expect((await aggregates.list('wf'))[0].summary?.summary).toBe('Network delays');
+    expect(await aggregates.prepare('b')).toEqual([]);
+    await insert('c', 'run-a', 3, false);
+    const updated = await aggregates.list('wf');
+    expect(updated[0].flowIds).toEqual(['run-b']);
+    expect(updated[0].stale).toBe(true);
+    expect((await aggregates.list('other'))).toEqual([]);
+    await expect(aggregates.complete('c', jobs[0].id, summary)).rejects.toThrow();
+    const retry = await aggregates.prepare('c');
+    expect(retry).toHaveLength(1);
+    expect(await aggregates.prepare('c')).toEqual([]);
+    await db.exec('UPDATE workflow_evolution_analysis_runs SET requested_at_ms = 1 WHERE analysis_id = ?', [retry[0].id]);
+    const recovered = await aggregates.prepare('c');
+    expect(recovered).toHaveLength(1);
+    expect(recovered[0].id).not.toBe(retry[0].id);
+    await expect(aggregates.complete('c', retry[0].id, summary)).rejects.toThrow();
+  });
   it("normalizes legacy applied suggestions to applied-unverified for clients", async () => {
     const suggestion = await repo.createSuggestion({
       workflowId: "wf-legacy",

--- a/src/evolverun/clawweb/public/modules/clawevolve/server/routes/__tests__/evolve-knowledge.test.ts
+++ b/src/evolverun/clawweb/public/modules/clawevolve/server/routes/__tests__/evolve-knowledge.test.ts
@@ -67,6 +67,32 @@ afterEach(async () => {
 });
 
 describe("evolve knowledge endpoints", () => {
+  it.each([false, true])('refreshes removed run-set sources with partial findings=%s', async (partial) => {
+    const insert = async (id: string, flows: string[], findings: string[], time: number) => {
+      const result = { schemaVersion: 'workflow-evolution-analysis/v1', analysisId: id, facts: [], inferences: [], unknowns: [],
+        diagnoses: findings.map(flow => ({ diagnosisId: flow, flowIds: [flow], nodeId: 'fetch', failureSignature: 'timeout · cli · fetch',
+          failureMode: 'timeout', severity: 'high', reasoning: 'network delay', evidenceEventIds: [] })) };
+      await db.exec(`INSERT INTO workflow_evolution_analysis_runs
+        (analysis_id, request_key, scope_type, scope_json, workflow_id, status, analysis_version, result_json, requested_at_ms, completed_at_ms)
+        VALUES (?, ?, 'run_set', ?, 'wf', 'completed', 'v1', ?, ?, ?)`,
+      [id, id, JSON.stringify({ flowIds: flows }), JSON.stringify(result), time, time]);
+    };
+    await insert('old', ['run-a', 'run-b'], ['run-a', 'run-b'], 1);
+    const aggregates = new IssueAggregationRepository(db);
+    const [old] = await aggregates.prepare('old');
+    await aggregates.complete('old', old.id, { summary: 'Old conclusion', unknowns: [], causes: [{
+      title: 'Network', conclusion: 'Slow upstream', certainty: 'hypothesis', sourceIds: old.input.sources.map(s => s.sourceId),
+    }] });
+    await insert('replacement', ['run-a', 'run-c'], partial ? ['run-c'] : [], 2);
+    // A partial result uses a different signature, so it cannot accidentally refresh the removed cause.
+    if (partial) await db.exec("UPDATE workflow_evolution_analysis_runs SET result_json = replace(result_json, 'timeout · cli · fetch', 'timeout · approval · review') WHERE analysis_id = 'replacement'");
+    const jobs = await aggregates.prepare('replacement');
+    const refreshed = jobs.find(job => job.input.signature === 'timeout · cli · fetch');
+    expect(refreshed?.input.flowIds).toEqual(['run-b']);
+    expect(refreshed?.input.sources.map(s => s.flowId)).toEqual(['run-b']);
+    expect(jobs).toHaveLength(partial ? 2 : 1);
+    expect(await aggregates.prepare('replacement')).toEqual([]);
+  });
   it('retains competing cause proposals without overwriting a single executable suggestion', async () => {
     const analyses = new WorkflowEvolutionRepository(db);
     await analyses.createAnalysisRun({ analysisId: 'multi', requestKey: 'multi', workflowId: 'wf', flowId: 'run', scopeType: 'single_run', scope: { flowIds: ['run'] }, analysisVersion: 'v1', requestedAtMs: 1 });

--- a/src/evolverun/clawweb/public/modules/clawevolve/server/routes/evolve-knowledge.ts
+++ b/src/evolverun/clawweb/public/modules/clawevolve/server/routes/evolve-knowledge.ts
@@ -5,6 +5,7 @@ import type { EvolveRepository } from "../repositories/evolve-repository.js"
 import type { BotWorkflowPermissionRepository } from "@avernet/clawweb-shared/server/repositories/bot-workflow-permission-repository"
 import { requireWorkflowAccess } from "@avernet/clawweb-shared/server/services/workflow-access"
 import { WorkflowEvolutionRepository } from "../repositories/workflow-evolution-repository.js"
+import { IssueAggregationRepository } from '../repositories/issue-aggregation-repository.js';
 
 function lessonSuccessRate(hitCount: number, rescuedCount: number): number {
   if (!hitCount) return 0;
@@ -64,6 +65,17 @@ export function createEvolveKnowledgeRouter(
 ): Router {
   const router = Router();
   const workflowEvolutionRepo = new WorkflowEvolutionRepository(_db);
+
+  router.get('/issue-groups', async (req: Request, res: Response) => {
+    const workflowId = textOrNull(req.query.workflowId);
+    if (!workflowId) { res.status(400).json({ error: 'workflowId is required' }); return; }
+    if (!await requireWorkflowAccess(req, res, botPermRepo, workflowId, 'view')) return;
+    try {
+      res.json({ groups: await new IssueAggregationRepository(_db).list(workflowId) });
+    } catch {
+      res.status(500).json({ error: 'issue_groups_unavailable' });
+    }
+  });
 
   router.get("/lessons", async (req: Request, res: Response) => {
     if (!repo) {

--- a/src/evolverun/clawweb/public/modules/clawevolve/server/routes/internal/evolve.ts
+++ b/src/evolverun/clawweb/public/modules/clawevolve/server/routes/internal/evolve.ts
@@ -8,6 +8,7 @@
  * 所有 LLM 分析都发生在 ClawMind plugin 内。
  */
 import { Router, type Request, type Response } from "express";
+import { IssueAggregationRepository } from '../../repositories/issue-aggregation-repository.js';
 import type { IDatabase, Row } from "@avernet/clawweb-shared/server/db";
 import type { EvolveRepository } from "../../repositories/evolve-repository.js";
 import crypto from "node:crypto";
@@ -273,7 +274,7 @@ export function createInternalEvolveRouter(repos: InternalEvolveRepos): Router {
         }
       }
     }
-    res.json({ ...input, workflowSpecDigest, workflowSpec });
+    res.json({ ...input, workflowSpecDigest, workflowSpec, issueAggregationSupported: true });
   });
 
   router.post("/analysis-runs/:analysisId/claim", async (req: Request, res: Response) => {
@@ -336,6 +337,31 @@ export function createInternalEvolveRouter(repos: InternalEvolveRepos): Router {
     } catch (error) {
       const status = error instanceof AnalysisBotMismatchError ? 403 : 400;
       res.status(status).json({ error: status === 403 ? "analysis_bot_mismatch" : "invalid_analysis_progress", message: error instanceof Error ? error.message : String(error) });
+    }
+  });
+
+  router.post('/analysis-runs/:analysisId/aggregations', async (req: Request, res: Response) => {
+    try {
+      const parentId = String(req.params.analysisId);
+      const parent = await workflowEvolutionRepo.findAnalysisRun(parentId);
+      if (!parent) { res.status(404).json({ error: 'analysis_not_found' }); return; }
+      await assertLinkedAnalysisBot(parent, textOrNull(req.body?.botId));
+      res.json({ jobs: await new IssueAggregationRepository(db).prepare(parentId) });
+    } catch (error) {
+      res.status(error instanceof AnalysisBotMismatchError ? 403 : 400).json({ error: 'aggregation_request_failed' });
+    }
+  });
+
+  router.post('/analysis-runs/:analysisId/aggregations/:aggregationId', async (req: Request, res: Response) => {
+    try {
+      const parentId = String(req.params.analysisId);
+      const parent = await workflowEvolutionRepo.findAnalysisRun(parentId);
+      if (!parent) { res.status(404).json({ error: 'analysis_not_found' }); return; }
+      await assertLinkedAnalysisBot(parent, textOrNull(req.body?.botId));
+      await new IssueAggregationRepository(db).complete(parentId, String(req.params.aggregationId), req.body?.result, req.body?.failed === true);
+      res.json({ ok: true });
+    } catch (error) {
+      res.status(error instanceof AnalysisBotMismatchError ? 403 : 400).json({ error: 'aggregation_result_rejected' });
     }
   });
 

--- a/src/evolverun/clawweb/public/modules/clawevolve/server/services/evolution/__tests__/issue-aggregation.test.ts
+++ b/src/evolverun/clawweb/public/modules/clawevolve/server/services/evolution/__tests__/issue-aggregation.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { buildIssueGroups, validateIssueSummary } from '../issue-aggregation.js';
+
+const diagnosis = (id: string, signature = 'timeout · cli · fetch') => ({
+  diagnosisId: id, flowIds: ['run-a'], nodeId: 'fetch', failureSignature: signature,
+  failureMode: 'timeout', severity: 'high' as const, reasoning: id, evidenceEventIds: [`event-${id}`],
+});
+const analysis = (id: string, flowId: string, time: number, diagnoses: ReturnType<typeof diagnosis>[]) => ({
+  analysisId: id, flowId, completedAtMs: time,
+  diagnoses: diagnoses.map(d => ({ ...d, flowIds: [flowId] })),
+});
+
+describe('issue aggregation', () => {
+  it('replaces the entire older analysis, retaining two causes in the latest run and counting unique runs', () => {
+    const groups = buildIssueGroups('wf', [
+      analysis('old', 'run-a', 1, [diagnosis('obsolete')]),
+      analysis('new', 'run-a', 2, [diagnosis('network'), diagnosis('retry')]),
+      analysis('other', 'run-b', 3, [diagnosis('network-b')]),
+    ]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].flowIds).toEqual(['run-a', 'run-b']);
+    expect(groups[0].sources.map(s => s.diagnosisId).sort()).toEqual(['network', 'network-b', 'retry']);
+  });
+  it('does not resurrect an old issue when the latest completed analysis is empty', () => {
+    expect(buildIssueGroups('wf', [analysis('old', 'run-a', 1, [diagnosis('old')]), analysis('new', 'run-a', 2, [])])).toEqual([]);
+    expect(buildIssueGroups('wf', [analysis('old', 'run-a', 1, [diagnosis('old')]),
+      { analysisId: 'batch', flowId: null, flowIds: ['run-a'], completedAtMs: 3, diagnoses: [] }])).toEqual([]);
+  });
+  it('keeps separate signatures and a stable digest regardless of input order', () => {
+    const inputs = [analysis('a', 'run-a', 1, [diagnosis('a')]), analysis('b', 'run-b', 2, [diagnosis('b', 'timeout · approval · review')])];
+    expect(buildIssueGroups('wf', inputs)).toEqual(buildIssueGroups('wf', [...inputs].reverse()));
+    expect(buildIssueGroups('wf', inputs)).toHaveLength(2);
+  });
+  it('preserves multiple causes and rejects invented or unaccounted source references', () => {
+    const group = buildIssueGroups('wf', [analysis('a', 'run-a', 1, [diagnosis('network'), diagnosis('retry')])])[0];
+    const result = { summary: 'Two possible causes', causes: group.sources.map(s => ({
+      title: s.diagnosisId, conclusion: s.reasoning, certainty: 'hypothesis', sourceIds: [s.sourceId],
+    })), unknowns: ['Needs verification'] };
+    expect(validateIssueSummary(result, group).causes).toHaveLength(2);
+    expect(() => validateIssueSummary({ ...result, causes: [{ ...result.causes[0], sourceIds: ['invented'] }] }, group)).toThrow();
+    expect(() => validateIssueSummary({ ...result, causes: result.causes.slice(0, 1) }, group)).toThrow();
+  });
+});

--- a/src/evolverun/clawweb/public/modules/clawevolve/server/services/evolution/issue-aggregation.ts
+++ b/src/evolverun/clawweb/public/modules/clawevolve/server/services/evolution/issue-aggregation.ts
@@ -1,0 +1,65 @@
+import { digestCanonicalJson, type WorkflowEvolutionDiagnosis } from './contracts.js';
+
+export type IssueAnalysis = { analysisId: string; flowId: string | null; flowIds?: string[]; completedAtMs: number; diagnoses: WorkflowEvolutionDiagnosis[] };
+export type IssueSource = WorkflowEvolutionDiagnosis & { sourceId: string; analysisId: string; flowId: string; completedAtMs: number };
+export type IssueGroup = { workflowId: string; signature: string; inputDigest: string; flowIds: string[]; sources: IssueSource[] };
+export type IssueSummary = {
+  summary: string;
+  causes: Array<{ title: string; conclusion: string; certainty: 'supported' | 'hypothesis' | 'unknown'; sourceIds: string[] }>;
+  unknowns: string[];
+};
+
+/** Select entire latest successful analyses before grouping; an empty result replaces older findings. */
+export function buildIssueGroups(workflowId: string, analyses: IssueAnalysis[]): IssueGroup[] {
+  const latest = new Map<string, IssueAnalysis>();
+  const ordered = [...analyses].sort((a, b) => b.completedAtMs - a.completedAtMs || b.analysisId.localeCompare(a.analysisId));
+  for (const analysis of ordered) {
+    const flowIds = new Set([...(analysis.flowIds ?? []), ...(analysis.flowId ? [analysis.flowId] : []), ...analysis.diagnoses.flatMap(d => d.flowIds)]);
+    for (const flowId of flowIds) if (!latest.has(flowId)) latest.set(flowId, analysis);
+  }
+  const groups = new Map<string, IssueSource[]>();
+  for (const [flowId, analysis] of latest) {
+    for (const diagnosis of analysis.diagnoses.filter(d => d.flowIds.includes(flowId))) {
+      const source: IssueSource = { ...diagnosis, flowIds: [flowId], flowId, analysisId: analysis.analysisId,
+        completedAtMs: analysis.completedAtMs,
+        sourceId: digestCanonicalJson([analysis.analysisId, diagnosis.diagnosisId, flowId]),
+      };
+      const sources = groups.get(diagnosis.failureSignature) ?? [];
+      sources.push(source);
+      groups.set(diagnosis.failureSignature, sources);
+    }
+  }
+  return [...groups].sort(([a], [b]) => a.localeCompare(b)).map(([signature, sources]) => {
+    sources.sort((a, b) => a.sourceId.localeCompare(b.sourceId));
+    return { workflowId, signature, sources, flowIds: [...new Set(sources.map(s => s.flowId))].sort(),
+      inputDigest: digestCanonicalJson({ workflowId, signature, sources }),
+    };
+  });
+}
+
+export function validateIssueSummary(raw: unknown, group: IssueGroup): IssueSummary {
+  const text = (value: unknown, max = 8000): string => {
+    if (typeof value !== 'string' || !value.trim() || value.length > max) throw new Error('invalid aggregation text');
+    return value.trim();
+  };
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) throw new Error('invalid aggregation');
+  const value = raw as Record<string, unknown>;
+  if (!Array.isArray(value.causes) || !value.causes.length || value.causes.length > 100) throw new Error('invalid causes');
+  const allowed = new Set(group.sources.map(s => s.sourceId));
+  const covered = new Set<string>();
+  const causes = value.causes.map((entry): IssueSummary['causes'][number] => {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) throw new Error('invalid cause');
+    const c = entry as Record<string, unknown>;
+    if (!['supported', 'hypothesis', 'unknown'].includes(String(c.certainty))) throw new Error('invalid certainty');
+    if (!Array.isArray(c.sourceIds) || !c.sourceIds.length || c.sourceIds.length > allowed.size) throw new Error('invalid sourceIds');
+    const sourceIds = [...new Set(c.sourceIds.map(id => text(id, 64)))];
+    for (const id of sourceIds) {
+      if (!allowed.has(id)) throw new Error('unknown source reference');
+      covered.add(id);
+    }
+    return { title: text(c.title, 200), conclusion: text(c.conclusion), certainty: c.certainty as IssueSummary['causes'][number]['certainty'], sourceIds };
+  });
+  if (covered.size !== allowed.size) throw new Error('aggregation omitted source diagnoses');
+  if (!Array.isArray(value.unknowns) || value.unknowns.length > 100) throw new Error('invalid unknowns');
+  return { summary: text(value.summary), causes, unknowns: value.unknowns.map(v => text(v)) };
+}

--- a/src/evolverun/clawweb/public/modules/workflow/web/components/workflow-workspace/EvolutionTab.tsx
+++ b/src/evolverun/clawweb/public/modules/workflow/web/components/workflow-workspace/EvolutionTab.tsx
@@ -282,6 +282,10 @@ function DiagnosisPanel({
     const status = resolveSuggestionStatus(suggestion, localStatus, applyTaskMap[suggestion.id])
     return [suggestion.signature, { ...suggestion, status }] as const
   }))
+  const clusterSignatures = new Set(clusters.map(cluster => cluster.signature))
+  const standaloneSuggestions = suggestions
+    .filter(suggestion => !clusterSignatures.has(suggestion.signature))
+    .map(suggestion => ({ ...suggestion, status: resolveSuggestionStatus(suggestion, localStatus, applyTaskMap[suggestion.id]) }))
   const enriched = clusters.map((cluster) => {
     const suggestion = suggestionBySignature.get(cluster.signature)
     const runIds = Array.from(new Set([
@@ -334,7 +338,7 @@ function DiagnosisPanel({
         <p className="mt-1 text-xs leading-5 text-slate-500">同类异常按失败特征聚合；建议只在具备可执行方案时出现，应用完成后仍需验证实际效果。</p>
       </div>
 
-      {diagnoses.length === 0 && (
+      {diagnoses.length === 0 && standaloneSuggestions.length === 0 && (
         <div className="rounded-xl border border-slate-200 bg-white p-5 text-xs text-slate-500">
           当前工作流暂无已记录异常。任务护航会分析失败运行，也会保留成功运行中的异常和退化信号。
         </div>
@@ -445,6 +449,32 @@ function DiagnosisPanel({
               </button>
             </div>
           </article>
+          })}
+        </div>
+      </section>}
+
+      {standaloneSuggestions.length > 0 && <section aria-label="已有建议跟进" className="overflow-hidden rounded-xl border border-slate-200 bg-white">
+        <div className="border-b border-slate-200 px-4 py-3">
+          <h3 className="text-sm font-semibold text-slate-900">已有建议跟进</h3>
+          <p className="mt-1 text-xs leading-5 text-slate-500">最新分析已无对应诊断；已有建议和任务仍需独立跟进，不代表修复已验证有效。</p>
+        </div>
+        <div className="divide-y divide-slate-100">
+          {standaloneSuggestions.map(suggestion => {
+            const status = SUGGESTION_STATUS[suggestion.status] ?? SUGGESTION_STATUS.pending
+            return <article key={suggestion.id} className="flex flex-wrap items-start justify-between gap-3 px-4 py-3">
+              <div className="min-w-0 flex-1">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="text-sm font-semibold text-slate-900">{suggestion.weakNode || '工作流建议'}</span>
+                  <span className={`rounded-full px-2 py-0.5 text-[10px] font-medium ${status.cls}`}>{status.label}</span>
+                </div>
+                <p className="mt-1.5 break-words text-xs leading-5 text-slate-600">{suggestion.description}</p>
+                <p className="mt-1 break-all text-[10px] text-slate-400">{suggestion.signature}</p>
+                <ApplyTaskStatusBadge task={applyTaskMap[suggestion.id]} />
+              </div>
+              <div className="flex flex-wrap items-center gap-2">
+                <SuggestionActions suggestion={suggestion} canEdit={canEdit} onAction={onAction} onApply={onApply} />
+              </div>
+            </article>
           })}
         </div>
       </section>}

--- a/src/evolverun/clawweb/public/modules/workflow/web/components/workflow-workspace/EvolutionTab.tsx
+++ b/src/evolverun/clawweb/public/modules/workflow/web/components/workflow-workspace/EvolutionTab.tsx
@@ -2,7 +2,6 @@ import { useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import {
   useEvolveLessons,
-  useEvolveDiagnoses,
   useEvolveSuggestions,
   useRecordSuggestionAction,
   useEligibleBotsForSuggestion,
@@ -14,6 +13,8 @@ import {
 import type { EvolveSuggestion, SuggestionApplyTask } from '@avernet/clawweb-shared/web/api/client'
 import RunEvolutionAnalysis from '../evolution/RunEvolutionAnalysis'
 import { aggregateDiagnoses, diffWorkflowPatchOperations, timeValue, type DiagnosisCluster } from './evolution-utils'
+import { groupDiagnoses, useIssueGroups } from './issue-groups'
+import IssueSummary from './IssueSummary'
 
 export type EvoTab = 'diagnosis' | 'remedies'
 
@@ -146,24 +147,25 @@ function IssueDetailDrawer({ cluster, suggestion, task, previousTask, selectedFl
             <span className="rounded-full bg-slate-100 px-2 py-0.5 text-[10px] text-slate-600">{cluster.mode}</span>
             {status ? <span className={`rounded-full px-2 py-0.5 text-[10px] font-medium ${status.cls}`}>{status.label}</span> : <span className="rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-medium text-slate-500">观察中</span>}
           </div>
-          <p className="mt-1 text-xs text-slate-400">{cluster.diagnoses.length} 次出现 · 影响 {cluster.runIds.length} 个运行</p>
+          <p className="mt-1 text-xs text-slate-400">影响 {cluster.runIds.length} 个运行</p>
         </div>
         <button type="button" onClick={onClose} className="flex h-8 w-8 items-center justify-center rounded-lg text-lg text-slate-400 hover:bg-slate-100 hover:text-slate-700" aria-label="关闭">×</button>
       </header>
 
       <div className="min-h-0 flex-1 overflow-y-auto px-5 py-5">
-        <section>
-          <p className="text-xs font-semibold text-slate-900">聚合结论</p>
+        {cluster.aggregation ? <IssueSummary group={cluster.aggregation} /> : <section>
+          <p className="text-xs font-semibold text-slate-900">最新诊断结论</p>
           <p className="mt-2 whitespace-pre-wrap break-words text-sm leading-6 text-slate-600">{summary}</p>
           <p className="mt-2 truncate font-mono text-[10px] text-slate-400" title={cluster.signature}>{cluster.signature}</p>
-        </section>
+        </section>}
 
         <section className="mt-6 border-t border-slate-100 pt-5">
           <div className="flex flex-wrap items-center gap-2">
-            <p className="text-xs font-semibold text-slate-900">当前建议</p>
+            <p className="text-xs font-semibold text-slate-900">已有建议</p>
             {suggestion && <span className="rounded-full bg-slate-100 px-2 py-0.5 text-[10px] text-slate-600">{REMEDY_KIND[suggestion.kind] ?? suggestion.kind}</span>}
           </div>
           {suggestion ? <>
+            <p className="mt-2 text-xs text-amber-700">建议与聚合结论独立；应用或验证此建议不代表所有原因均已解决。</p>
             <p className="mt-2 whitespace-pre-wrap break-words text-sm leading-6 text-slate-600">{suggestion.description}</p>
             {suggestion.verificationStatus === 'recurrence_detected' && <p className="mt-3 rounded-lg bg-red-50 px-3 py-2 text-xs leading-5 text-red-600">应用后再次出现 {suggestion.recurrenceCount ?? 1} 次，需要重新判断。</p>}
             {proposalDiff && (proposalDiff.added.length + proposalDiff.changed.length + proposalDiff.removed.length > 0) && <div className="mt-3 rounded-lg border border-blue-100 bg-blue-50/60 px-3 py-2 text-xs leading-5 text-slate-600">
@@ -206,11 +208,11 @@ function IssueDetailDrawer({ cluster, suggestion, task, previousTask, selectedFl
           {cluster.instances.length > 10 && <p className="mt-2 text-[10px] text-slate-400">仅展示最近 10 条分析记录</p>}
         </section>
 
-        {selectedInstance?.analysisId !== 'legacy' && <section className="mt-6 border-t border-slate-100 pt-5">
-          <div className="flex flex-wrap items-baseline justify-between gap-2">
+        {selectedInstance?.analysisId !== 'legacy' && <details open className="mt-6 border-t border-slate-100 pt-5">
+          <summary className="flex cursor-pointer flex-wrap items-baseline justify-between gap-2">
             <p className="text-xs font-semibold text-slate-900">所选分析详情</p>
             <p className="font-mono text-[10px] text-slate-400">{selectedInstance.analysisId}</p>
-          </div>
+          </summary>
           {instanceAnalysis.isLoading && <p className="mt-2 text-xs text-slate-500">加载所选分析...</p>}
           {instanceAnalysis.isError && <p className="mt-2 text-xs text-red-600">分析结果加载失败</p>}
           {!instanceAnalysis.isLoading && !instanceAnalysis.isError && !instanceAnalysis.data?.analysis && (
@@ -224,7 +226,7 @@ function IssueDetailDrawer({ cluster, suggestion, task, previousTask, selectedFl
             focusDiagnosisId={selectedInstance.diagnosisId}
             focusFailureSignature={cluster.signature}
           /></div>}
-        </section>}
+        </details>}
       </div>
 
       {suggestion && <footer className="flex min-h-16 items-center justify-end gap-2 border-t border-slate-200 bg-white px-5 py-3">
@@ -261,8 +263,8 @@ function DiagnosisPanel({
   onApply: (ids: string[]) => void
   canEdit: boolean
 }) {
-  const { data, isLoading } = useEvolveDiagnoses({ workflowId, limit: 100 })
-  const diagnoses = data?.diagnoses ?? []
+  const { data, isLoading, isError, refetch } = useIssueGroups(workflowId)
+  const diagnoses = (data?.groups ?? []).flatMap(groupDiagnoses)
   const [nodeFilter, setNodeFilter] = useState<string>('all')
   const [modeFilter, setModeFilter] = useState<string>('all')
   const [stateFilter, setStateFilter] = useState<IssueState | 'all'>('all')
@@ -270,8 +272,10 @@ function DiagnosisPanel({
   const [selectedSuggestionIds, setSelectedSuggestionIds] = useState<string[]>([])
 
   if (isLoading || suggestionsLoading) return <div className="p-4 text-xs text-slate-500">加载问题与建议...</div>
+  if (isError) return <div role="alert" className="p-4 text-xs text-red-600">问题分组加载失败，不能显示为没有问题。<button type="button" onClick={() => void refetch()} className="ml-2 underline">重试</button></div>
 
   const clusters = aggregateDiagnoses(diagnoses)
+  for (const cluster of clusters) cluster.aggregation = data?.groups.find(group => group.signature === cluster.signature)
   const nodes = Array.from(new Set(clusters.map((cluster) => cluster.node))).sort()
   const modes = Array.from(new Set(clusters.map((cluster) => cluster.mode).filter(Boolean)))
   const suggestionBySignature = new Map(suggestions.map((suggestion) => {
@@ -282,7 +286,6 @@ function DiagnosisPanel({
     const suggestion = suggestionBySignature.get(cluster.signature)
     const runIds = Array.from(new Set([
       ...cluster.runIds,
-      ...(suggestion?.evidenceRuns ?? []),
     ]))
     const instances = [
       ...cluster.instances,
@@ -293,7 +296,7 @@ function DiagnosisPanel({
         occurredAtMs: timeValue(cluster.latest.gmt_create),
         diagnosis: cluster.latest,
       })),
-    ]
+    ].filter((instance, index, all) => all.findIndex(item => item.flowId === instance.flowId) === index)
     return {
       cluster: { ...cluster, runIds, instances },
       suggestion,
@@ -401,7 +404,7 @@ function DiagnosisPanel({
         <div className="divide-y divide-slate-100">
           {filtered.map(({ cluster, suggestion }) => {
           const status = suggestion ? SUGGESTION_STATUS[suggestion.status] ?? SUGGESTION_STATUS.pending : null
-          const summary = cluster.latest.error_text ?? cluster.latest.reasoning ?? cluster.mode
+          const summary = cluster.aggregation?.summary?.summary ?? '聚合结论尚未生成，查看单次运行分析。'
           const task = suggestion ? applyTaskMap[suggestion.id] : undefined
           const selectable = canEdit && suggestion != null && ['pending', 'adopted', 'failed'].includes(suggestion.status)
           return <article key={cluster.signature} data-layout="compact-issue-row" className="px-4 py-3 transition-colors hover:bg-slate-50/70">
@@ -428,7 +431,6 @@ function DiagnosisPanel({
                 {suggestion?.verificationStatus === 'recurrence_detected' && <p className="mt-1.5 text-[11px] text-red-600">应用后再次出现 {suggestion.recurrenceCount ?? 1} 次，需要重新判断。</p>}
                 <ApplyTaskStatusBadge task={task} />
                 <div className="mt-2 flex flex-wrap items-center gap-x-3 text-[10px] text-slate-400">
-                  <span>{cluster.diagnoses.length} 次出现</span>
                   <span>影响 {cluster.runIds.length} 个运行</span>
                   <span>{new Date(timeValue(cluster.latest.gmt_create)).toLocaleString()}</span>
                 </div>

--- a/src/evolverun/clawweb/public/modules/workflow/web/components/workflow-workspace/IssueSummary.tsx
+++ b/src/evolverun/clawweb/public/modules/workflow/web/components/workflow-workspace/IssueSummary.tsx
@@ -1,0 +1,40 @@
+import type { IssueGroupView } from './issue-groups';
+
+export default function IssueSummary({ group }: { group: IssueGroupView }) {
+  const statusText = group.aggregationStatus === 'queued' ? '正在生成聚合结论…'
+    : group.aggregationStatus === 'failed' ? '聚合失败，单次分析已保留；下次分析时会重试。'
+    : group.aggregationStatus === 'too_large' ? '诊断输入过多，暂不能生成完整聚合；请查看单次分析。'
+    : '尚未生成聚合结论；下一次运行分析完成后更新。';
+  const sources = group.summarySources ?? group.sources;
+  return <section aria-label="聚合结论">
+    <h4 className="text-xs font-semibold text-slate-900">聚合结论</h4>
+    {group.aggregationStatus !== 'completed' && <p role="status" className="mt-2 text-xs text-amber-700">{statusText}</p>}
+    {group.stale && <p className="mt-2 text-xs text-amber-700">以下为上次聚合，尚未覆盖最新分析。</p>}
+    {group.summary && <>
+      <p className="mt-2 whitespace-pre-wrap break-words text-sm leading-6 text-slate-600">{group.summary.summary}</p>
+      <div className="mt-4 divide-y divide-slate-100">
+        {group.summary.causes.map((cause, index) => {
+          const linked = sources.filter(s => cause.sourceIds.includes(s.sourceId));
+          const runIds = [...new Set(linked.map(s => s.flowId))];
+          return <article key={index} className="py-3">
+            <div className="flex flex-wrap items-center gap-2"><h5 className="text-sm font-medium text-slate-900">{cause.title}</h5>
+              <span className="text-[10px] text-slate-500">{cause.certainty === 'supported' ? '有依据' : cause.certainty === 'hypothesis' ? '推测' : '待确认'}</span>
+              <span className="text-[10px] text-slate-400">影响 {runIds.length} 个运行</span></div>
+            <p className="mt-1 whitespace-pre-wrap text-xs leading-5 text-slate-600">{cause.conclusion}</p>
+            <details className="mt-2 text-xs text-slate-500"><summary className="cursor-pointer">查看来源运行与依据</summary>
+              {runIds.map(id => <p key={id} className="mt-2 break-all font-mono text-[10px]">{id}</p>)}
+              {linked.map(s => <div key={s.sourceId} className="mt-2 border-l-2 border-slate-100 pl-2">
+                <p className="text-[10px]">{s.analysisId}</p><p className="mt-1 leading-5">{s.reasoning}</p>
+                {!!s.evidenceEventIds?.length && <p className="mt-1 break-all text-[10px]">证据：{s.evidenceEventIds.join('、')}</p>}
+                {s.proposal && <p className="mt-1 text-xs text-slate-600">该诊断的候选建议（非聚合执行指令）：{s.proposal.summary}</p>}
+              </div>)}
+            </details>
+          </article>;
+        })}
+      </div>
+      {group.summary.unknowns.length > 0 && <div className="mt-2 rounded bg-amber-50 p-3 text-xs leading-5 text-amber-800">
+        <p className="font-medium">待确认</p>{group.summary.unknowns.map((text, i) => <p key={i}>{text}</p>)}
+      </div>}
+    </>}
+  </section>;
+}

--- a/src/evolverun/clawweb/public/modules/workflow/web/components/workflow-workspace/__tests__/EvolutionIssueFlow.test.tsx
+++ b/src/evolverun/clawweb/public/modules/workflow/web/components/workflow-workspace/__tests__/EvolutionIssueFlow.test.tsx
@@ -3,6 +3,25 @@ import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 import { describe, expect, it, vi } from 'vitest'
 
+vi.mock('../issue-groups', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../issue-groups')>();
+  const hooks = await import('../../../api/hooks');
+  return { ...actual, useIssueGroups: () => {
+    const rows = hooks.useEvolveDiagnoses().data!.diagnoses;
+    const signatures = [...new Set(rows.map(row => row.failure_signature))];
+    return { isLoading: false, isError: false, data: { groups: signatures.map(signature => ({
+      workflowId: 'wf-1', signature, flowIds: rows.filter(r => r.failure_signature === signature).map(r => r.flow_id),
+      inputDigest: 'fixture', aggregationStatus: 'not_generated', summary: null, stale: false,
+      sources: rows.filter(row => row.failure_signature === signature).map(row => ({
+        sourceId: String(row.id), analysisId: row.analysis_id ?? 'legacy', diagnosisId: row.diagnosis_id,
+        flowId: row.flow_id, flowIds: [row.flow_id], nodeId: row.node_id, failureMode: row.failure_mode,
+        completedAtMs: Number(row.gmt_create), reasoning: row.reasoning ?? row.error_text,
+        evidenceEventIds: row.evidence_event_ids ?? [],
+      })),
+    })) } };
+  } };
+});
+
 const { mutate, applyBatch, eligibleBots, applyTasks, runAnalysis } = vi.hoisted(() => ({
   mutate: vi.fn(),
   applyBatch: vi.fn(),
@@ -204,7 +223,7 @@ describe('issue and optimization flow', () => {
     await userEvent.click(within(actionableIssue!).getByRole('button', { name: '查看' }))
     const drawer = screen.getByRole('dialog', { name: '问题详情' })
     expect(within(drawer).getByText('聚合结论')).toBeInTheDocument()
-    expect(within(drawer).getByText('当前建议')).toBeInTheDocument()
+    expect(within(drawer).getByText('已有建议')).toBeInTheDocument()
     expect(within(drawer).getByText('相关分析记录')).toBeInTheDocument()
     expect(within(drawer).getByText('所选分析详情')).toBeInTheDocument()
     expect(within(drawer).getByText('判断依据')).toBeInTheDocument()
@@ -250,7 +269,7 @@ describe('issue and optimization flow', () => {
 
     const drawer = screen.getByRole('dialog', { name: '问题详情' })
     expect(within(drawer).getByRole('button', { name: '选择分析 run-1 AN-1' })).toBeInTheDocument()
-    expect(within(drawer).getAllByText('请求超时')).toHaveLength(2)
+    expect(within(drawer).getAllByText('请求超时')).toHaveLength(1)
     expect(runAnalysis).toHaveBeenCalledWith('run-1', 'AN-1', true)
   })
 

--- a/src/evolverun/clawweb/public/modules/workflow/web/components/workflow-workspace/__tests__/EvolutionIssueFlow.test.tsx
+++ b/src/evolverun/clawweb/public/modules/workflow/web/components/workflow-workspace/__tests__/EvolutionIssueFlow.test.tsx
@@ -1,13 +1,16 @@
 import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const lifecycle = vi.hoisted(() => ({ hideGroups: false, status: 'pending', canEdit: true }))
+afterEach(() => { lifecycle.hideGroups = false; lifecycle.status = 'pending'; lifecycle.canEdit = true })
 
 vi.mock('../issue-groups', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../issue-groups')>();
   const hooks = await import('../../../api/hooks');
   return { ...actual, useIssueGroups: () => {
-    const rows = hooks.useEvolveDiagnoses().data!.diagnoses;
+    const rows = lifecycle.hideGroups ? [] : hooks.useEvolveDiagnoses().data!.diagnoses;
     const signatures = [...new Set(rows.map(row => row.failure_signature))];
     return { isLoading: false, isError: false, data: { groups: signatures.map(signature => ({
       workflowId: 'wf-1', signature, flowIds: rows.filter(r => r.failure_signature === signature).map(r => r.flow_id),
@@ -175,7 +178,7 @@ vi.mock('../../../api/hooks', () => ({
           impactRuns: 2,
           evidenceRuns: ['run-1', 'run-4'],
           description: '将超时阈值调整为 90 秒',
-          status: 'pending',
+          status: lifecycle.status,
           proposalDigest: 'a'.repeat(64),
         },
         {
@@ -197,7 +200,7 @@ vi.mock('../../../api/hooks', () => ({
     refetch: vi.fn(),
   }),
   useSuggestionApplyTasks: applyTasks,
-  useWorkflowAccess: () => ({ data: { canEdit: true } }),
+  useWorkflowAccess: () => ({ data: { canEdit: lifecycle.canEdit } }),
   useRecordSuggestionAction: () => ({ mutate }),
   useEligibleBotsForSuggestion: eligibleBots,
   useApplySuggestion: () => ({ mutateAsync: vi.fn() }),
@@ -209,6 +212,35 @@ vi.mock('../../../api/hooks', () => ({
 import EvolutionTab from '../EvolutionTab'
 
 describe('issue and optimization flow', () => {
+  it.each(['pending', 'applying', 'applied_unverified'])('preserves suggestion-only controls for %s', async (status) => {
+    lifecycle.hideGroups = true
+    lifecycle.status = status
+    render(<MemoryRouter><EvolutionTab workflowId="wf-1" section="diagnosis" /></MemoryRouter>)
+    const row = screen.getByText('将超时阈值调整为 90 秒').closest('article')!
+    expect(row).not.toBeNull()
+    expect(screen.queryByText(/当前工作流暂无已记录异常/)).not.toBeInTheDocument()
+    if (status === 'pending') {
+      await userEvent.click(within(row).getByRole('button', { name: '应用建议' }))
+      expect(screen.getByRole('dialog', { name: '选择 Bot 自动应用建议' })).toBeInTheDocument()
+    } else if (status === 'applied_unverified') {
+      expect(within(row).getByRole('button', { name: '确认有效' })).toBeInTheDocument()
+      expect(within(row).getByRole('button', { name: '未达预期' })).toBeInTheDocument()
+      const confirm = vi.spyOn(window, 'confirm').mockReturnValue(true)
+      await userEvent.click(within(row).getByRole('button', { name: '确认有效' }))
+      expect(mutate).toHaveBeenLastCalledWith(expect.objectContaining({ suggestionId: 's-1', action: 'verified' }), expect.anything())
+      confirm.mockRestore()
+    } else {
+      expect(within(row).getByText('应用中')).toBeInTheDocument()
+      expect(within(row).queryByRole('button', { name: '应用建议' })).not.toBeInTheDocument()
+    }
+  })
+  it('keeps suggestion-only controls read-only without workflow edit permission', () => {
+    lifecycle.hideGroups = true
+    lifecycle.canEdit = false
+    render(<MemoryRouter><EvolutionTab workflowId="wf-1" section="diagnosis" /></MemoryRouter>)
+    expect(screen.getByText('将超时阈值调整为 90 秒')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: '应用建议' })).not.toBeInTheDocument()
+  })
   it('keeps the list compact and opens problem actions in a detail drawer', async () => {
     render(<MemoryRouter><EvolutionTab workflowId="wf-1" section="diagnosis" /></MemoryRouter>)
 
@@ -218,6 +250,7 @@ describe('issue and optimization flow', () => {
     expect(within(actionableIssue!).getByText('将超时阈值调整为 90 秒')).toBeInTheDocument()
     expect(within(actionableIssue!).getByText('将超时阈值调整为 90 秒')).toHaveClass('line-clamp-2')
     expect(within(actionableIssue!).getByText('建议')).toBeInTheDocument()
+    expect(screen.queryByRole('region', { name: '已有建议跟进' })).not.toBeInTheDocument()
     expect(within(actionableIssue!).queryByRole('button', { name: '采纳' })).not.toBeInTheDocument()
 
     await userEvent.click(within(actionableIssue!).getByRole('button', { name: '查看' }))
@@ -334,7 +367,8 @@ describe('issue and optimization flow', () => {
     })
   })
 
-  it('shows the selected Bot and current application progress', async () => {
+  it.each([false, true])('shows application progress with diagnosis groups removed=%s', async (hideGroups) => {
+    lifecycle.hideGroups = hideGroups
     const now = Date.now()
     applyTasks.mockReturnValueOnce({
       data: {

--- a/src/evolverun/clawweb/public/modules/workflow/web/components/workflow-workspace/__tests__/IssueSummary.test.tsx
+++ b/src/evolverun/clawweb/public/modules/workflow/web/components/workflow-workspace/__tests__/IssueSummary.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import IssueSummary from '../IssueSummary';
+
+describe('IssueSummary', () => {
+  it('shows distinct causes with their own source runs and does not invent a shared suggestion', () => {
+    render(<IssueSummary group={{ aggregationStatus: 'completed', stale: false,
+      summary: { summary: 'Different timeout causes', unknowns: ['Need traces'], causes: [
+        { title: 'Network', conclusion: 'Slow endpoint', certainty: 'hypothesis', sourceIds: ['a'] },
+        { title: 'Approval', conclusion: 'Waiting for a person', certainty: 'supported', sourceIds: ['b'] },
+      ] }, sources: [{ sourceId: 'a', flowId: 'run-a' }, { sourceId: 'b', flowId: 'run-b' }] } as never} />);
+    expect(screen.getByText('Network')).toBeTruthy();
+    expect(screen.getByText('Approval')).toBeTruthy();
+    expect(screen.getByText('run-a')).toBeTruthy();
+    expect(screen.getByText('run-b')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /应用/ })).toBeNull();
+  });
+  it('shows missing and failed aggregation explicitly instead of labeling the latest diagnosis a summary', () => {
+    render(<IssueSummary group={{ aggregationStatus: 'failed', summary: null, stale: false, sources: [] } as never} />);
+    expect(screen.getByText(/聚合失败/)).toBeTruthy();
+  });
+});

--- a/src/evolverun/clawweb/public/modules/workflow/web/components/workflow-workspace/evolution-utils.ts
+++ b/src/evolverun/clawweb/public/modules/workflow/web/components/workflow-workspace/evolution-utils.ts
@@ -1,6 +1,8 @@
 import type { EvolveRunDiagnosis } from '@avernet/clawweb-shared/web/api/client'
+import type { IssueGroupView } from './issue-groups'
 
 export type DiagnosisCluster = {
+  aggregation?: IssueGroupView
   key: string
   workflowId: string
   signature: string

--- a/src/evolverun/clawweb/public/modules/workflow/web/components/workflow-workspace/issue-groups.ts
+++ b/src/evolverun/clawweb/public/modules/workflow/web/components/workflow-workspace/issue-groups.ts
@@ -1,0 +1,31 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchJson, type EvolveRunDiagnosis } from '@avernet/clawweb-shared/web/api/client';
+
+export type IssueGroupView = {
+  workflowId: string; signature: string; inputDigest: string; flowIds: string[];
+  aggregationStatus: string; aggregationId: string | null; stale: boolean;
+  sources: Array<{ sourceId: string; flowId: string; flowIds: string[]; analysisId: string; diagnosisId: string;
+    nodeId: string | null; failureSignature: string; failureMode: string; reasoning: string; completedAtMs: number; evidenceEventIds: string[];
+    proposal?: { summary: string; operations: unknown[] } }>;
+  summarySources?: IssueGroupView['sources'];
+  summary: null | { summary: string; unknowns: string[]; causes: Array<{ title: string; conclusion: string;
+    certainty: 'supported' | 'hypothesis' | 'unknown'; sourceIds: string[] }> };
+};
+
+export function useIssueGroups(workflowId: string) {
+  return useQuery({ queryKey: ['evolve-issue-groups', workflowId],
+    queryFn: () => fetchJson<{ groups: IssueGroupView[] }>(`/api/evolve/issue-groups?workflowId=${encodeURIComponent(workflowId)}`),
+    enabled: !!workflowId,
+    refetchInterval: query => query.state.data?.groups.some(group => group.aggregationStatus === 'queued') ? 15_000 : 60_000,
+  });
+}
+
+export function groupDiagnoses(group: IssueGroupView): EvolveRunDiagnosis[] {
+  return group.sources.map(source => ({
+    id: source.sourceId, diagnosis_id: source.diagnosisId, analysis_id: source.analysisId,
+    flow_id: source.flowId, flow_ids: [source.flowId], workflow_id: group.workflowId, run_id: source.flowId,
+    node_id: source.nodeId, weak_node_id: source.nodeId, failure_signature: group.signature, failure_mode: source.failureMode,
+    executor_type: null, suggested_fix_kind: null, lesson_id_hit: null, error_text: null, reasoning: source.reasoning,
+    evidence_event_ids: source.evidenceEventIds, created_by: null, gmt_create: source.completedAtMs, gmt_modified: source.completedAtMs,
+  }));
+}

--- a/src/evolverun/clawweb/public/shared/web/api/hooks.ts
+++ b/src/evolverun/clawweb/public/shared/web/api/hooks.ts
@@ -152,6 +152,7 @@ export function useAnalyzeRun() {
     onSuccess: (_data, input) => {
       void queryClient.invalidateQueries({ queryKey: ['runs'] })
       void queryClient.invalidateQueries({ queryKey: ['evolve-diagnoses'] })
+      void queryClient.invalidateQueries({ queryKey: ['evolve-issue-groups'] })
       void queryClient.invalidateQueries({ queryKey: ['evolve-suggestions'] })
       void queryClient.invalidateQueries({ queryKey: ['run', input.flowId] })
     },
@@ -203,6 +204,7 @@ export function useAnalyzeWorkflowLogs() {
     mutationFn: (input: Parameters<typeof api.evolve.analyzeWorkflowLogs>[0]) => api.evolve.analyzeWorkflowLogs(input),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['evolve-diagnoses'] })
+      void queryClient.invalidateQueries({ queryKey: ['evolve-issue-groups'] })
       void queryClient.invalidateQueries({ queryKey: ['evolve-suggestions'] })
     },
   })
@@ -223,6 +225,7 @@ export function useAnalyzeFlow() {
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['runs'] })
       void queryClient.invalidateQueries({ queryKey: ['evolve-diagnoses'] })
+      void queryClient.invalidateQueries({ queryKey: ['evolve-issue-groups'] })
     },
   })
 }


### PR DESCRIPTION
## Problem
Issue groups displayed a recent diagnosis as an aggregated conclusion. Repeated analyses could inflate counts, and different causes sharing one failure signature could be lost.

## Solution
- Select the latest completed analysis per run, including empty replacement results, then group by canonical failure signature.
- Add independent, digest-bound model-summary snapshots and signed prepare/completion endpoints with Bot binding, source validation, idempotency and stale/expired-job handling.
- Show distinct causes, uncertainty and source evidence, count unique affected runs, and retain collapsible single-run analysis details.
- Keep competing proposal candidates without silently overwriting an executable suggestion.

## Validation
- Workflow: 194 tests passed.
- ClawEvolve: 291 tests passed.
- Both affected packages: type checks and builds passed after rebasing onto dev.
- Git diff and pre-push secret checks passed.
- Live Bot integration and deployed UI validation remain pending.

## Compatibility and risk
Deploy this server/UI change before the companion analysis-agent change. Older clients continue single-run analysis; newer clients only synthesize when the optional capability is advertised. Reuses the existing analysis table with a distinct scope; no database-column migration. Aggregation failure does not fail a completed single-run analysis. Oversized groups are explicitly marked rather than silently sampled.

Multiple independently executable suggestions per cause are NOT implemented in this PR. Existing suggestion actions remain separate from the aggregated conclusion; aggregation does not automatically apply or verify fixes.

## Spec
- src/evolverun/clawweb/public/modules/clawevolve/docs/issue-aggregation-contract.md
- src/evolverun/clawweb/public/modules/clawevolve/docs/2026-09-10-issue-cause-aggregation.md

## Related issues
Companion analysis-agent change is required to generate model summaries. This PR excludes the earlier run-list-filter commits.