### PR TITLE
docs(apply): document domain-model shapes with per-road examples

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/activation_delegates.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/activation_delegates.py
@@ -41,12 +41,23 @@ from agentclaw.community.core.skill_center.direct_activation_service_protocol im
 class _DelegatingActivation(ActivationPort):
     """Forwards the port's six methods to the service, pinning ``project``.
 
+    Six methods: two reads (``list_installed_mcps``,
+    ``platform_default_mcp_codes``) passed through untouched, and four async
+    writes (``activate_mcp``, ``deactivate_mcp``, ``activate_skill``,
+    ``deactivate_skill``) that gain ``project=self._PROJECT``.
+
+    ``list_installed_mcps`` answers a ``set[str]`` of server codes, e.g.
+    ``{"gh", "old"}``; ``platform_default_mcp_codes`` answers an iterable of
+    the same. The four writes answer the service's own result dict, which
+    ``mcp`` and ``skills`` discard.
+
     Subclasses set ``_PROJECT`` and add nothing else; writing the delegation
     twice would let the two families drift apart in a method neither subclass
     is about.
     """
 
-    #: The ``project`` value every write is forwarded with.
+    #: The ``project`` value every write is forwarded with. ``True`` projects
+    #: the row onto the live container, ``False`` writes the row only.
     _PROJECT: bool
 
     def __init__(self, inner: DirectActivationServiceProtocol) -> None:
@@ -102,13 +113,22 @@ class _DelegatingActivation(ActivationPort):
 
 
 class DeviceActivation(_DelegatingActivation):
-    """ARCA: write the rows, then project onto the live container (pre-W8)."""
+    """ARCA: write the rows, then project onto the live container.
+
+    Bound as ``MaterialiserPorts.activation_service`` for the ARCA family, and
+    for teclaw while the platform-managed switch is off.
+    """
 
     _PROJECT = True
 
 
 class PlatformActivation(_DelegatingActivation):
-    """Platform-managed teclaw: write the rows only; the artifact delivers."""
+    """Platform-managed teclaw: write the rows only; the artifact delivers.
+
+    Bound as ``MaterialiserPorts.activation_service`` in the store-backed
+    bundle. The projection the ``True`` variant would make per skill and per
+    MCP server is replaced by the strategy's single closing redeliver.
+    """
 
     _PROJECT = False
 

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/apply_task.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/apply_task.py
@@ -40,13 +40,16 @@ from agentclaw.community.log import get_logger
 
 logger = get_logger()
 
-#: The registry key. One type for all three cases (module docstring).
+#: The registry key, ``"config_manifest.apply"``. One type for all three cases
+#: (see the module docstring); the apply record's ``trigger`` column is what
+#: distinguishes them.
 APPLY_TASK_TYPE = "config_manifest.apply"
 
-#: Give-up horizon for one apply. Generous on purpose: this bounds a *task*, and
-#: an apply that legitimately takes minutes (W5 fetching several sources) must
-#: not be retired mid-write. It sits inside the apply lock's own TTL so a task
-#: retired here cannot outlive the lock that a later apply would reap.
+#: Give-up horizon for one apply, in seconds: 1200, i.e. 20 minutes. Generous
+#: on purpose — this bounds a *task*, and an apply that legitimately takes
+#: minutes fetching several sources must not be retired mid-write. It sits
+#: inside the apply lock's own 30-minute TTL, so a task retired here cannot
+#: outlive the lock that a later apply would reap.
 APPLY_TASK_DEADLINE_SECONDS = 20 * 60
 
 
@@ -68,6 +71,32 @@ def build_apply_task_payload(
     bot_type: Optional[str] = None,
 ) -> dict[str, Any]:
     """The task payload: identifiers, never state.
+
+    A plain JSON-safe dict, stored in ``ac_task_queue.payload``::
+
+        {
+            "apply_id": "ap_01HZX8",
+            "entity_id": "ent_7",
+            "bot_id": "bot_42",
+            "owner_id": "usr_owner",
+            "actor_id": "usr_collaborator",
+            "env": "prod",
+            "tenant": "acme",
+            "trigger": "create:pre_container",
+            "lock_token": "lk_3f9c...",
+            "started_at": "2026-03-01T09:00:00+00:00",
+            "phases": ["pre_container"],     # sorted .value strings
+            "carry_from_apply_id": None,     # or an earlier phase's apply_id
+            "engine_type": "claude_code",    # only read when there is no
+            "bot_type": "arca",              # bot record yet
+        }
+
+    ``phases`` is sorted so two enqueues of one apply cannot differ by set
+    iteration order, and is never ``None``: what an apply covers is always
+    stated rather than reconstructed from a default at the far end.
+
+    Consumed by: :meth:`ApplyTaskHandler.handle`, which passes it straight to
+    ``BotConfigManifestApplyService.run_apply_task``.
 
     Two things are deliberately absent, and both would be bugs to add.
 
@@ -117,7 +146,16 @@ def build_apply_task_payload(
 
 
 def phases_from_payload(value: Sequence[str]) -> frozenset[ApplyPhase]:
-    """The phases the payload names. Always present — see the builder."""
+    """The phases the payload names, back as enum members::
+
+        phases_from_payload(["pre_container"])
+        # -> frozenset({ApplyPhase.PRE_CONTAINER})
+        phases_from_payload(["on_container", "pre_container"])
+        # -> ALL_PHASES
+
+    Raises ``ValueError`` on an unknown phase name rather than dropping it.
+    Always present in a payload — see the builder.
+    """
     return frozenset(ApplyPhase(item) for item in value)
 
 

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/budget.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/budget.py
@@ -1,26 +1,27 @@
 """One apply's fetch allowance — the ledger behind the lock TTL's sanity.
 
-`fetch/limits.py` defines the two apply-scope numbers (a wall-clock budget
-and a total downloaded bytes cap) and W4's comments promised an orchestrator
-threading them through every entry. Nothing ever did — W4 fetched nothing,
-so the promise was inert; W5 put real fetches behind it and an audit caught
-the gap live: 50 entries x 60s-per-hop x a 30-minute lock TTL can hold the
-per-bot lock long enough that the stale-lock reaper hands a still-running
-apply's lock to a second one, and the UNIQUE lock guard is then the only
-thing between two concurrent writers of the same bot.
-
-This object is that threading. One instance per apply, carried by the (--
-otherwise frozen) ``ApplyContext`` and consulted by the entry fetcher:
+One instance per apply, carried on the otherwise frozen ``ApplyContext`` and
+consulted by the entry fetcher:
 
 - **before** each fetch — an entry that starts past the deadline is
   refused without touching the network, so a budget-exhausted apply ends
   in bounded time and the lock is released for the next attempt;
 - **after** each network fetch — its bytes are charged to the total.
 
+Created by: ``services/config_manifest_apply_service`` (both the apply and the
+dry-run path) as ``ApplyFetchBudget(deadline=time.monotonic() +
+APPLY_BUDGET_S, total_bytes=APPLY_FETCH_TOTAL_LIMIT)`` — 300 seconds and
+500 MiB, from ``fetch/limits.py``.
+Consumed by: ``apply/entry_fetch.EntryFetcher`` (``fetch``,
+``fetch_declared``, ``acquire_object``, ``file_bytes``) and
+``apply/source_fetchers.GitSourceFetcher.fetch``.
+
 Deliberately mutable: it is a ledger threaded through an immutable context,
 the way a run's writes are a ledger threaded through an immutable bot id.
-Reads answered from the platform's own copy cost neither half (no network
-was touched); that is the fast path, and making it free is the point.
+
+The numbers are apply-scope and the lock TTL is why they are enforced at all:
+50 entries at 60 seconds per hop can outrun a 30-minute lock TTL, and the
+stale-lock reaper would then hand a still-running apply's lock to a second one.
 """
 from __future__ import annotations
 
@@ -29,7 +30,43 @@ from typing import Callable
 
 
 class ApplyFetchBudget:
-    """The wall-clock and byte allowance one apply's fetches must fit in."""
+    """The wall-clock and byte allowance one apply's fetches must fit in.
+
+    ``deadline`` is an absolute ``time.monotonic()`` reading, not a duration:
+    the budget is exhausted once ``clock()`` reaches it. ``total_bytes`` is a
+    running cap on everything charged. ``clock`` is the test seam; production
+    leaves it at ``time.monotonic``::
+
+        ApplyFetchBudget(
+            deadline=time.monotonic() + 300.0,   # APPLY_BUDGET_S
+            total_bytes=500 * 1024 * 1024,       # APPLY_FETCH_TOTAL_LIMIT
+        )
+
+        # A test pins both halves instead:
+        ApplyFetchBudget(deadline=0.0, total_bytes=10**9)   # already expired
+        ApplyFetchBudget(deadline=9e99, total_bytes=5)      # byte-starved
+
+    What a ``charge`` looks like on each road:
+
+    * object store and HTTPS URL — ``ctx.budget.charge(fetched.size_bytes)``
+      in ``entry_fetch.fetch``, and ``charge(len(content))`` in
+      ``acquire_object``: the bytes that came over the wire.
+    * git — ``ctx.budget.charge(checkout.tree_bytes)`` in
+      ``source_fetchers.GitSourceFetcher.fetch``: the whole tree's declared
+      size, charged only when *this* call did the fetching.
+    * canonical bytes filed back — ``charge(len(content))`` in
+      ``entry_fetch.file_bytes``, so a git entry's canonical form is on the
+      ledger too.
+
+    What is deliberately **not** charged:
+
+    * a store hit, pinned or ``keep_last`` — no network moved, so the fast
+      path is free;
+    * a cached git checkout, when another entry already fetched that
+      ``(url, ref)`` this apply — that call answers a read, not a fetch;
+    * anything on a caller with no budget at all (``ctx.budget is None``),
+      which is the hand-driven and single-install road.
+    """
 
     def __init__(
         self,
@@ -45,6 +82,15 @@ class ApplyFetchBudget:
 
     def expired(self) -> str | None:
         """Why the budget is exhausted, or ``None`` when it is not.
+
+        The string is report-safe and lands verbatim as an entry's ``reason``::
+
+            "this apply's fetch budget is exhausted (time): its entries have
+             spent the whole of the apply's fetch time allowance — remaining
+             entries fail rather than hold the bot's apply lock any longer"
+
+        Time is checked first, so an apply that has run out of both reports the
+        time reason.
 
         A reason rather than a boolean: bytes and time name different fixes
         for the caller, and an error that says which one ran out saves the
@@ -67,7 +113,12 @@ class ApplyFetchBudget:
         return None
 
     def charge(self, size_bytes: int) -> None:
-        """Account one network fetch against the total."""
+        """Account one network fetch against the total.
+
+        Non-positive sizes are ignored, so a zero-byte object costs nothing.
+        Charging never raises: it can push the ledger past its cap, and the
+        next :meth:`expired` call is what refuses the following entry.
+        """
         if size_bytes > 0:
             self._spent_bytes += size_bytes
 

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/carry_forward.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/carry_forward.py
@@ -30,6 +30,27 @@ def carry_forward(
 ) -> ApplyReport:
     """Fold an earlier apply's categories into this one's report.
 
+    Answers a **new** :class:`~...outcomes.ApplyReport` that keeps this
+    apply's own identity (``apply_id``, ``trigger``, both timestamps) and
+    concatenates the earlier apply's ``categories``, ``sources`` and ``notes``
+    in front of this one's, re-deriving ``status`` over the union::
+
+        # phase A wrote script and failed it; phase B wrote mcp cleanly
+        carry_forward(phase_b_report, ctx=ctx,
+                      carry_from_apply_id="ap_phaseA", ...)
+        # -> ApplyReport(apply_id="ap_phaseB",
+        #                status=ApplyStatus.PARTIAL,      # re-derived
+        #                categories=(<script, aborted>, <mcp, clean>))
+
+    ``applies`` is the apply record repository (its ``get`` is called with
+    ``env``/``entity_id``/``bot_id``/``apply_id``) and ``to_report`` is the
+    codec that decodes a record back into a report. Both are passed in rather
+    than imported, so this module needs no part of the apply service.
+
+    Returns ``report`` unchanged, never raising, when
+    ``carry_from_apply_id`` is falsy, names no record for this bot, or decodes
+    to nothing.
+
     One creation produces **two** applies — the pre-container phase writes
     ``script``, the post-container phase writes everything else — separated by
     the whole of container provisioning. Each mints its own ``apply_id`` and its

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/context.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/context.py
@@ -1,16 +1,15 @@
 """Who and what one apply runs as.
 
 Built once at the top of an apply and handed to every materialiser, so that a
-materialiser never re-derives an identity.
+materialiser never re-derives an identity. It carries identity, addressing and
+resolved capabilities, and nothing else.
 
-It carries identity and resolved capabilities, and nothing else. A ``coords_for``
-helper wrapping W10's ``CONFIG_SURFACE`` lived here and has been removed: no
-materialiser called it. The two that ship reach their area through the owning
-service (``BotStartupScriptService``, ``DirectActivationService``), which is
-where the write and its guards already live, so a second addressing path was
-speculative. W5/W6 can reach ``CONFIG_SURFACE`` directly when a materialiser
-genuinely needs a coordinate — importing it lazily, because that table indexes
-six core packages and one of them reaches the DI container at import time.
+A materialiser reaches its area through the owning service
+(``BotStartupScriptService``, ``DirectActivationService``), which is where the
+write and its guards already live, so there is no addressing helper here. One
+that genuinely needs a coordinate imports ``CONFIG_SURFACE`` directly, and
+lazily: that table indexes six core packages, one of which reaches the DI
+container at import time.
 """
 from __future__ import annotations
 
@@ -31,6 +30,45 @@ from agentclaw.community.core.bot_config_manifest.capabilities import (
 class ApplyContext:
     """The identity and addressing one apply runs under.
 
+    Built once at the top of an apply and handed to every materialiser's
+    ``resolve``, ``plan`` and ``write``. One filled-in example::
+
+        ApplyContext(
+            bot_id="bot_42",
+            owner_id="usr_owner",
+            actor_id="usr_collaborator",
+            entity_id="ent_7",
+            env="prod",
+            tenant="acme",
+            engine_type="claude_code",
+            bot_type="arca",
+            bot={...},                       # the bot record; see below
+            capabilities=ManifestCapabilities(...),
+            apply_id="ap_01HZX8",            # None on a dry run
+            budget=ApplyFetchBudget(...),    # None without a fetch pipeline
+            source_session=SourceSession(...),   # None likewise
+        )
+
+    ``bot`` is normally the full bot record read from the database. On exactly
+    one path it is a **minimal stand-in**: the creation job's pre-container
+    phase runs before the bot row exists, so
+    ``config_manifest_apply_service`` substitutes a four-key dict::
+
+        {
+            "bot_id": "bot_42",
+            "entity_id": "ent_7",
+            "active_engine": "claude_code",
+            "bot_type": "arca",
+        }
+
+    No shipped materialiser reads ``bot``, and the one that runs in that phase
+    (``script``) reads only ``engine_type``, ``env`` and ``tenant``, so the
+    stand-in is sufficient there.
+
+    Created by: ``services/config_manifest_apply_service._context``.
+    Consumed by: every materialiser stage, ``apply/orchestrator``, and the
+    fetch pipeline through the narrower ``entry_fetch.FetchContext`` protocol.
+
     ``owner_id`` and ``actor_id`` differ on a shared bot: the bot is resolved as
     the *owner's*, while the actor is whoever is applying. Materialisers that
     call a bot-configuration service pass both, exactly as the routers do.
@@ -45,44 +83,55 @@ class ApplyContext:
     #: Storage key, resolved server-side from the bot record. Never a request
     #: parameter and never a response field.
     entity_id: str
+    #: The deployment environment, e.g. ``"prod"``. One of the three axes
+    #: ``${BOT_*}`` placeholders substitute against, and one axis of the
+    #: content store's scope.
     env: str
+    #: The tenant, e.g. ``"acme"``, read from the ambient request context.
+    #: The second placeholder axis.
     tenant: str
+    #: The bot's active engine, e.g. ``"claude_code"``. The third placeholder
+    #: axis, and what capabilities resolve against.
     engine_type: str
+    #: The bot's family, e.g. ``"arca"`` or ``"teclaw"``. Decides which
+    #: delivery strategy runs and how the phases are ordered.
     bot_type: str
-    #: The bot record. Carried rather than re-fetched so a materialiser that
-    #: needs engine or template facts has them; unread by the two that ship.
+    #: The bot record, carried rather than re-fetched so a materialiser needing
+    #: engine or template facts has them. On the creation job's pre-container
+    #: phase this is the four-key stand-in described in the class docstring,
+    #: because the row does not exist yet. No shipped materialiser reads it.
     bot: dict[str, Any]
-    #: Resolved once per apply and carried, rather than re-resolved per
-    #: materialiser. Two reasons: the resolver needs the teclaw engine test
-    #: injected, and a materialiser reaching for it would drag that dependency
-    #: into every one of them; and a single resolution cannot disagree with
-    #: itself midway through an apply.
+    #: Which constructs this bot can actually take, resolved from
+    #: ``engine_type`` and ``bot_type``. A materialiser asks it two things:
+    #: ``capabilities.supports(ManifestSection.SCRIPT)`` and, when that is
+    #: false, ``capabilities.reason_for(...)`` for the refusal string it puts
+    #: on the entry's report row.
     #:
-    #: Re-asked at apply time rather than trusted from the ``PUT`` that accepted
-    #: the document: a bot's engine can change after a manifest is stored, and
-    #: the construct that was appliable then may not be now.
+    #: Resolved once per apply and carried, so a single resolution cannot
+    #: disagree with itself midway through. Re-asked at apply time rather than
+    #: trusted from the ``PUT`` that accepted the document: a bot's engine can
+    #: change after a manifest is stored, and the construct that was appliable
+    #: then may not be now.
     capabilities: ManifestCapabilities
-    #: The apply's own id, stamped into every receipt the fetch pipeline files
-    #: (W11's linkage column) — so "what did apply X fetch" is an indexed read,
-    #: which that table's own DDL says is why the column exists. ``None`` only
-    #: for a dry run, which mints no id by the same rule that makes it write
-    #: no report row; the entry identity half of the linkage is per fetch and
-    #: rides the materialisers' call instead.
+    #: This apply's own id, e.g. ``"ap_01HZX8"``, stamped into every receipt the
+    #: fetch pipeline files so "what did apply X fetch" is an indexed read.
+    #: ``None`` only for a dry run, which mints no id by the same rule that
+    #: makes it write no report row. The entry-identity half of that linkage is
+    #: per fetch and rides the materialiser's call instead.
     apply_id: Optional[str] = None
-    #: One apply's fetch allowance — the ledger that makes the fetch-time
-    #: budget and byte cap of ``fetch/limits.py`` real (an audit caught them
-    #: defined but threaded by nothing, while W5's fetches could legitimately
-    #: outrun the 30-minute apply-lock TTL). Mutable by design inside the
-    #: frozen context: consult before each fetch, charge after. ``None`` for
-    #: callers that run no fetch pipeline (tests, hand-driven use).
+    #: This apply's fetch allowance: 300 seconds and 500 MiB, from
+    #: ``fetch/limits.py``. Mutable by design inside the frozen context —
+    #: consult before each fetch, charge after. ``None`` for callers that run
+    #: no fetch pipeline (tests, hand-driven use), and every budget check is
+    #: written to tolerate that.
     budget: Optional["ApplyFetchBudget"] = None
-    #: One apply's named-source state (W7): the document's ``sources``, the
+    #: This apply's named-source state: the document's ``sources`` map, the
     #: strict-mode baselines read back from the last apply's report, and the
-    #: git checkout cache. Mutable by design inside the frozen context — the
-    #: same ruling as ``budget``, and for the same reason: the alternative is
-    #: state on a DI-singleton fetcher, which would leak across applies.
-    #: ``None`` for callers that run no ``from``/git pipeline (tests,
-    #: hand-driven use); ``fetch_declared`` refuses such entries loudly.
+    #: git checkout cache. Mutable by design inside the frozen context, for the
+    #: same reason as ``budget``: the alternative is state on a DI-singleton
+    #: fetcher, which would leak across applies. ``None`` for callers that run
+    #: no ``from``/git pipeline; ``fetch_declared`` refuses such entries loudly
+    #: rather than fetching anonymously.
     source_session: Optional[SourceSession] = None
 
 

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/delivery.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/delivery.py
@@ -68,7 +68,11 @@ from agentclaw.community.core.bot_config_manifest.apply.order import (
 from agentclaw.community.core.bot_config_manifest.apply.outcomes import ApplyReport
 from agentclaw.community.core.bot_config_manifest.capabilities import ManifestSection
 
-#: The yaml key under ``user_config.bot_config_manifest``.
+#: The yaml key under ``user_config.bot_config_manifest``::
+#:
+#:     user_config:
+#:       bot_config_manifest:
+#:         teclaw_platform_managed: true
 TECLAW_PLATFORM_MANAGED_KEY = "teclaw_platform_managed"
 
 
@@ -96,11 +100,17 @@ class CreationSequence(StrEnum):
 class MaterialiserPorts:
     """The write targets a strategy hands ``build_materialisers``.
 
-    Field for field the keyword arguments that function takes; a strategy
-    differs from another by which objects sit behind these names, never by
-    which materialisers exist. Each field is typed by the narrow port the
-    materialiser calls through, so a device-backed service and a store-backed
-    port are interchangeable by shape.
+    Ten fields, matching that function's keyword arguments name for name, so
+    :meth:`as_kwargs` can splat them straight in. A strategy differs from
+    another by which **objects** sit behind these names, never by which
+    materialisers exist: ARCA binds device-backed services, platform-managed
+    teclaw binds store-backed ports, and each field is typed by the narrow port
+    the materialiser calls through so the two are interchangeable by shape.
+
+    Created by: ``ArcaDelivery.ports`` and ``TeclawDelivery.ports``, each
+    delegating to a lazy callable bound by the composition root.
+    Consumed by: ``apply/registry.build_materialisers``, via
+    :meth:`as_kwargs`.
     """
 
     script_service: BotStartupScriptServiceProtocol
@@ -118,6 +128,10 @@ class MaterialiserPorts:
     cli_tool_service: CliToolService
 
     def as_kwargs(self) -> dict[str, Any]:
+        """The same ten fields as a plain dict, ready to splat into
+        ``build_materialisers(**ports.as_kwargs())``. Written out by hand
+        rather than derived, so adding a field here without adding a
+        materialiser parameter is a visible edit."""
         return {
             "script_service": self.script_service,
             "activation_service": self.activation_service,
@@ -135,6 +149,32 @@ class MaterialiserPorts:
 class DeliveryStrategy(Protocol):
     """What differs between engine families, and nothing else.
 
+    The four things it owns, and how the two implementations answer:
+
+    ======================  =====================  ========================
+    Member                  ``ArcaDelivery``       ``TeclawDelivery``
+                                                   (platform-managed on)
+    ======================  =====================  ========================
+    ``family``              ``"arca"``             ``"teclaw"``
+    ``creation_sequence``   ``CREATE_BETWEEN_``    ``RECORD_APPLY_``
+                            ``PHASES``             ``PROVISION``
+    ``phase_of(step)``      the table's own        ``PRE_CONTAINER`` for
+                            ``step.phase``         everything but ``script``
+    ``needs_container()``   ``True``               ``False``
+    ``ports()``             device-backed          store-backed
+    ``finish()``            ``None``               one whole-artifact
+                                                   redeliver
+    ======================  =====================  ========================
+
+    With the switch **off**, ``TeclawDelivery`` answers the ARCA column for
+    every row except ``family`` and ``ports`` — that is the point of the
+    switch.
+
+    Created by: ``DeliveryStrategyFactory.for_engine`` / ``for_bot``.
+    Consumed by: the apply service (``ports``, ``finish``), the orchestrator
+    (``steps_for``), and the creation job (``creation_sequence``,
+    ``needs_container``).
+
     Implemented by ``ArcaDelivery`` and ``TeclawDelivery`` below, which
     subclass it explicitly so the implementations are one jump away.
     """
@@ -150,31 +190,52 @@ class DeliveryStrategy(Protocol):
         ...
 
     @property
-    def creation_sequence(self) -> CreationSequence: ...
+    def creation_sequence(self) -> CreationSequence:
+        """Which of the two creation orders this family runs."""
+        ...
 
     def phase_of(self, step: ApplyStep) -> ApplyPhase:
-        """Which phase this family delivers the step's construct in."""
+        """Which phase this family delivers the step's construct in.
+
+        May disagree with ``step.phase``, which is the ARCA reading.
+        """
         ...
 
     def steps_for(
         self, phases: frozenset[ApplyPhase] | None = None
     ) -> tuple[ApplyStep, ...]:
-        """The steps in the requested phases, in position order."""
+        """The steps in the requested phases, in position order.
+
+        Same contract as ``apply.order.steps_for``, but filtered through this
+        family's :meth:`phase_of` rather than the table's own column. This is
+        the callable handed to ``ApplyOrchestrator``.
+        """
         ...
 
     def needs_container(self) -> bool:
-        """Whether any construct of this family lands only after the container."""
+        """Whether any construct of this family lands only after the container.
+
+        ``False`` means the creation job may skip waiting for ``ACTIVE`` and
+        run no post-container phase.
+        """
         ...
 
     def ports(self) -> MaterialiserPorts:
-        """The write targets for this family's materialisers."""
+        """The write targets for this family's materialisers.
+
+        Called per apply, not cached: the callables behind it reach the device
+        graph, which is resolved lazily.
+        """
         ...
 
     async def finish(self, ctx: ApplyContext, report: ApplyReport) -> Optional[str]:
         """Close an apply after every category is written.
 
-        Returns a note for the report (a failure that must not raise — §2.7),
-        or ``None`` when there is nothing to say.
+        Answers a string that becomes one of ``ApplyReport.notes``, or ``None``
+        when there is nothing to say. ARCA always answers ``None``; teclaw
+        answers ``None`` on success and the redeliver's failure text otherwise.
+        A failure here must **not** raise: every category is already written,
+        and losing the report would be worse than recording the note.
         """
         ...
 
@@ -192,7 +253,12 @@ def _steps(
 
 
 class ArcaDelivery(DeliveryStrategy):
-    """Today's behaviour, named: the phase table is ``APPLY_ORDER``'s own."""
+    """The container family: the phase table is ``APPLY_ORDER``'s own.
+
+    Every answer is the table's, unchanged — ``phase_of`` returns
+    ``step.phase``, ``needs_container`` is ``True``, and ``finish`` has
+    nothing to do because the owning services project as they write.
+    """
 
     family = "arca"
     creation_sequence = CreationSequence.CREATE_BETWEEN_PHASES
@@ -220,10 +286,18 @@ class ArcaDelivery(DeliveryStrategy):
         return None
 
 
-#: The closing step for a platform-managed teclaw apply: one whole-artifact
-#: redeliver to the running container, or nothing when the bot has no live
-#: binding (provisioning composes the first artifact instead). Returns a note
-#: on failure.
+#: The closing step for a platform-managed teclaw apply. Takes the apply's
+#: context and answers ``None`` on success, or a report-safe note on failure::
+#:
+#:     async def redeliver(ctx: ApplyContext) -> Optional[str]: ...
+#:
+#: One whole-artifact redeliver to the running container, or nothing at all
+#: when the bot has no live binding — on the creation path, provisioning
+#: composes the first artifact instead, so there is nothing to redeliver to.
+#: The note it answers becomes one of ``ApplyReport.notes``.
+#:
+#: Implemented by: ``apply/redeliver``. Consumed by:
+#: :meth:`TeclawDelivery.finish`.
 Redeliver = Callable[[ApplyContext], Awaitable[Optional[str]]]
 
 
@@ -231,12 +305,24 @@ Redeliver = Callable[[ApplyContext], Awaitable[Optional[str]]]
 class TeclawPlatformBindings:
     """What the platform-managed teclaw path needs bound, as one DI value.
 
-    The store-backed ports and the closing redeliver are built in the
-    manifest-fetch graph (beside the store they write) and handed to the apply
-    service, whose own module is at its size cap, as a single parameter.
+    Two fields, both callables, so nothing is resolved until an apply actually
+    runs on a teclaw bot::
+
+        TeclawPlatformBindings(
+            platform_ports=lambda: MaterialiserPorts(...),  # store-backed
+            redeliver=<an async (ApplyContext) -> Optional[str]>,
+        )
+
+    Created by: the composition root, in the manifest-fetch graph beside the
+    store these ports write to.
+    Consumed by: the apply service, which unpacks it into
+    ``DeliveryStrategyFactory``.
     """
 
+    #: Builds the store-backed port bundle. Lazy: it reaches the object store
+    #: graph.
     platform_ports: Callable[[], MaterialiserPorts]
+    #: The closing whole-artifact redeliver. See :data:`Redeliver`.
     redeliver: Redeliver
 
 
@@ -344,6 +430,25 @@ _FALSE_SCALARS = frozenset({"false", "no", "off", "0"})
 def teclaw_platform_managed_from_config(tree: Mapping[str, Any] | None) -> bool:
     """The switch, read from the ``user_config`` tree. Absent is off.
 
+    ``tree`` is the merged ``user_config`` mapping; the block this reads is
+    ``tree["bot_config_manifest"][TECLAW_PLATFORM_MANAGED_KEY]``.
+
+    ============================================  =====================
+    Value at that key                             Result
+    ============================================  =====================
+    absent, or the block is missing/not a         ``False``
+    mapping, or ``tree`` is ``None``
+    ``None`` (``teclaw_platform_managed:``        ``False``
+    with nothing after it)
+    ``True`` / ``False``                          as written
+    ``"true"``, ``"yes"``, ``"on"``, ``"1"``      ``True``
+    ``"false"``, ``"no"``, ``"off"``, ``"0"``     ``False``
+    ``0`` / ``1``                                 ``False`` / ``True``
+    anything else                                 raises ``ValueError``
+    ============================================  =====================
+
+    Called by: the composition root, at boot.
+
     Strict, and the strictness is the point: YAML may hand back a string, and
     ``bool("false")`` is ``True``. A switch that turns a delivery path on
     because someone quoted ``"off"`` would fail every teclaw apply in a
@@ -381,7 +486,17 @@ def teclaw_platform_managed_from_config(tree: Mapping[str, Any] | None) -> bool:
 
 
 class DeliveryStrategyFactory:
-    """Pick the strategy for a bot. The one reader of the switch."""
+    """Pick the strategy for a bot. The one reader of the switch.
+
+    ``for_engine("claude_code")`` answers an :class:`ArcaDelivery`;
+    ``for_engine("teclaw")`` answers a :class:`TeclawDelivery` carrying the
+    switch. ``for_bot(bot)`` is the same thing keyed off
+    ``bot["active_engine"]``.
+
+    Raises ``RuntimeError`` when the switch is on and no platform ports are
+    bound: a misconfiguration should be loud, not a quiet fallback to writing
+    into a container through the device ports.
+    """
 
     def __init__(
         self,

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/entry_delivery.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/entry_delivery.py
@@ -278,28 +278,35 @@ class EntryDelivery(Protocol):
     read) and :class:`GitDelivery` (a proven checkout). What each member
     answers, per road:
 
-    ==================  =====================  ==========================  ==========================
-    Method              Called by              ``BlobDelivery`` answers    ``GitDelivery`` answers
-    ==================  =====================  ==========================  ==========================
-    ``is_tree()``       ``skills``             ``False``                   ``True``
-    ``members()``       ``resources``          the archive unpacked, or    every file under the
-                                               a stored tree decoded       composed ``subpath``
-    ``single()``        ``resources``,         the whole blob              the one file ``subpath``
-                        ``identity``,                                      names
-                        ``cli_tools``
-    ``note()``          all four               the ``keep_last``           the moved-ref note
-                                               fallback reason
-    ``digest()``        ``cli_tools``          the content digest          ``None`` (git has no
-                                                                           declarable digest)
-    ``receipt_url()``   all four               ``https://…`` or            ``git+…@<sha>:<subpath>``
-                                               ``oss://…``
-    ``auth()``          all four               ``None`` (the fetch         the credential name
-                                               already filed it)
-    ``source_url()``    ``skills``             the fetched URL             the repository URL
-    ``content_type()``  ``skills``             what the source said        ``None``
-    ``from_store()``    ``skills``             True on a store hit         always ``False``
-    ``needs_receipt()`` all four               ``False``                   ``True``
-    ==================  =====================  ==========================  ==========================
+    ===================  ======================  =========================
+    Method               ``BlobDelivery``        ``GitDelivery``
+    ===================  ======================  =========================
+    ``is_tree()``        ``False``               ``True``
+    ``members()``        the archive unpacked,   every file under the
+                         or a stored tree        composed ``subpath``
+                         decoded
+    ``single()``         the whole blob          the one file ``subpath``
+                                                 names
+    ``note()``           the ``keep_last``       the moved-ref note
+                         fallback reason
+    ``digest()``         the content digest      ``None``; git declares no
+                                                 digest
+    ``receipt_url()``    ``https://…`` or        ``git+…@<sha>:<subpath>``
+                         ``oss://…``
+    ``auth()``           ``None``; the fetch     the credential name
+                         already filed it
+    ``source_url()``     the fetched URL         the repository URL
+    ``content_type()``   what the source said    ``None``
+    ``from_store()``     ``True`` on a store     always ``False``
+                         hit
+    ``needs_receipt()``  ``False``               ``True``
+    ===================  ======================  =========================
+
+    Which category asks which: ``skills`` alone calls ``is_tree``,
+    ``source_url``, ``content_type`` and ``from_store``; ``resources`` calls
+    ``members``; ``resources``, ``identity`` and ``cli_tools`` call
+    ``single``; ``cli_tools`` alone calls ``digest``; and all four call
+    ``note``, ``receipt_url``, ``auth`` and ``needs_receipt``.
 
     Created by: ``apply/source_fetchers`` (both fetchers) and
     ``apply/entry_fetch.fetch_declared`` on the legacy inline-URL road.

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/entry_delivery.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/entry_delivery.py
@@ -84,12 +84,72 @@ class EntryFetchError(Exception):
 
 @dataclass(frozen=True)
 class FetchedEntry:
-    """One entry's bytes, their content address, and where they came from."""
+    """One entry's bytes, their content address, and where they came from.
 
+    Three states, and a caller tells them apart by ``from_store`` and
+    ``fallback_reason``.
+
+    A **fresh fetch** — the wire moved and the bytes were filed with the
+    store::
+
+        FetchedEntry(
+            content=b"PK\x03\x04...",
+            digest="sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b...",
+            from_store=False,
+            content_type="application/zip",
+            fallback_reason=None,
+            source_url="https://example.com/tools/qc-v2.zip",
+        )
+
+    A **pinned store hit** — the entry declared a ``digest``, the platform
+    already held those exact bytes, and no network was touched. Silent by
+    design: this is the legitimate fast path, so there is no note::
+
+        FetchedEntry(
+            content=b"PK\x03\x04...",
+            digest="sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b...",
+            from_store=True,
+            content_type="application/zip",
+            fallback_reason=None,
+            source_url="oss://team-artifacts/tools/qc/v2.tgz",
+        )
+
+    A **keep_last fallback** — the source was fetched, it failed, and the
+    stored copy stood in. ``from_store`` is true *and* a reason is set, which
+    is the only combination that means "fallback"::
+
+        FetchedEntry(
+            content=b"acm-tree-v1\n...",
+            digest="sha256:2c26b46b68ffc68ff99b453c1d30413413422d70...",
+            from_store=True,
+            content_type=None,
+            fallback_reason=(
+                "delivered from the platform's stored copy (keep_last): "
+                "the git fetch failed"
+            ),
+            source_url=(
+                "git+https://code.example.com/team/content.git"
+                "@4f2a9c1b8e7d6a5c4b3a2918f7e6d5c4b3a29187:kb"
+            ),
+        )
+
+    Created by: ``apply/entry_fetch.EntryFetcher`` — ``fetch``,
+    ``acquire_object`` and ``_git_keep_last``.
+    Consumed by: ``apply/entry_delivery.BlobDelivery``, which is the only thing
+    that wraps one.
+    """
+
+    #: The entry's bytes, whole and in memory. For a stored git tree these are
+    #: the canonical framing :func:`canonical_tree_bytes` produced, not a file.
     content: bytes
+    #: ``"sha256:"`` followed by 64 lowercase hex characters, over ``content``.
     digest: str
     #: True when the platform's own copy answered — no network was touched.
+    #: True for both a pinned hit and a ``keep_last`` fallback;
+    #: ``fallback_reason`` is what separates them.
     from_store: bool
+    #: What the source said the bytes are, e.g. ``"application/zip"``, or
+    #: ``None`` when it said nothing. The object-store road never sets one.
     content_type: Optional[str] = None
     #: Set only when the platform's copy answered as a ``keep_last``
     #: FALLBACK — the source was fetched and failed, the stored bytes stood
@@ -99,9 +159,16 @@ class FetchedEntry:
     #: entry's note. A plain store-hit (from_store, no note) is the
     #: legitimate pinned fast path and stays silent.
     fallback_reason: Optional[str] = None
-    #: The URL the bytes came by, when the caller needs it for shape
-    #: inference (the skills materialiser's archive-kind detection). ``None``
-    #: on the roads that never knew one.
+    #: The address these bytes are filed under, in one of three shapes
+    #: depending on the road that produced them::
+    #:
+    #:     "https://example.com/tools/qc-v2.zip"       # inline URL road
+    #:     "oss://team-artifacts/tools/qc/v2.tgz"      # object store road
+    #:     "git+https://code.example.com/team/content.git@<40-hex sha>:kb"
+    #:
+    #: The last two are receipt identities, not fetchable URLs. Callers also
+    #: read this to infer an archive's kind from its extension (the skills
+    #: materialiser). ``None`` on the roads that never knew one.
     source_url: Optional[str] = None
 
 
@@ -109,24 +176,55 @@ class FetchedEntry:
 class GitEntrySource:
     """A fresh git checkout for one entry to consume — files, not bytes.
 
+    One example, a ``resources`` entry reading ``kb/faq.csv`` out of a source
+    whose ref moved since the last apply::
+
+        GitEntrySource(
+            checkout=GitCheckout(
+                root=PosixPath("/tmp/acm-git-x9"),
+                sha="4f2a9c1b8e7d6a5c4b3a2918f7e6d5c4b3a29187",
+                url="https://code.example.com/team/content.git",
+                ref="v1.2.0",
+                members=(("100644", "kb/faq.csv", 812),),
+            ),
+            source_url="https://code.example.com/team/content.git",
+            subpath="kb/faq.csv",
+            moved_from="1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b",
+            auth="git-prod",
+            file_limit=104857600,      # FETCH_ENTRY_LIMITS["resources_file"]
+        )
+
+    Created by: ``apply/source_fetchers.GitSourceFetcher.fetch``.
+    Consumed by: ``apply/entry_delivery.GitDelivery``, which is the only thing
+    that wraps one.
+
     The object road hands back bytes because there was exactly one blob to
     read; the git road hands back a proven tree and lets the materialiser read
     it, because what "the entry's bytes" are is a *category* question this
     layer must not answer.
-
-    ``file_limit`` is the category's per-entry byte cap (the same
-    ``FETCH_ENTRY_LIMITS`` number the object road enforces at the transport) —
-    the tree's readers refuse a member by its *declared* size against it.
-    ``auth`` is the credential **name** the acquisition rode, threaded to the
-    receipts so W11's lineage attributes git-sourced bytes the way it does
-    object-sourced ones.
     """
 
+    #: The fetched tree on disk, its members already enumerated and proven
+    #: plain files. Shared with every other entry on the same ``(url, ref)``.
     checkout: GitCheckout
+    #: The **repository** URL, substituted, with no ``git+`` prefix and no sha.
+    #: :meth:`receipt_url` is what turns it into the receipt identity.
     source_url: str
+    #: The composed path to read out of the tree: the source's ``subpath``
+    #: then the entry's, e.g. ``"kb/faq.csv"``. ``None`` means the whole tree.
     subpath: Optional[str]
+    #: The SHA the last apply recorded, when this apply resolved a different
+    #: one — the non-strict road's "the ref moved" signal, surfaced by
+    #: :meth:`moved_note`. ``None`` when the ref did not move, or had no
+    #: baseline to move from.
     moved_from: Optional[str]
+    #: The credential's **name**, never its value, threaded to the receipts so
+    #: lineage attributes git-sourced bytes the way it does object-sourced
+    #: ones. ``None`` for an anonymous fetch.
     auth: Optional[str] = None
+    #: The category's per-entry byte cap, in bytes — the same
+    #: ``FETCH_ENTRY_LIMITS`` number the object road enforces at the transport.
+    #: The tree's readers refuse a member by its *declared* size against it.
     file_limit: Optional[int] = None
 
     def files(self) -> list[tuple[str, bytes]]:
@@ -142,11 +240,25 @@ class GitEntrySource:
             raise EntryFetchError(str(exc)) from exc
 
     def receipt_url(self) -> str:
-        """The W11 identity for this entry's git-sourced bytes."""
+        """The receipt identity for this entry's git-sourced bytes::
+
+            "git+https://code.example.com/team/content.git"
+            "@4f2a9c1b8e7d6a5c4b3a2918f7e6d5c4b3a29187:kb/faq.csv"
+
+        Keyed on the *resolved* sha, so a moved ref is a different address and
+        a bare source with no subpath ends in a trailing colon.
+        """
         return git_receipt_url(self.source_url, self.checkout.sha, self.subpath)
 
     def moved_note(self) -> Optional[str]:
-        """The non-strict road's report line about a moved ref."""
+        """The non-strict road's report line about a moved ref, or ``None``::
+
+            "ref moved: the last apply recorded 1a2b3c4d..., this one
+             resolved 4f2a9c1b..."
+
+        Surfaces as the entry's ``note`` on a **successful** row. Strict mode
+        never reaches here: it refuses the entry instead.
+        """
         if self.moved_from is None:
             return None
         return (
@@ -162,11 +274,42 @@ class GitEntrySource:
 class EntryDelivery(Protocol):
     """What one entry's source delivered, read on the category's terms.
 
-    Every member below has exactly one caller family, named in its docstring.
-    The surface is wide because the four fetching categories genuinely want
+    Two implementations: :class:`BlobDelivery` (an HTTPS GET or one object
+    read) and :class:`GitDelivery` (a proven checkout). What each member
+    answers, per road:
+
+    ==================  =====================  ==========================  ==========================
+    Method              Called by              ``BlobDelivery`` answers    ``GitDelivery`` answers
+    ==================  =====================  ==========================  ==========================
+    ``is_tree()``       ``skills``             ``False``                   ``True``
+    ``members()``       ``resources``          the archive unpacked, or    every file under the
+                                               a stored tree decoded       composed ``subpath``
+    ``single()``        ``resources``,         the whole blob              the one file ``subpath``
+                        ``identity``,                                      names
+                        ``cli_tools``
+    ``note()``          all four               the ``keep_last``           the moved-ref note
+                                               fallback reason
+    ``digest()``        ``cli_tools``          the content digest          ``None`` (git has no
+                                                                           declarable digest)
+    ``receipt_url()``   all four               ``https://…`` or            ``git+…@<sha>:<subpath>``
+                                               ``oss://…``
+    ``auth()``          all four               ``None`` (the fetch         the credential name
+                                               already filed it)
+    ``source_url()``    ``skills``             the fetched URL             the repository URL
+    ``content_type()``  ``skills``             what the source said        ``None``
+    ``from_store()``    ``skills``             True on a store hit         always ``False``
+    ``needs_receipt()`` all four               ``False``                   ``True``
+    ==================  =====================  ==========================  ==========================
+
+    Created by: ``apply/source_fetchers`` (both fetchers) and
+    ``apply/entry_fetch.fetch_declared`` on the legacy inline-URL road.
+    Consumed by: every fetching materialiser — ``skills``, ``resources``,
+    ``identity``, ``cli_tools``.
+
+    Every member has exactly one caller family, named in its docstring. The
+    surface is wide because the four fetching categories genuinely want
     different things out of one delivery — but it is not *open*: a member with
-    no caller does not belong here, the same discipline
-    ``plugin_api/object_storage.py`` states for its own protocol.
+    no caller does not belong here.
     """
 
     @abstractmethod
@@ -281,8 +424,27 @@ class EntryDelivery(Protocol):
 
 @dataclass(frozen=True)
 class BlobDelivery(EntryDelivery):
-    """One object's bytes, however they were acquired."""
+    """One object's bytes, however they were acquired.
 
+    The object-store road, the legacy inline-URL road, and every ``keep_last``
+    fallback — including a git one, whose stored bytes arrive here as a
+    canonical tree blob rather than as a checkout::
+
+        BlobDelivery(fetched=FetchedEntry(
+            content=b"PK\x03\x04...",
+            digest="sha256:9f86d081...",
+            from_store=False,
+            content_type="application/zip",
+            source_url="oss://team-artifacts/tools/qc/v2.tgz",
+        ))
+
+    Differs from :class:`GitDelivery` in four answers: ``is_tree`` is
+    ``False``, ``digest`` is a real content address, ``needs_receipt`` is
+    ``False`` (the fetch already filed these bytes) and ``auth`` is ``None``
+    (there is no second write for a credential name to ride on).
+    """
+
+    #: The bytes and their provenance. Every method here is a read of this.
     fetched: FetchedEntry
 
     def is_tree(self) -> bool:
@@ -344,8 +506,29 @@ class BlobDelivery(EntryDelivery):
 
 @dataclass(frozen=True)
 class GitDelivery(EntryDelivery):
-    """A checked-out tree, read on the category's terms."""
+    """A checked-out tree, read on the category's terms.
 
+    The git road, and only a *successful* one: a git fetch that failed and fell
+    back to ``keep_last`` comes back as a :class:`BlobDelivery` instead::
+
+        GitDelivery(source=GitEntrySource(
+            checkout=<the shared checkout>,
+            source_url="https://code.example.com/team/content.git",
+            subpath="kb/faq.csv",
+            moved_from=None,
+            auth="git-prod",
+            file_limit=104857600,
+        ))
+
+    Differs from :class:`BlobDelivery` in four answers: ``is_tree`` is
+    ``True``, ``digest`` is ``None`` (the schema refuses ``digest`` on a git
+    source, so there is nothing for the pin belt to compare), ``needs_receipt``
+    is ``True`` (a checkout is not bytes, and only the caller knows which bytes
+    this entry delivers) and ``auth`` is the credential name, because those
+    bytes are still owed to the store.
+    """
+
+    #: The checkout and the entry's view into it.
     source: GitEntrySource
 
     def is_tree(self) -> bool:
@@ -403,12 +586,36 @@ class GitDelivery(EntryDelivery):
 def archive_refusal(unpack: object, strip_components: object) -> Optional[str]:
     """The archive fields a directory entry over ``oss`` must carry, or why not.
 
-    Pure, and asked twice on purpose: once by ``resources`` **before** the
-    fetch, so a doomed entry costs no network against this apply's byte budget
-    and lock TTL, and once by :meth:`BlobDelivery.members` after, for the entry
-    whose protocol that belt could not determine up front. Two calls of one
-    function, never two rules — which is why it takes the two *values* rather
-    than the entry: the pre-fetch caller has an entry, the delivery does not.
+    Both arguments are the entry's declared values, **unvalidated** — typed
+    ``object`` because they came straight out of parsed YAML and may be
+    anything. ``None`` means they are acceptable; a string is the refusal::
+
+        archive_refusal("zip", 0)        -> None
+        archive_refusal("tar.gz", 1)     -> None
+        archive_refusal(None, 0)         -> "a directory entry fetched over
+                                             'oss' must declare
+                                             'unpack: zip|tar.gz' — ..."
+        archive_refusal(["zip"], 0)      -> the same refusal (unhashable, so
+                                            the str check has to come first)
+        archive_refusal("zip", -1)       -> "'strip_components' must be a
+                                             non-negative integer"
+        archive_refusal("zip", True)     -> the same; bool is rejected even
+                                            though it is an int
+
+    The values reach here from a ``resources`` entry::
+
+        - path: data/prices/
+          from: artifacts
+          key: prices.tgz
+          unpack: tar.gz          # <- unpack
+          strip_components: 1     # <- strip_components
+
+    Called by: ``materialisers/resources`` before the fetch, so a doomed entry
+    costs no network against this apply's byte budget and lock TTL, and
+    :meth:`BlobDelivery.members` after it, for the entry whose protocol that
+    belt could not determine up front. Two calls of one function, never two
+    rules — which is why it takes the two *values* rather than the entry: the
+    pre-fetch caller has an entry, the delivery does not.
     """
     # Str first: ``VALID_UNPACK`` is a frozenset, and an unhashable ``unpack``
     # (a YAML list) would raise on the membership test where this owes a
@@ -433,14 +640,30 @@ def unpack_members(
 ) -> list[tuple[str, bytes]] | str:
     """The guarded unpack, platform-side, into a throwaway directory.
 
+    ``archive`` is the fetched bytes. ``kind`` and ``strip_components`` are the
+    entry's own ``unpack`` and ``strip_components``, already proven well-formed
+    by :func:`archive_refusal` — ``kind`` is one of ``VALID_UNPACK``
+    (``"zip"`` or ``"tar.gz"``) and ``strip_components`` a non-negative int.
+    Both reach here from the entry via :meth:`BlobDelivery.members`, which is
+    handed them by the materialiser that read them off the YAML.
+
+    Answers either the members or a refusal string::
+
+        unpack_members(<a tar.gz of qc-v2/bin/qc and qc-v2/README>,
+                       "tar.gz", 1)
+        # -> [("bin/qc", b"..."), ("README", b"...")]
+        #    strip_components=1 dropped the "qc-v2/" prefix
+
+        unpack_members(b"not an archive", "zip", 0)
+        # -> "..." the UnpackError's own message
+
+    Paths are relative and directories are structural, so only files come back.
+
     The bot is never a scratch space: ``unpack_archive`` writes only into a
-    fresh temporary directory, so a bad or oversized archive (W1's member /
+    fresh temporary directory, so a bad or oversized archive (the member and
     unpacked-size limits live inside it) fails before anything is delivered.
-    Returned members are ``(relative path, bytes)`` with ``strip_components``
-    already applied — the bytes are read back before the throwaway dir goes
-    away; a refusal comes back as its reason string rather than an exception,
-    keeping every failure in ``resolve``'s currency and the bot's tree
-    untouched.
+    A refusal comes back as its reason string rather than an exception, keeping
+    every failure in ``resolve``'s currency and the bot's tree untouched.
     """
     try:
         with tempfile.TemporaryDirectory(prefix="manifest-resources-") as tmp:
@@ -457,16 +680,36 @@ def unpack_members(
         return str(exc)
 
 
-#: Marks the stored form of a git-delivered tree. Self-describing on purpose:
-#: ``keep_last`` reads a receipt back as plain bytes with no idea what shape
-#: they are, and "guess from the URL" is not identification. The version digit
-#: is what lets the framing change later without a stored copy being decoded
-#: under the wrong rules.
+#: Marks the stored form of a git-delivered tree, and opens every blob
+#: :func:`canonical_tree_bytes` produces.
+#:
+#: The framing after it is ``<path length>:<path><byte length>:<bytes>``
+#: repeated, members sorted by path, all lengths in decimal ASCII and paths in
+#: UTF-8. A two-file tree, byte for byte::
+#:
+#:     canonical_tree_bytes([("faq.csv", b"q,a\n"), ("a.txt", b"hi")])
+#:     # -> b'acm-tree-v1\n5:a.txt2:hi7:faq.csv4:q,a\n'
+#:     #       magic       ^^^^^^^^^^^^ "a.txt" (5 bytes) -> b"hi" (2 bytes)
+#:     #                               ^^^^^^^^^^^^^^^^^ "faq.csv" (7) ->
+#:     #                                                 b"q,a\n" (4)
+#:
+#: Note the sort: ``a.txt`` is emitted first although it was passed second.
+#:
+#: Self-describing on purpose: ``keep_last`` reads a receipt back as plain
+#: bytes with no idea what shape they are, and "guess from the URL" is not
+#: identification. The version digit is what lets the framing change later
+#: without a stored copy being decoded under the wrong rules.
 TREE_MAGIC = b"acm-tree-v1\n"
 
 
 def canonical_tree_bytes(members: list[tuple[str, bytes]]) -> bytes:
     """One deterministic byte string standing for a whole delivered tree.
+
+    Takes ``(relative path, bytes)`` pairs in any order and answers the framing
+    :data:`TREE_MAGIC` documents, which shows a worked two-file example.
+
+    Called by: ``materialisers/resources`` and ``materialisers/skills``, for the
+    bytes a git-delivered entry owes the store.
 
     Two jobs, and the second is why it is **reversible**:
 
@@ -492,7 +735,16 @@ def canonical_tree_bytes(members: list[tuple[str, bytes]]) -> bytes:
 
 
 def decode_tree_bytes(blob: bytes) -> Optional[list[tuple[str, bytes]]]:
-    """The members back out, or ``None`` when these are not a canonical tree.
+    """The members back out, or ``None`` when these are not a canonical tree::
+
+        decode_tree_bytes(b"acm-tree-v1\n5:a.txt2:hi7:faq.csv4:q,a\n")
+        # -> [("a.txt", b"hi"), ("faq.csv", b"q,a\n")]
+
+        decode_tree_bytes(b"PK\x03\x04...")   # a zip; no magic
+        # -> None
+
+    Called by: :meth:`BlobDelivery.members`, first thing, to tell a stored git
+    tree from an archive.
 
     ``None`` rather than an exception: the caller is asking "is this a stored
     git tree or an archive?", and a shape it does not recognise is an answer,

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/entry_fetch.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/entry_fetch.py
@@ -860,7 +860,7 @@ class EntryFetcher:
                        content=b"acm-tree-v1\n5:a.txt2:hi...",
                        source_url=("git+https://code.example.com/team/"
                                    "content.git@4f2a9c1b...:kb"),
-                       category="resources_unpacked",
+                       category="resources_archive",
                        entry_identity="data/prices/",
                        credential_name="git-prod")
             # -> "sha256:2c26b46b68ffc68ff99b453c1d30413413422d70..."

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/entry_fetch.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/entry_fetch.py
@@ -1,9 +1,53 @@
 """One entry's fetch, from a declared source to materialisable bytes.
 
 The second half of ``resolve`` for every fetch-consuming category: substitute
-``${BOT_*}``, consult the platform's own copy (W11) before the network, fetch
-through the guarded transport (W2) under a named credential (W3), and file the
-result with the content store so delivery and audit share one copy (§2.8).
+``${BOT_*}``, consult the platform's own copy before the network, fetch through
+the guarded transport under a named credential, and file the result with the
+content store so delivery and audit share one copy.
+
+**The four entry points**, and which is which:
+
+``fetch(ctx, *, source_url=…)``
+    Called by :meth:`EntryFetcher.fetch_declared` on the legacy bare-string
+    ``source:`` road, and by nothing else in this package. Its ``source_url``
+    is a plain ``https://…`` URL, never ``oss://`` and never ``git+…``. Files
+    a receipt. Charges the budget on a real fetch, not on a store hit.
+
+``fetch_declared(ctx, *, entry=…)``
+    The front door every fetching materialiser calls. Takes no URL at all: it
+    reads the entry, resolves the declaration and dispatches. Files a receipt
+    and charges the budget through whichever road it picked.
+
+``acquire_object(ctx, *, target=…, key=…)``
+    Called by ``source_fetchers.ObjectStoreFetcher``. Takes an
+    ``ObjectStoreTarget`` and a key rather than a URL, and builds the
+    ``oss://`` receipt identity itself. Files a receipt. Charges the budget on
+    a real read.
+
+``file_bytes(ctx, *, content=…, source_url=…)``
+    Called by the ``resources`` and ``skills`` materialisers for the git
+    road's canonical bytes. Its ``source_url`` is the caller's own receipt
+    identity, normally a ``git+…`` one. Files a receipt and always charges,
+    because the caller is declaring what the entry cost.
+
+**Three ``source_url`` shapes exist**, and which method sees which matters::
+
+    "https://example.com/tools/qc-v2.zip"
+        the inline bare-string source, and the ONLY shape ``fetch`` ever
+        takes as its ``source_url=`` argument. Never ``oss://``, never
+        ``git+…``.
+
+    "oss://team-artifacts/tools/qc/v2.tgz"
+        built by ``source_fetchers.object_receipt_url`` inside
+        ``acquire_object``. A receipt identity, not a fetchable URL: the
+        endpoint is deliberately absent.
+
+    "git+https://code.example.com/team/content.git@<40-hex sha>:kb/faq.csv"
+        built by ``fetch/git_source.git_receipt_url``. Also a receipt
+        identity. Ends in a bare colon when there is no subpath.
+
+``FetchedEntry.source_url`` and every receipt ``source_url`` can be any of the
+three, because they are written by whichever road ran.
 
 Fetch lives here **and only here** — the registry's contract says ``resolve``
 is where a category's failures are collected before anything is written, and a
@@ -147,41 +191,58 @@ logger = get_logger()
 class FetchContext(Protocol):
     """Exactly what a fetch reads off its caller's context, and nothing more.
 
-    :class:`~agentclaw.community.core.bot_config_manifest.apply.context.ApplyContext`
-    is the original and still the usual one. It is not the only one: W9's
-    ``cli_tools`` service is called by an HTTP route as well as by a
-    materialiser, and both must fetch through *this* funnel — a second fetch
-    path is how two callers of one feature drift apart.
+    Nine attributes, no methods. ``ApplyContext`` satisfies it structurally and
+    is the usual one; the ``cli_tools`` service passes its own object, because
+    it is called by an HTTP route as well as by a materialiser and both must
+    fetch through *this* funnel.
 
-    Declaring the seam rather than leaving the annotation reading
-    ``"ApplyContext"`` while a second type is passed makes the dependency
-    honest in the one direction that matters: a maintainer who adds a
+    A minimal satisfying value::
+
+        ctx.bot_id        == "bot_42"
+        ctx.entity_id     == "ent_7"
+        ctx.env           == "prod"
+        ctx.tenant        == "acme"
+        ctx.engine_type   == "claude_code"
+        ctx.actor_id      == "usr_collaborator"
+        ctx.apply_id      == "ap_01HZX8"   # or None
+        ctx.budget        == ApplyFetchBudget(...)   # or None
+        ctx.source_session == SourceSession(...)     # or None
+
+    The first six are read for the store scope, placeholder substitution and
+    the receipt's ``modifier``. The last three are legitimately ``None`` for a
+    caller that is not an apply: an unbudgeted single install files a receipt
+    with no apply linkage, which is what that column's nullability means.
+
+    Declaring the seam rather than annotating ``"ApplyContext"`` while a second
+    type is passed keeps the dependency honest: a maintainer who adds a
     ``ctx.something`` read below adds it here too, and the other caller fails
     to type-check instead of failing at apply time.
-
-    ``budget``, ``apply_id`` and ``source_session`` are legitimately ``None``
-    for a caller that is not an apply — an unbudgeted single install files a
-    receipt with no apply linkage, which is what that column's nullability
-    means.
     """
 
     bot_id: str
+    #: Storage key for the bot; one axis of the content store's scope.
     entity_id: str
     env: str
     tenant: str
     engine_type: str
+    #: Who is fetching. Lands on the receipt as ``modifier``.
     actor_id: str
+    #: Stamped into every receipt this fetch files. ``None`` off the apply path.
     apply_id: Optional[str]
     budget: Optional[ApplyFetchBudget]
     source_session: Optional[SourceSession]
 
 
 def scope_of(ctx: FetchContext) -> ContentScope:
-    """The store scope for the bot an apply runs against.
+    """The store scope for the bot an apply runs against::
 
-    The three axes the bot record already carries — the same scope every store
-    event for this apply is filed under, so the receipts this pipeline reads
-    and the ones it writes are one log.
+        scope_of(ctx)
+        # -> ContentScope(env="prod", entity_id="ent_7", bot_id="bot_42")
+
+    Three axes, all read straight off the context. Every receipt this pipeline
+    reads and every one it writes is filed under this scope, so they are one
+    log. Called by ``fetch``, ``acquire_object``, ``file_bytes`` and
+    ``_git_keep_last``.
     """
     return ContentScope(env=ctx.env, entity_id=ctx.entity_id, bot_id=ctx.bot_id)
 
@@ -189,11 +250,15 @@ def scope_of(ctx: FetchContext) -> ContentScope:
 class EntryFetcher:
     """Fetches one manifest entry's bytes on a bot's behalf.
 
+    The one funnel every fetching category goes through: ``skills``,
+    ``resources``, ``identity`` and ``cli_tools``. Four public entry points,
+    tabulated in this module's docstring; ``fetch_declared`` is the one a
+    materialiser normally calls.
+
     Composed once per apply — the transport is stateless per hop, so there is
     nothing to hold between entries — and handed to every materialiser that
-    fetches. One funnel for W5's two categories and W6's ``resources`` when it
-    arrives; a category that bypassed it would acquire unrecorded bytes, and
-    §2.8's audit and ``keep_last`` both read from exactly this log.
+    fetches. A category that bypassed it would acquire unrecorded bytes, and
+    both the audit log and ``keep_last`` read from exactly this log.
     """
 
     def __init__(
@@ -230,9 +295,24 @@ class EntryFetcher:
         keep_last: bool = False,
         entry_identity: Optional[str] = None,
     ) -> FetchedEntry:
-        """Acquire one entry's bytes. Raises :class:`EntryFetchError`.
+        """Acquire one entry's bytes over HTTPS. Raises :class:`EntryFetchError`.
 
-        ``${BOT_*}`` substitution happens **before** the fetch and therefore
+        ``source_url`` is a plain ``https://…`` URL — the legacy bare-string
+        ``source:`` spelling, which the schema now refuses at ``PUT`` but which
+        stored documents still carry. It is never ``oss://`` and never
+        ``git+…``; those roads have their own entry points. ``${BOT_*}`` is
+        substituted here, so the argument may still contain placeholders::
+
+            fetch(ctx,
+                  source_url="https://cdn.example.com/${BOT_ENV}/kb.zip",
+                  digest="sha256:9f86d081...",   # or None when unpinned
+                  auth="cdn-prod",               # a credential NAME, or None
+                  category="resources_file",
+                  keep_last=True,
+                  entry_identity="data/faq.csv")
+            # -> FetchedEntry(..., source_url="https://cdn.example.com/prod/kb.zip")
+
+        Substitution happens **before** the fetch and therefore
         before prefix authorization: the W3 policy re-authorises every hop
         against the URL the request will actually name, so a substituted URL
         cannot steer the request outside its credential's prefixes (or inside
@@ -412,6 +492,31 @@ class EntryFetcher:
         """Resolve one entry's declared source — inline, or by ``from`` name —
         and acquire it. Raises :class:`EntryFetchError`.
 
+        ``entry`` is the raw manifest mapping. Which of its keys is present
+        decides the road::
+
+            {"path": "data/faq.csv", "from": "content", "subpath": "faq.csv"}
+                # a named source: looked up in session.sources, then parsed.
+                # Needs a source session.
+
+            {"name": "qc", "source": {"protocol": "oss",
+                                      "bucket": "team-artifacts",
+                                      "key": "qc/v2.tgz"}}
+                # an inline declaration. Needs a source session.
+
+            {"path": "data/kb.zip", "source": "https://example.com/kb.zip"}
+                # the legacy bare string: straight to ``fetch``, no session
+                # needed.
+
+        ``category`` is a :class:`FetchCategory` value as a string, e.g.
+        ``"resources_file"``; it is coerced to the enum here, so a misspelling
+        is a loud ``ValueError`` at the front door rather than a quiet fall
+        back to the file cap inside a fetcher.
+
+        Answers an :class:`~...entry_delivery.EntryDelivery` on every road —
+        see ``apply/entry_delivery.py`` for why the caller does not branch on
+        which one it got.
+
         **The front door does what every road shares, then dispatches.** The
         budget check, the source-session requirement, ``keep_last``, the
         ``from`` lookup and parsing the declaration happen once, here; the
@@ -421,15 +526,10 @@ class EntryFetcher:
 
         One road never reaches a fetcher: a bare-string ``source`` is a URL
         with no declaration to parse, so it goes straight to :meth:`fetch`.
-        The schema now **refuses** that spelling at ``PUT`` (§2.2 — declare
-        ``protocol: git`` or ``protocol: oss``), so no new document can take
-        it. It survives here for the documents already stored under the old
-        grammar, which an apply still has to be able to read; delete it only
-        once those are known to be gone.
-
-        Every road answers with an :class:`EntryDelivery` — see
-        ``apply/entry_delivery.py`` for why the caller does not branch on
-        which one it got.
+        The schema now **refuses** that spelling at ``PUT``, so no new document
+        can take it. It survives here for the documents already stored under
+        the old grammar, which an apply still has to be able to read; delete it
+        only once those are known to be gone.
         """
         expired = ctx.budget.expired() if ctx.budget is not None else None
         if expired is not None:
@@ -540,9 +640,18 @@ class EntryFetcher:
         display: str,
         keep_last: bool,
     ) -> Optional[FetchedEntry]:
-        """`keep_last` for the git road: the receipt of the *last-resolved*
-        SHA, when there was one. A first-time source has no baseline — and
-        therefore no stored copy entitled to answer for it."""
+        """``keep_last`` for the git road: the receipt of the *last-resolved*
+        SHA, when there was one.
+
+        Looks the baseline up by ``display`` and reads the receipt filed under
+        ``git+<url>@<baseline sha>:<subpath>``. Answers ``None`` — meaning
+        "no fallback, let the failure stand" — in three cases: ``keep_last`` is
+        off, the source has no baseline (a first-time source has no stored copy
+        entitled to answer for it), or no receipt exists at that address.
+
+        On a hit the :class:`FetchedEntry` carries ``from_store=True`` and a
+        ``fallback_reason``, which is what the report's note comes from.
+        """
         if not keep_last:
             return None
         baseline = session.baseline(display)
@@ -586,6 +695,25 @@ class EntryFetcher:
         entry_identity: Optional[str],
     ) -> FetchedEntry:
         """One object out of a tenant-named bucket, through the object store.
+
+        Takes the resolved ``ObjectStoreTarget`` (bucket plus the endpoint and
+        key pair off the credential row) and the already-composed, already
+        substituted ``key``. The address it files under is built here::
+
+            acquire_object(ctx,
+                           target=ObjectStoreTarget(bucket="team-artifacts",
+                                                    ...),
+                           key="tools/qc/v2.tgz",
+                           digest=None,
+                           auth="oss-prod",
+                           category="cli_tools",
+                           keep_last=True,
+                           entry_identity="qc")
+            # -> FetchedEntry(...,
+            #        source_url="oss://team-artifacts/tools/qc/v2.tgz")
+
+        ``content_type`` is always ``None`` on this road: the store client
+        reports none.
 
         The same shape :meth:`fetch` has on the URL road — pinned fast path,
         acquire, ``keep_last``, file — with the transport swapped and four of
@@ -725,6 +853,18 @@ class EntryFetcher:
         canonical form (a package's canonical zip, a single file's bytes)
         — so audit and ``keep_last`` read the same store everyone else does.
 
+        ``source_url`` is the caller's own receipt identity, normally the
+        ``git+…`` one from ``GitDelivery.receipt_url()``::
+
+            file_bytes(ctx,
+                       content=b"acm-tree-v1\n5:a.txt2:hi...",
+                       source_url=("git+https://code.example.com/team/"
+                                   "content.git@4f2a9c1b...:kb"),
+                       category="resources_unpacked",
+                       entry_identity="data/prices/",
+                       credential_name="git-prod")
+            # -> "sha256:2c26b46b68ffc68ff99b453c1d30413413422d70..."
+
         ``credential_name`` threads the acquisition's auth into the W11
         lineage exactly as the URL road's store call does, so a git-sourced
         receipt answers "which named credential distributed this content"
@@ -790,17 +930,37 @@ def declared_protocol(
     """Which protocol :meth:`EntryFetcher.fetch_declared` will take, **without
     fetching anything**.
 
-    A caller needs this when a rule has to be decided *before* the network is
-    touched — the resources materialiser validates an archive's ``unpack``
-    before spending a fetch that a missing one guarantees to waste, and the
-    ``cli_tools`` materialiser asks whether the digest rule applies. Both used
-    to answer it their own way, or after the fact.
+    ==============================================  ====================
+    ``entry``                                       Answer
+    ==============================================  ====================
+    ``{"source": "https://example.com/kb.zip"}``    ``SourceKind.OSS``
+    ``{"source": {"protocol": "oss", "bucket":      ``SourceKind.OSS``
+    "b", "key": "k", "auth": "a"}}``
+    ``{"source": {"protocol": "git", "url":         ``SourceKind.GIT``
+    "https://x/y.git"}}``                           
+    ``{"from": "content"}`` naming a git source     ``SourceKind.GIT``
+    ``{"from": "nope"}``, not under ``sources``     ``None``
+    ``{"source": {"protocol": "bogus"}}``           ``None``
+    ``{"source": {"protocol": "oss", "bucket":      ``None``
+    "b"}}`` — incomplete; ``oss`` requires
+    ``auth``, so it does not parse                  
+    ``{"content": "inline text"}``                  ``None``
+    ==============================================  ====================
+
+    A bare-string ``source`` answers ``OSS`` because that legacy road is served
+    by the object-store side of the pipeline, even though it fetches over
+    HTTPS. Anything that does not parse cleanly answers ``None``, which is why
+    an incomplete declaration reads the same as an absent one here.
+
+    Called by: ``materialisers/resources``, which validates an archive's
+    ``unpack`` before spending a fetch that a missing one guarantees to waste,
+    and ``materialisers/cli_tools``, which asks whether the digest rule
+    applies.
 
     Read through the same parser the ``PUT`` validator and ``fetch_declared``
     use, so a fourth derivation cannot appear. ``None`` means "cannot say from
-    the declaration alone" — an inline URL string is ``OSS`` and a malformed or
-    undeclared source is ``None``; the caller then falls through to the fetch,
-    which raises the real error with the real message.
+    the declaration alone"; the caller then falls through to the fetch, which
+    raises the real error with the real message.
     """
     inline = entry.get("source")
     if isinstance(inline, str):

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/identity_files.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/identity_files.py
@@ -37,7 +37,42 @@ if TYPE_CHECKING:  # pragma: no cover — see the module docstring
 
 
 class DeviceIdentity(IdentityFilePort):
-    """The ARCA identity road: files onto the bot's live container."""
+    """The ARCA identity road: files onto the bot's live container.
+
+    Three methods, each forwarded verbatim, and the only one in this package
+    whose arguments are **positional**. What a call looks like from the
+    ``identity`` materialiser::
+
+        await port.list_bot_files(
+            "staff", "ent_7", "bot_42", "usr_owner",
+            engine_type="claude_code", stage="draft",
+        )   # -> [("SOUL.md", True), ("RULES.md", False), ...]
+            #    one (file_type, exists) pair per name in
+            #    VALID_IDENTITY_FILES, the WHOLE whitelist, not just the
+            #    files that exist. "exists" is bool(content), so an empty
+            #    file reports False.
+
+        await port.read_identity_file(
+            "staff", "ent_7", "bot_42", "SOUL.md", "usr_owner",
+            engine_type="claude_code", stage="draft",
+        )   # -> the file's text, or "" when it is missing
+
+        await port.update_bot_file(
+            "staff", "ent_7", "bot_42", "SOUL.md", "# who I am\n",
+            "usr_collaborator",           # the operator: the ACTOR, not owner
+            "claude_code", stage="draft",
+        )
+
+    The ``file_type`` is a whitelisted filename — ``"SOUL.md"``,
+    ``"RULES.md"``, ``"MEMORY.md"`` and so on — which is also the ``type`` an
+    identity entry declares and the ``identity`` its report row carries.
+    Content is ``str`` here, not ``bytes``: identity files are text. Removal is
+    an empty write, because the domain reads absent and empty as one state.
+
+    Bound as ``MaterialiserPorts.identity_service`` for the ARCA family. Its
+    platform-managed counterpart is ``PlatformIdentity`` in
+    ``managed_files/ports.py``.
+    """
 
     def __init__(self, inner: IdentityService) -> None:
         self._inner = inner

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/__init__.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/__init__.py
@@ -4,10 +4,27 @@ One module per construct, each holding the three stages and nothing about
 ordering, aborting or reporting — those belong to the orchestrator, once, for
 every category.
 
-Six ship today: ``script`` and ``mcp`` (W4, fetch-free — registry entries plus
-a plain row write), ``skills`` and ``identity`` (W5, the two fetching
-materialisers), ``resources`` (W6, the one write chain with tree-replacement
-semantics) and ``cli_tools`` (W9, a translator over ``CliToolService``, which
-the management API calls too). ``engine_config`` arrives when X2/T3 lets it
-back in.
+Six ship today. What each keys its entries by, and what its ``Intent.value``
+carries:
+
+=================  =================  ====================================
+Module             ``identity`` from  ``Intent.value``
+=================  =================  ====================================
+``script``         fixed ``"script"`` the substituted body ``str``, or
+                                      ``None`` for a declared-empty section
+``mcp``            ``server_code``    the server code again
+``identity``       ``type``           the decoded text body, a ``str``
+``skills``         ``name``           a ``_SkillPackage``
+``resources``      ``path``           the member's ``bytes``, or the
+                                      ``_DECLARED_TREE`` marker
+``cli_tools``      ``name``           a ``CliToolDecl``
+=================  =================  ====================================
+
+``script`` and ``mcp`` fetch nothing. ``identity``, ``skills`` and
+``resources`` fetch in ``resolve``, through the one ``EntryFetcher`` funnel.
+``cli_tools`` is the exception: it fetches in ``write``, because the service
+it translates for owns fetching for both of its callers.
+
+``engine_config`` has no module: a document declaring it takes the
+orchestrator's no-materialiser path.
 """

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/cli_tools.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/cli_tools.py
@@ -1,5 +1,33 @@
 """``cli_tools`` → ``CliToolService``. The manifest as a second caller.
 
+**The entry shape.** ``identity`` for this category is the entry's ``name``,
+the command as it will be invoked. Both source spellings are accepted, and a
+``digest`` is mandatory on everything but git::
+
+    manifest:
+      cli_tools:
+        # a named object-store source. The source's key is a prefix and the
+        # entry's is the rest, so this reads oss://team-artifacts/tools/qc/v2.tgz
+        - name: qc
+          from: artifacts
+          key: qc/v2.tgz
+          digest: sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b...
+          version: "2.1.0"           # a label only; never decides convergence
+
+        # an inline source
+        - name: mycli
+          source: https://x/mycli
+          digest: sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b...
+
+        # over git the resolved commit SHA is the pin, so 'digest' is
+        # refused rather than required
+        - name: tool
+          from: content
+          subpath: bin/tool
+
+An entry reaches ``resolve`` as the raw mapping, e.g. ``{"name": "mycli",
+"source": "https://x/mycli", "digest": "sha256:…"}``.
+
 This materialiser fetches nothing, verifies nothing, stores nothing and
 delivers nothing. It translates: manifest entries into ``CliToolDecl``s on the
 way in, and the service's per-tool outcomes into report rows on the way out.
@@ -61,9 +89,21 @@ from agentclaw.community.core.bot_config_manifest.apply.entry_fetch import (
 from agentclaw.community.core.bot_config_manifest.schema import placeholders
 from agentclaw.community.core.bot_config_manifest.support_matrix import SourceKind
 
-#: How the service's four outcomes read on a report row. ``REMOVED`` has no
-#: declared entry to attach to — the orchestrator reports removals from the
-#: plan — so it never reaches this map.
+#: ``CliToolStatus`` → the :class:`~...outcomes.EntryOutcome` its report row
+#: carries::
+#:
+#:     CliToolStatus.INSTALLED -> EntryOutcome.UPDATED
+#:     CliToolStatus.UNCHANGED -> EntryOutcome.UNCHANGED
+#:     CliToolStatus.FAILED    -> EntryOutcome.FAILED
+#:     CliToolStatus.CONFLICT  -> EntryOutcome.FAILED
+#:
+#: Note that ``INSTALLED`` maps to ``UPDATED``, not ``CREATED``: the service
+#: reports that it wrote the tool, not whether one was there before, and the
+#: created/updated split is decided in ``plan`` from the current area instead.
+#:
+#: ``CliToolStatus.REMOVED`` is deliberately absent: a removal has no declared
+#: entry to attach to, so the orchestrator reports it from the plan's
+#: ``removals`` and it never reaches this map.
 _OUTCOMES = {
     CliToolStatus.INSTALLED: EntryOutcome.UPDATED,
     CliToolStatus.UNCHANGED: EntryOutcome.UNCHANGED,
@@ -76,7 +116,23 @@ _OUTCOMES = {
 
 
 def context_for(ctx: ApplyContext) -> CliToolContext:
-    """The apply's identity, in the service's vocabulary.
+    """The apply's identity, in the service's vocabulary::
+
+        context_for(ctx)
+        # -> CliToolContext(
+        #        bot_id="bot_42", owner_id="usr_owner",
+        #        actor_id="usr_collaborator", entity_id="ent_7",
+        #        env="prod", engine_type=<the bot's engine>, tenant="acme",
+        #        apply_id="ap_01HZX8",        # None off the apply path
+        #        budget=ApplyFetchBudget(...),      # None likewise
+        #        source_session=SourceSession(...), # None likewise
+        #    )
+
+    Ten fields, all copied straight off :class:`ApplyContext`. The service
+    itself satisfies ``FetchContext`` through this object, which is how its
+    fetch is charged to this apply's budget. ``engine_type`` is carried but
+    never compared here: this module must not name an engine, and a structural
+    test pins that against its whole source, docstrings included.
 
     ``actor_id`` stays the person applying — the audit field must not lose that
     a collaborator, not the owner, ran this — while ``installed_by`` is the
@@ -104,7 +160,23 @@ def context_for(ctx: ApplyContext) -> CliToolContext:
 
 
 class CliToolsMaterialiser(Materialiser):
-    """Converges this bot's installed CLI tools toward the declaration."""
+    """Converges this bot's installed CLI tools toward the declaration.
+
+    ``identity`` is the entry's ``name``; ``Intent.value`` is a
+    ``CliToolDecl``, the service's own declaration type. Unlike the other
+    fetching categories, ``resolve`` performs **no fetch** — the service owns
+    fetching for both of its callers — so a source that is down produces a
+    ``FAILED`` row out of ``write`` rather than aborting the category::
+
+        resolve -> ResolveResult(intents=(Intent(
+                       identity="mycli",
+                       value=CliToolDecl(name="mycli", ...)),))
+        plan    -> CategoryPlan(
+                       entries=(PlannedEntry(<that intent>, "created"),),
+                       removals=("retired-tool",))
+        write   -> (EntryResult(ManifestCategory.CLI_TOOLS, "mycli",
+                                EntryOutcome.CREATED),)
+    """
 
     construct = ManifestCategory.CLI_TOOLS
 

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/identity.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/identity.py
@@ -1,6 +1,31 @@
 """``identity`` → ``IdentityService`` — the file set, minus the reserved names.
 
-The area this overwrites is the one work-items §3.2 names: the bot's identity
+**The entry shape.** ``identity`` for this category is the entry's ``type``,
+which is a whitelisted **filename** — ``SOUL.md``, ``RULES.md``, ``OKR.md``
+and the rest of ``VALID_IDENTITY_FILES`` — not a free-form label. Both an
+inline body and a fetched one are accepted::
+
+    manifest:
+      identity:
+        # inline content: no fetch at all
+        - type: RULES.md
+          content: |
+            # rules
+
+        # an inline source, the legacy bare-string spelling
+        - type: SOUL.md
+          source: https://content.example/identity/soul.md
+
+        # a named source: the entry's subpath must name ONE file, because
+        # this category delivers a single body per entry
+        - type: OKR.md
+          from: content
+          subpath: okr.md
+
+An entry reaches ``resolve`` as the raw mapping, e.g. ``{"type": "SOUL.md",
+"source": "https://content.example/identity/soul.md"}``.
+
+The area this overwrites is the bot's identity
 file set, minus ``MEMORY.md`` / ``IDENTITY.md`` — engine-generated runtime
 state that apply never writes and never removes, whatever a document says.
 The validator refuses their *declaration*; this module refuses to reach them
@@ -67,6 +92,9 @@ if TYPE_CHECKING:
         ApplyContext,
     )
 
+#: The fetch category every entry here is charged and capped under. The
+#: identity cap is the smallest of the six, 1 MiB, because these are text
+#: files.
 _FETCH_CATEGORY = FetchCategory.IDENTITY
 
 
@@ -82,7 +110,24 @@ def _decode_utf8(body: bytes) -> Optional[str]:
 
 
 class IdentityMaterialiser(Materialiser):
-    """Converges the bot's identity file set toward the declaration."""
+    """Converges the bot's identity file set toward the declaration.
+
+    ``identity`` is the entry's ``type``; ``Intent.value`` is the decoded
+    **text** body, a ``str``, not bytes — this is the one category that
+    insists its bytes are UTF-8::
+
+        resolve -> ResolveResult(intents=(Intent(
+                       identity="SOUL.md", value="# who I am\n"),))
+        plan    -> CategoryPlan(
+                       entries=(PlannedEntry(<that intent>, "updated"),),
+                       removals=("OKR.md",))
+        write   -> (EntryResult(ManifestCategory.IDENTITY, "SOUL.md",
+                                EntryOutcome.UPDATED),)
+
+    A removal is an **empty write**, not a delete: the domain reads absent and
+    empty as one state, and ``IdentityService`` exposes no delete. A reserved
+    name (``MEMORY.md``, ``IDENTITY.md``) never receives even that.
+    """
 
     construct = ManifestCategory.IDENTITY
 

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/mcp.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/mcp.py
@@ -1,6 +1,18 @@
 """``mcp`` → ``DirectActivationService``. Converges the enabled-server set.
 
-The area this overwrites is the one work-items §3.2 names for this category —
+**The entry shape.** ``identity`` for this category is the entry's
+``server_code``, and that is the entry's only key: this category fetches
+nothing, so it has no source spelling at all::
+
+    manifest:
+      mcp:
+        - server_code: gh
+        - server_code: slack
+
+An entry reaches ``resolve`` as ``{"server_code": "gh"}``. A category
+declared empty (``mcp: []``) deactivates every server the manifest owns.
+
+The area this overwrites is the enabled-server set for this category —
 "the enabled-server set" — the MCP servers active on *this bot*, stored in
 ``ac_bot_mcp_installation`` and keyed ``(bot_id, owner_id, env, server_code)``.
 Declared and not active ⇒ activated. Active and no longer declared ⇒
@@ -44,7 +56,22 @@ from agentclaw.community.core.ports.activation_port import ActivationPort
 
 
 class McpMaterialiser(Materialiser):
-    """Converges this bot's enabled MCP servers toward the declaration."""
+    """Converges this bot's enabled MCP servers toward the declaration.
+
+    ``identity`` and ``Intent.value`` are both the server code — there is
+    nothing else to write, so the value carries no extra shape::
+
+        resolve -> ResolveResult(intents=(Intent("gh", "gh"),))
+        plan    -> CategoryPlan(
+                       entries=(PlannedEntry(Intent("gh", "gh"), "unchanged"),),
+                       removals=("old",))
+        write   -> (EntryResult(ManifestCategory.MCP, "gh",
+                                EntryOutcome.UNCHANGED),)
+
+    ``plan`` answers only ``unchanged`` or ``created``: a server is either in
+    the installed set or it is not, so there is no third state to call
+    ``updated``.
+    """
 
     construct = ManifestCategory.MCP
 

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/resources.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/resources.py
@@ -1,6 +1,36 @@
 """``resources`` → ``ResourceFileService``: workspace files and directory trees.
 
-Three invariants, all from the W6 work item:
+**The entry shape.** ``identity`` for this category is the entry's ``path``,
+verbatim including any trailing slash. The trailing slash is the **form
+discriminator**: ``data/faq.csv`` is a file entry, ``data/prices/`` is a
+directory entry. Three source spellings are accepted::
+
+    manifest:
+      resources:
+        # inline content: no fetch at all
+        - path: notes/hello.txt
+          content: |
+            hello
+
+        # a named source, file form
+        - path: data/faq.csv
+          from: content
+          subpath: faq.csv          # composes with the source's subpath
+
+        # a named source, directory form. Over 'oss' the tree must travel
+        # as an archive, so 'unpack' is required; over git it is refused,
+        # because a repository hands over a real tree.
+        - path: data/prices/
+          from: artifacts
+          key: prices.tgz
+          unpack: tar.gz
+          strip_components: 1
+
+An entry reaches ``resolve`` as the raw mapping, e.g. ``{"path":
+"data/prices/", "from": "artifacts", "key": "prices.tgz", "unpack":
+"tar.gz", "strip_components": 1}``.
+
+Three invariants:
 
 - **One write chain for both engine families.** ``ResourceFileService``'s
   dispatcher already fans out per transport (arca / baas: device sync; teclaw:
@@ -101,6 +131,14 @@ class _DeclaredTree:
     """The declared-tree marker intent's value — an explicit object, never
     ``None``.
 
+    Carries no data: it exists so ``write`` can tell "delete this whole tree
+    first" from an ordinary member write. One directory entry produces one
+    marker intent plus one intent per member::
+
+        Intent(identity="data/prices/", value=_DECLARED_TREE)
+        Intent(identity="data/prices/2026.csv", value=b"date,price\n...")
+        Intent(identity="data/prices/2025.csv", value=b"date,price\n...")
+
     ``None`` is ``Intent.value``'s dataclass *default*, so keying the tree
     marker on it would let any future intent constructed without an
     explicit value silently promise a whole-tree deletion at write time.
@@ -110,13 +148,40 @@ class _DeclaredTree:
     __slots__ = ()
 
 
-#: The single marker instance: ``Intent.value`` for a declared directory,
-#: identity the declared path with its trailing slash.
+#: The single marker instance, shared by every declared directory. Compared by
+#: identity, so there is deliberately only ever one. ``Intent.value`` for a
+#: declared directory; the intent's ``identity`` is the declared path with its
+#: trailing slash, e.g. ``"data/prices/"``.
 _DECLARED_TREE = _DeclaredTree()
 
 
 class ResourcesMaterialiser(Materialiser):
-    """Converges declared workspace resources toward the declaration."""
+    """Converges declared workspace resources toward the declaration.
+
+    ``identity`` is the entry's ``path``; ``Intent.value`` is the member's
+    ``bytes``, or :data:`_DECLARED_TREE` for a directory marker. A directory
+    entry fans out into several intents, so a plan usually carries more
+    entries than the document declared::
+
+        # from one entry, path "data/prices/", whose archive ships two files
+        resolve -> ResolveResult(intents=(
+                       Intent("data/prices/", _DECLARED_TREE),
+                       Intent("data/prices/2026.csv", b"date,price\n..."),
+                       Intent("data/prices/2025.csv", b"date,price\n...")))
+        plan    -> CategoryPlan(entries=(
+                       PlannedEntry(<2026>, "created"),
+                       PlannedEntry(<2025>, "created")),
+                       removals=("data/prices/",))
+        write   -> (EntryResult(RESOURCES, "data/prices/2026.csv", CREATED),
+                    EntryResult(RESOURCES, "data/prices/2025.csv", CREATED))
+
+    The marker does **not** become a ``PlannedEntry``: it leaves ``resolve``
+    as an intent and leaves ``plan`` as a ``removals`` row, which is what
+    gives the destructive tree replacement its audit row.
+
+    ``plan`` never answers ``unchanged`` for this category: every apply
+    rewrites every member, so the category is never ``is_noop``.
+    """
 
     construct = ManifestCategory.RESOURCES
 

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/script.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/script.py
@@ -1,5 +1,19 @@
 """``script`` → ``BotStartupScriptService``. One row write, and nothing else.
 
+**The entry shape.** ``script`` is a top-level *section*, not a category, so it
+is one object rather than a list and it has no entity key: its ``identity`` is
+always the fixed string ``"script"``. It fetches nothing, so there is no source
+spelling::
+
+    script:
+      body: |
+        #!/bin/sh
+        echo "${BOT_ENV}"
+
+The orchestrator wraps the section in a one-entry list, so ``resolve`` receives
+``[{"body": "#!/bin/sh\necho \"${BOT_ENV}\"\n"}]``. An explicitly-null
+``script:`` arrives as ``[]`` and means "remove the row".
+
 **Apply never triggers the script's execution.** Writing the
 ``ac_bot_startup_script`` row is the whole of this materialiser: no restart, no
 republish, no payload rebuild, no call to anything that would run it. That is
@@ -58,7 +72,27 @@ DELIVERY_NOTE = (
 
 
 class ScriptMaterialiser(Materialiser):
-    """Writes the bot's startup script row. Runs nothing."""
+    """Writes the bot's startup script row. Runs nothing.
+
+    ``identity`` is always ``"script"``; ``Intent.value`` is the
+    **substituted** body text, or ``None`` for a declared-empty section::
+
+        resolve -> ResolveResult(intents=(Intent(
+                       identity="script", value="#!/bin/sh\necho prod\n"),))
+        plan    -> CategoryPlan(
+                       entries=(PlannedEntry(<that intent>, "created"),))
+        write   -> (EntryResult(ManifestSection.SCRIPT, "script",
+                                EntryOutcome.CREATED, note=DELIVERY_NOTE),)
+
+    A declared-empty section inverts that: ``resolve`` answers
+    ``Intent("script", None)``, ``plan`` answers
+    ``CategoryPlan(entries=(), removals=("script",))``, and ``write`` deletes
+    the row and returns no rows at all.
+
+    Every successful row carries :data:`DELIVERY_NOTE`, including an
+    ``unchanged`` one — the timing caveat is true whether or not this apply
+    wrote anything.
+    """
 
     construct = ManifestSection.SCRIPT
 

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/skills.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/skills.py
@@ -1,6 +1,29 @@
 """``skills`` → local upload + direct activation — the active skill set.
 
-The area is the one work-items §3.2 names: the bot's **active** skill set —
+**The entry shape.** ``identity`` for this category is the entry's ``name``,
+which must equal the name in the package's own ``SKILL.md`` front matter.
+Both source spellings are accepted::
+
+    manifest:
+      skills:
+        # a named source
+        - name: quality-check
+          from: packages
+          subpath: quality-check     # selects a subtree, then re-packed
+          on_fetch_failure: keep_last
+
+        # an inline source; the legacy bare-string spelling shown here is
+        # what the tests drive, and is still readable from stored documents
+        - name: quality-check
+          source: https://content.example/skills/quality-check.zip
+          digest: sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b...
+
+An entry reaches ``resolve`` as the raw mapping, e.g.
+``{"name": "quality-check", "source": "https://…/quality-check.zip",
+"digest": "sha256:…"}``.
+
+The area is the one the all-or-nothing rule names: the bot's **active** skill
+set —
 ``BotCapabilityStateReader.active_skill_assets`` after its flush, the same
 read the public listing answers from. Declared and not active ⇒ uploaded and
 activated. Active and no longer declared ⇒ deactivated. Active and unchanged
@@ -95,16 +118,25 @@ logger = get_logger()
 
 _FETCH_CATEGORY = FetchCategory.SKILLS
 
-#: URL path suffix → archive kind. Ordered so the longer tar suffix is tried
-#: before a hypothetical shorter one; ``.tgz`` is the autoroute of the same
-#: kind.
+#: URL path suffix → the archive kind ``unpack_archive`` takes::
+#:
+#:     "https://content.example/skills/quality-check.zip"  -> "zip"
+#:     "https://content.example/skills/qc.tar.gz"          -> "tar.gz"
+#:     "https://content.example/skills/qc.tgz"             -> "tar.gz"
+#:
+#: Matched against the delivery's ``source_url``, which on the object road is
+#: the ``oss://bucket/key`` form — so the key's own extension is what decides.
+#: Tried before :data:`_KIND_BY_CONTENT_TYPE`.
 _KIND_BY_SUFFIX: tuple[tuple[str, str], ...] = (
     (".zip", "zip"),
     (".tar.gz", "tar.gz"),
     (".tgz", "tar.gz"),
 )
 
-#: Fallback when the URL does not say: the media type the source served.
+#: Fallback when the URL does not say: the media type the source served, as
+#: ``EntryDelivery.content_type()`` reports it. ``None`` there — which is
+#: always the case on the git road and usual on the object road — means the
+#: source said nothing, and the entry is refused rather than guessed at.
 _KIND_BY_CONTENT_TYPE: tuple[tuple[str, str], ...] = (
     ("application/zip", "zip"),
     ("application/x-zip-compressed", "zip"),
@@ -115,11 +147,46 @@ _KIND_BY_CONTENT_TYPE: tuple[tuple[str, str], ...] = (
 
 
 class _PackageRefusal(Exception):
-    """The fetched bytes can never become a skill package — refuse the entry."""
+    """The fetched bytes can never become a skill package — refuse the entry.
+
+    Internal to this module: raised by the packaging helpers and caught in
+    ``resolve``, which turns ``str(exc)`` into the entry's
+    :class:`~...registry.ResolveFailure` reason. Distinct from
+    :class:`~...entry_delivery.EntryFetchError`, which means the bytes never
+    arrived at all.
+    """
 
 
 class _SkillPackage:
-    """One entry's validated, upload-ready package — the intent's value."""
+    """One entry's validated, upload-ready package — the intent's value.
+
+    Carried as ``Intent.value``, so a planned entry reads
+    ``planned.intent.value.canonical_zip``::
+
+        _SkillPackage(
+            name="quality-check",          # from the package's SKILL.md
+            canonical_zip=b"PK\x03\x04...",  # what upload_local_skill takes
+            from_store=False,
+            note=None,
+        )
+        # .content_digest is derived, not passed:
+        #   "sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b..."
+
+    On a ``keep_last`` fallback the same object carries the reason, which the
+    write puts on the entry's report row::
+
+        _SkillPackage(
+            name="quality-check",
+            canonical_zip=b"PK\x03\x04...",
+            from_store=True,
+            note=("delivered from the platform's stored copy (keep_last): "
+                  "the source fetch failed — ..."),
+        )
+
+    Created by: :meth:`SkillsMaterialiser.resolve`.
+    Consumed by: that materialiser's ``plan`` (``content_digest``) and
+    ``write`` (``canonical_zip``, ``name``, ``note``).
+    """
 
     __slots__ = ("name", "canonical_zip", "content_digest", "from_store", "note")
 
@@ -149,7 +216,21 @@ class _SkillPackage:
 
 
 class SkillsMaterialiser(Materialiser):
-    """Converges the bot's active skills toward the declared package set."""
+    """Converges the bot's active skills toward the declared package set.
+
+    ``identity`` is the entry's ``name``, e.g. ``"quality-check"``, and
+    ``Intent.value`` is a :class:`_SkillPackage`. The three stages, for one
+    entry naming a skill the bot does not yet have::
+
+        resolve -> ResolveResult(intents=(Intent(
+                       identity="quality-check",
+                       value=_SkillPackage("quality-check", b"PK...", ...)),))
+        plan    -> CategoryPlan(
+                       entries=(PlannedEntry(<that intent>, "created"),),
+                       removals=("retired-skill",))
+        write   -> (EntryResult(ManifestCategory.SKILLS, "quality-check",
+                                EntryOutcome.CREATED),)
+    """
 
     construct = ManifestCategory.SKILLS
 

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/orchestrator.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/orchestrator.py
@@ -49,7 +49,27 @@ def declared_entries(
 ) -> Sequence[dict[str, Any]] | None:
     """What the document declares for one construct, or ``None`` if it does not.
 
-    The distinction this returns is the load-bearing one in §3.2, and it is why
+    ``parsed`` is the whole validated document. Worked through for one
+    document::
+
+        parsed = {
+            "schema_version": 1,
+            "script": {"body": "echo hi"},
+            "manifest": {"mcp": [{"server_code": "gh"}], "skills": []},
+        }
+
+        declared_entries(parsed, ManifestSection.SCRIPT)
+        # -> [{"body": "echo hi"}]      a section arrives as a one-entry list
+        declared_entries(parsed, ManifestCategory.MCP)
+        # -> [{"server_code": "gh"}]
+        declared_entries(parsed, ManifestCategory.SKILLS)
+        # -> []                         declared empty: remove everything
+        declared_entries(parsed, ManifestCategory.RESOURCES)
+        # -> None                       not declared: do not touch the area
+
+    Called by: :meth:`ApplyOrchestrator.apply`, once per step it walks.
+
+    The distinction this returns is the load-bearing one, and it is why
     the return type is ``None``-or-list rather than just a list:
 
     * ``None`` — **not declared**. No opinion; the area is untouched and nothing
@@ -85,9 +105,15 @@ def declared_entries(
 class ApplyOrchestrator:
     """Applies a parsed manifest to one bot, category by category.
 
+    Constructed with the registry map (construct → materialiser) and a
+    ``steps`` callable, which is the engine family's phase table: ARCA passes
+    ``apply.order.steps_for``, teclaw passes its delivery strategy's re-phased
+    version. There is no default, so the table in use is always visible at the
+    call site.
+
     Holds no per-apply state: everything is passed in and the report comes back
-    out. That is what lets W13 call it twice — once per phase, around container
-    provisioning — and get one report from each.
+    out. That is what lets the creation job call it twice — once per phase,
+    around container provisioning — and get one report from each.
     """
 
     def __init__(
@@ -116,6 +142,11 @@ class ApplyOrchestrator:
         dry_run: bool = False,
     ) -> ApplyReport:
         """Walk the order, apply what is declared, and report what happened.
+
+        Answers one :class:`~...outcomes.ApplyReport` carrying one
+        :class:`~...outcomes.CategoryResult` per **declared** construct — a
+        construct the document does not mention contributes no row at all, so
+        a report's ``categories`` is usually shorter than the order table.
 
         ``phases`` selects which half runs; ``None`` is both, which is what an
         apply on an existing bot wants. ``dry_run`` stops each construct after
@@ -170,10 +201,22 @@ class ApplyOrchestrator:
     ) -> CategoryResult:
         """One declared construct, through the three stages.
 
-        Every failure path here leaves the construct's area **exactly as it
-        was**. That is §3.2's all-or-nothing rule, and under overwrite it is not
-        a nicety: writing ``{A}`` when the declaration was ``{A, B}`` deletes B,
-        so a partially-materialised category is a *destructive* one.
+        The five exits, and what each answers:
+
+        * no materialiser registered → aborted, every entry ``FAILED`` with
+          ``NO_MATERIALISER_REASON``;
+        * ``resolve`` raised, or ``plan`` raised → aborted, every entry
+          ``FAILED`` with ``"resolve failed: …"`` / ``"plan failed: …"``;
+        * ``resolve`` returned failures → aborted, the named entries
+          ``FAILED``, their neighbours ``SKIPPED``;
+        * ``dry_run`` → the plan, shaped as the result it predicts, not
+          aborted;
+        * ``write`` raised → aborted **and** ``partially_written=True``.
+
+        Every failure path except the last leaves the construct's area exactly
+        as it was. That is the all-or-nothing rule, and under overwrite it is
+        not a nicety: writing ``{A}`` when the declaration was ``{A, B}``
+        deletes B, so a partially-materialised category is a *destructive* one.
         """
         materialiser = self._materialisers.get(construct)
         if materialiser is None:
@@ -268,6 +311,11 @@ class ApplyOrchestrator:
     ) -> CategoryResult:
         """The category was not written. Report every entry, blame precisely.
 
+        Exactly one of ``cause`` and ``reason`` is meaningful. ``reason`` is a
+        whole-category cause, so every entry carries it verbatim; ``cause``
+        carries per-entry failures, so the named entries get their own reason
+        and the rest are ``SKIPPED``.
+
         The entry that *caused* the abort is ``FAILED`` with its own reason;
         every other declared entry is ``SKIPPED`` — "not written because its
         category was aborted". Getting that split right is what makes a report
@@ -322,7 +370,14 @@ class ApplyOrchestrator:
     def _projected(
         self, construct: ApplyConstruct, plan: CategoryPlan
     ) -> CategoryResult:
-        """A dry run's answer: the plan, shaped as the result it predicts."""
+        """A dry run's answer: the plan, shaped as the result it predicts.
+
+        Each :class:`~...registry.PlannedEntry` becomes an
+        :class:`~...outcomes.EntryResult` carrying the same outcome, with no
+        ``reason`` and no ``note`` — a projection cannot know what a write
+        would have reported. ``aborted`` is ``False``: a plan that could be
+        computed is not a failure.
+        """
         return CategoryResult(
             construct=construct,
             entries=tuple(

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/order.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/order.py
@@ -23,6 +23,16 @@ from agentclaw.community.core.bot_config_manifest.capabilities import (
 class ApplyPhase(StrEnum):
     """Whether a construct can be materialised before a container exists.
 
+    Two values, lowercase on the wire::
+
+        ApplyPhase.PRE_CONTAINER.value == "pre_container"
+        ApplyPhase.ON_CONTAINER.value  == "on_container"
+
+    Created by: this module's :data:`APPLY_ORDER` table, one phase per step.
+    Consumed by: :func:`steps_for` as the filter, the creation job (which
+    passes one at a time), and ``apply/delivery``, which re-phases every
+    non-script step to ``PRE_CONTAINER`` for teclaw.
+
     The split is not organisational. The two halves have **opposite**
     delivery-time constraints, and an orchestrator that ignored that would be
     one W13 has to bypass:
@@ -47,10 +57,24 @@ class ApplyPhase(StrEnum):
 
 @dataclass(frozen=True)
 class ApplyStep:
-    """One construct's place in the order."""
+    """One construct's place in the order::
 
+        ApplyStep(ManifestSection.SCRIPT, ApplyPhase.PRE_CONTAINER, 0)
+        ApplyStep(ManifestCategory.IDENTITY, ApplyPhase.ON_CONTAINER, 1)
+
+    Created by: :data:`APPLY_ORDER`, and rebuilt with a swapped ``phase`` by
+    ``apply/delivery`` for the teclaw family.
+    Consumed by: :func:`steps_for` and ``apply/orchestrator``, which walks the
+    steps in order.
+    """
+
+    #: Which construct this step applies.
     construct: ApplyConstruct
+    #: Which half of the creation path it belongs to. The **ARCA** family's
+    #: answer; teclaw's delivery strategy overrides it.
     phase: ApplyPhase
+    #: The sort key, 0-6, unique across the table. Shared by both families —
+    #: only the phase is family-specific.
     position: int
 
 
@@ -91,12 +115,21 @@ ALL_PHASES: frozenset[ApplyPhase] = frozenset(ApplyPhase)
 
 
 def steps_for(phases: frozenset[ApplyPhase] | None = None) -> tuple[ApplyStep, ...]:
-    """The steps in the requested phases, in position order.
+    """The steps in the requested phases, in position order::
+
+        steps_for()                                     # all seven, 0..6
+        steps_for(ALL_PHASES)                           # the same
+        steps_for(frozenset({ApplyPhase.PRE_CONTAINER}))
+        # -> (ApplyStep(ManifestSection.SCRIPT, PRE_CONTAINER, 0),)
+        steps_for(frozenset({ApplyPhase.ON_CONTAINER}))
+        # -> the other six, positions 1..6
+
+    Called by: ``apply/orchestrator`` and ``apply/delivery``.
 
     ``None`` means both, which is what an ordinary apply on an existing bot
-    wants. W13 passes one at a time — ``PRE_CONTAINER`` before the start command
-    is composed, ``ON_CONTAINER`` once the container is up — and gets one report
-    from each.
+    wants. The creation job passes one at a time — ``PRE_CONTAINER`` before the
+    start command is composed, ``ON_CONTAINER`` once the container is up — and
+    gets one report from each.
     """
     wanted = ALL_PHASES if phases is None else phases
     return tuple(

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/outcomes.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/outcomes.py
@@ -139,7 +139,7 @@ class EntryResult:
     Construct        Key read           Example ``identity``
     ===============  =================  ==================================
     ``skills``       ``name``           ``"code-review"``
-    ``identity``     ``type``           ``"avatar"``
+    ``identity``     ``type``           ``"SOUL.md"``
     ``resources``    ``path``           ``"data/faq.csv"``
     ``mcp``          ``server_code``    ``"gh"``
     ``cli_tools``    ``name``           ``"qc"``
@@ -168,7 +168,10 @@ class EntryResult:
             construct=ManifestCategory.RESOURCES,
             identity="data/prices/",
             outcome=EntryOutcome.SKIPPED,
-            reason="another entry in this category failed",
+            reason=(
+                "not written: another entry in this category could not be "
+                "materialized, and a category is written in full or not at all"
+            ),
             note=None,
         )
 

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/outcomes.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/outcomes.py
@@ -22,18 +22,53 @@ from agentclaw.community.core.bot_config_manifest.capabilities import (
 
 #: What a construct is, for the purposes of applying it: one of the six
 #: categories under ``manifest``, or the top-level ``script`` section.
+#:
+#: Always an enum member, never a bare string. ``.value`` is both the wire form
+#: and the manifest key::
+#:
+#:     ManifestCategory.SKILLS         # .value == "skills"
+#:     ManifestCategory.RESOURCES      # .value == "resources"
+#:     ManifestCategory.IDENTITY       # .value == "identity"
+#:     ManifestCategory.MCP            # .value == "mcp"
+#:     ManifestCategory.CLI_TOOLS      # .value == "cli_tools"
+#:     ManifestCategory.ENGINE_CONFIG  # .value == "engine_config"
+#:     ManifestSection.SCRIPT          # .value == "script"
+#:
+#: Created by: ``apply/order.APPLY_ORDER`` (one row per construct) and each
+#: materialiser's own ``construct`` class attribute.
+#: Consumed by: ``apply/registry.build_materialisers`` (as the map key),
+#: ``EntryResult.as_dict`` and ``CategoryResult.as_dict`` (as ``.value``).
 ApplyConstruct = ManifestCategory | ManifestSection
 
 
 class EntryOutcome(StrEnum):
-    """What happened to one **declared** entry.
+    """What happened to one **declared** entry. A lowercase string on the wire.
+
+    The five values, and what triggers each:
+
+    ==============  ==========================================================
+    Value           Trigger
+    ==============  ==========================================================
+    ``created``     The entry was not in the bot's area; it was written.
+    ``updated``     It was there with different content; it was overwritten.
+    ``unchanged``   It was there and already matched; no write was made.
+    ``skipped``     Its category was aborted by *another* entry's failure.
+    ``failed``      This entry itself could not be resolved or written.
+    ==============  ==========================================================
+
+    Example::
+
+        EntryOutcome.CREATED.value == "created"
+
+    Created by: each materialiser's ``plan`` and ``write`` for the first three;
+    ``apply/orchestrator`` assigns ``FAILED`` and ``SKIPPED``.
+    Consumed by: ``outcomes.derive_status``, and ``EntryResult.as_dict`` as the
+    wire field ``action``.
 
     ``SKIPPED`` means *"not written because its category was aborted"* — the
-    all-or-nothing rule in work-items §3.2 refusing to write a partial set. It
-    no longer means "the author allowed this one to be missing": that reading
-    belonged to ``on_fetch_failure: skip``, which was removed when §3.2 became
-    category overwrite, because under overwrite "skip this entry" would mean
-    "delete it" — the opposite of the name.
+    all-or-nothing rule refusing to write a partial set. It does not mean "the
+    author allowed this one to be missing": under category overwrite, "skip
+    this entry" would mean "delete it", the opposite of the name.
 
     The entry that *caused* an abort is ``FAILED``; its blameless neighbours in
     the same category are ``SKIPPED``.
@@ -47,17 +82,35 @@ class EntryOutcome(StrEnum):
 
 
 class ApplyStatus(StrEnum):
-    """The report's own state.
+    """The report's own state. Upper case on the wire, unlike
+    :class:`EntryOutcome`.
+
+    ===============  ========================================================
+    Value            Meaning
+    ===============  ========================================================
+    ``RUNNING``      Still working; no terminal value decided yet.
+    ``SUCCEEDED``    Every declared entry was delivered, or nothing was
+                     declared at all.
+    ``PARTIAL``      Some entries were delivered and some were not.
+    ``FAILED``       Nothing was delivered.
+    ===============  ========================================================
+
+    Example::
+
+        ApplyStatus.PARTIAL.value == "PARTIAL"
+
+    Created by: the apply service at start (``RUNNING``), then
+    :func:`derive_status` for the three terminal values.
+    Consumed by: ``ApplyReport.as_payload`` as the wire field ``result``, and
+    by whoever polls the apply record.
 
     ``RUNNING`` exists because apply is **started, not awaited**: the route
     answers ``202`` with an id and the work continues on a background thread, so
-    a poller needs to tell "still working" from "finished, and partially" — the
-    distinction W13's ``APPLYING`` state is built on.
+    a poller needs to tell "still working" from "finished, and partially".
 
     The three terminal values are **derived** from the entry outcomes once every
     decision has been made. Nothing in this engine branches on one, and nothing
-    writes one to a bot record (§2.7). They are a summary for whoever reads the
-    report.
+    writes one to a bot record. They are a summary for whoever reads the report.
     """
 
     RUNNING = "RUNNING"
@@ -78,12 +131,68 @@ NO_MATERIALISER_REASON = (
 
 @dataclass(frozen=True)
 class EntryResult:
-    """One declared entry's outcome.
+    """One declared entry's outcome — one row of the report's ``entries`` list.
 
-    ``identity`` is whatever its category keys entries by — a skill ``name``, an
-    identity ``type``, a resource ``path``, an mcp ``server_code``. The report
-    names entries the way their author wrote them, so a reader can find the line
-    they need to fix.
+    ``identity`` is the value of whichever key that category names entries by:
+
+    ===============  =================  ==================================
+    Construct        Key read           Example ``identity``
+    ===============  =================  ==================================
+    ``skills``       ``name``           ``"code-review"``
+    ``identity``     ``type``           ``"avatar"``
+    ``resources``    ``path``           ``"data/faq.csv"``
+    ``mcp``          ``server_code``    ``"gh"``
+    ``cli_tools``    ``name``           ``"qc"``
+    ``script``       none; fixed        ``"script"``
+    ===============  =================  ==================================
+
+    ``script`` has no entity key of its own, because there is one script, so it
+    reports under the section's own name (``materialisers/script._IDENTITY``).
+    A malformed entry carrying none of those keys falls back to
+    :func:`entry_identity`'s positional form, ``"[0]"``.
+
+    Three states, all real. A failure, the entry that caused its category's
+    abort::
+
+        EntryResult(
+            construct=ManifestCategory.RESOURCES,
+            identity="data/faq.csv",
+            outcome=EntryOutcome.FAILED,
+            reason="the git tree has no file at subpath 'kb/faq.csv'",
+            note=None,
+        )
+
+    A blameless neighbour in that same aborted category::
+
+        EntryResult(
+            construct=ManifestCategory.RESOURCES,
+            identity="data/prices/",
+            outcome=EntryOutcome.SKIPPED,
+            reason="another entry in this category failed",
+            note=None,
+        )
+
+    A success carrying a note::
+
+        EntryResult(
+            construct=ManifestSection.SCRIPT,
+            identity="script",
+            outcome=EntryOutcome.CREATED,
+            reason=None,
+            note=(
+                "delivered now; executes at this bot's next device "
+                "provisioning (create, restart or republish). Apply does "
+                "not run it."
+            ),
+        )
+
+    Created by: each materialiser's ``write``; ``apply/orchestrator`` builds the
+    ``FAILED`` and ``SKIPPED`` rows.
+    Consumed by: ``CategoryResult.entries`` and ``ApplyReport.entries``, then
+    :meth:`as_dict`.
+
+    The report names entries the way their author wrote them, so a reader can
+    find the line they need to fix.
     """
 
     construct: ApplyConstruct
@@ -101,7 +210,16 @@ class EntryResult:
     note: str | None = None
 
     def as_dict(self) -> dict[str, Any]:
-        """The wire shape for one entry."""
+        """The wire shape for one entry. The keys are renamed on the way out::
+
+            {
+                "category": "resources",     # construct.value
+                "name": "data/faq.csv",      # identity
+                "action": "failed",          # outcome.value
+                "error": "the git tree has no file at subpath 'kb/faq.csv'",
+                "note": None,
+            }
+        """
         return {
             "category": self.construct.value,
             "name": self.identity,
@@ -115,12 +233,54 @@ class EntryResult:
 class CategoryResult:
     """One construct's entries, plus what overwriting its area removed.
 
-    ``removals`` is its own field rather than a sixth :class:`EntryOutcome`, and
-    the distinction is precision rather than taste: the five outcomes classify
-    **declared** entries, and a removal has no declared entry to classify —
-    ``skills: []`` deletes every skill while declaring none of them. Folding
-    removals into the enum would either invent a value the acceptance criteria
-    do not list, or leave the destructive half of overwrite unaudited.
+    ``aborted`` and ``partially_written`` together say what the bot's area now
+    holds:
+
+    ===========  ==================  ======================================
+    ``aborted``  ``partially_``      What it means for the bot's area
+                 ``written``
+    ===========  ==================  ======================================
+    False        False               Converged. The area is what the
+                                     document declared.
+    True         False               Nothing was written. The area is
+                                     exactly as it was before this apply.
+    True         True                Some writes landed. Do not trust the
+                                     area; re-apply to converge it.
+    False        True                Never produced. ``partially_written``
+                                     is only ever set alongside an abort.
+    ===========  ==================  ======================================
+
+    A converged category::
+
+        CategoryResult(
+            construct=ManifestCategory.MCP,
+            entries=(EntryResult(ManifestCategory.MCP, "gh",
+                                 EntryOutcome.CREATED),),
+            removals=("old-server",),
+            aborted=False,
+            partially_written=False,
+        )
+
+    One aborted in ``resolve``, before any write::
+
+        CategoryResult(
+            construct=ManifestCategory.RESOURCES,
+            entries=(<the FAILED entry>, <its SKIPPED neighbours>),
+            removals=(),
+            aborted=True,
+            partially_written=False,
+        )
+
+    Created by: ``apply/orchestrator`` (one per construct it walks).
+    Consumed by: ``ApplyReport.categories``, :func:`derive_status`, and
+    :meth:`as_dict`.
+
+    ``removals`` is its own field rather than a sixth :class:`EntryOutcome`: the
+    five outcomes classify **declared** entries, and a removal has no declared
+    entry to classify — ``skills: []`` deletes every skill while declaring none
+    of them. Folding removals into the enum would either invent a value the
+    acceptance criteria do not list, or leave the destructive half of overwrite
+    unaudited.
     """
 
     construct: ApplyConstruct
@@ -153,7 +313,17 @@ class CategoryResult:
     partially_written: bool = False
 
     def as_dict(self) -> dict[str, Any]:
-        """The wire shape for one category's summary."""
+        """The wire shape for one category's summary. Note that the entries are
+        **not** nested here — they are flattened into the report's own
+        ``entries`` list::
+
+            {
+                "category": "resources",
+                "aborted": True,
+                "partially_written": False,
+                "removed": [],
+            }
+        """
         return {
             "category": self.construct.value,
             "aborted": self.aborted,
@@ -164,17 +334,48 @@ class CategoryResult:
 
 @dataclass(frozen=True)
 class SourceResolution:
-    """A named source, and what its ref resolved to.
+    """A git source this apply resolved, and the commit it landed on.
 
-    Empty in v1's URL wave — sources are inline URLs only — and filled by
-    W7, the wave that resolves named and git sources. Records the
-    credential's **name** and never its value: the report is what a support
-    engineer reads, so this is a security property rather than tidiness.
+    Only the git road produces these: an object-store source resolves no ref,
+    so it contributes no row. A named source::
+
+        SourceResolution(
+            name="content",             # the 'from' name
+            ref="v1.2.0",               # the declared ref, verbatim
+            resolved_sha="4f2a9c1b8e7d6a5c4b3a2918f7e6d5c4b3a29187",
+            auth="git-prod",            # the credential NAME
+        )
+
+    An inline git source has no ``from`` name, so it is recorded under its
+    repository URL instead::
+
+        SourceResolution(
+            name="https://code.example.com/team/content.git",
+            ref="HEAD",
+            resolved_sha="4f2a9c1b8e7d6a5c4b3a2918f7e6d5c4b3a29187",
+            auth=None,
+        )
+
+    ``name`` is the same key the strict-mode baselines are read back by, so the
+    report and ``SourceSession.baselines`` agree on a source's identity.
+
+    Created by: ``apply/source_session.SourceSession.adopt``, one per distinct
+    ``display`` name, returned through ``resolution_records()``.
+    Consumed by: ``ApplyReport.sources``, and read back by the apply service to
+    build the next apply's ``SourceSession.baselines``.
+
+    Records the credential's **name** and never its value: the report is what a
+    support engineer reads, so this is a security property rather than tidiness.
     """
 
+    #: The ``from`` name, or the repository URL for an inline source.
     name: str
+    #: The ref as declared: a tag, a branch, or a full SHA. ``"HEAD"`` when the
+    #: source declared none.
     ref: str | None = None
+    #: The 40-character commit id the ref actually resolved to.
     resolved_sha: str | None = None
+    #: The credential's name, never its value. ``None`` for an anonymous fetch.
     auth: str | None = None
 
     def as_dict(self) -> dict[str, Any]:
@@ -188,29 +389,64 @@ class SourceResolution:
 
 @dataclass(frozen=True)
 class ApplyReport:
-    """Everything one apply produced. Shape follows design §7.
+    """Everything one apply produced. Apply's only output.
 
-    Apply's only output. It is not a projection of some richer internal state —
-    there is no richer state, because §2.7 makes the per-entry records the whole
-    of what apply knows.
+    One filled-in example, an apply whose ``mcp`` converged and whose
+    ``resources`` aborted::
+
+        ApplyReport(
+            apply_id="ap_01HZX8",
+            bot_id="bot_42",
+            trigger="explicit",
+            status=ApplyStatus.PARTIAL,
+            started_at=datetime(2026, 3, 1, 9, 0, 0, tzinfo=timezone.utc),
+            finished_at=datetime(2026, 3, 1, 9, 0, 4, tzinfo=timezone.utc),
+            categories=(
+                CategoryResult(ManifestCategory.MCP, entries=(...,)),
+                CategoryResult(
+                    ManifestCategory.RESOURCES,
+                    entries=(...,),
+                    aborted=True,
+                ),
+            ),
+            sources=(
+                SourceResolution(
+                    name="content",
+                    ref="v1.2.0",
+                    resolved_sha="4f2a9c1b8e7d6a5c4b3a2918f7e6d5c4b3a29187",
+                    auth="git-prod",
+                ),
+            ),
+            notes=(),
+        )
+
+    Created by: ``apply/orchestrator`` at the end of an apply, and by
+    ``apply/apply_task`` for the background path.
+    Consumed by: :meth:`as_payload` for the HTTP response, and the apply record
+    the poller reads.
+
+    It is not a projection of some richer internal state — there is no richer
+    state, because the per-entry records are the whole of what apply knows.
     """
 
+    #: This apply's own id, as ``ApplyContext.apply_id`` carried it.
     apply_id: str
     bot_id: str
-    #: What started the apply. The vocabulary lives in ``apply/triggers.py``:
-    #: ``explicit``, ``put`` (W8), and W13's ``create:pre_container`` /
-    #: ``create:on_container``. Restart and republish are not triggers in
-    #: iteration 1 (spec D-1).
+    #: What started the apply, as one of ``apply/triggers.ALL_TRIGGERS``:
+    #: ``"explicit"``, ``"put"``, ``"create:pre_container"`` or
+    #: ``"create:on_container"``. Restart and republish are not triggers.
     trigger: str
     status: ApplyStatus
     started_at: datetime
     finished_at: datetime | None = None
+    #: One per construct the apply walked, in ``APPLY_ORDER`` position order.
     categories: tuple[CategoryResult, ...] = ()
-    #: Resolved named sources. Empty in v1's URL wave; W7 fills it.
+    #: One per distinct git source this apply resolved. Empty when the document
+    #: names no git source, which includes every object-store-only document.
     sources: tuple[SourceResolution, ...] = field(default=())
-    #: Apply-level notes that belong to no category — today only the delivery
-    #: strategy's closing step (W8): a teclaw redeliver that failed after every
-    #: category was written is recorded here rather than raised (§2.7).
+    #: Apply-level notes belonging to no category. Today's only producer is the
+    #: delivery strategy's closing step: a teclaw redeliver that failed after
+    #: every category was written is recorded here rather than raised.
     notes: tuple[str, ...] = field(default=())
 
     @property
@@ -222,6 +458,26 @@ class ApplyReport:
 
     def as_payload(self) -> dict[str, Any]:
         """The wire shape, defined here and nowhere else.
+
+        ``status`` is emitted as ``result``, the timestamps as ISO strings, and
+        the categories' entries are flattened into one top-level list::
+
+            {
+                "apply_id": "ap_01HZX8",
+                "bot_id": "bot_42",
+                "trigger": "explicit",
+                "result": "PARTIAL",
+                "started_at": "2026-03-01T09:00:00+00:00",
+                "finished_at": "2026-03-01T09:00:04+00:00",
+                "sources": [{"name": "content", "ref": "v1.2.0",
+                             "resolved_sha": "4f2a9c1b...", "auth": "git-prod"}],
+                "categories": [{"category": "mcp", "aborted": False,
+                                "partially_written": False, "removed": []}],
+                "entries": [{"category": "mcp", "name": "gh",
+                             "action": "created", "error": None,
+                             "note": None}],
+                "notes": [],
+            }
 
         Every field is named explicitly. There is no passthrough of a declared
         entry or of a materialiser's internals, which is what makes it
@@ -244,10 +500,11 @@ class ApplyReport:
         }
 
 
-#: The entity-key field each category names its entries by, in the order they
-#: are tried. Schema §3 gives each category its own key — ``skills.name``,
-#: ``identity.type``, ``resources.path``, ``mcp.server_code`` — and a report
-#: that could not name an entry would be one a caller cannot act on.
+#: The entity-key fields an entry may name itself by, in the order they are
+#: tried. One list for every category rather than a per-category lookup: each
+#: category's entries carry exactly one of these, so the first hit is that
+#: category's key — ``skills.name``, ``identity.type``, ``resources.path``,
+#: ``mcp.server_code``, ``cli_tools.name``.
 #:
 #: Lives here rather than in the orchestrator on purpose: which field to *print*
 #: is vocabulary, and the orchestrator is held to naming no category at all.
@@ -257,9 +514,25 @@ _ENTITY_KEY_FIELDS: tuple[str, ...] = ("name", "type", "path", "server_code")
 def entry_identity(entry: Any, index: int) -> str:
     """How an entry names itself in a report.
 
-    Falls back to the entry's position, and the fallback is load-bearing: a
-    category can be aborted over a document whose entries are malformed, and
-    those entries still have to appear in the report.
+    Takes the raw entry mapping and its position in the declared list, and
+    answers the string :class:`EntryResult` will carry as ``identity``::
+
+        entry_identity({"name": "code-review", "from": "pkgs"}, 0)
+        # -> "code-review"
+        entry_identity({"path": "data/faq.csv"}, 1)
+        # -> "data/faq.csv"
+
+        # No recognised key, or not a mapping at all: the position, in
+        # brackets. This is what a malformed entry reports as.
+        entry_identity({"nmae": "typo"}, 2)   # -> "[2]"
+        entry_identity("not a mapping", 0)    # -> "[0]"
+
+    Called by: ``apply/orchestrator``, when building the ``FAILED`` and
+    ``SKIPPED`` rows for an aborted category.
+
+    The fallback is load-bearing: a category can be aborted over a document
+    whose entries are malformed, and those entries still have to appear in the
+    report.
     """
     if isinstance(entry, dict):
         for key in _ENTITY_KEY_FIELDS:
@@ -272,9 +545,14 @@ def entry_identity(entry: Any, index: int) -> str:
 def derive_status(categories: tuple[CategoryResult, ...]) -> ApplyStatus:
     """The summary, computed once every decision has already been made.
 
+    Takes every :class:`CategoryResult` the apply produced and answers one of
+    the three terminal :class:`ApplyStatus` values (never ``RUNNING``).
+
+    Called by: ``apply/orchestrator`` and ``apply/apply_task``, once, at the end.
+
     Deliberately a free function taking the finished results: it cannot be
     consulted mid-apply, which is the mechanical form of "the summary decides
-    nothing" (§2.7).
+    nothing".
 
     * Nothing declared at all ⇒ ``SUCCEEDED``. A bot with no manifest, or one
       whose manifest declares no category, applied everything it was asked to.

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/redeliver.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/redeliver.py
@@ -23,25 +23,47 @@ from agentclaw.community.log import get_logger
 
 logger = get_logger()
 
-#: ``(bot_id, owner_id) -> DeviceContext``; raises ``not_bound`` when the bot
-#: has no active binding.
+#: ``(bot_id, owner_id) -> DeviceContext``, called positionally and
+#: **synchronously** (the redeliver runs it on a worker thread). Raises the
+#: ``not_bound`` exception type when the bot has no active binding::
+#:
+#:     resolve("bot_42", "usr_owner")   # -> a DeviceContext, or raises
+#:
+#: Typed ``Any`` on the device side because this package does not depend on
+#: ``core.devices``; DI binds the real callable.
 ResolveDeviceContext = Callable[[str, str], Any]
-#: ``DeviceContext -> TeclawDeviceSyncService`` — the dispatcher's
-#: ``dispatch``, which answers the teclaw service for a teclaw device; the
-#: redeliver calls its ``deliver_manifest_apply``.
+#: ``DeviceContext -> TeclawDeviceSyncService`` — the device dispatcher's
+#: ``dispatch``, which answers the teclaw sync service for a teclaw device.
+#: The redeliver then calls that service's ``deliver_manifest_apply()``::
+#:
+#:     dispatch(device).deliver_manifest_apply()
+#:     # -> {"success": True} | {"success": False, "message": "..."}
 DispatchDeviceSync = Callable[[Any], Any]
 
 
 class TeclawRedeliver:
     """Deliver the whole artifact to the bot's running container, once.
 
+    Satisfies :data:`~...delivery.Redeliver`: called with the apply's context
+    and answering ``None`` on success or a report-safe note on failure::
+
+        await redeliver(ctx)
+        # -> None                       delivered, or no container to deliver to
+        # -> "artifact could not be redelivered to the running container: <why>"
+
+    Three outcomes, and only the third produces a note: the bot has no active
+    binding (``None``, not an error), the delivery succeeded (``None``), or the
+    sync service answered ``{"success": False, ...}``.
+
+    Created by: the composition root, bound as
+    ``TeclawPlatformBindings.redeliver``.
+    Consumed by: ``TeclawDelivery.finish``.
+
     "Re-deliver" because the container already received an artifact when it
-    was provisioned (and on every runtime edit since); after a manifest apply
+    was provisioned, and on every runtime edit since; after a manifest apply
     changed platform state, the same delivery is made again so the container
-    catches up. A bot with an active device binding — a live container — gets
-    it; a bot without one (still being created, or its container gone) gets
-    nothing, because provisioning composes the first artifact from the
-    platform state itself.
+    catches up. A bot without a live container gets nothing, because
+    provisioning composes the first artifact from the platform state itself.
     """
 
     def __init__(

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/registry.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/registry.py
@@ -1,11 +1,47 @@
 """What materialises each construct, and the three-stage contract they honour.
 
+**The contract is ``resolve`` → ``plan`` → ``write``**, and each stage has its
+own currency. Worked end to end for ``mcp``, on a bot that already has ``gh``
+installed plus an ``old`` server the document no longer declares::
+
+    # The declared entries the orchestrator hands in:
+    [{"server_code": "gh"}, {"server_code": "slack"}]
+
+    # 1. resolve(ctx, entries) -> ResolveResult
+    #    Declared entries become intents. Everything that can fail before
+    #    touching the bot fails here.
+    ResolveResult(
+        intents=(Intent(identity="gh", value="gh", note=None),
+                 Intent(identity="slack", value="slack", note=None)),
+        failures=(),
+    )
+
+    # 2. plan(ctx, intents) -> CategoryPlan
+    #    Read-only. Each intent is classified against what is actually there,
+    #    and what is there but no longer declared becomes a removal.
+    CategoryPlan(
+        entries=(PlannedEntry(Intent("gh", "gh"), "unchanged"),
+                 PlannedEntry(Intent("slack", "slack"), "created")),
+        removals=("old",),
+    )
+
+    # 3. write(ctx, plan) -> Sequence[EntryResult]
+    #    Executes it. "unchanged" calls nothing; removals are deactivated.
+    (EntryResult(ManifestCategory.MCP, "gh", EntryOutcome.UNCHANGED),
+     EntryResult(ManifestCategory.MCP, "slack", EntryOutcome.CREATED))
+
+Had ``slack`` been unpermitted, ``resolve`` would have answered
+``ResolveResult(intents=(...gh...), failures=(ResolveFailure("slack", "this
+tenant does not have permission to enable this MCP server"),))`` and the
+orchestrator would have aborted the category without calling ``plan`` at all —
+so ``gh`` reports ``skipped`` and ``old`` is never removed.
+
 **The registry is sparse on purpose.** ``APPLY_ORDER`` names every construct the
 vocabulary defines; this maps only the ones some shipped code can act on. A
 construct declared in a document with no entry here is an **expected state**,
 not a gap: the orchestrator fails its entries with a readable reason and aborts
-the category, so nothing is destroyed, and W5/W6 close the window by registering
-a materialiser rather than by deleting a branch.
+the category, so nothing is destroyed, and the window closes by registering a
+materialiser rather than by deleting a branch.
 """
 from __future__ import annotations
 
@@ -52,33 +88,70 @@ from agentclaw.community.core.bot_config_manifest.apply.outcomes import (
 class Intent:
     """One declared entry, resolved into something writable.
 
-    ``identity`` is what the category keys entries by; ``value`` is whatever the
-    materialiser needs to write, already substituted and validated. The
-    orchestrator never inspects ``value`` — it is the materialiser's own
-    currency — which is what keeps category knowledge out of the orchestrator.
+    ``value`` is the materialiser's own currency and differs completely per
+    category::
 
-    ``note`` is a successful write's caveat, surfaced by the materialiser on
-    the entry's report row — today's only producer is a ``keep_last``
-    fallback, whose published contract is that the report states it. It rides
-    with the intent because the fetch resolved it and the write reports it,
-    and neither stage should reach into the other's currency.
+        # mcp: the server code, again — there is nothing else to write
+        Intent(identity="gh", value="gh")
+
+        # script: the substituted body, never the raw document text
+        Intent(identity="script", value="#!/bin/sh\necho prod\n")
+
+        # skills: the materialiser's private package dataclass
+        Intent(identity="code-review", value=_SkillPackage(...),
+               note="delivered from the platform's stored copy (keep_last): "
+                    "the git fetch failed")
+
+    Created by: each materialiser's ``resolve``.
+    Consumed by: that same materialiser's ``plan`` and ``write``, wrapped in a
+    :class:`PlannedEntry`.
+
+    ``identity`` is what the category keys entries by. The orchestrator never
+    inspects ``value``, which is what keeps category knowledge out of it.
+
+    ``note`` is a successful write's caveat, surfaced on the entry's report
+    row — today's only producer is a ``keep_last`` fallback, whose published
+    contract is that the report states it. It rides with the intent because the
+    fetch resolved it and the write reports it, and neither stage should reach
+    into the other's currency.
     """
 
+    #: How the entry names itself, e.g. ``"gh"`` or ``"data/faq.csv"``. The
+    #: same string that ends up as ``EntryResult.identity``.
     identity: str
+    #: Whatever this materialiser needs in order to write, already substituted
+    #: and validated. Opaque to everything except the materialiser that made it.
     value: Any = None
+    #: A caveat to put on the entry's report row even though the write
+    #: succeeded. ``None`` on the ordinary path.
     note: Optional[str] = None
 
 
 @dataclass(frozen=True)
 class ResolveFailure:
-    """One entry that could not be turned into an intent, and why.
+    """One entry that could not be turned into an intent, and why::
 
-    A single one of these aborts its whole category (§3.2 all-or-nothing): under
-    overwrite a partial set is *destructive*, because writing ``{A}`` when the
-    declaration was ``{A, B}`` deletes B.
+        ResolveFailure(
+            identity="slack",
+            reason=("this tenant does not have permission to enable this "
+                    "MCP server"),
+        )
+
+    Created by: each materialiser's ``resolve``.
+    Consumed by: ``apply/orchestrator``, which turns each into a ``FAILED``
+    :class:`~...outcomes.EntryResult` and marks every other entry in the
+    category ``SKIPPED``.
+
+    A single one of these aborts its whole category: under overwrite a partial
+    set is *destructive*, because writing ``{A}`` when the declaration was
+    ``{A, B}`` deletes B.
     """
 
+    #: The entry's own name, or ``entry_identity``'s ``"[0]"`` fallback when
+    #: the entry was too malformed to name itself.
     identity: str
+    #: Report-safe text, handed to the report verbatim. May name a credential;
+    #: never carries its value.
     reason: str
 
 
@@ -86,12 +159,32 @@ class ResolveFailure:
 class ResolveResult:
     """What ``resolve`` learned, keyed so the orchestrator can report per entry.
 
+    The two halves are independent: an entry is in exactly one of them, and a
+    result may carry both::
+
+        # every entry resolved; the category proceeds to plan
+        ResolveResult(intents=(Intent("gh", "gh"),), failures=())
+
+        # one entry failed: the category is aborted, and the resolved
+        # intents are never written
+        ResolveResult(
+            intents=(Intent("gh", "gh"),),
+            failures=(ResolveFailure("slack", "this tenant does not have "
+                                     "permission to enable this MCP server"),),
+        )
+
+    Created by: each materialiser's ``resolve``.
+    Consumed by: ``apply/orchestrator``, which checks :attr:`ok` before calling
+    ``plan``.
+
     Both halves are returned rather than raising on the first problem: a caller
     fixing a document should see every entry that failed, not discover them one
     resubmission at a time.
     """
 
+    #: The entries that resolved, in declaration order.
     intents: tuple[Intent, ...] = ()
+    #: The entries that did not. Non-empty means the category is aborted.
     failures: tuple[ResolveFailure, ...] = ()
 
     @property
@@ -102,27 +195,55 @@ class ResolveResult:
 
 @dataclass(frozen=True)
 class PlannedEntry:
-    """One intent, classified against what is actually there."""
+    """One intent, classified against what is actually there::
+
+        PlannedEntry(intent=Intent("gh", "gh"), outcome="unchanged")
+        PlannedEntry(intent=Intent("slack", "slack"), outcome="created")
+
+    Created by: each materialiser's ``plan``.
+    Consumed by: that materialiser's ``write``, which reads ``outcome`` to
+    decide whether to call the service at all.
+    """
 
     intent: Intent
-    #: ``created`` / ``updated`` / ``unchanged`` — never ``failed`` or
-    #: ``skipped``, which are the orchestrator's to assign.
+    #: The plain **string** value of an :class:`~...outcomes.EntryOutcome`, not
+    #: the enum: ``"created"``, ``"updated"`` or ``"unchanged"``. Never
+    #: ``"failed"`` or ``"skipped"``, which are the orchestrator's to assign.
     outcome: str
 
 
 @dataclass(frozen=True)
 class CategoryPlan:
-    """What ``write`` would do, computed without doing any of it.
+    """What ``write`` would do, computed without doing any of it::
 
-    ``dry_run`` returns after this stage, which is why the stage exists as its
-    own call: a preview that cannot write is one that is *missing the call*,
-    rather than one that is disciplined about not making it.
+        CategoryPlan(
+            entries=(PlannedEntry(Intent("gh", "gh"), "unchanged"),
+                     PlannedEntry(Intent("slack", "slack"), "created")),
+            removals=("old",),
+        )
+
+        # A converged document: nothing to write, nothing to remove.
+        # ``is_noop`` is True here and only here.
+        CategoryPlan(
+            entries=(PlannedEntry(Intent("gh", "gh"), "unchanged"),),
+            removals=(),
+        )
+
+    Created by: each materialiser's ``plan``.
+    Consumed by: that materialiser's ``write``, and by ``dry_run``, which stops
+    here.
+
+    ``dry_run`` returning after this stage is why the stage exists as its own
+    call: a preview that cannot write is one that is *missing the call*, rather
+    than one that is disciplined about not making it.
     """
 
+    #: One per resolved intent, in declaration order.
     entries: tuple[PlannedEntry, ...] = ()
     #: Identities present in the area and no longer declared — what overwriting
-    #: removes. Reported separately from entry outcomes because a removal has no
-    #: declared entry to attach to.
+    #: removes, e.g. ``("old",)``. Sorted by the materialisers that produce
+    #: them, so a report reads deterministically. Reported separately from entry
+    #: outcomes because a removal has no declared entry to attach to.
     removals: tuple[str, ...] = field(default=())
 
     @property
@@ -142,16 +263,25 @@ class CategoryPlan:
 class Materialiser(Protocol):
     """Three stages, because three acceptance criteria need boundaries there.
 
+    The currencies, in order: ``Sequence[dict]`` in, :class:`ResolveResult`,
+    :class:`CategoryPlan`, ``Sequence[EntryResult]`` out. This module's own
+    docstring works one category through all three.
+
+    Six ship: ``script``, ``mcp``, ``identity``, ``skills``, ``resources`` and
+    ``cli_tools``. All three stages are ``async``, including the ones whose
+    shipped implementations never await.
+
     Every member is ``@abstractmethod`` and each materialiser **inherits** this
-    Protocol — the shape ``BotConfigManifestServiceProtocol`` and the repository
-    contracts already use here. Omitting a stage then fails at construction
-    naming it, rather than as an ``AttributeError`` the first time a category
-    reaches that stage: for ``write``, that would be mid-apply on a real bot,
-    after ``resolve`` and ``plan`` had already succeeded.
+    Protocol rather than merely satisfying it structurally. Omitting a stage
+    then fails at construction naming it, rather than as an ``AttributeError``
+    the first time a category reaches that stage: for ``write``, that would be
+    mid-apply on a real bot, after ``resolve`` and ``plan`` had already
+    succeeded.
     """
 
-    #: Which construct this materialises. Read by the registry test that pins
-    #: every key here to an ``APPLY_ORDER`` row.
+    #: Which construct this materialises, e.g. ``ManifestCategory.MCP``. Also
+    #: the key :func:`build_materialisers` files the instance under, so a
+    #: materialiser cannot be registered under the wrong one.
     construct: ApplyConstruct
 
     @abstractmethod
@@ -160,11 +290,17 @@ class Materialiser(Protocol):
     ) -> ResolveResult:
         """Declared entries → intents.
 
+        ``entries`` are the raw mappings straight out of the parsed document,
+        in declaration order, e.g. ``[{"server_code": "gh"}, {"path":
+        "data/faq.csv", "from": "content"}]``. A category declared empty
+        (``mcp: []``) arrives as ``[]`` and must still be handled: it means
+        "remove everything", not "do nothing".
+
         Everything that can fail **before touching the bot** fails here:
-        placeholder substitution, the W10 seam's validators, permission checks.
-        W5's fetch lands in this stage and nowhere else — which is why the
-        transient-failure criterion is satisfied for W5 by construction rather
-        than by W5 remembering to satisfy it.
+        placeholder substitution, validators, permission checks. The fetch
+        lands in this stage and nowhere else, which is why the
+        transient-failure criterion is satisfied by construction rather than by
+        each materialiser remembering to satisfy it.
         """
         ...
 
@@ -174,6 +310,9 @@ class Materialiser(Protocol):
     ) -> CategoryPlan:
         """Read current state, classify each intent, and compute removals.
 
+        ``intents`` is :attr:`ResolveResult.intents`, reached only when that
+        result carried no failures.
+
         **Read-only.** Nothing here writes, and ``dry_run`` stops after it.
         """
         ...
@@ -182,7 +321,13 @@ class Materialiser(Protocol):
     async def write(
         self, ctx: ApplyContext, plan: CategoryPlan
     ) -> Sequence[EntryResult]:
-        """Execute the plan.
+        """Execute the plan, and answer one :class:`~...outcomes.EntryResult`
+        per planned entry.
+
+        Removals are performed but produce **no** result rows: they are carried
+        on :attr:`CategoryPlan.removals` and reported through
+        ``CategoryResult.removals`` instead, because a removal has no declared
+        entry to attach an outcome to.
 
         Reached only when ``resolve`` produced no failures. A plan that is
         ``is_noop`` must perform no write at all — that absence is what the
@@ -204,26 +349,38 @@ def build_materialisers(
     resource_service: ResourceFilePort,
     cli_tool_service: CliToolService,
 ) -> dict[ApplyConstruct, Materialiser]:
-    """The registry, built from injected services.
+    """The registry, built from injected services::
+
+        {
+            ManifestSection.SCRIPT:          ScriptMaterialiser(...),
+            ManifestCategory.MCP:            McpMaterialiser(...),
+            ManifestCategory.IDENTITY:       IdentityMaterialiser(...),
+            ManifestCategory.SKILLS:         SkillsMaterialiser(...),
+            ManifestCategory.RESOURCES:      ResourcesMaterialiser(...),
+            ManifestCategory.CLI_TOOLS:      CliToolsMaterialiser(...),
+        }
+
+    Six keys, and ``ManifestCategory.ENGINE_CONFIG`` deliberately absent: a
+    document declaring it takes the orchestrator's no-materialiser path, which
+    is an expected state rather than a gap.
+
+    Called by: the composition root, once, and by the test rigs that assemble
+    an engine.
 
     A function taking its dependencies rather than a module-level dict: the
     materialisers hold service references, and a module-level registry would
-    both construct services at import time (``test_no_module_level_service_instances``
-    exists for that class of thing) and pull the bot-configuration graph into
-    anything that merely wants the ordering table.
+    both construct services at import time and pull the bot-configuration graph
+    into anything that merely wants the ordering table.
 
-    **W4 registered two, W5 four, W6 five, W9 six.** The map is keyed by each
-    materialiser's own ``construct`` rather than by a name written here — so
-    a materialiser cannot be registered under the wrong key. The fetch-side
-    dependencies (``package_validator``, ``entry_fetcher``) exist because the
-    two W5 categories materialise fetched bytes: the validator is the upload
-    path's own gate, the entry fetcher is the W2/W3/W11 funnel, and neither
-    belongs inside the engine. ``cli_tools`` (W9) takes neither: it is handed one
-    dependency, the service both *it* and the management API call, which already
-    holds the family's delivery port — so the family difference stays where W6
-    put it. ``engine_config`` arrives when X2/T3 lets it back in; until then a
-    document declaring it takes the orchestrator's no-materialiser path: an
-    expected state, not a gap.
+    The map is keyed by each materialiser's own ``construct`` rather than by a
+    name written here, so a materialiser cannot be registered under the wrong
+    key. The fetch-side dependencies (``package_validator``,
+    ``entry_fetcher``) exist because ``skills`` and ``identity`` materialise
+    fetched bytes: the validator is the upload path's own gate, the entry
+    fetcher is the fetch funnel, and neither belongs inside the engine.
+    ``cli_tools`` takes neither — it is handed one dependency, the service both
+    *it* and the management API call, which already holds the family's delivery
+    port.
     """
     from agentclaw.community.core.bot_config_manifest.apply.materialisers.cli_tools import (
         CliToolsMaterialiser,

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/resource_files.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/resource_files.py
@@ -35,7 +35,34 @@ if TYPE_CHECKING:  # pragma: no cover — see the module docstring
 
 
 class DeviceResource(ResourceFilePort):
-    """The ARCA resource road: workspace files onto the bot's live container."""
+    """The ARCA resource road: workspace files onto the bot's live container.
+
+    Three methods, each forwarded verbatim. What a call looks like from the
+    ``resources`` materialiser::
+
+        await port.upload_file(
+            entity_id="ent_7", bot_id="bot_42",
+            engine_type="claude_code",
+            target_dir="data",            # the directory part of the path
+            filename="faq.csv",           # the file part
+            data=b"q,a\n...",
+        )                                  # -> the service's own result dict
+
+        await port.exists(entity_id="ent_7", bot_id="bot_42",
+                          engine_type="claude_code",
+                          path="data/faq.csv")     # -> True | False
+
+        await port.delete(entity_id="ent_7", bot_id="bot_42",
+                          engine_type="claude_code",
+                          path="data/faq.csv")     # -> True | False
+
+    ``entity_type`` defaults to ``"staff"`` on all three; apply never passes
+    anything else.
+
+    Bound as ``MaterialiserPorts.resource_service`` for the ARCA family. Its
+    platform-managed counterpart is ``PlatformResource`` in
+    ``managed_files/ports.py``.
+    """
 
     def __init__(self, inner: ResourceFileService) -> None:
         self._inner = inner

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/skill_package_upload.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/skill_package_upload.py
@@ -30,7 +30,28 @@ from agentclaw.community.core.skill_center.local_skill_upload_service_protocol i
 
 
 class DeviceSkillPackageUpload(SkillPackageUploadPort):
-    """The ARCA upload road: package files onto the bot's device."""
+    """The ARCA upload road: package files onto the bot's device.
+
+    Two methods. What a call looks like from the ``skills`` materialiser::
+
+        await port.upload_local_skill(
+            bot_id="bot_42", owner_id="usr_owner",
+            actor_id="usr_collaborator",
+            package=b"PK\x03\x04...",     # the validated canonical zip
+        )                                   # -> the service's result dict
+
+        await port.installed_package_digest(
+            bot=ctx.bot, bot_id="bot_42", owner_id="usr_owner",
+            name="code-review",             # the skill's manifest name
+        )   # -> "sha256:9f86d081..." when that skill is installed,
+            #    None when it is not — which the materialiser reads as
+            #    "nothing to compare", so the entry is written.
+
+    Bound as ``MaterialiserPorts.upload_service`` for the ARCA family. Its
+    platform-managed counterpart is ``PlatformSkillPackageUpload`` in
+    ``managed_files/ports.py``; unlike the activation delegates, the two share
+    no body — only the port and the skill row they record.
+    """
 
     def __init__(self, inner: LocalSkillUploadServiceProtocol) -> None:
         self._inner = inner

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/source_fetchers.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/source_fetchers.py
@@ -1,13 +1,9 @@
 """One fetcher per protocol, and the table that picks between them.
 
-``fetch_declared`` used to end in ``if decl.protocol is not SourceKind.GIT:``
-with the object road above it and ninety lines of git below. Adding a protocol
-meant editing that branch, and every consumer downstream with it.
-
-Here the front door does the work that is the same on every road — budget,
-session, ``keep_last``, and parsing the declaration once — then looks the
-protocol up in :data:`FETCHERS` and calls it. Adding a protocol is a class and
-a row; the branch has no third arm to grow.
+The front door (``entry_fetch.fetch_declared``) does the work that is the same
+on every road — budget, session, ``keep_last``, and parsing the declaration
+once — then looks the protocol up in :data:`FETCHER_TYPES` and calls it.
+Adding a protocol is a class and a row; the branch has no third arm to grow.
 
 **The table is exhaustive by construction**, the discipline
 ``support_matrix._build_matrix`` already uses: a :class:`SourceKind` with no
@@ -96,55 +92,135 @@ class DeclaredFetch:
               key: qc/v2.tgz
               on_fetch_failure: keep_last
 
-    the front door hands :class:`ObjectStoreFetcher` a ``DeclaredFetch``
-    whose ``decl`` is the parsed ``artifacts`` declaration, ``entry`` is the
-    ``qc`` mapping, ``name`` is ``"artifacts"``, ``category`` is
-    ``FetchCategory.CLI_TOOLS`` and ``keep_last`` is ``True``.
+    (``auth`` is mandatory on an ``oss`` source: the endpoint and the key pair
+    come off the named credential, so a declaration without one does not parse.)
+
+    the front door hands :class:`ObjectStoreFetcher`::
+
+        DeclaredFetch(
+            ctx=<the ApplyContext>,
+            decl=SourceDecl(protocol=SourceKind.OSS, bucket="team-artifacts",
+                            key="tools/", auth="oss-prod"),
+            entry={"name": "qc", "from": "artifacts", "key": "qc/v2.tgz",
+                   "on_fetch_failure": "keep_last"},
+            category=FetchCategory.CLI_TOOLS,
+            entry_identity="qc",
+            keep_last=True,
+            session=<the SourceSession>,
+            name="artifacts",
+        )
+
+    The git road differs only in ``decl`` and in the entry's own keys. For::
+
+        sources:
+          content:
+            protocol: git
+            url: https://code.example.com/team/content.git
+            ref: v1.2.0
+            subpath: kb
+            auth: git-prod
+
+        manifest:
+          resources:
+            - path: data/faq.csv
+              from: content
+              subpath: faq.csv
+
+    :class:`GitSourceFetcher` is handed::
+
+        DeclaredFetch(
+            ctx=<the ApplyContext>,
+            decl=SourceDecl(protocol=SourceKind.GIT,
+                            url="https://code.example.com/team/content.git",
+                            ref="v1.2.0", subpath="kb", auth="git-prod",
+                            mode="non_strict"),
+            entry={"path": "data/faq.csv", "from": "content",
+                   "subpath": "faq.csv"},
+            category=FetchCategory.RESOURCES_FILE,
+            entry_identity="data/faq.csv",
+            keep_last=True,          # the default when unspecified
+            session=<the SourceSession>,
+            name="content",
+        )
+
+    An **inline** source differs in exactly one field: ``name`` is ``None`` and
+    ``decl`` is parsed from the entry's own ``source:`` mapping.
+
+    Created by: ``apply/entry_fetch.EntryFetcher.fetch_declared``, the only
+    place one is built.
+    Consumed by: :meth:`SourceFetcher.fetch` — that is, both fetchers below.
 
     Assembled once, by the front door, so no fetcher re-derives it — two
     fetchers each deciding what ``keep_last`` means, or each looking up the
     ``from`` name, is how the roads drift apart while both look correct.
     """
 
+    #: This apply's context. Read for ``env``/``tenant``/``engine_type``
+    #: (placeholder substitution) and for ``budget``.
     ctx: FetchContext
+    #: The source declaration, already parsed by ``schema.sources.parse_source``
+    #: — whether it came from the ``sources`` map or from the entry's own
+    #: inline ``source:`` mapping.
     decl: SourceDecl
+    #: The manifest entry itself, raw as parsed from YAML. The fetcher reads
+    #: only the keys its protocol owns: ``key``/``digest`` on the object road,
+    #: ``subpath``/``digest``/``auth`` on the git road.
     entry: Mapping[str, Any]
-    #: The fetch category, as the closed vocabulary rather than a bare
-    #: string. Review asked whether an enum for this already existed — it
-    #: does, and every caller was already passing its members (some as
-    #: ``.value``), so only the annotation was loose. Typing it here makes
-    #: ``FETCH_ENTRY_LIMITS`` a total lookup below instead of one guarded by
-    #: a default that silently narrowed a mis-typed category to the file cap.
+    #: The fetch category, as the closed vocabulary rather than a bare string,
+    #: e.g. ``FetchCategory.CLI_TOOLS``. Typed rather than loose so
+    #: ``FETCH_ENTRY_LIMITS`` is a total lookup instead of one guarded by a
+    #: default that would silently narrow a mis-typed category to the file cap.
     category: FetchCategory
+    #: How the entry names itself in the report, e.g. ``"qc"`` or
+    #: ``"data/faq.csv"``. Rides into the receipt as the linkage's entry half.
+    #: ``None`` when the caller genuinely does not know.
     entry_identity: Optional[str]
-    #: ``on_fetch_failure`` already resolved to its boolean.
+    #: ``on_fetch_failure`` already resolved to its boolean: ``True`` for
+    #: ``keep_last`` (the default when the entry says nothing), ``False``
+    #: otherwise.
     keep_last: bool
-    #: ``None`` only on roads that need no session; a fetcher that reads it
-    #: is one the front door already refused without one.
+    #: This apply's source session. ``None`` only on roads that need no
+    #: session; a fetcher that reads it is one the front door already refused
+    #: without one, so :class:`GitSourceFetcher` asserts rather than branches.
     session: Optional[SourceSession]
-    #: The declared ``from`` name, or ``None`` for an inline source. The
-    #: report's name for the source, and the key its baseline is read by.
+    #: The declared ``from`` name, e.g. ``"content"``, or ``None`` for an
+    #: inline source. The git road falls back to the repository URL when this
+    #: is ``None``, and the result is the ``display`` that names the source in
+    #: the report and keys its baseline.
     name: Optional[str]
 
 
 @runtime_checkable
 class SourceFetcher(Protocol):
-    """Acquire one entry's content over one protocol."""
+    """Acquire one entry's content over one protocol.
+
+    One method, one argument, one return type: :class:`DeclaredFetch` in,
+    :class:`~...entry_delivery.EntryDelivery` out. Two implementations ship,
+    below.
+    """
 
     @abstractmethod
     def fetch(self, request: DeclaredFetch) -> EntryDelivery:
-        """Raises :class:`EntryFetchError` with a report-safe reason."""
+        """The delivery, or :class:`EntryFetchError` with a report-safe reason.
+
+        The reason lands verbatim on the entry's report row, so it may name a
+        credential but never carry its value.
+        """
         ...
 
 
 class ObjectStoreFetcher(SourceFetcher):
     """``protocol: oss`` — one request, one object, addressed by the source.
 
-    The source carries the credential (W7 — the declaration, not the entry).
-    An entry's ``subpath`` is **not** part of the address: on this road it
-    selects inside the fetched object, which the materialiser applies after
-    unpacking. One rule, both protocols — ``subpath`` selects within what the
-    source delivered; git delivers a tree, an object store delivers an object.
+    Always answers a :class:`~...entry_delivery.BlobDelivery`. The address is
+    ``bucket`` from the declaration plus the composed ``key``; the endpoint and
+    the key pair come off the named credential, so there is no anonymous road.
+
+    The source carries the credential — the declaration, not the entry. An
+    entry's ``subpath`` is **not** part of the address: on this road it selects
+    inside the fetched object, which the materialiser applies after unpacking.
+    One rule, both protocols — ``subpath`` selects within what the source
+    delivered; git delivers a tree, an object store delivers an object.
     """
 
     def __init__(self, owner: EntryFetcher) -> None:
@@ -196,12 +272,19 @@ class ObjectStoreFetcher(SourceFetcher):
 class GitSourceFetcher(SourceFetcher):
     """``protocol: git`` — one checkout per ``(url, ref)`` per apply.
 
+    Answers a :class:`~...entry_delivery.GitDelivery` on success, and a
+    :class:`~...entry_delivery.BlobDelivery` when the fetch failed and
+    ``keep_last`` stood in with the baseline SHA's stored tree.
+
+    Refuses two entry keys outright, both with report-safe reasons: ``digest``
+    (pin by writing the commit SHA as the source's ref instead) and
+    entry-level ``auth`` (declare it inside the source object).
+
     The ref resolves once through the apply's source session, ``mode`` is
     enforced against the last apply's resolved SHA, and what comes back is a
-    tree for the entry to interpret. ``keep_last`` falls back to the
-    baseline-SHA receipt under the same keep_last-only ruling wire failures
-    get: a *refusal* is configuration and must not be masked, a *failure* is
-    the transport and may be.
+    tree for the entry to interpret. ``keep_last`` falls back under the same
+    ruling wire failures get: a *refusal* is configuration and must not be
+    masked, a *failure* is the transport and may be.
     """
 
     def __init__(self, owner: EntryFetcher) -> None:
@@ -317,9 +400,17 @@ class GitSourceFetcher(SourceFetcher):
         )
 
 
-#: Which fetcher serves which protocol. ``CONTENT`` is absent on purpose: it
-#: is a :class:`SourceKind` but never a *source* — inline text is written on
-#: the entry and there is nothing to acquire.
+#: Which fetcher **class** serves which protocol — the types, not instances::
+#:
+#:     {
+#:         SourceKind.OSS: ObjectStoreFetcher,
+#:         SourceKind.GIT: GitSourceFetcher,
+#:     }
+#:
+#: :func:`build_fetchers` is what turns it into instances bound to one
+#: pipeline. ``CONTENT`` is absent on purpose: it is a :class:`SourceKind` but
+#: never a *source* — inline text is written on the entry and there is nothing
+#: to acquire. The import-time check below refuses any other omission.
 FETCHER_TYPES: Mapping[SourceKind, type] = MappingProxyType(
     {
         SourceKind.OSS: ObjectStoreFetcher,
@@ -341,21 +432,35 @@ if _UNSERVED:
 
 
 def build_fetchers(owner: EntryFetcher) -> Mapping[SourceKind, SourceFetcher]:
-    """The table, bound to one pipeline's collaborators."""
+    """The table, bound to one pipeline's collaborators::
+
+        {
+            SourceKind.OSS: ObjectStoreFetcher(owner),
+            SourceKind.GIT: GitSourceFetcher(owner),
+        }
+
+    Called once per :class:`~...entry_fetch.EntryFetcher`, in its constructor.
+    """
     return MappingProxyType(
         {kind: cls(owner) for kind, cls in FETCHER_TYPES.items()}
     )
 
 
 def object_receipt_url(bucket: str, key: str) -> str:
-    """The W11 identity for bytes read out of a bucket.
+    """The receipt identity for bytes read out of a bucket::
 
-    ``oss://bucket/key`` — deliberately not a fetchable URL. It is a stable
-    *name* for a delivery, the way ``git_receipt_url`` names a tree at a
-    commit: the endpoint is not part of it, because the same object read
-    through an internal and an external endpoint is the same object, and a
-    receipt keyed on the endpoint would file it twice and let ``keep_last``
-    miss its own copy.
+        object_receipt_url("team-artifacts", "tools/qc/v2.tgz")
+        # -> "oss://team-artifacts/tools/qc/v2.tgz"
+
+        object_receipt_url("team-artifacts", "/leading/slash.tgz")
+        # -> "oss://team-artifacts/leading/slash.tgz"
+
+    **The endpoint is deliberately not part of it**, and this is not an
+    omission: the same object read through an internal and an external endpoint
+    is the same object, so a receipt keyed on the endpoint would file it twice
+    and let ``keep_last`` miss its own copy. The result is therefore a stable
+    *name*, not a fetchable URL — the way ``git_receipt_url`` names a tree at a
+    commit.
     """
     return f"oss://{bucket}/{key.lstrip('/')}"
 
@@ -363,7 +468,24 @@ def object_receipt_url(bucket: str, key: str) -> str:
 def compose_key(source_key: Optional[str], entry_key: Any) -> Optional[str]:
     """The source's key prefix, then the entry's — one object name.
 
-    Exactly ``compose_subpath``'s rule on the other road, and re-checked by
+    ====================  ==============  ====================================
+    ``source_key``        ``entry_key``   Result
+    ====================  ==============  ====================================
+    ``"tools/"``          ``"qc/v2.tgz"`` ``"tools/qc/v2.tgz"``
+    ``None``              ``"qc/v2.tgz"`` ``"qc/v2.tgz"``
+    ``"tools/"``          ``None``        ``"tools/"`` (the prefix is the
+                                          whole name)
+    ``None``              ``None``        ``None`` (the caller then refuses:
+                                          the entry named no object)
+    ``"tools"``           ``"/qc.tgz"``   ``"tools/qc.tgz"`` (one slash; the
+                                          join strips both sides)
+    ====================  ==============  ====================================
+
+    ``entry_key`` is typed ``Any`` because it comes raw from YAML: a non-string
+    or an empty string raises :class:`EntryFetchError`, as does a composition
+    that fails the schema's path predicate.
+
+    Exactly :func:`compose_subpath`'s rule on the other road, and re-checked by
     the same pure predicate for the same reason: two safe halves can compose
     into an unsafe whole, and a second weaker rule here is how a traversal
     gets through one layer by satisfying the other.
@@ -391,20 +513,32 @@ def compose_subpath(
 ) -> Optional[str]:
     """The source's ``subpath``, then the entry's — one path, re-checked.
 
-    **This is what lets one source serve many entries.** Before it, an entry
-    ``subpath`` beside a git source was refused at apply time (defect D3), so a
-    source addressed exactly one file and a second file from the same
-    repository needed a second source block carrying duplicate ``url``, ``ref``
-    and ``auth`` — reintroducing precisely the drift named sources exist to
-    remove. ``resources`` over git is not useful without it: a resources entry
-    names a workspace ``path`` *and* a source path, and those differ per entry
-    by construction.
+    ====================  ================  ==================================
+    ``source_subpath``    ``entry_subpath`` Result
+    ====================  ================  ==================================
+    ``"kb"``              ``"faq.csv"``     ``"kb/faq.csv"``
+    ``None``              ``"faq.csv"``     ``"faq.csv"``
+    ``"kb"``              ``None``          ``"kb"``
+    ``None``              ``None``          ``None`` (the whole tree)
+    ``"kb"``              ``"../etc"``      raises: "...compose to
+                                            'kb/../etc', which is refused:
+                                            subpath must not contain a '..'
+                                            segment"
+    ====================  ================  ==================================
+
+    ``entry_subpath`` is typed ``Any`` because it comes raw from YAML: a
+    non-string or an empty string raises :class:`EntryFetchError`.
+
+    **This is what lets one source serve many entries**: ``resources`` over git
+    is not useful without it, because a resources entry names a workspace
+    ``path`` *and* a source path, and those differ per entry by construction.
+    Without composition each file needs its own source block carrying duplicate
+    ``url``, ``ref`` and ``auth``.
 
     The composed value is re-checked by the schema's own pure predicate rather
-    than by a local rule. Two safe segments can compose into an unsafe path
-    (``a/b`` under ``..``-free halves is fine, but the join is what the
-    checkout is finally asked to read), and a second, weaker rule here is
-    exactly how a traversal gets through one layer by satisfying the other.
+    than by a local rule. Two safe segments can compose into an unsafe path,
+    and a second, weaker rule here is exactly how a traversal gets through one
+    layer by satisfying the other.
     """
     if entry_subpath is None:
         return source_subpath
@@ -425,7 +559,18 @@ def compose_subpath(
 
 
 def substitute(ctx: FetchContext, source_url: str) -> str:
-    """``${BOT_*}`` in a source URL, against this apply's deployment context.
+    """``${BOT_*}`` in one string, against this apply's deployment context.
+
+    Despite the parameter name it is used on every addressing string, not only
+    URLs — the object road substitutes the bucket and the composed key too::
+
+        substitute(ctx, "https://cdn.example.com/${BOT_ENV}/kb.zip")
+        # -> "https://cdn.example.com/prod/kb.zip"
+
+        substitute(ctx, "${BOT_TENANT}-artifacts")     # a bucket
+        # -> "acme-artifacts"
+
+    The three axes come off the context: ``engine_type``, ``env``, ``tenant``.
 
     Unknown names are left untouched by the resolver itself — they cannot
     reach here through a stored document, because the write path refuses

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/source_session.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/source_session.py
@@ -1,13 +1,13 @@
-"""One apply's named-source state (W7, #1475).
+"""One apply's named-source state.
 
 The four things a single apply needs and nothing more: the document's
 ``sources`` declarations, the strict-mode baselines read back from the last
 apply that resolved each source, a checkout cache keyed on the substituted
-``(url, ref)``, and the `SourceResolution` records the report will carry. It
-hangs on ``ApplyContext`` beside ``budget`` — mutable by design inside a frozen
-context, the precedent that ruling cites — because the fetcher is a DI
-singleton (state there would leak across applies) and a re-resolution per
-entry would break "the same {git, ref} is pulled once per apply".
+``(url, ref)``, and the :class:`SourceResolution` records the report will
+carry. It hangs on ``ApplyContext`` beside ``budget``, mutable by design inside
+a frozen context, because the fetcher is a DI singleton (state there would leak
+across applies) and a re-resolution per entry would break "the same
+``(url, ref)`` is pulled once per apply".
 
 A checkout and its resolution are **deliberately two events**. Fetching the
 tree answers "what does the ref name right now"; adopting it answers "and this
@@ -43,21 +43,85 @@ _rmtree = shutil.rmtree
 @dataclass
 class SourceSession:
     """Per-apply: what ``from`` may name, what last time resolved, what this
-    apply fetched. Created by the apply service at ``start_apply``/``dry_run``
-    and closed in every terminal path — including launch failure."""
+    apply fetched.
 
-    #: The stored document's top-level ``sources`` map, frozen at apply start.
+    Created by: ``services/config_manifest_apply_service``, at ``start_apply``
+    and ``dry_run``, and closed in every terminal path including launch
+    failure.
+    Consumed by: ``apply/source_fetchers.GitSourceFetcher.fetch`` and
+    ``apply/entry_fetch`` (``fetch_declared``, ``_git_keep_last``,
+    ``declared_protocol``).
+    """
+
+    #: The stored document's top-level ``sources`` map, verbatim and frozen at
+    #: apply start: declared name → the raw declaration mapping, unparsed.
+    #: ``fetch_declared`` looks an entry's ``from`` name up here and hands the
+    #: value to ``parse_source``::
+    #:
+    #:     {
+    #:         "content": {
+    #:             "protocol": "git",
+    #:             "url": "https://code.example.com/team/content.git",
+    #:             "ref": "v1.2.0",
+    #:             "subpath": "kb",
+    #:             "auth": "git-prod",
+    #:         },
+    #:         "artifacts": {
+    #:             "protocol": "oss",
+    #:             "bucket": "team-artifacts",
+    #:             "key": "tools/",
+    #:             "auth": "oss-prod",
+    #:         },
+    #:     }
+    #:
+    #: Empty when the document declares no ``sources``; an entry naming one
+    #: then fails with "is not declared under 'sources'".
     sources: Mapping[str, Mapping[str, Any]]
-    #: Named source → the SHA the last apply that resolved it recorded
-    #: (``ApplyReport.sources`` read back through the report history). A
-    #: source absent here has no strict opinion yet.
+    #: Display name → the 40-character SHA the last apply that resolved that
+    #: source recorded. Read back out of ``ApplyReport.sources`` through the
+    #: report history, so the keys are ``SourceResolution.name`` values: the
+    #: declared ``from`` name for a named source, the repository URL for an
+    #: inline one::
+    #:
+    #:     {
+    #:         "content": "4f2a9c1b8e7d6a5c4b3a2918f7e6d5c4b3a29187",
+    #:         "https://code.example.com/solo.git": "9b1c...",
+    #:     }
+    #:
+    #: A source absent here has no strict opinion yet, so strict mode admits
+    #: its first resolution and ``keep_last`` has no baseline receipt to reuse.
     baselines: Mapping[str, str]
     #: The git transport; injected so tests script it and production gets the
     #: subprocess client via the DI provider.
     git: GitSourceClient
 
+    #: ``(substituted repository url, ref)`` → the checkout that pair produced.
+    #: The key deliberately excludes ``subpath``, which is what lets two
+    #: entries reading different paths out of one commit share one fetch::
+    #:
+    #:     {
+    #:         ("https://code.example.com/team/content.git", "v1.2.0"):
+    #:             GitCheckout(root=..., sha="4f2a9c1b...", ...),
+    #:     }
+    #:
+    #: Both of these entries hit that one key, and only the first fetches::
+    #:
+    #:     - path: data/faq.csv
+    #:       from: content
+    #:       subpath: faq.csv        # composes to "kb/faq.csv"
+    #:     - path: data/prices/
+    #:       from: content
+    #:       subpath: prices         # composes to "kb/prices"
+    #:
+    #: The url is the **substituted** one (``${BOT_*}`` already resolved), so
+    #: two entries whose urls differ only before substitution still share.
     _checkouts: dict[tuple[str, str], GitCheckout] = field(default_factory=dict)
+    #: The report's ``sources`` rows, in the order they were adopted.
     _resolutions: list[SourceResolution] = field(default_factory=list)
+    #: The display names already in ``_resolutions``. Makes :meth:`adopt`
+    #: idempotent per source, so ten entries naming one source produce one row::
+    #:
+    #:     {"content", "https://code.example.com/solo.git"}
     _recorded: set[str] = field(default_factory=set)
 
     def checkout(
@@ -69,13 +133,31 @@ class SourceSession:
     ) -> "tuple[GitCheckout, bool]":
         """The checkout for one ``(url, ref)``, fetching only the first time.
 
-        Returns the checkout and whether **this call** did the fetching (a
-        cache hit answers ``False`` — those bytes were charged when they were
-        actually moved). ``display`` is the report's name for the source: the
-        declared ``from`` name for a named source, the repository URL for an
-        inline one — the same key the baselines are read back by, so strict
-        mode and the report agree on identity. Nothing is recorded here: see
-        :meth:`adopt`.
+        Returns ``(checkout, fetched_here)``::
+
+            # first entry naming this source
+            (GitCheckout(root=PosixPath("/tmp/acm-git-x9"),
+                         sha="4f2a9c1b8e7d6a5c4b3a2918f7e6d5c4b3a29187",
+                         url="https://code.example.com/team/content.git",
+                         ref="v1.2.0",
+                         members=(("100644", "kb/faq.csv", 812), ...)),
+             True)
+
+            # a later entry on the same (url, ref)
+            (<the same GitCheckout>, False)
+
+        ``fetched_here`` is what the caller charges the apply budget on: a
+        cache hit answers ``False``, because those bytes were charged when they
+        actually moved.
+
+        ``display`` is the report's name for the source — the declared ``from``
+        name, or the repository URL for an inline one — and is the same key
+        ``baselines`` is read by, so strict mode and the report agree on
+        identity. It is not part of the cache key and nothing is recorded here:
+        see :meth:`adopt`.
+
+        ``headers`` carries the credential's injected headers, or is empty for
+        an anonymous fetch.
         """
         key = (spec.url, spec.ref)
         checkout = self._checkouts.get(key)
@@ -95,12 +177,27 @@ class SourceSession:
     ) -> None:
         """Record that this apply stands behind ``display`` → ``checkout.sha``.
 
-        Called by the fetch pipeline only once the strict-mode gate has
-        passed for the entry — a refused move is not adopted, so the report
-        of a refusing (failed) apply carries no poisoned baseline, and the
-        last apply's record keeps refusing the moved ref until the document
-        is re-pinned. Idempotent per display: every entry that names the
-        source stands behind the same resolution.
+        Appends one :class:`SourceResolution` and returns nothing::
+
+            adopt(display="content",
+                  spec=GitSourceSpec(url="https://code.example.com/team/"
+                                         "content.git", ref="v1.2.0", ...),
+                  checkout=<the checkout>,
+                  auth_name="git-prod")
+
+            # _resolutions now ends with
+            SourceResolution(name="content", ref="v1.2.0",
+                             resolved_sha="4f2a9c1b8e7d6a5c4b3a2918f7e6d5c4b3a29187",
+                             auth="git-prod")
+
+        ``auth_name`` is the credential's **name** or ``None``, never a value.
+
+        Called by the fetch pipeline only once the strict-mode gate has passed
+        for the entry — a refused move is not adopted, so the report of a
+        refusing (failed) apply carries no poisoned baseline, and the last
+        apply's record keeps refusing the moved ref until the document is
+        re-pinned. Idempotent per display: every entry that names the source
+        stands behind the same resolution.
         """
         if display in self._recorded:
             return
@@ -115,16 +212,24 @@ class SourceSession:
         )
 
     def resolution_records(self) -> tuple[SourceResolution, ...]:
-        """What the report's ``sources`` section will carry."""
+        """What the report's ``sources`` section will carry — one row per
+        distinct ``display``, adoption order. Empty when this apply resolved no
+        git source, which includes every object-store-only document."""
         return tuple(self._resolutions)
 
     def baseline(self, display: str) -> Optional[str]:
-        """The SHA the last apply that resolved this source found, or ``None``."""
+        """The SHA the last apply that resolved this source found, or ``None``.
+
+        ``baseline("content")`` → ``"4f2a9c1b8e7d6a5c4b3a2918f7e6d5c4b3a29187"``
+        for a source resolved before, ``None`` for one seen the first time.
+        """
         return self.baselines.get(display)
 
     def close(self) -> None:
-        """Remove every checkout's tree. Idempotent — every terminal path of
-        an apply calls it, including the launch-failure one."""
+        """Remove every checkout's temporary tree from disk and empty the
+        cache. Idempotent — every terminal path of an apply calls it, including
+        the launch-failure one. The resolution records survive: they are the
+        report's, not the checkouts'."""
         for checkout in self._checkouts.values():
             _rmtree(checkout.root, ignore_errors=True)
         self._checkouts.clear()

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/triggers.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/triggers.py
@@ -1,20 +1,39 @@
-"""What started an apply — the vocabulary of ``ApplyReport.trigger`` (W8).
+"""What started an apply — the vocabulary of ``ApplyReport.trigger``.
+
+Every value is a plain lowercase string, stored verbatim in the apply record's
+``trigger`` column and echoed unchanged in the report payload.
+
+========================  =================================================
+Value                     Who produces it
+========================  =================================================
+``explicit``              ``POST …/config-manifest/apply``, through
+                          ``adapters/http/…/bots/config_manifest_apply``.
+                          Also ``start_apply``'s default, so any caller
+                          naming no trigger records this one.
+``put``                   ``PUT …/config-manifest`` on an existing bot,
+                          through
+                          ``adapters/http/…/bots/config_manifest_support``.
+``create:pre_container``  The creation job's first phase, through
+                          ``creation.ManifestCreationSteps`` and
+                          ``create_job``. Applies ``PRE_CONTAINER`` only.
+``create:on_container``   The creation job's second phase, same producers.
+                          Applies ``ON_CONTAINER`` only.
+========================  =================================================
+
+Example::
+
+    ApplyReport(..., trigger="create:pre_container", ...)
 
 One module so a trigger is spelled once. The two creation triggers stay in
 ``creation.py``, which owns the creation job's recognition of its own phases;
 they are re-exported here for readers, not redefined.
 
-The vocabulary in iteration 1:
+On teclaw with the platform-managed switch on, only ``create:pre_container``
+occurs: the whole manifest is delivered before the container exists.
 
-* ``explicit`` — ``POST …/config-manifest/apply``.
-* ``put`` — ``PUT …/config-manifest`` on an existing bot (§2.6).
-* ``create:pre_container`` / ``create:on_container`` — W13's creation job. On
-  teclaw with the platform-managed switch on only the first occurs: the whole
-  manifest is delivered before the container exists.
-
-Restart and republish are **not** triggers in this iteration: nothing
-previously applied is lost on either path, so a re-apply there was deferred
-(spec D-1). The column is ``String(32)``; every value here fits.
+Restart and republish are **not** triggers: nothing previously applied is lost
+on either path, so a re-apply there was deferred. The column is ``String(32)``;
+every value here fits.
 """
 from __future__ import annotations
 
@@ -28,7 +47,12 @@ PUT = "put"
 CREATE_PRE_CONTAINER = CREATE_PRE_CONTAINER_TRIGGER
 CREATE_ON_CONTAINER = CREATE_ON_CONTAINER_TRIGGER
 
-#: Every trigger a report may carry, for tests and readers.
+#: Every trigger a report may carry, for tests and readers::
+#:
+#:     ("explicit", "put", "create:pre_container", "create:on_container")
+#:
+#: Not enforced anywhere — ``start_apply`` takes a plain ``str``. This is the
+#: closed list a reader and a test can check against.
 ALL_TRIGGERS: tuple[str, ...] = (
     EXPLICIT,
     PUT,
@@ -36,7 +60,9 @@ ALL_TRIGGERS: tuple[str, ...] = (
     CREATE_ON_CONTAINER,
 )
 
-#: The apply record's ``trigger`` column width (``apply_models.py``).
+#: The apply record's ``trigger`` column width (``apply_models.py``), in
+#: characters. ``"create:pre_container"`` is the longest value at 20, so every
+#: trigger above fits with room to spare.
 TRIGGER_COLUMN_WIDTH = 32
 
 __all__ = [


### PR DESCRIPTION
## Problem

The comments across `bot_config_manifest/apply/` were long on rationale (why a decision was made, which review round asked for it, which wave introduced it) and short on shape. A reader opening a file cold could not answer "what does this variable actually contain?" without tracing three files.

Two concrete gaps that motivated this:

- `EntryFetcher.fetch(source_url=...)` said nothing about what a `source_url` looks like. It is always a plain `https://...` URL (the legacy bare-string `source:` spelling), never `oss://` and never `git+...` — while `FetchedEntry.source_url` and every receipt `source_url` can be any of three shapes depending on the road. None of that was stated where the field is declared.
- `SourceSession._checkouts: dict[tuple[str, str], GitCheckout]` did not say what the tuple is. It is `(substituted repository url, ref)`, deliberately excluding `subpath` so two entries reading different paths out of one commit share one checkout.

## Solution

Comments and docstrings only, across all 26 Python files in `apply/` and `apply/materialisers/`. Zero behavioural change.

Every domain model (dataclass, Protocol, enum, type alias, and any `dict`/`tuple` field whose element type is not self-explanatory) now carries, in this order:

1. a one-sentence purpose;
2. field-by-field **shape** — the concrete form of the value, not just the Python type;
3. a concrete example instance in a `::` literal block, showing **both the git and object-store roads** where a model differs between them, and each meaningfully different state (`FetchedEntry` gets fresh-fetch, pinned store-hit, and `keep_last` fallback);
4. one line each for where it is created and where it is consumed, as `module.function` references.

Highlights:

- **`outcomes.py`** — trigger tables for the five `EntryOutcome` values and the four `ApplyStatus` values; the per-category `identity` key table; the `aborted`/`partially_written` truth table; a full `ApplyReport` and its `as_payload` wire shape.
- **`entry_fetch.py`** — the three `source_url` shapes spelled out with which method sees which, and the four entry points (`fetch` / `fetch_declared` / `acquire_object` / `file_bytes`) described by caller, URL shape, receipt and budget behaviour.
- **`entry_delivery.py`** — a method-by-road answer table for `EntryDelivery`, and the `TREE_MAGIC` wire format shown byte-for-byte for a two-file tree.
- **`registry.py`** — the `resolve` → `plan` → `write` contract worked end to end for `mcp`, including what an unpermitted entry does to the whole category.
- **`materialisers/*.py`** — a YAML entry example per category in both `from:` and inline `source:` forms, what `identity` is, and what `Intent.value` carries; summary table in the package `__init__`.

Existing rationale was kept where a maintainer needs it and trimmed where it was review-round, defect-number or wave-number history.

Example values were verified against the code and the tests rather than written from reading. Where I could not confirm a value I derived it by execution — the canonical tree framing, `compose_key`/`compose_subpath` input→output tables, `declared_protocol`'s answers, and `git_receipt_url`'s trailing-colon form were each produced by running the function. Three initial guesses were corrected this way (see below).

## Validation

- `uv run --no-sync python -m pytest -q -o addopts="" -W ignore tests/community/core/bot_config_manifest/` — **1059 passed**, same as the pre-change baseline.
- `uv run --no-sync ruff check src/agentclaw/community/core/bot_config_manifest/apply/` — clean.
- **Proved the diff is docstring-only mechanically** rather than by reading it: for each of the 26 changed files, parsed the base and working versions, stripped every module/class/function docstring, and compared `ast.dump` output. All 26 identical. Since comments never enter an AST, nothing executable changed.
- No file outside `bot_config_manifest/apply/` is touched. `uv.lock` and `pyproject.toml` are unmodified (`git diff --name-only` against the base returns nothing for either).
- Every line I added wraps within the surrounding style; the long lines that remain in these files were all present before this change.

Environment note: the default package index in `pyproject.toml` is an aliyun mirror unreachable from this sandbox, and `--index-url` does not override a named `default = true` index. `uv lock --default-index https://pypi.org/simple` (without `--upgrade`, so the pinned versions are preserved) followed by `uv sync` works; `uv.lock` was restored from git afterwards and verified clean before each commit.

## Compatibility and risk

None. No code, signatures, names, or ordering changed.

One behavioural constraint worth flagging for future doc edits: `test_cli_tools_materialiser.py::test_no_materialiser_names_an_engine` greps the **raw module source**, so an engine name in a `cli_tools.py` docstring fails it — even though `test_materialisers_name_no_engine.py` is AST-based and explicitly permits engine names in docstrings ("Docstrings and comments may *mention* an engine to explain a port's contract"). The two tests disagree. I worked within the stricter one and noted the constraint in the docstring; reconciling them is out of scope here.

## Observations not fixed

Noticed while reading; deliberately left alone per the comments-only scope.

1. **`FETCH_ENTRY_LIMITS` lookups are inconsistent between the two roads.** `source_fetchers.GitSourceFetcher.fetch` uses a total lookup, `FETCH_ENTRY_LIMITS[request.category]`, with a comment explaining that a missing member should raise rather than be papered over. `entry_fetch.acquire_object` does the opposite three lines of code away: `FETCH_ENTRY_LIMITS.get(category, FETCH_ENTRY_LIMITS["resources_file"])` — the silent narrowing-to-the-file-cap fallback that `DeclaredFetch.category`'s own comment says typing the field was meant to eliminate. Not currently reachable (the front door coerces to `FetchCategory` before any fetcher runs, and `StrEnum` members hash as their string value so the enum keys the string-keyed dict correctly), but the two sites state opposite policies.

2. **`FetchCategory.RESOURCES_UNPACKED` is never used as a fetch category.** Its docstring calls the enum "the closed vocabulary a fetch's category lives in", but this member is only ever read as a size constant — `FETCH_ENTRY_LIMITS["resources_unpacked"]` for `unpacked_size_limit` in `fetch/unpack.py` and `materialisers/skills.py`. No fetch is ever charged or capped under it. It is a limit wearing a category's clothes.

3. **`source_fetchers.substitute` is misnamed for what it does.** Its parameter is `source_url` and its docstring says "in a source URL", but `ObjectStoreFetcher.fetch` calls it on the bucket name and on the composed object key, neither of which is a URL. The behaviour is right; the name and signature describe a narrower job than the function has. I documented the wider actual usage rather than renaming.

4. **`source_fetchers`' module docstring referenced `:data:`FETCHERS`**, a name that does not exist — the table is `FETCHER_TYPES`. Corrected, since it is docstring text.

5. **`SourceResolution`'s docstring claimed it is "Empty in v1's URL wave — sources are inline URLs only".** That is stale: `SourceSession.adopt` fills it on every git road. Rewritten to describe what it actually carries (git sources only; the object-store road resolves no ref and contributes no row).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015J5SVbGkKQSqGPwuJWhCfY

---
_Generated by [Claude Code](https://claude.ai/code/session_015J5SVbGkKQSqGPwuJWhCfY)_