### PR TITLE
fix(backend): report oversized Skill packages

### DIFF
--- a/src/backend/specs/2026-08-20-skill-capability-upgrade/frontend-api.md
+++ b/src/backend/specs/2026-08-20-skill-capability-upgrade/frontend-api.md
@@ -209,9 +209,12 @@ file_paths=["SKILL.md","references/example.md"]
 
 校验失败：
 
+浏览器文件夹上传必须在读取、大小计算和 multipart 组装前排除 `.git/**`，并向用户说明已忽略的文件数量；后端仍执行相同的 package metadata 过滤与独立资源上限保护。
+
 | 合同符号名（映射到 Envelope code） | UI |
 | --- | --- |
 | `SKILL_PACKAGE_INVALID` | 展示包级错误 |
+| `SKILL_PACKAGE_TOO_LARGE` | 明确提示文件包超限，并引导移除非运行时文件后重试 |
 | `SKILL_MANIFEST_MISSING` | 提示缺少 SKILL.md |
 | `SKILL_MANIFEST_MULTIPLE` | 提示只能存在一个目标 SKILL.md |
 | `SKILL_PATH_INVALID` | 展示非法相对路径 |

--- a/src/backend/specs/2026-08-20-skill-capability-upgrade/phase2-openapi-contract.md
+++ b/src/backend/specs/2026-08-20-skill-capability-upgrade/phase2-openapi-contract.md
@@ -609,6 +609,7 @@ reference_id DESC`。目标 Set 已被删除时，历史 Operation 仍可按 Bot
 | `IDEMPOTENCY_KEY_REUSED` | `409305` | 409 | 创建、升级、发布、Reference | 同一 Key 被用于不同请求 |
 | `SKILL_NAME_CHANGED` | `422203` | 422 | Draft save/refresh/publish | SKILL.md name 与 Identity 不一致 |
 | `SKILL_PACKAGE_INVALID` | `422202` | 422 | 创建、refresh、materialize | 包结构或 SKILL.md 非法 |
+| `SKILL_PACKAGE_TOO_LARGE` | `422209` | 422 | 创建、refresh、materialize | 文件数、单文件、展开总量或 canonical ZIP 超出上限 |
 | `SKILL_MANIFEST_MISSING` | `422205` | 422 | folder/Git 创建 | 缺少目标 SKILL.md |
 | `SKILL_MANIFEST_MULTIPLE` | `422206` | 422 | folder 创建 | 上传包包含多个候选 SKILL.md |
 | `SKILL_PATH_INVALID` | `422207` | 422 | folder/Draft file | 相对路径非法或越界 |

--- a/src/backend/specs/2026-08-20-skill-capability-upgrade/spec.md
+++ b/src/backend/specs/2026-08-20-skill-capability-upgrade/spec.md
@@ -277,7 +277,7 @@ Phase 2 复用一条 `ac_skill` 作为跨版本稳定 Identity：
   Object read 必须区分 FOUND/NOT_FOUND/FAILED，禁止把存储故障误判为不存在后覆盖。
 - `SkillPackageValidator` 是 Local、Draft 和精确版本物化共用的纯 package 边界：负责
   安全相对路径、压缩/展开大小与文件数、唯一 `SKILL.md`、frontmatter 的
-  name/description/config、wrapper、平台 metadata 忽略和 deterministic canonical ZIP，
+  name/description/config、wrapper、平台 metadata（包括 `.git/**`）忽略和 deterministic canonical ZIP，
   返回稳定 `ValidatedSkillPackage`；默认入口严格要求 frontmatter。只有既有 Local 上传
   生命周期可调用显式 legacy-compatible 入口兼容无 frontmatter 历史包，Draft、Git import
   和精确版本物化不得继承该 fallback。Validator 不拥有 Bot 授权、容器/Pool 写入、数据库

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/errors_space.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/errors_space.py
@@ -26,6 +26,7 @@ class SpaceErrorCode(IntEnum):
     DRAFT_NOT_FOUND = 404204
     SKILL_PATH_INVALID = 422207
     DRAFT_SOURCE_NOT_REFRESHABLE = 422208
+    SKILL_PACKAGE_TOO_LARGE = 422209
     SKILL_GIT_UNAVAILABLE = 502202
     SKILL_DRAFT_STORE_UNAVAILABLE = 503202
     PUBLICATION_ATTEMPT_NOT_FOUND = 404205
@@ -62,6 +63,7 @@ class SpacePublicErrorMessage(StrEnum):
     DRAFT_NOT_FOUND = "Not found"
     SKILL_PATH_INVALID = "Skill file path is invalid"
     DRAFT_SOURCE_NOT_REFRESHABLE = "Draft is not backed by a Git snapshot"
+    SKILL_PACKAGE_TOO_LARGE = "Skill package is too large"
     SKILL_GIT_UNAVAILABLE = "Git snapshot is unavailable"
     SKILL_DRAFT_STORE_UNAVAILABLE = "Draft content store is unavailable"
     PUBLICATION_ATTEMPT_NOT_FOUND = "Not found"

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/errors_space_skill.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/errors_space_skill.py
@@ -97,7 +97,7 @@ SPACE_SKILL_HTTP_ERRORS = {
     ),
     SkillNameChangedError: (422, SpacePublicErrorMessage.SKILL_NAME_CHANGED),
     SkillPackageInvalidError: (422, SpacePublicErrorMessage.SKILL_PACKAGE_INVALID),
-    SkillPackageTooLargeError: (422, SpacePublicErrorMessage.SKILL_PACKAGE_INVALID),
+    SkillPackageTooLargeError: (422, SpacePublicErrorMessage.SKILL_PACKAGE_TOO_LARGE),
     GitSnapshotInvalidError: (422, SpacePublicErrorMessage.SKILL_PACKAGE_INVALID),
     GitSnapshotError: (502, SpacePublicErrorMessage.SKILL_GIT_UNAVAILABLE),
     DraftContentStoreError: (
@@ -161,7 +161,7 @@ SPACE_SKILL_ERROR_CODES = {
     DraftSourceNotRefreshableError: SpaceErrorCode.DRAFT_SOURCE_NOT_REFRESHABLE,
     SkillNameChangedError: SpaceErrorCode.SKILL_NAME_CHANGED,
     SkillPackageInvalidError: SpaceErrorCode.SKILL_PACKAGE_INVALID,
-    SkillPackageTooLargeError: SpaceErrorCode.SKILL_PACKAGE_INVALID,
+    SkillPackageTooLargeError: SpaceErrorCode.SKILL_PACKAGE_TOO_LARGE,
     GitSnapshotInvalidError: SpaceErrorCode.SKILL_PACKAGE_INVALID,
     GitSnapshotError: SpaceErrorCode.SKILL_GIT_UNAVAILABLE,
     DraftContentStoreError: SpaceErrorCode.SKILL_DRAFT_STORE_UNAVAILABLE,

--- a/src/backend/src/agentclaw/community/core/skill_center/skill_package.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/skill_package.py
@@ -332,6 +332,7 @@ class SkillPackageValidator:
         return (
             name == ".DS_Store"
             or parts[0] == "__MACOSX"
+            or ".git" in parts
             or "__pycache__" in parts
             or name.endswith((".pyc", ".pyo"))
         )

--- a/src/backend/tests/community/adapters/http/openapi_v1/spaces/test_contract.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/spaces/test_contract.py
@@ -890,7 +890,8 @@ def test_folder_creation_caps_each_file_before_multipart_spooling(
     )
 
     assert response.status_code == 422
-    assert response.json()["code"] == 422202
+    assert response.json()["code"] == 422209
+    assert response.json()["message"] == "Skill package is too large"
     skill_application_service.create_from_folder.assert_not_called()
 
 
@@ -938,7 +939,7 @@ def test_folder_creation_caps_aggregate_files_before_multipart_spooling(
     )
 
     assert response.status_code == 422
-    assert response.json()["code"] == 422202
+    assert response.json()["code"] == 422209
     skill_application_service.create_from_folder.assert_not_called()
 
 
@@ -961,7 +962,7 @@ def test_folder_creation_caps_file_count_during_multipart_parsing(
     )
 
     assert response.status_code == 422
-    assert response.json()["code"] == 422202
+    assert response.json()["code"] == 422209
     skill_application_service.create_from_folder.assert_not_called()
 
 
@@ -992,7 +993,7 @@ def test_folder_creation_rejects_oversized_multipart_body_before_spooling(
     )
 
     assert response.status_code == 422
-    assert response.json()["code"] == 422202
+    assert response.json()["code"] == 422209
     skill_application_service.create_from_folder.assert_not_called()
 
 
@@ -1036,7 +1037,7 @@ def test_folder_creation_caps_streamed_body_without_content_length(
     )
 
     assert response.status_code == 422
-    assert response.json()["code"] == 422202
+    assert response.json()["code"] == 422209
     skill_application_service.create_from_folder.assert_not_called()
 
 
@@ -1141,7 +1142,7 @@ def test_draft_file_save_caps_streamed_json_before_fastapi_parsing(
     )
 
     assert response.status_code == 422
-    assert response.json()["code"] == 422202
+    assert response.json()["code"] == 422209
     skill_application_service.save_draft_file.assert_not_called()
 
 
@@ -1163,7 +1164,7 @@ def test_draft_file_save_rejects_decoded_utf8_content_without_full_copy(
     )
 
     assert response.status_code == 422
-    assert response.json()["code"] == 422202
+    assert response.json()["code"] == 422209
     skill_application_service.save_draft_file.assert_not_called()
 
 

--- a/src/backend/tests/community/core/skill_center/test_skill_package_validator.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_package_validator.py
@@ -86,10 +86,16 @@ def test_directory_and_zip_ignore_metadata_before_applying_file_limits(
     validator = SkillPackageValidator(SkillParser())
     manifest = _skill_md()
     monkeypatch.setattr(package_module, "MAX_FILES", 2)
+    monkeypatch.setattr(package_module, "MAX_FILE_BYTES", 100)
     entries = [
         ("weather/SKILL.md", manifest),
         ("weather/script.py", b"pass"),
         ("weather/.DS_Store", b"metadata"),
+        ("weather/.git/config", b"metadata"),
+        (
+            "weather/.git/objects/pack/large.pack",
+            b"x" * 101,
+        ),
         ("__MACOSX/._SKILL.md", b"metadata"),
         ("weather/__pycache__/script.pyc", b"metadata"),
     ]


### PR DESCRIPTION
## Summary

- return the dedicated 422209 error code for oversized Space Skill packages
- ignore .git metadata consistently in the shared directory and ZIP package validator
- retain compressed, expanded, per-file, file-count, and receive-time transport limits
- document the browser and backend filtering contract

## Validation

- 90 focused backend tests passed
- Ruff passed for all changed Python files
- Standards and Spec reviews found no blocking issues

## Full-suite note

The Community suite reached 87% and then the Python process exited with a segmentation fault while many existing poller and task-harness threads were active. The focused package-validator and Space Skill contract suites pass. OCB gitlink integration and deployment are intentionally outside this PR.
