### PR TITLE
fix(baas): add fail-fast precheck to ORM distributed-lock try_acquire_lock

### DIFF
--- a/src/baas/src/secbaas/community/core/repository/distributed_lock/_orm_repository.py
+++ b/src/baas/src/secbaas/community/core/repository/distributed_lock/_orm_repository.py
@@ -2,6 +2,13 @@
 
 Uses @with_orm_session decorator for SQLAlchemy ORM Session lifecycle.
 Corresponds to ZdasDistributedLockRepository (ac_lock_table).
+
+``try_acquire_lock`` first runs a non-blocking fail-fast precheck SELECT on the
+same session: when the lock is held by another caller and unexpired, it returns
+``False`` without dispatching the ``uk_lock_name`` upsert that would wait on the
+row lock and trigger OB_MYSQL ``1205`` (Lock wait timeout exceeded). Correctness
+is unaffected — the precheck is an optimization path and the TOCTOU window is
+closed by the unique key + ``on_duplicate_key_update`` atomic semantics.
 """
 
 from datetime import datetime
@@ -184,13 +191,25 @@ class OrmDistributedLockRepository(OrmConnectionMixin, DistributedLockRepository
         lock_holder: str,
         expire_time: datetime,
     ) -> bool:
-        """Atomically try to acquire a lock with a single upsert.
+        """Atomically try to acquire a lock with a fail-fast precheck + upsert.
 
-        Issues one atomic upsert keyed on ``uk_lock_name``: a missing row is
-        initialized by INSERT, while an existing row is overwritten only when
-        it is acquirable (same holder, no ``expire_time``, or expired) and left
-        untouched otherwise. A confirming read SELECT then decides whether the
-        caller now holds the lock.
+        First emits a non-blocking read-only SELECT on the same ``self._session``
+        (same ``@with_orm_session`` transaction, no ``FOR UPDATE``): when an
+        existing row is held by a different caller and its ``expire_time`` has
+        not passed, return ``False`` immediately without dispatching the upsert
+        that would otherwise wait on the ``uk_lock_name`` row lock and trigger
+        OceanBase/MySQL-compatible ``1205`` (Lock wait timeout exceeded). Rows
+        that are missing, expired, or already held by the same caller fall
+        through to the atomic upsert.
+
+        The upsert keyed on ``uk_lock_name`` then initializes a missing row by
+        INSERT, or overwrites an existing row only when it is acquirable (same
+        holder, no ``expire_time``, or expired) and leaves it untouched
+        otherwise. A confirming read SELECT decides whether the caller now holds
+        the lock. The precheck is purely an optimization path: correctness does
+        not depend on it, and the TOCTOU window between precheck and upsert is
+        closed by ``uk_lock_name`` + ``on_duplicate_key_update``'s ``CASE WHEN
+        acquirable`` atomic semantics (at most one caller holds the lock).
 
         Replacing the former ``UPDATE → SELECT → INSERT`` three-step flow with
         a single upsert removes the concurrent INSERT that produced the
@@ -211,6 +230,32 @@ class OrmDistributedLockRepository(OrmConnectionMixin, DistributedLockRepository
         env = get_current_env()
 
         try:
+            # ── fail-fast 预检：复用同一 session，只读 SELECT（无 FOR UPDATE）──
+            # 若锁已被他方持有且未过期，直接返回 False，不再下发会等待
+            # uk_lock_name 行锁的 upsert，从根因消除 OB_MYSQL 1205。预检仅是
+            # 优化路径，TOCTOU 由 uk_lock_name + on_duplicate_key_update 兜底。
+            existing = self._session.execute(
+                select(DistributedLockModel).where(
+                    DistributedLockModel.lock_name == lock_name
+                )
+            ).scalar_one_or_none()
+
+            if existing is not None:
+                held_by_other = existing.lock_holder != lock_holder
+                unexpired = (
+                    existing.expire_time is not None
+                    and existing.expire_time > now
+                )
+                if held_by_other and unexpired:
+                    log.info(
+                        "[distributed-lock:try_acquire_lock] fail-fast: "
+                        "lock_name=%s held by %s",
+                        lock_name,
+                        existing.lock_holder,
+                    )
+                    return False
+            # 其余分支（无行 / 已过期 / 同 holder）继续走原子 upsert，
+            # 正确性不依赖预检。
             self._session.execute(
                 self._build_acquire_upsert(
                     lock_name, lock_holder, expire_time, env, now

--- a/src/baas/tests/integration/core/repository/test_distributed_lock_repository.py
+++ b/src/baas/tests/integration/core/repository/test_distributed_lock_repository.py
@@ -230,7 +230,42 @@ class TestDistributedLockRepositoryProtocol:
         deleted = distributed_lock_repository.delete_lock("nonexistent-lock")
         assert deleted is False
 
-    # ── 8. Full lifecycle: acquire → get → renew → delete ──
+    # ── 8. fail-fast precheck leaves holder untouched ──
+
+    def test_try_acquire_failfast_leaves_holder_untouched_when_held_unexpired(
+        self,
+        distributed_lock_repository: DistributedLockRepository,
+        db_transaction,
+    ):
+        """A second caller against an unexpired held lock returns False and the
+        existing holder row is left untouched (the fail-fast precheck short-
+        circuits before the upsert, so no ``gmt_modified`` bump and no 1205).
+        """
+        lock_name = f"failfast_{_generate_uuid()[:12]}"
+        holder_a = f"holder_{_generate_uuid()[:8]}"
+        holder_b = f"holder_{_generate_uuid()[:8]}"
+        expire_time = datetime.now() + timedelta(minutes=5)
+
+        acquired_a = distributed_lock_repository.try_acquire_lock(
+            lock_name=lock_name, lock_holder=holder_a, expire_time=expire_time
+        )
+        assert acquired_a is True
+
+        before = distributed_lock_repository.get_by_lock_name(lock_name)
+        assert before is not None
+
+        acquired_b = distributed_lock_repository.try_acquire_lock(
+            lock_name=lock_name, lock_holder=holder_b, expire_time=expire_time
+        )
+        assert acquired_b is False
+
+        after = distributed_lock_repository.get_by_lock_name(lock_name)
+        assert after is not None
+        assert after.lock_holder == holder_a
+        # Holder row not overwritten by a no-op upsert.
+        assert after.gmt_modified == before.gmt_modified
+
+    # ── 9. Full lifecycle: acquire → get → renew → delete ──
 
     def test_full_lifecycle_acquire_get_renew_delete(
         self,

--- a/src/baas/tests/integration/core/repository/test_distributed_lock_sqlite.py
+++ b/src/baas/tests/integration/core/repository/test_distributed_lock_sqlite.py
@@ -142,6 +142,35 @@ class TestDistributedLockSqliteOrmEquivalence:
         repo = get_container().repository.distributed_lock_repository()
         assert repo.delete_lock(f"nonexistent_{_generate_uuid()}") is False
 
+    def test_try_acquire_failfast_leaves_holder_untouched_when_held_unexpired(self):
+        """A second caller against an unexpired held lock returns False; the
+        fail-fast precheck short-circuits before the upsert so the existing
+        holder row is left untouched (no ``gmt_modified`` bump, no 1205 path).
+        """
+        repo = get_container().repository.distributed_lock_repository()
+        lock_name = f"failfast_{_generate_uuid()[:12]}"
+        holder_a = _generate_uuid()
+        holder_b = _generate_uuid()
+        expire_time = datetime.now() + timedelta(minutes=5)
+
+        acquired_a = repo.try_acquire_lock(
+            lock_name=lock_name, lock_holder=holder_a, expire_time=expire_time
+        )
+        assert acquired_a is True
+
+        before = repo.get_by_lock_name(lock_name)
+        assert before is not None
+
+        acquired_b = repo.try_acquire_lock(
+            lock_name=lock_name, lock_holder=holder_b, expire_time=expire_time
+        )
+        assert acquired_b is False
+
+        after = repo.get_by_lock_name(lock_name)
+        assert after is not None
+        assert after.lock_holder == holder_a
+        assert after.gmt_modified == before.gmt_modified
+
     def test_concurrent_acquire_same_new_lock_no_conflict_raised(self):
         """Two holders racing for the same brand-new lock must not raise and
         must serialize via the upsert: exactly one acquires, the other gets

--- a/src/baas/tests/unit/core/repository/distributed_lock/test_orm_distributed_lock_repository.py
+++ b/src/baas/tests/unit/core/repository/distributed_lock/test_orm_distributed_lock_repository.py
@@ -355,6 +355,9 @@ class TestTryAcquireLock:
 
     def test_acquire_emits_mysql_upsert_with_bindparams(self):
         repo, mock_session = _make_repo("mysql")
+        # All executes (precheck SELECT, upsert, confirm read) return this row.
+        # The precheck sees holder-A == caller → not held_by_other → falls
+        # through to the upsert + confirming read.
         mock_session.execute.return_value = _make_exec_result(
             _make_model(lock_holder="holder-A", expire_time=FUTURE)
         )
@@ -364,9 +367,11 @@ class TestTryAcquireLock:
         )
 
         assert result is True
-        assert mock_session.execute.call_count == 2
+        # precheck SELECT + upsert + confirming read
+        assert mock_session.execute.call_count == 3
 
-        upsert_stmt = mock_session.execute.call_args_list[0][0][0]
+        # call_args_list[0] is the precheck SELECT; [1] is the upsert.
+        upsert_stmt = mock_session.execute.call_args_list[1][0][0]
         compiled = upsert_stmt.compile(dialect=mysql.dialect())
         sql_text = str(compiled)
 
@@ -404,7 +409,8 @@ class TestTryAcquireLock:
         )
 
         assert result is True
-        upsert_stmt = mock_session.execute.call_args_list[0][0][0]
+        # [0] = precheck SELECT, [1] = upsert.
+        upsert_stmt = mock_session.execute.call_args_list[1][0][0]
         compiled = upsert_stmt.compile(dialect=sqlite.dialect())
         sql_text = str(compiled)
 
@@ -431,7 +437,8 @@ class TestTryAcquireLock:
             lock_name="cf-lock", lock_holder="holder-A", expire_time=FUTURE
         )
 
-        confirm_stmt = mock_session.execute.call_args_list[1][0][0]
+        # [0] = precheck SELECT, [1] = upsert, [2] = confirming read.
+        confirm_stmt = mock_session.execute.call_args_list[2][0][0]
         compiled = confirm_stmt.compile(dialect=mysql.dialect())
         assert "SELECT" in str(compiled)
         assert "ac_lock_table" in str(compiled)
@@ -450,6 +457,8 @@ class TestTryAcquireLock:
 
     def test_acquire_returns_false_when_held_by_other(self):
         repo, mock_session = _make_repo("mysql")
+        # Precheck returns a row held by another, unexpired caller: the
+        # fail-fast path returns False without dispatching the upsert.
         mock_session.execute.return_value = _make_exec_result(
             _make_model(lock_holder="holder-B", expire_time=FUTURE)
         )
@@ -459,7 +468,11 @@ class TestTryAcquireLock:
         )
 
         assert result is False
-        # No rollback on a clean not-acquired outcome.
+        # Only the precheck SELECT was dispatched; no upsert, no confirming read.
+        assert mock_session.execute.call_count == 1
+        precheck_stmt = mock_session.execute.call_args_list[0][0][0]
+        assert "SELECT" in str(precheck_stmt.compile(dialect=mysql.dialect()))
+        # No rollback on a clean fail-fast outcome.
         mock_session.rollback.assert_not_called()
 
     def test_acquire_returns_false_when_confirm_read_missing(self):
@@ -496,7 +509,11 @@ class TestTryAcquireLock:
         orig.__str__.return_value = (
             "Lock wait timeout exceeded; try restarting transaction"
         )
-        mock_session.execute.side_effect = SADatabaseError("INSERT ...", {}, orig)
+        # Precheck SELECT succeeds (no existing row); the upsert then hits 1205.
+        mock_session.execute.side_effect = [
+            _make_exec_result(None),
+            SADatabaseError("INSERT ...", {}, orig),
+        ]
 
         result = repo.try_acquire_lock(
             lock_name="busy-lock", lock_holder="holder-A", expire_time=FUTURE
@@ -512,12 +529,159 @@ class TestTryAcquireLock:
         orig = MagicMock()
         orig.errno = 1146  # not a lock-wait-timeout
         orig.__str__.return_value = "Table doesn't exist"
-        mock_session.execute.side_effect = SADatabaseError("INSERT ...", {}, orig)
+        # Precheck SELECT succeeds; the upsert then raises a non-1205 error.
+        mock_session.execute.side_effect = [
+            _make_exec_result(None),
+            SADatabaseError("INSERT ...", {}, orig),
+        ]
 
         with pytest.raises(SADatabaseError):
             repo.try_acquire_lock(
                 lock_name="err-lock", lock_holder="holder-A", expire_time=FUTURE
             )
+
+    # ── fail-fast precheck branches (U1–U5 + null-expire semantics) ──
+
+    def test_failfast_returns_false_and_skips_upsert_when_held_by_other_unexpired(
+        self,
+    ):
+        # U1: existing row held by another, unexpired → False, only the precheck
+        # SELECT is dispatched, no upsert is compiled.
+        repo, mock_session = _make_repo("mysql")
+        mock_session.execute.return_value = _make_exec_result(
+            _make_model(lock_holder="holder-B", expire_time=FUTURE)
+        )
+
+        result = repo.try_acquire_lock(
+            lock_name="held-lock", lock_holder="holder-A", expire_time=FUTURE
+        )
+
+        assert result is False
+        assert mock_session.execute.call_count == 1
+        precheck_stmt = mock_session.execute.call_args_list[0][0][0]
+        sql_text = str(precheck_stmt.compile(dialect=mysql.dialect()))
+        assert "SELECT" in sql_text
+        assert "ac_lock_table" in sql_text
+        assert "INSERT INTO ac_lock_table" not in sql_text
+        mock_session.rollback.assert_not_called()
+
+    def test_failfast_passes_when_no_existing_row_then_acquires(self):
+        # U2: precheck sees no row → falls through → upsert → confirm shows self.
+        repo, mock_session = _make_repo("mysql")
+        mock_session.execute.side_effect = [
+            _make_exec_result(None),
+            _make_exec_result(
+                _make_model(lock_holder="holder-A", expire_time=FUTURE)
+            ),
+            _make_exec_result(
+                _make_model(lock_holder="holder-A", expire_time=FUTURE)
+            ),
+        ]
+
+        result = repo.try_acquire_lock(
+            lock_name="free-lock", lock_holder="holder-A", expire_time=FUTURE
+        )
+
+        assert result is True
+        assert mock_session.execute.call_count == 3
+        precheck_stmt = mock_session.execute.call_args_list[0][0][0]
+        assert "SELECT" in str(precheck_stmt.compile(dialect=mysql.dialect()))
+        upsert_stmt = mock_session.execute.call_args_list[1][0][0]
+        assert "INSERT INTO ac_lock_table" in str(
+            upsert_stmt.compile(dialect=mysql.dialect())
+        )
+
+    def test_failfast_passes_when_existing_row_expired(self):
+        # U3: existing row held by another but expired → precheck falls through
+        # → upsert takes over → confirm shows the new holder.
+        repo, mock_session = _make_repo("mysql")
+        mock_session.execute.side_effect = [
+            _make_exec_result(_make_model(lock_holder="holder-B", expire_time=PAST)),
+            _make_exec_result(
+                _make_model(lock_holder="holder-A", expire_time=FUTURE)
+            ),
+            _make_exec_result(
+                _make_model(lock_holder="holder-A", expire_time=FUTURE)
+            ),
+        ]
+
+        result = repo.try_acquire_lock(
+            lock_name="expired-lock", lock_holder="holder-A", expire_time=FUTURE
+        )
+
+        assert result is True
+        assert mock_session.execute.call_count == 3
+
+    def test_failfast_passes_when_existing_row_same_holder(self):
+        # U4: existing row held by the same caller → precheck falls through
+        # → upsert renews → confirm shows self.
+        repo, mock_session = _make_repo("mysql")
+        mock_session.execute.side_effect = [
+            _make_exec_result(
+                _make_model(lock_holder="holder-A", expire_time=FUTURE)
+            ),
+            _make_exec_result(
+                _make_model(lock_holder="holder-A", expire_time=FUTURE)
+            ),
+            _make_exec_result(
+                _make_model(lock_holder="holder-A", expire_time=FUTURE)
+            ),
+        ]
+
+        result = repo.try_acquire_lock(
+            lock_name="renew-lock", lock_holder="holder-A", expire_time=FUTURE
+        )
+
+        assert result is True
+        assert mock_session.execute.call_count == 3
+
+    def test_toctou_upsert_guard_still_returns_false_when_confirm_read_shows_other(
+        self,
+    ):
+        # U5: precheck sees no row, but a concurrent caller grabs the lock
+        # before the upsert (TOCTOU). The upsert's CASE guard makes it a no-op,
+        # the confirming read shows the other holder → False. Correctness does
+        # not depend on the precheck.
+        repo, mock_session = _make_repo("mysql")
+        mock_session.execute.side_effect = [
+            _make_exec_result(None),
+            _make_exec_result(
+                _make_model(lock_holder="holder-A", expire_time=FUTURE)
+            ),
+            _make_exec_result(
+                _make_model(lock_holder="holder-B", expire_time=FUTURE)
+            ),
+        ]
+
+        result = repo.try_acquire_lock(
+            lock_name="race-lock", lock_holder="holder-A", expire_time=FUTURE
+        )
+
+        assert result is False
+        assert mock_session.execute.call_count == 3
+        mock_session.rollback.assert_not_called()
+
+    def test_failfast_skips_when_existing_row_has_null_expire_time(self):
+        # expire_time IS NULL is treated as "held, only same holder may
+        # overwrite" (aligned with the upsert acquirable predicate): the
+        # precheck does not short-circuit on a null expire row held by another.
+        repo, mock_session = _make_repo("mysql")
+        mock_session.execute.side_effect = [
+            _make_exec_result(_make_model(lock_holder="holder-B", expire_time=None)),
+            _make_exec_result(
+                _make_model(lock_holder="holder-A", expire_time=FUTURE)
+            ),
+            _make_exec_result(
+                _make_model(lock_holder="holder-A", expire_time=FUTURE)
+            ),
+        ]
+
+        result = repo.try_acquire_lock(
+            lock_name="no-ttl-lock", lock_holder="holder-A", expire_time=FUTURE
+        )
+
+        assert result is True
+        assert mock_session.execute.call_count == 3
 
 
 # ==================== DistributedLockRepository Protocol Tests ====================
@@ -701,11 +865,15 @@ class TestEdgeCases:
         assert result.lock_holder == ""
 
     def test_consecutive_try_acquire_different_names(self, repository, mock_session):
-        # Each try_acquire issues upsert + confirming read; both executes for
-        # one logical call report that call's caller as the holder.
+        # Each try_acquire now issues precheck + upsert + confirming read; the
+        # precheck sees the same holder as the caller (not held_by_other) and
+        # falls through, so both executes for one logical call report that
+        # call's caller as the holder.
         mock_session.execute.side_effect = [
             _make_exec_result(_make_model(lock_holder="h1", expire_time=FUTURE)),
             _make_exec_result(_make_model(lock_holder="h1", expire_time=FUTURE)),
+            _make_exec_result(_make_model(lock_holder="h1", expire_time=FUTURE)),
+            _make_exec_result(_make_model(lock_holder="h2", expire_time=FUTURE)),
             _make_exec_result(_make_model(lock_holder="h2", expire_time=FUTURE)),
             _make_exec_result(_make_model(lock_holder="h2", expire_time=FUTURE)),
         ]


### PR DESCRIPTION
## Summary

`try_acquire_lock` on the ORM distributed-lock repository now runs a
non-blocking read-only SELECT precheck on the same session before
dispatching the atomic upsert on `uk_lock_name`. When the lock is held by
a different caller and unexpired, the call returns `False` immediately
without issuing the upsert that would wait on the `uk_lock_name` row lock.

## Background

Under contention, the `uk_lock_name` upsert waits on the row lock of the
held row; on OceanBase / MySQL-compatible engines this surfaces as
`OB_MYSQL 1205 (Lock wait timeout exceeded)` when a second caller attempts
to acquire a lock still held by another. Adding a fail-fast precheck on
the same `@with_orm_session` transaction (no `FOR UPDATE`) lets the common
"already held by another caller" case short-circuit before the
lock-waiting write.

## Correctness

The precheck is an optimization path only:

- Rows that are missing, expired, or already held by the same caller fall
  through to the upsert + confirming read, unchanged.
- The TOCTOU window between the precheck SELECT and the upsert is closed
  by `uk_lock_name` + `on_duplicate_key_update`'s `CASE WHEN acquirable`
  atomic semantics — at most one caller holds the lock. A concurrent
  acquirer that wins between the precheck and the upsert still causes the
  losing caller's upsert to be a no-op, and the confirming read SELECT
  still decides the final result.
- `expire_time IS NULL` rows are treated as "held, only same holder may
  overwrite" (consistent with the upsert's acquirable predicate), so the
  precheck does not short-circuit on a null-TTL row held by another.

## Files

- `src/baas/src/secbaas/community/core/repository/distributed_lock/_orm_repository.py`
  — add the precheck SELECT + fail-fast return; update the docstring.
- `src/baas/tests/unit/core/repository/distributed_lock/test_orm_distributed_lock_repository.py`
  — update `call_count 2 -> 3`; add cases for expired-row fall-through,
  same-holder fall-through, TOCTOU confirm-shows-other, and null
  `expire_time` fall-through.
- `src/baas/tests/integration/core/repository/test_distributed_lock_repository.py`
  — add `test_try_acquire_failfast_leaves_holder_untouched_when_held_unexpired`.
- `src/baas/tests/integration/core/repository/test_distributed_lock_sqlite.py`
  — mirror the fail-fast leaves-holder-untouched case for the SQLite ORM
  equivalence suite.

## Test results

- 99 passed / 0 failed / 0 skipped across the distributed_lock unit and
  integration suites referenced above.
- `ruff check` clean on the changed source and test files.

## Privacy / security scan

- Public-diff privacy scan: `introduced = []`, `preexisting = []`,
  status = `passed`. No newly introduced or preexisting hardcoded
  credentials, tokens, PII, or internal-only identifiers in the diff.

## Known risks / rollback

- Risk: the precheck adds one extra read SELECT per acquire attempt on
  the readable session. This is a same-transaction, non-locking read and
  is negligible relative to the avoided row-lock wait on the contended
  path.
- Rollback: revert the precheck block; the upsert + confirming read path
  is unchanged and remains correct on its own. The unit-test
  `call_count` assertions would need to be reverted to `2` accordingly.

## Review notes

- Code review clear: 0 blocking findings. Two optional, non-blocking
  follow-ups were recorded (a P2 test-mock-realism note on one
  precheck side_effect and a P3 comment-language-consistency note on two
  inline comments); neither blocks this change.