### PR TITLE
feat(bcs): support group context delivery in session create

### DIFF
--- a/src/bcs/crates/adapters/http/bcs-http/tests/cli_session_integration.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/cli_session_integration.rs
@@ -295,7 +295,7 @@ async fn cli_create_session_emits_id_and_session_id_keys() {
     let client = BcsClient::with_token(&server.base_url, &server.token);
 
     let body = client
-        .create_session("g-1", Some("hello"), None, None, None)
+        .create_session("g-1", Some("hello"), None, None, None, None)
         .await
         .expect("create_session should succeed against the in-process server");
 
@@ -326,7 +326,7 @@ async fn cli_list_sessions_returns_items_array_and_group_id() {
 
     // Create one session so the list isn't empty.
     let _ = client
-        .create_session("g-1", Some("title"), None, None, None)
+        .create_session("g-1", Some("title"), None, None, None, None)
         .await
         .unwrap();
 
@@ -363,7 +363,7 @@ async fn cli_get_session_returns_full_row() {
     let client = BcsClient::with_token(&server.base_url, &server.token);
 
     let created = client
-        .create_session("g-1", None, None, None, None)
+        .create_session("g-1", None, None, None, None, None)
         .await
         .unwrap();
     let sid = created.get("id").and_then(|v| v.as_str()).unwrap();
@@ -384,7 +384,7 @@ async fn cli_session_messages_returns_array() {
     let client = BcsClient::with_token(&server.base_url, &server.token);
 
     let created = client
-        .create_session("g-1", None, None, None, None)
+        .create_session("g-1", None, None, None, None, None)
         .await
         .unwrap();
     let sid = created.get("id").and_then(|v| v.as_str()).unwrap();

--- a/src/bcs/crates/tools/bcs-cli/bcs-coordination/references/session.md
+++ b/src/bcs/crates/tools/bcs-cli/bcs-coordination/references/session.md
@@ -49,7 +49,7 @@ Running → Completed
 在 Group 内创建新的 Session：
 
 ```bash
-bcs session create --group "<group_id>" [--title "<标题>"] [--kind chat|service_invocation] [--input '<json>'] [--meta '<json>']
+bcs session create --group "<group_id>" [--title "<标题>"] [--kind chat|service_invocation] [--input '<json>'] [--meta '<json>'] [--group-context-delivery send|inject]
 ```
 
 **示例：**
@@ -57,6 +57,14 @@ bcs session create --group "<group_id>" [--title "<标题>"] [--kind chat|servic
 ```bash
 bcs session create --group "grp-001" --title "第二轮讨论"
 ```
+
+`--group-context-delivery` 控制初始 `<GroupContext>` 发给 Driver 时的投递方式：
+
+- `send`（默认）：要求 Driver 主动响应。
+- `inject`：Driver 静默接收上下文。
+
+其他参与者仍然通过 `chat.inject` 接收初始上下文。ManagerWorker Group
+始终通过 `chat.send` 向 Manager 投递上下文，不受该参数影响。
 
 ---
 

--- a/src/bcs/crates/tools/bcs-cli/src/client.rs
+++ b/src/bcs/crates/tools/bcs-cli/src/client.rs
@@ -2204,6 +2204,7 @@ impl BcsClient {
         session_kind: Option<&str>,
         input: Option<&serde_json::Value>,
         meta: Option<&serde_json::Value>,
+        group_context_delivery: Option<&str>,
     ) -> Result<serde_json::Value> {
         let url = format!("{}/groups/{}/sessions", self.base_url, group_id);
         let mut payload = serde_json::Map::new();
@@ -2218,6 +2219,12 @@ impl BcsClient {
         }
         if let Some(meta) = meta {
             payload.insert("meta".to_string(), meta.clone());
+        }
+        if let Some(delivery) = group_context_delivery {
+            payload.insert(
+                "group_context_delivery".to_string(),
+                serde_json::json!(delivery),
+            );
         }
 
         let response = self
@@ -4201,6 +4208,38 @@ mod tests {
             "Content-Type must match the prepared upload content type, but the request was:\n{}",
             request
         );
+    }
+
+    #[tokio::test]
+    async fn create_session_sends_group_context_delivery() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/groups/g-1/sessions"))
+            .respond_with(
+                ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                    "id": "g-1:abcdef12",
+                    "session_id": "g-1:abcdef12",
+                })),
+            )
+            .mount(&server)
+            .await;
+
+        let client = BcsClient::with_token(&server.uri(), "bot-token");
+        client
+            .create_session("g-1", None, None, None, None, Some("inject"))
+            .await
+            .expect("create session should succeed");
+
+        let requests = server.received_requests().await.expect("captured requests");
+        let req = requests
+            .iter()
+            .find(|r| r.method.as_str() == "POST" && r.url.path() == "/groups/g-1/sessions")
+            .expect("create session POST request");
+        let body: serde_json::Value = serde_json::from_slice(&req.body).unwrap();
+        assert_eq!(body["group_context_delivery"], "inject");
     }
 
     // Regression: `share --ttl N` must send `ttl_seconds` (the ShareRequest DTO

--- a/src/bcs/crates/tools/bcs-cli/src/main.rs
+++ b/src/bcs/crates/tools/bcs-cli/src/main.rs
@@ -1782,6 +1782,10 @@ enum SessionCommands {
         /// Optional metadata (JSON)
         #[arg(long)]
         meta: Option<String>,
+
+        /// Initial GroupContext delivery for the driver (send or inject)
+        #[arg(long, value_parser = ["send", "inject"])]
+        group_context_delivery: Option<String>,
     },
 
     /// List sessions under a group.
@@ -4250,6 +4254,7 @@ pub async fn run() -> Result<()> {
                     kind,
                     input,
                     meta,
+                    group_context_delivery,
                 } => {
                     let input_json = input
                         .as_deref()
@@ -4271,6 +4276,7 @@ pub async fn run() -> Result<()> {
                             "session_kind": &kind,
                             "input": &input_json,
                             "meta": &meta_json,
+                            "group_context_delivery": &group_context_delivery,
                         })
                     );
 
@@ -4281,6 +4287,7 @@ pub async fn run() -> Result<()> {
                             kind.as_deref(),
                             input_json.as_ref(),
                             meta_json.as_ref(),
+                            group_context_delivery.as_deref(),
                         )
                         .await?;
 
@@ -6392,6 +6399,7 @@ mod tests {
                         kind,
                         input,
                         meta,
+                        group_context_delivery,
                     },
                 ..
             } => {
@@ -6400,9 +6408,58 @@ mod tests {
                 assert!(kind.is_none());
                 assert!(input.is_none());
                 assert!(meta.is_none());
+                assert!(group_context_delivery.is_none());
             }
             _ => panic!("expected session create command"),
         }
+    }
+
+    #[test]
+    fn test_session_create_accepts_group_context_delivery() {
+        let cli = Cli::try_parse_from([
+            "bcs-cli",
+            "session",
+            "create",
+            "--group",
+            "g-1",
+            "--group-context-delivery",
+            "inject",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Commands::Session {
+                command:
+                    SessionCommands::Create {
+                        group_context_delivery,
+                        ..
+                    },
+                ..
+            } => {
+                assert_eq!(group_context_delivery.as_deref(), Some("inject"));
+            }
+            _ => panic!("expected session create command"),
+        }
+    }
+
+    #[test]
+    fn test_session_create_rejects_invalid_group_context_delivery() {
+        let err = match Cli::try_parse_from([
+            "bcs-cli",
+            "session",
+            "create",
+            "--group",
+            "g-1",
+            "--group-context-delivery",
+            "silent",
+        ]) {
+            Ok(_) => panic!("expected invalid delivery mode to be rejected"),
+            Err(err) => err,
+        };
+
+        assert_eq!(err.kind(), ErrorKind::InvalidValue);
+        assert!(err.to_string().contains("send"));
+        assert!(err.to_string().contains("inject"));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`bcs-cli session create` did not expose the existing `group_context_delivery` option supported by the legacy HTTP session endpoint. Operators therefore could not request silent initial GroupContext delivery from the CLI.

## Solution

- Add `--group-context-delivery <send|inject>` to `bcs-cli session create` with CLI-side value validation.
- Forward the selected value through `BcsClient::create_session` as the `group_context_delivery` JSON field for `POST /groups/{group_id}/sessions`.
- Preserve existing behavior when the option is omitted, including server-side defaults and ManagerWorker delivery semantics.
- Add CLI parsing and HTTP wire-serialization coverage, update the CLI session reference, and keep existing integration tests compatible.

## Validation

- `cargo check -p bcs-cli --all-targets` — passed.
- `cargo test -p bcs-cli --bin bcs-cli session_create` — 3 passed.
- `cargo test -p bcs-cli --lib create_session_sends_group_context_delivery` — passed.
- `cargo test -p bcs-http --test cli_session_integration` — 4 passed.
- `cargo test -p bcs-http --test session_create_request_dto` — 3 passed.
- The full `cargo test -p bcs-cli --lib` run still has two unrelated pre-existing failures: `test_chat_async_returns_transport_error_on_non_listening_port` received HTTP 503 instead of the expected transport error, and `test_chat_poll_run_times_out_with_ids_from_submit` reported `poll_error` instead of `timeout`.

## Compatibility and risk

- This is backward compatible: the new option is optional and omitted requests remain unchanged.
- The server-side HTTP contract and core session delivery implementation are unchanged.
- `inject` affects the initial Driver GroupContext only; other participants continue to receive injected context, and ManagerWorker groups continue to force `send` for the Manager.
