### PR TITLE
fix(bcs): remove dynamic status cache I/O from bot heartbeats

### DIFF
--- a/src/bcs/Cargo.lock
+++ b/src/bcs/Cargo.lock
@@ -491,7 +491,6 @@ dependencies = [
  "async-trait",
  "bcs-bot",
  "bcs-bot-store",
- "bcs-cache-local",
  "bcs-db-api",
  "bcs-friend",
  "bcs-group",
@@ -558,7 +557,6 @@ dependencies = [
  "async-trait",
  "bcs-bot",
  "bcs-bot-store",
- "bcs-cache-local",
  "bcs-db-api",
  "bcs-domain",
  "bcs-friend",
@@ -711,7 +709,6 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "bcs-bot-store",
- "bcs-cache-local",
  "bcs-config",
  "bcs-db-api",
  "bcs-db-local",
@@ -737,8 +734,6 @@ name = "bcs-bot-store"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "bcs-cache-api",
- "bcs-cache-local",
  "bcs-config",
  "bcs-db-api",
  "bcs-db-local",

--- a/src/bcs/crates/adapters/http/bcs-http/tests/bot_events_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/bot_events_contract.rs
@@ -1568,6 +1568,7 @@ async fn agentpass_resolve_returns_agent_code_binding_and_bot() {
     assert_eq!(body["provider_bot_binding"]["bot_uuid"], registered.bot_uuid);
     assert_eq!(body["bot"]["bot_uuid"], registered.bot_uuid);
     assert_eq!(body["bot"]["capabilities"]["name"], "Code Reviewer");
+    assert!(body["bot"].get("dynamic_status").is_none());
 }
 
 #[tokio::test]

--- a/src/bcs/crates/adapters/http/bcs-http/tests/route_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/route_contract.rs
@@ -1111,7 +1111,7 @@ async fn cancel_chat_run_route_uses_a2a_run_service() {
 }
 
 #[tokio::test]
-async fn bot_status_route_updates_dynamic_status_with_bot_token() {
+async fn bot_status_route_accepts_payload_without_retaining_it() {
     let temp_dir = TempDir::new().unwrap();
     let registry = Arc::new(BotCore::with_base_dir(temp_dir.path().to_path_buf()));
     registry
@@ -1161,13 +1161,12 @@ async fn bot_status_route_updates_dynamic_status_with_bot_token() {
     assert_eq!(json["updated"], true);
     assert_eq!(json["bot_uuid"], "bot-alpha");
     assert_eq!(json["status"]["status"], "busy");
+    assert_eq!(json["status"]["dynamic_summary"], "running task");
+    assert_eq!(json["status"]["load"], 0.75);
+    assert_eq!(json["status"]["updated_at"], 42);
 
     let stored = registry.get("bot-alpha").await.unwrap();
-    assert_eq!(stored.dynamic_status.status, "busy");
-    assert_eq!(
-        stored.dynamic_status.dynamic_summary.as_deref(),
-        Some("running task")
-    );
+    assert!(serde_json::to_value(stored).unwrap().get("dynamic_status").is_none());
 }
 
 #[tokio::test]

--- a/src/bcs/crates/application/v1/bcs-app-bot/tests/v1_bot_service.rs
+++ b/src/bcs/crates/application/v1/bcs-app-bot/tests/v1_bot_service.rs
@@ -355,7 +355,6 @@ fn search_hit(
                 visibility: "public".to_string(),
                 ..Default::default()
             },
-            dynamic_status: Default::default(),
             env: None,
             created_by: None,
             actor_kind: ActorKind::Bot,

--- a/src/bcs/crates/application/v1/bcs-app-group/Cargo.toml
+++ b/src/bcs/crates/application/v1/bcs-app-group/Cargo.toml
@@ -21,7 +21,6 @@ tracing = { workspace = true }
 [dev-dependencies]
 bcs-bot = { workspace = true }
 bcs-bot-store = { workspace = true }
-bcs-cache-local = { workspace = true }
 bcs-db-api = { workspace = true }
 bcs-friend = { workspace = true }
 bcs-group = { workspace = true }

--- a/src/bcs/crates/application/v1/bcs-app-group/tests/v1_group_service.rs
+++ b/src/bcs/crates/application/v1/bcs-app-group/tests/v1_group_service.rs
@@ -5,7 +5,6 @@ use std::sync::{Arc, Mutex};
 use async_trait::async_trait;
 use bcs_bot::BotCore;
 use bcs_bot_store::PersistentBotRepo;
-use bcs_cache_local::InMemoryCachePlugin;
 use bcs_db_api::{
     DbError, DbExecuteResult, DbHealth, DbPlugin, DbResult, DbRow, DbStatement, DbTransactionStep,
     DbTransactionStepResult, DbValue,
@@ -1261,7 +1260,7 @@ async fn get_public_group_readable_without_participation() {
 #[tokio::test]
 async fn group_detail_propagates_owned_bot_lookup_database_failure() {
     let bots = Arc::new(BotCore::with_repo(Arc::new(
-        PersistentBotRepo::with_plugins(Arc::new(InMemoryCachePlugin::new()), Arc::new(FailingDb)),
+        PersistentBotRepo::new(Arc::new(FailingDb)),
     )));
     let fixture = Fixture::new_with_bots(bots).await;
     fixture
@@ -2245,7 +2244,7 @@ async fn explicit_view_requires_the_target_bot_to_exist_and_be_owned() {
 #[tokio::test]
 async fn explicit_view_propagates_registry_database_failure() {
     let bots = Arc::new(BotCore::with_repo(Arc::new(
-        PersistentBotRepo::with_plugins(Arc::new(InMemoryCachePlugin::new()), Arc::new(FailingDb)),
+        PersistentBotRepo::new(Arc::new(FailingDb)),
     )));
     let fixture = Fixture::new_with_bots(bots).await;
 
@@ -2307,10 +2306,7 @@ async fn create_group_propagates_quota_lookup_database_failure() {
 #[tokio::test]
 async fn create_group_propagates_non_driver_registry_database_failure() {
     let bots = Arc::new(BotCore::with_repo(Arc::new(
-        PersistentBotRepo::with_plugins(
-            Arc::new(InMemoryCachePlugin::new()),
-            Arc::new(DriverThenFailingDb::default()),
-        ),
+        PersistentBotRepo::new(Arc::new(DriverThenFailingDb::default())),
     )));
     let fixture = Fixture::new_with_bots(bots).await;
 
@@ -2350,10 +2346,7 @@ async fn create_group_propagates_non_driver_registry_database_failure() {
 #[tokio::test]
 async fn bot_dm_propagates_caller_registry_failure_after_target_validation() {
     let bots = Arc::new(BotCore::with_repo(Arc::new(
-        PersistentBotRepo::with_plugins(
-            Arc::new(InMemoryCachePlugin::new()),
-            Arc::new(DriverThenFailingDb::default()),
-        ),
+        PersistentBotRepo::new(Arc::new(DriverThenFailingDb::default())),
     )));
     let fixture = Fixture::new_with_bots(bots).await;
 

--- a/src/bcs/crates/application/v1/bcs-app-session/Cargo.toml
+++ b/src/bcs/crates/application/v1/bcs-app-session/Cargo.toml
@@ -20,7 +20,6 @@ tracing = { workspace = true }
 [dev-dependencies]
 bcs-bot = { workspace = true }
 bcs-bot-store = { workspace = true }
-bcs-cache-local = { workspace = true }
 bcs-db-api = { workspace = true }
 bcs-friend = { workspace = true }
 bcs-group = { workspace = true }

--- a/src/bcs/crates/application/v1/bcs-app-session/tests/v1_session_service.rs
+++ b/src/bcs/crates/application/v1/bcs-app-session/tests/v1_session_service.rs
@@ -12,7 +12,6 @@ use async_trait::async_trait;
 use bcs_app_session::{SessionServiceConfig, SessionServiceImpl};
 use bcs_bot::BotCore;
 use bcs_bot_store::PersistentBotRepo;
-use bcs_cache_local::InMemoryCachePlugin;
 use bcs_db_api::{
     DbError, DbExecuteResult, DbHealth, DbPlugin, DbResult, DbRow, DbStatement, DbTransactionStep,
     DbTransactionStepResult,
@@ -1066,7 +1065,7 @@ async fn session_detail_preserves_legacy_json_input_and_metadata() {
 #[tokio::test]
 async fn session_detail_propagates_owned_bot_lookup_database_failure() {
     let bots = Arc::new(BotCore::with_repo(Arc::new(
-        PersistentBotRepo::with_plugins(Arc::new(InMemoryCachePlugin::new()), Arc::new(FailingDb)),
+        PersistentBotRepo::new(Arc::new(FailingDb)),
     )));
     let fixture = Fixture::new_with_bots(bots).await;
     fixture.store_group("g1", "driver", None).await;

--- a/src/bcs/crates/bootstrap/bcs/src/server.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/server.rs
@@ -4106,11 +4106,9 @@ impl BcsServer {
             .unwrap_or_else(|| Arc::new(bcs_cache_local::InMemoryCachePlugin::new()));
         let cache_key_prefix = config.cache.redis.effective_key_prefix();
         info!(db_plugin = %db_kind, "Initializing DB-backed bot registry");
-        let bot_repo = Arc::new(PersistentBotRepo::with_plugins_flavor_and_cache_key_prefix(
-            cache_plugin.clone(),
+        let bot_repo = Arc::new(PersistentBotRepo::with_sql_flavor(
             db_plugin.clone(),
             db_flavor,
-            cache_key_prefix.clone(),
         ));
         let control_plane_repo: Arc<dyn BotControlPlaneRepoPort> = bot_repo.clone();
         let bot_metrics_snapshot: Arc<dyn BotMetricsSnapshotPort> = bot_repo.clone();

--- a/src/bcs/crates/bootstrap/bcs/tests/human_actor_orthogonality_integration.rs
+++ b/src/bcs/crates/bootstrap/bcs/tests/human_actor_orthogonality_integration.rs
@@ -62,7 +62,6 @@ impl MutableRegistry {
         let row = RegisteredBot {
             bot_uuid: bot_uuid.to_string(),
             capabilities: caps,
-            dynamic_status: BotDynamicStatus::default(),
             env: None,
             created_by: None,
             actor_kind,

--- a/src/bcs/crates/bootstrap/bcs/tests/human_friend_dual_write_integration.rs
+++ b/src/bcs/crates/bootstrap/bcs/tests/human_friend_dual_write_integration.rs
@@ -56,7 +56,6 @@ impl TestRegistry {
         let row = RegisteredBot {
             bot_uuid: bot_uuid.to_string(),
             capabilities: caps,
-            dynamic_status: BotDynamicStatus::default(),
             env: None,
             created_by: None,
             actor_kind,

--- a/src/bcs/crates/contracts/bcs-domain/src/registry.rs
+++ b/src/bcs/crates/contracts/bcs-domain/src/registry.rs
@@ -180,8 +180,8 @@ where
     deserializer.deserialize_seq(SkillsVisitor)
 }
 
-/// Dynamic bot status for real-time discovery.
-/// This is updated periodically (less frequently than heartbeat).
+/// Legacy status heartbeat payload accepted for wire compatibility.
+/// Repositories refresh liveness without retaining this payload.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct BotDynamicStatus {
     /// Current status (e.g., "idle", "busy", "offline").
@@ -221,8 +221,6 @@ pub struct RegisteredBot {
     pub bot_uuid: String,
     /// Bot capabilities for discovery.
     pub capabilities: BotCapabilities,
-    /// Dynamic status updated periodically.
-    pub dynamic_status: BotDynamicStatus,
     /// Server environment (prod, gray, pre, dev).
     pub env: Option<String>,
     /// User who created this bot (staff_no). Set during onboard, immutable.

--- a/src/bcs/crates/service-api/bcs-service-api/src/core/registry.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/core/registry.rs
@@ -112,7 +112,7 @@ pub trait BotRegistryCoreService: Send + Sync {
         })
     }
 
-    /// Update a bot's dynamic status.
+    /// Renew a known registration heartbeat. The legacy payload is not retained.
     async fn update_status(&self, bot_id: &str, status: BotDynamicStatus) -> bool;
 
     /// Get a bot's registration info.

--- a/src/bcs/crates/service-api/bcs-service-api/src/port/repo/bot.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/port/repo/bot.rs
@@ -48,6 +48,7 @@ pub trait BotRepoPort: Send + Sync {
         self.register(bot_id.to_string(), capabilities).await
     }
 
+    /// Renew a known registration heartbeat. The legacy payload is not retained.
     async fn update_status(&self, bot_id: &str, status: BotDynamicStatus) -> bool;
     async fn get(&self, bot_id: &str) -> Option<RegisteredBot>;
 

--- a/src/bcs/crates/service-api/bcs-service-api/tests/candidate_search_core_contract.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/tests/candidate_search_core_contract.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 
 use async_trait::async_trait;
 use bcs_service_api::{
-    ActorKind, ActorStatus, BotCandidateVisibility, BotCapabilities, BotDynamicStatus,
+    ActorKind, ActorStatus, BotCandidateVisibility, BotCapabilities,
     RegisteredBot, ServiceResult, WorkerProfile as RootWorkerProfile,
     WorkerProfileService as RootWorkerProfileService,
     WorkerRecommendCommand as RootWorkerRecommendCommand,
@@ -45,7 +45,6 @@ fn candidate_hit() -> BotCandidateSearchHit {
         bot: RegisteredBot {
             bot_uuid: "bot-2".to_string(),
             capabilities: BotCapabilities::default(),
-            dynamic_status: BotDynamicStatus::default(),
             env: Some("pre".to_string()),
             created_by: Some("staff-1".to_string()),
             actor_kind: ActorKind::Bot,

--- a/src/bcs/crates/services/bcs-bot-store/Cargo.toml
+++ b/src/bcs/crates/services/bcs-bot-store/Cargo.toml
@@ -10,7 +10,6 @@ version = { workspace = true }
 [dependencies]
 bcs-observability = { workspace = true }
 async-trait = { workspace = true }
-bcs-cache-api = { workspace = true }
 bcs-config = { workspace = true }
 bcs-db-api = { workspace = true }
 bcs-service-api = { workspace = true }
@@ -21,7 +20,6 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 
 [dev-dependencies]
-bcs-cache-local = { workspace = true }
 bcs-db-local = { workspace = true }
 bcs-test-support = { workspace = true, features = ["diagnostic-logs"] }
 tempfile = { workspace = true }

--- a/src/bcs/crates/services/bcs-bot-store/src/lib.rs
+++ b/src/bcs/crates/services/bcs-bot-store/src/lib.rs
@@ -20,7 +20,6 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::{RwLock, oneshot};
 use tracing::{debug, info, warn};
 
-use bcs_cache_api::CachePlugin;
 use bcs_config::resolve_env_str as resolve_env;
 use bcs_db_api::{
     DbPlugin, DbRow, DbSqlFlavor, DbStatement, DbValue as Value, db_get_column, db_get_column_opt,
@@ -245,19 +244,13 @@ pub struct PersistentBotRepo {
 }
 
 impl PersistentBotRepo {
-    /// Create a DB-backed repository; the legacy cache argument is unused.
-    pub fn with_plugins(
-        cache: Arc<dyn CachePlugin>,
-        db: Arc<dyn DbPlugin>,
-    ) -> Self {
-        Self::with_plugins_flavor(cache, db, DbSqlFlavor::Mysql)
+    /// Create a DB-backed repository using the MySQL dialect.
+    pub fn new(db: Arc<dyn DbPlugin>) -> Self {
+        Self::with_sql_flavor(db, DbSqlFlavor::Mysql)
     }
 
     /// Create a DB-backed repository with the selected SQL flavor.
-    /// The legacy cache argument is accepted for composition-root compatibility
-    /// but is not retained or used by the repository.
-    pub fn with_plugins_flavor(
-        _cache: Arc<dyn CachePlugin>,
+    pub fn with_sql_flavor(
         db: Arc<dyn DbPlugin>,
         flavor: DbSqlFlavor,
     ) -> Self {
@@ -270,25 +263,6 @@ impl PersistentBotRepo {
             flavor,
             pending_requests: RwLock::new(HashMap::new()),
         }
-    }
-
-    /// Compatibility constructor; the former status-cache prefix is ignored.
-    pub fn with_plugins_flavor_and_cache_key_prefix(
-        cache: Arc<dyn CachePlugin>,
-        db: Arc<dyn DbPlugin>,
-        flavor: DbSqlFlavor,
-        _cache_key_prefix: impl Into<String>,
-    ) -> Self {
-        Self::with_plugins_flavor(cache, db, flavor)
-    }
-
-    /// Create a new distributed registry.
-    pub fn new(
-        cache: Arc<dyn CachePlugin>,
-        db: Arc<dyn DbPlugin>,
-        _legacy_db: String,
-    ) -> Self {
-        Self::with_plugins(cache, db)
     }
 
     async fn db_query(&self, sql: &str, params: Vec<Value>) -> bcs_db_api::DbResult<Vec<DbRow>> {
@@ -2329,7 +2303,7 @@ impl BotRepoPort for PersistentBotRepo {
         let result = self.find_bot_by_token_in_db(token).await;
         if result.is_none() {
             let prefix = &token[..8.min(token.len())];
-            warn!(request_id = %bcs_observability::CurrentRequestId, token_prefix = %prefix, "find_bot_by_token: token not found in any layer (cache/memory/database)");
+            warn!(request_id = %bcs_observability::CurrentRequestId, token_prefix = %prefix, "find_bot_by_token: token not found in memory or database");
         }
         result
     }
@@ -3483,7 +3457,7 @@ impl BotControlPlaneRepoPort for PersistentBotRepo {
 mod tests {
     use super::*;
 
-    // Note: These tests require external cache and database connections.
+    // Note: These tests require external database connections.
     // Run with: cargo test --package bcs-bot -- --ignored
 
     #[test]
@@ -3793,14 +3767,14 @@ mod tests {
         assert_eq!(parsed.scopes, bot_info.scopes);
     }
 
-    // ===== Integration tests (require external cache and database) =====
+    // ===== Integration tests (require external database) =====
     // Run with: cargo test --package bcs-bot -- --ignored
 
     #[tokio::test]
-    #[ignore = "Requires external cache and database connections"]
+    #[ignore = "Requires external database connections"]
     async fn integration_test_register_and_retrieve() {
         // This test documents the expected workflow:
-        // 1. Create PersistentBotRepo with CachePlugin and DbPlugin handles
+        // 1. Create PersistentBotRepo with a DbPlugin handle
         // 2. Register a bot
         // 3. Retrieve the bot from memory (fast path)
         // 4. Verify capabilities are persisted to the database
@@ -3820,7 +3794,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "Requires external cache and database connections"]
+    #[ignore = "Requires external database connections"]
     async fn integration_test_token_persistence() {
         // This test documents the expected workflow:
         // 1. Register WS connection (generates token)
@@ -3837,14 +3811,14 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "Requires external cache and database connections"]
+    #[ignore = "Requires external database connections"]
     async fn integration_test_reconnect_streaming_recover_from_storage() {
         // This test documents the failover recovery workflow:
-        // 1. Bot connects and has capabilities in database, status in cache
+        // 1. Bot connects and persists capabilities and its token in the database
         // 2. WS disconnects (but token is preserved)
         // 3. Server restarts (memory cleared)
         // 4. Bot reconnects with existing token
-        // 5. Server recovers capabilities from database and status from cache
+        // 5. Server recovers capabilities and its token from the database, then renews liveness
         //
         // Example:
         // let (tx, _rx) = mpsc::channel(10);
@@ -3860,7 +3834,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "Requires external cache and database connections"]
+    #[ignore = "Requires external database connections"]
     async fn integration_test_sql_injection_protection() {
         // This test documents SQL injection protection:
         // Bot IDs and other fields are escaped before SQL queries

--- a/src/bcs/crates/services/bcs-bot-store/src/lib.rs
+++ b/src/bcs/crates/services/bcs-bot-store/src/lib.rs
@@ -1,7 +1,6 @@
 //! Plugin-backed bot repository implementation.
 //!
 //! This module provides a bot repository backed by:
-//! - **Cache plugin**: Dynamic status with TTL for failover recovery
 //! - **Database plugin**: Persistent storage for bot capabilities and tokens
 //! - **Process Memory**: streaming connection state and heartbeat tracking
 //!
@@ -9,20 +8,19 @@
 //!
 //! ```text
 //! Layer 1 (Memory):    ws_connection, last_heartbeat, token_to_bot mapping
-//! Layer 2 (Cache):     dynamic_status (TTL 600s)
-//! Layer 3 (Database):  bot_info JSON, session_token, name
+//! Layer 2 (Database):  bot_info JSON, session_token, name
 //! ```
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use tokio::sync::{RwLock, oneshot};
 use tracing::{debug, info, warn};
 
-use bcs_cache_api::{CacheError, CachePlugin};
+use bcs_cache_api::CachePlugin;
 use bcs_config::resolve_env_str as resolve_env;
 use bcs_db_api::{
     DbPlugin, DbRow, DbSqlFlavor, DbStatement, DbValue as Value, db_get_column, db_get_column_opt,
@@ -45,21 +43,16 @@ fn log_bot_cache_source(source: &'static str) {
 pub mod memory;
 pub mod provider;
 
+#[cfg(test)]
+#[path = "../tests/unit/heartbeat.rs"]
+mod heartbeat_tests;
+
 pub use bcs_service_api::port::repo::BotRepoPort;
 pub use memory::MemoryBotRepo;
 pub use provider::{DbProviderStore, MemoryProviderStore};
 
 /// Maximum time before a bot registration expires (5 minutes).
 const BOT_EXPIRY: Duration = Duration::from_secs(300);
-
-/// Cache TTL for dynamic status (10 minutes = 10x heartbeat interval).
-const STATUS_CACHE_TTL_SECONDS: i64 = 600;
-
-/// Default cache key prefix used by legacy constructors.
-const DEFAULT_CACHE_KEY_PREFIX: &str = "bcs:";
-
-/// Cache key namespace for bot status.
-const STATUS_CACHE_KEY_NAMESPACE: &str = "status:";
 
 fn bot_info_json_set(
     updates: Vec<(&'static str, serde_json::Value)>,
@@ -154,8 +147,6 @@ struct RegisteredBotInner {
     last_heartbeat: Instant,
     /// Bot capabilities (loaded from database).
     capabilities: BotCapabilities,
-    /// Dynamic status (synced to cache).
-    dynamic_status: BotDynamicStatus,
     /// Active streaming connection (if connected).
     ws_connection: Option<BotConnection>,
     /// Session token (persisted in database).
@@ -218,7 +209,6 @@ impl RegisteredBotInner {
         RegisteredBot {
             bot_uuid: self.bot_uuid.clone(),
             capabilities,
-            dynamic_status: self.dynamic_status.clone(),
             env: self.env.clone(),
             created_by: self.created_by.clone(),
             actor_kind: self.actor_kind,
@@ -227,12 +217,11 @@ impl RegisteredBotInner {
     }
 }
 
-/// Persistent bot repository backed by cache and DB plugins.
+/// Persistent bot repository backed by a DB plugin.
 ///
-/// Uses a three-layer storage architecture:
-/// - Layer 1: Process memory for WebSocket connections and heartbeats
-/// - Layer 2: Cache plugin for dynamic status with TTL
-/// - Layer 3: Database plugin for persistent capabilities and tokens
+/// Process memory holds WebSocket connections and heartbeat timestamps;
+/// the database holds persistent capabilities and tokens. Heartbeat payloads
+/// are neither retained nor written to an external cache.
 pub struct PersistentBotRepo {
     // Layer 1: Process Memory
     /// Bot connections and state.
@@ -244,13 +233,7 @@ pub struct PersistentBotRepo {
     /// Process-local runtime info, e.g. client_kind from bot.connect.
     bot_info_overrides: RwLock<HashMap<(String, String), String>>,
 
-    // Layer 2: Cache
-    /// Cache plugin for dynamic status storage.
-    cache: Arc<dyn CachePlugin>,
-    /// Business cache key prefix resolved from configuration.
-    cache_key_prefix: String,
-
-    // Layer 3: Database
+    // Layer 2: Database
     /// DB plugin for persistent storage.
     db: Arc<dyn DbPlugin>,
 
@@ -262,7 +245,7 @@ pub struct PersistentBotRepo {
 }
 
 impl PersistentBotRepo {
-    /// Create a new persistent bot repository with cache and DB plugins.
+    /// Create a DB-backed repository; the legacy cache argument is unused.
     pub fn with_plugins(
         cache: Arc<dyn CachePlugin>,
         db: Arc<dyn DbPlugin>,
@@ -270,38 +253,33 @@ impl PersistentBotRepo {
         Self::with_plugins_flavor(cache, db, DbSqlFlavor::Mysql)
     }
 
-    /// Create a new persistent bot repository with cache, DB plugins, and SQL flavor.
+    /// Create a DB-backed repository with the selected SQL flavor.
+    /// The legacy cache argument is accepted for composition-root compatibility
+    /// but is not retained or used by the repository.
     pub fn with_plugins_flavor(
-        cache: Arc<dyn CachePlugin>,
+        _cache: Arc<dyn CachePlugin>,
         db: Arc<dyn DbPlugin>,
         flavor: DbSqlFlavor,
-    ) -> Self {
-        Self::with_plugins_flavor_and_cache_key_prefix(
-            cache,
-            db,
-            flavor,
-            DEFAULT_CACHE_KEY_PREFIX,
-        )
-    }
-
-    /// Create a new distributed registry with an explicit business cache key prefix.
-    pub fn with_plugins_flavor_and_cache_key_prefix(
-        cache: Arc<dyn CachePlugin>,
-        db: Arc<dyn DbPlugin>,
-        flavor: DbSqlFlavor,
-        cache_key_prefix: impl Into<String>,
     ) -> Self {
         Self {
             bots: RwLock::new(HashMap::new()),
             token_to_bot: RwLock::new(HashMap::new()),
             binding_channel_index: Arc::new(RwLock::new(HashMap::new())),
             bot_info_overrides: RwLock::new(HashMap::new()),
-            cache,
-            cache_key_prefix: cache_key_prefix.into(),
             db,
             flavor,
             pending_requests: RwLock::new(HashMap::new()),
         }
+    }
+
+    /// Compatibility constructor; the former status-cache prefix is ignored.
+    pub fn with_plugins_flavor_and_cache_key_prefix(
+        cache: Arc<dyn CachePlugin>,
+        db: Arc<dyn DbPlugin>,
+        flavor: DbSqlFlavor,
+        _cache_key_prefix: impl Into<String>,
+    ) -> Self {
+        Self::with_plugins_flavor(cache, db, flavor)
     }
 
     /// Create a new distributed registry.
@@ -311,28 +289,6 @@ impl PersistentBotRepo {
         _legacy_db: String,
     ) -> Self {
         Self::with_plugins(cache, db)
-    }
-
-    /// Get current timestamp in milliseconds.
-    fn current_timestamp() -> u64 {
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map(|d| d.as_millis() as u64)
-            .unwrap_or(0)
-    }
-
-    /// Build cache key for bot status.
-    #[cfg(test)]
-    fn status_cache_key(bot_uuid: &str) -> String {
-        Self::status_cache_key_with_prefix(DEFAULT_CACHE_KEY_PREFIX, bot_uuid)
-    }
-
-    fn configured_status_cache_key(&self, bot_uuid: &str) -> String {
-        Self::status_cache_key_with_prefix(&self.cache_key_prefix, bot_uuid)
-    }
-
-    fn status_cache_key_with_prefix(cache_key_prefix: &str, bot_uuid: &str) -> String {
-        format!("{}{}{}", cache_key_prefix, STATUS_CACHE_KEY_NAMESPACE, bot_uuid)
     }
 
     async fn db_query(&self, sql: &str, params: Vec<Value>) -> bcs_db_api::DbResult<Vec<DbRow>> {
@@ -348,19 +304,6 @@ impl PersistentBotRepo {
             .execute(DbStatement::with_params(sql, params))
             .await
             .map(|result| result.affected_rows)
-    }
-
-    fn cache_hash_to_strings(
-        fields: BTreeMap<String, Vec<u8>>,
-    ) -> Result<HashMap<String, String>, CacheError> {
-        fields
-            .into_iter()
-            .map(|(field, value)| {
-                String::from_utf8(value)
-                    .map(|value| (field, value))
-                    .map_err(|err| CacheError::Backend(err.to_string()))
-            })
-            .collect()
     }
 
     /// Save bot capabilities to the configured database.
@@ -654,87 +597,6 @@ impl PersistentBotRepo {
             .flatten()
     }
 
-    /// Save dynamic status to the configured cache.
-    async fn save_status_to_cache(&self, bot_uuid: &str, status: &BotDynamicStatus) {
-        let key = self.configured_status_cache_key(bot_uuid);
-        let now = Self::current_timestamp();
-        let started = Instant::now();
-        let mut failed_commands = 0u64;
-
-        // HSET multiple fields
-        if let Err(..) = self
-            .cache
-            .hash_set(&key, "status", status.status.as_bytes().to_vec())
-            .await
-        {
-            warn!(target: "bcs_observation", request_id = %bcs_observability::current_request_id(), failed_commands = 1, outcome = "error", duration_ms = started.elapsed().as_secs_f64() * 1000.0, "bot_status.save.finished");
-            return;
-        }
-
-        if let Some(ref summary) = status.dynamic_summary {
-            let result = self
-                .cache
-                .hash_set(&key, "dynamic_summary", summary.as_bytes().to_vec())
-                .await;
-            failed_commands += u64::from(result.is_err());
-        }
-        if let Some(load) = status.load {
-            let result = self
-                .cache
-                .hash_set(&key, "load", load.to_string().into_bytes())
-                .await;
-            failed_commands += u64::from(result.is_err());
-        }
-        let result = self
-            .cache
-            .hash_set(&key, "updated_at", now.to_string().into_bytes())
-            .await;
-        failed_commands += u64::from(result.is_err());
-
-        // Set TTL
-        let result = self
-            .cache
-            .expire(&key, Duration::from_secs(STATUS_CACHE_TTL_SECONDS as u64))
-            .await;
-        failed_commands += u64::from(result.is_err());
-
-        if failed_commands > 0 {
-            warn!(target: "bcs_observation", request_id = %bcs_observability::current_request_id(), failed_commands, outcome = "partial_failure", duration_ms = started.elapsed().as_secs_f64() * 1000.0, "bot_status.save.finished");
-        } else {
-            debug!(target: "bcs_observation", request_id = %bcs_observability::current_request_id(), failed_commands, outcome = "success", duration_ms = started.elapsed().as_secs_f64() * 1000.0, "bot_status.save.finished");
-        }
-    }
-
-    /// Load dynamic status from the configured cache.
-    async fn load_status_from_cache(&self, bot_uuid: &str) -> BotDynamicStatus {
-        let key = self.configured_status_cache_key(bot_uuid);
-
-        let raw = match bcs_observability::observe_result("bot_status.cache_read", self.cache.hash_get_all(&key)).await {
-            Ok(raw) => raw,
-            Err(_) => {
-                bcs_observability::count("bot_status.fallback", "cache_error");
-                warn!(target: "bcs_observation", request_id = %bcs_observability::current_request_id(), outcome = "cache_error", fallback = "default_status", "bot_status.load.fallback");
-                return BotDynamicStatus::default();
-            }
-        };
-        match bcs_observability::observe_result("bot_status.decode", async { Self::cache_hash_to_strings(raw) }).await {
-            Ok(map) => {
-                bcs_observability::count("bot_status.cache", if map.is_empty() { "empty" } else { "hit" });
-                BotDynamicStatus {
-                    status: map.get("status").cloned().unwrap_or_default(),
-                    dynamic_summary: map.get("dynamic_summary").cloned(),
-                    load: map.get("load").and_then(|s| s.parse().ok()),
-                    updated_at: map.get("updated_at").and_then(|s| s.parse().ok()),
-                }
-            }
-            Err(_) => {
-                bcs_observability::count("bot_status.fallback", "decode_error");
-                warn!(target: "bcs_observation", request_id = %bcs_observability::current_request_id(), outcome = "decode_error", fallback = "default_status", "bot_status.load.fallback");
-                BotDynamicStatus::default()
-            }
-        }
-    }
-
     /// Read the `bot_info` JSON column for a given bot, parsed as a JSON object.
     /// Returns `None` if the row is missing, the column is NULL, or JSON parsing fails.
     async fn read_bot_info_json(&self, bot_uuid: &str) -> Option<serde_json::Value> {
@@ -895,7 +757,6 @@ impl PersistentBotRepo {
                         agent_code: None,
                         agent_token: None,
                     },
-                    dynamic_status: BotDynamicStatus::default(),
                     env,
                     created_by,
                     actor_kind,
@@ -1209,7 +1070,6 @@ impl PersistentBotRepo {
                     agent_code: None,
                     agent_token: None,
                 },
-                dynamic_status: BotDynamicStatus::default(),
                 env,
                 created_by,
                 actor_kind,
@@ -1368,7 +1228,6 @@ impl BotRepoPort for PersistentBotRepo {
                     bot_uuid: bot_id.clone(),
                     last_heartbeat: Instant::now(),
                     capabilities: caps,
-                    dynamic_status: BotDynamicStatus::default(),
                     ws_connection: None,
                     session_token: None,
                     env: Some(resolve_env()),
@@ -1491,7 +1350,6 @@ impl BotRepoPort for PersistentBotRepo {
                         bot_uuid: bot_id.clone(),
                         last_heartbeat: Instant::now(),
                         capabilities: caps,
-                        dynamic_status: BotDynamicStatus::default(),
                         ws_connection: None,
                         session_token: Some(token.to_string()),
                         env: Some(resolve_env()),
@@ -1515,12 +1373,11 @@ impl BotRepoPort for PersistentBotRepo {
         Ok(())
     }
 
-    async fn update_status(&self, bot_id: &str, status: BotDynamicStatus) -> bool {
+    async fn update_status(&self, bot_id: &str, _status: BotDynamicStatus) -> bool {
         // Update memory
         {
             let mut bots = self.bots.write().await;
             if let Some(bot) = bots.get_mut(bot_id) {
-                bot.dynamic_status = status.clone();
                 bot.last_heartbeat = Instant::now();
             } else {
                 debug!(bot_id = %bot_id, "Bot not found for status update");
@@ -1528,10 +1385,7 @@ impl BotRepoPort for PersistentBotRepo {
             }
         }
 
-        // Save to cache with TTL
-        self.save_status_to_cache(bot_id, &status).await;
-
-        debug!(bot_id = %bot_id, "Bot dynamic status updated");
+        debug!(bot_id = %bot_id, "Bot heartbeat renewed");
         true
     }
 
@@ -1568,7 +1422,7 @@ impl BotRepoPort for PersistentBotRepo {
             }
         }
 
-        // Fallback: load from database + cache
+        // Fallback: load persistent registration details from the database
         drop(bots);
         log_bot_cache_source("memory_miss");
 
@@ -1580,7 +1434,6 @@ impl BotRepoPort for PersistentBotRepo {
         else {
             return Ok(None);
         };
-        let dynamic_status = self.load_status_from_cache(bot_id).await;
 
         // 清除敏感字段，防止通过常规接口泄露
         capabilities.agent_token = None;
@@ -1588,7 +1441,6 @@ impl BotRepoPort for PersistentBotRepo {
         Ok(Some(RegisteredBot {
             bot_uuid: bot_id.to_string(),
             capabilities,
-            dynamic_status,
             env,
             created_by,
             actor_kind,
@@ -1618,7 +1470,6 @@ impl BotRepoPort for PersistentBotRepo {
 
         let (mut capabilities, env, _hidden, created_by, actor_kind, status) =
             self.load_from_db(bot_id, true).await?;
-        let dynamic_status = self.load_status_from_cache(bot_id).await;
 
         // 清除敏感字段，防止通过常规接口泄露
         capabilities.agent_code = None;
@@ -1627,7 +1478,6 @@ impl BotRepoPort for PersistentBotRepo {
         Some(RegisteredBot {
             bot_uuid: bot_id.to_string(),
             capabilities,
-            dynamic_status,
             env,
             created_by,
             actor_kind,
@@ -1802,7 +1652,6 @@ impl BotRepoPort for PersistentBotRepo {
                         agent_code: None,
                         agent_token: None,
                     },
-                    dynamic_status: BotDynamicStatus::default(),
                     env,
                     created_by,
                     actor_kind,
@@ -1815,8 +1664,8 @@ impl BotRepoPort for PersistentBotRepo {
     async fn list_bots_by_creator(&self, created_by: &str) -> Vec<RegisteredBot> {
         let current_env = resolve_env();
         // D-F: unified DB query — always query the database to include offline bots.
-        // InMemory dynamic_status is supplemented at the handler layer via
-        // `bot_is_effectively_online`, not here.
+        // User-facing online status is computed from runtime connectivity at
+        // the application layer, not persisted heartbeat payloads.
         match self
             .list_bots_by_creator_from_db(created_by, &current_env)
             .await
@@ -1852,11 +1701,6 @@ impl BotRepoPort for PersistentBotRepo {
                     .unwrap_or(false)
                     || b.capabilities
                         .summary
-                        .as_ref()
-                        .map(|s| s.to_lowercase().contains(&query_lower))
-                        .unwrap_or(false)
-                    || b.dynamic_status
-                        .dynamic_summary
                         .as_ref()
                         .map(|s| s.to_lowercase().contains(&query_lower))
                         .unwrap_or(false)
@@ -2346,7 +2190,6 @@ impl BotRepoPort for PersistentBotRepo {
                         agent_code: None,
                         agent_token: None,
                     },
-                    dynamic_status: BotDynamicStatus::default(),
                     env: Some(env.to_string()),
                     created_by,
                     actor_kind,
@@ -2565,7 +2408,6 @@ impl BotRepoPort for PersistentBotRepo {
                         bot_uuid: bot_id.clone(),
                         last_heartbeat: Instant::now(),
                         capabilities: BotCapabilities::default(),
-                        dynamic_status: BotDynamicStatus::default(),
                         status: bcs_service_api::ActorStatus::Online,
                         actor_kind: bcs_service_api::ActorKind::Bot,
                         ws_connection: Some(BotConnection {
@@ -2626,7 +2468,6 @@ impl BotRepoPort for PersistentBotRepo {
                             bot_uuid: bot_id.clone(),
                             last_heartbeat: Instant::now(),
                             capabilities: BotCapabilities::default(),
-                            dynamic_status: BotDynamicStatus::default(),
                             status: bcs_service_api::ActorStatus::Online,
                             actor_kind: bcs_service_api::ActorKind::Bot,
                             ws_connection: Some(BotConnection {
@@ -2710,7 +2551,6 @@ impl BotRepoPort for PersistentBotRepo {
                     bot_uuid: bot_id.clone(),
                     last_heartbeat: Instant::now(),
                     capabilities: BotCapabilities::default(),
-                    dynamic_status: BotDynamicStatus::default(),
                     status: bcs_service_api::ActorStatus::Online,
                     actor_kind: bcs_service_api::ActorKind::Bot,
                     ws_connection: Some(BotConnection {
@@ -2767,7 +2607,7 @@ impl BotRepoPort for PersistentBotRepo {
             bot.last_heartbeat = Instant::now();
             info!(bot_id = %bot_id, "reconnect_streaming: updated existing bot in memory");
         } else {
-            // Bot not in memory - load from database and cache
+            // Bot not in memory - load persistent registration details from the database
             drop(bots);
 
             // Code-Review fix #1: capture actor_kind/status from the database so the
@@ -2782,7 +2622,6 @@ impl BotRepoPort for PersistentBotRepo {
                     bcs_service_api::ActorKind::Bot,
                     bcs_service_api::ActorStatus::Online,
                 ));
-            let dynamic_status = self.load_status_from_cache(&bot_id).await;
 
             info!(bot_id = %bot_id, caps_loaded = capabilities.name.is_some(), "reconnect_streaming: loaded capabilities from storage");
 
@@ -2793,7 +2632,6 @@ impl BotRepoPort for PersistentBotRepo {
                     bot_uuid: bot_id.clone(),
                     last_heartbeat: Instant::now(),
                     capabilities,
-                    dynamic_status,
                     ws_connection: Some(BotConnection {
                         session_token: existing_token.clone(),
                         connected_at: Instant::now(),
@@ -2873,7 +2711,6 @@ impl BotRepoPort for PersistentBotRepo {
                         bot_uuid: bot_id.clone(),
                         last_heartbeat: Instant::now(),
                         capabilities: BotCapabilities::default(),
-                        dynamic_status: BotDynamicStatus::default(),
                         ws_connection: None,
                         session_token: Some(token.clone()),
                         env: Some(resolve_env()),
@@ -3673,41 +3510,11 @@ mod tests {
     }
 
     #[test]
-    fn test_status_cache_key_format() {
-        let key = PersistentBotRepo::status_cache_key("bot-123");
-        assert_eq!(key, "bcs:status:bot-123");
-    }
-
-    #[test]
-    fn test_status_cache_key_uses_configured_prefix() {
-        let key = PersistentBotRepo::status_cache_key_with_prefix("tenant:", "bot-123");
-        assert_eq!(key, "tenant:status:bot-123");
-    }
-
-    #[test]
-    fn test_registry_status_cache_key_uses_constructor_prefix() {
-        let cache = Arc::new(bcs_cache_local::InMemoryCachePlugin::new());
-        let db = Arc::new(bcs_db_local::LocalSqliteDbPlugin::new().unwrap());
-        let registry = PersistentBotRepo::with_plugins_flavor_and_cache_key_prefix(
-            cache,
-            db,
-            DbSqlFlavor::Sqlite,
-            "tenant:",
-        );
-
-        assert_eq!(
-            registry.configured_status_cache_key("bot-123"),
-            "tenant:status:bot-123"
-        );
-    }
-
-    #[test]
     fn test_bot_inner_expiry() {
         let bot = RegisteredBotInner {
             bot_uuid: "test".to_string(),
             last_heartbeat: Instant::now(),
             capabilities: BotCapabilities::default(),
-            dynamic_status: BotDynamicStatus::default(),
             ws_connection: None,
             session_token: None,
             env: None,
@@ -3732,7 +3539,6 @@ mod tests {
                 skills: vec![Skill::new("SQL Analysis"), Skill::new("Deadlock Debugging")],
                 ..Default::default()
             },
-            dynamic_status: BotDynamicStatus::default(),
             ws_connection: None,
             session_token: None,
             env: None,
@@ -3757,7 +3563,6 @@ mod tests {
                 domains: vec!["Database".to_string(), "MySQL".to_string()],
                 ..Default::default()
             },
-            dynamic_status: BotDynamicStatus::default(),
             ws_connection: None,
             session_token: None,
             env: None,
@@ -3781,7 +3586,6 @@ mod tests {
                 scopes: vec!["database:read".to_string(), "database:write".to_string()],
                 ..Default::default()
             },
-            dynamic_status: BotDynamicStatus::default(),
             ws_connection: None,
             session_token: None,
             env: None,
@@ -3805,11 +3609,6 @@ mod tests {
                 name: Some("Test Bot".to_string()),
                 ..Default::default()
             },
-            dynamic_status: BotDynamicStatus {
-                status: "busy".to_string(),
-                load: Some(0.5),
-                ..Default::default()
-            },
             ws_connection: None,
             session_token: None,
             env: Some("prod".to_string()),
@@ -3822,8 +3621,6 @@ mod tests {
         let registered = bot.to_registered_bot();
         assert_eq!(registered.bot_uuid, "test-uuid");
         assert_eq!(registered.capabilities.name, Some("Test Bot".to_string()));
-        assert_eq!(registered.dynamic_status.status, "busy");
-        assert_eq!(registered.dynamic_status.load, Some(0.5));
         assert_eq!(registered.env, Some("prod".to_string()));
     }
 
@@ -3871,24 +3668,6 @@ mod tests {
     }
 
     #[test]
-    fn test_status_cache_key_with_special_chars() {
-        let key = PersistentBotRepo::status_cache_key("bot-with-dashes_123");
-        assert_eq!(key, "bcs:status:bot-with-dashes_123");
-
-        let key = PersistentBotRepo::status_cache_key("中文机器人");
-        assert_eq!(key, "bcs:status:中文机器人");
-    }
-
-    #[test]
-    fn test_current_timestamp() {
-        let ts = PersistentBotRepo::current_timestamp();
-        // Should be a reasonable timestamp (after 2020)
-        assert!(ts > 1577836800000); // 2020-01-01 in ms
-        // Should be before 2100
-        assert!(ts < 4102444800000); // 2100-01-01 in ms
-    }
-
-    #[test]
     fn test_bot_inner_has_skill_partial_match() {
         let bot = RegisteredBotInner {
             bot_uuid: "test".to_string(),
@@ -3897,7 +3676,6 @@ mod tests {
                 skills: vec![Skill::new("SQL_Analysis_Expert")],
                 ..Default::default()
             },
-            dynamic_status: BotDynamicStatus::default(),
             ws_connection: None,
             session_token: None,
             env: None,
@@ -3925,7 +3703,6 @@ mod tests {
                 domains: vec!["Database-Administration".to_string()],
                 ..Default::default()
             },
-            dynamic_status: BotDynamicStatus::default(),
             ws_connection: None,
             session_token: None,
             env: None,
@@ -3946,7 +3723,6 @@ mod tests {
             bot_uuid: "empty".to_string(),
             last_heartbeat: Instant::now(),
             capabilities: BotCapabilities::default(),
-            dynamic_status: BotDynamicStatus::default(),
             ws_connection: None,
             session_token: None,
             env: None,
@@ -4041,28 +3817,6 @@ mod tests {
         //
         // let bot = registry.get("test-bot").await.unwrap();
         // assert_eq!(bot.capabilities.name, Some("Test Bot".into()));
-    }
-
-    #[tokio::test]
-    #[ignore = "Requires external cache and database connections"]
-    async fn integration_test_status_updates_to_cache() {
-        // This test documents the expected workflow:
-        // 1. Update bot status (which goes to cache with TTL)
-        // 2. Verify TTL is set correctly (600s)
-        // 3. After failover, status can be recovered from cache
-        //
-        // Example:
-        // let status = BotDynamicStatus {
-        //     status: "busy".into(),
-        //     dynamic_summary: Some("Processing request".into()),
-        //     load: Some(0.7),
-        //     ..Default::default()
-        // };
-        // registry.update_status("test-bot", status).await;
-        //
-        // // Status should be in cache with key "bcs:status:test-bot"
-        // let recovered = registry.load_status_from_cache("test-bot").await;
-        // assert_eq!(recovered.status, "busy");
     }
 
     #[tokio::test]

--- a/src/bcs/crates/services/bcs-bot-store/src/memory.rs
+++ b/src/bcs/crates/services/bcs-bot-store/src/memory.rs
@@ -173,8 +173,6 @@ struct RegisteredBotInner {
     last_heartbeat: Instant,
     /// Bot capabilities for discovery.
     capabilities: BotCapabilities,
-    /// Dynamic status updated periodically.
-    dynamic_status: BotDynamicStatus,
     /// Active streaming connection (if connected).
     ws_connection: Option<BotConnection>,
     /// Session token (persists across connections for reconnection).
@@ -243,7 +241,6 @@ impl RegisteredBotInner {
         RegisteredBot {
             bot_uuid: self.bot_id.clone(),
             capabilities,
-            dynamic_status: self.dynamic_status.clone(),
             env: self.env.clone().or_else(|| Some(resolve_env())),
             created_by: self.created_by.clone(),
             actor_kind: self.actor_kind,
@@ -528,7 +525,6 @@ impl BotRepoPort for MemoryBotRepo {
                     bot_id: bot_id.clone(),
                     last_heartbeat: Instant::now(),
                     capabilities,
-                    dynamic_status: BotDynamicStatus::default(),
                     ws_connection: None,
                     session_token: None,
                     env: Some(resolve_env()),
@@ -691,7 +687,6 @@ impl BotRepoPort for MemoryBotRepo {
                         bot_id: bot_id.clone(),
                         last_heartbeat: Instant::now(),
                         capabilities,
-                        dynamic_status: BotDynamicStatus::default(),
                         ws_connection: None,
                         session_token: Some(token.to_string()),
                         env: Some(resolve_env()),
@@ -723,13 +718,12 @@ impl BotRepoPort for MemoryBotRepo {
         Ok(())
     }
 
-    async fn update_status(&self, bot_id: &str, status: BotDynamicStatus) -> bool {
+    async fn update_status(&self, bot_id: &str, _status: BotDynamicStatus) -> bool {
         let mut bots = self.bots.write().await;
 
         if let Some(bot) = bots.get_mut(bot_id) {
-            bot.dynamic_status = status;
             bot.last_heartbeat = Instant::now();
-            debug!(bot_id = %bot_id, "Bot dynamic status updated");
+            debug!(bot_id = %bot_id, "Bot heartbeat renewed");
             true
         } else {
             debug!(bot_id = %bot_id, "Bot not found for status update");
@@ -900,10 +894,6 @@ impl BotRepoPort for MemoryBotRepo {
                     .unwrap_or(false)
                 // Check summary
                 || b.capabilities.summary.as_ref()
-                    .map(|s| s.to_lowercase().contains(&query_lower))
-                    .unwrap_or(false)
-                // Check dynamic summary (highest priority - real-time info)
-                || b.dynamic_status.dynamic_summary.as_ref()
                     .map(|s| s.to_lowercase().contains(&query_lower))
                     .unwrap_or(false)
                 // Check domains
@@ -1134,7 +1124,6 @@ impl BotRepoPort for MemoryBotRepo {
                 bot_id: bot_uuid.clone(),
                 last_heartbeat: Instant::now(),
                 capabilities: caps,
-                dynamic_status: BotDynamicStatus::default(),
                 ws_connection: None,
                 session_token: Some(session_token),
                 env: Some(resolve_env()),
@@ -1197,7 +1186,6 @@ impl BotRepoPort for MemoryBotRepo {
                 RegisteredBot {
                     bot_uuid: b.bot_id.clone(),
                     capabilities,
-                    dynamic_status: b.dynamic_status.clone(),
                     env: b.env.clone(),
                     created_by: b.created_by.clone(),
                     actor_kind: b.actor_kind.clone(),
@@ -1530,7 +1518,6 @@ impl BotRepoPort for MemoryBotRepo {
                         bot_id: bot_id.clone(),
                         last_heartbeat: Instant::now(),
                         capabilities: BotCapabilities::default(),
-                        dynamic_status: BotDynamicStatus::default(),
                         ws_connection: Some(BotConnection {
                             session_token: session_token.clone(),
                             connected_at: Instant::now(),
@@ -1593,7 +1580,6 @@ impl BotRepoPort for MemoryBotRepo {
                             bot_id: bot_id.clone(),
                             last_heartbeat: Instant::now(),
                             capabilities: BotCapabilities::default(),
-                            dynamic_status: BotDynamicStatus::default(),
                             status: bcs_service_api::ActorStatus::Online,
                             actor_kind: bcs_service_api::ActorKind::Bot,
                             created_by: None,
@@ -1675,7 +1661,6 @@ impl BotRepoPort for MemoryBotRepo {
                     bot_id: bot_id.clone(),
                     last_heartbeat: Instant::now(),
                     capabilities: BotCapabilities::default(),
-                    dynamic_status: BotDynamicStatus::default(),
                     ws_connection: Some(BotConnection {
                         session_token: session_token.clone(),
                         connected_at: Instant::now(),
@@ -1740,7 +1725,6 @@ impl BotRepoPort for MemoryBotRepo {
                     bot_id: bot_id.clone(),
                     last_heartbeat: Instant::now(),
                     capabilities: BotCapabilities::default(),
-                    dynamic_status: BotDynamicStatus::default(),
                     ws_connection: Some(BotConnection {
                         session_token: existing_token.clone(),
                         connected_at: Instant::now(),
@@ -1830,7 +1814,6 @@ impl BotRepoPort for MemoryBotRepo {
                         bot_id: bot_id.clone(),
                         last_heartbeat: Instant::now(),
                         capabilities: BotCapabilities::default(),
-                        dynamic_status: BotDynamicStatus::default(),
                         ws_connection: None,
                         session_token: Some(token.clone()),
                         env: Some(resolve_env()),
@@ -2490,7 +2473,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn update_dynamic_status() {
+    async fn heartbeat_renews_registration_without_retaining_dynamic_status() {
         let registry = MemoryBotRepo::new();
 
         let caps = BotCapabilities {
@@ -2506,16 +2489,14 @@ mod tests {
             load: Some(0.7),
             updated_at: Some(1234567890),
         };
+        registry.bots.write().await.get_mut("dba").unwrap().last_heartbeat =
+            Instant::now() - BOT_EXPIRY - Duration::from_secs(1);
         let updated = registry.update_status("dba", status.clone()).await;
         assert!(updated);
 
         let bot = registry.get("dba").await.unwrap();
-        assert_eq!(bot.dynamic_status.status, "busy");
-        assert_eq!(
-            bot.dynamic_status.dynamic_summary,
-            Some("Processing deadlock request".to_string())
-        );
-        assert_eq!(bot.dynamic_status.load, Some(0.7));
+        assert!(serde_json::to_value(bot).unwrap().get("dynamic_status").is_none());
+        assert!(!registry.bots.read().await["dba"].is_expired());
 
         let not_found = registry
             .update_status("unknown", BotDynamicStatus::default())
@@ -2781,7 +2762,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn discover_by_dynamic_summary() {
+    async fn discovery_ignores_dynamic_summary() {
         let registry = MemoryBotRepo::new();
 
         let caps = BotCapabilities {
@@ -2799,10 +2780,9 @@ mod tests {
         };
         registry.update_status("dba", status).await;
 
-        // Should find by dynamic summary content
-        let results = registry.discover("deadlock analysis").await;
-        assert_eq!(results.len(), 1);
-        assert_eq!(results[0].bot_uuid, "dba");
+        // Heartbeat descriptions are not part of the discovery contract.
+        assert!(registry.discover("deadlock analysis").await.is_empty());
+        assert_eq!(registry.discover("DBA").await.len(), 1);
     }
 
     #[tokio::test]

--- a/src/bcs/crates/services/bcs-bot-store/tests/bot_info_kv.rs
+++ b/src/bcs/crates/services/bcs-bot-store/tests/bot_info_kv.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use bcs_bot_store::PersistentBotRepo;
-use bcs_cache_local::InMemoryCachePlugin;
 use bcs_db_api::{DbPlugin, DbStatement};
 use bcs_db_local::LocalSqliteDbPlugin;
 use bcs_service_api::port::repo::BotRepoPort;
@@ -40,9 +39,8 @@ fn test_caps() -> BotCapabilities {
 }
 
 async fn create_persistent_bot_repo() -> PersistentBotRepo {
-    let cache = Arc::new(InMemoryCachePlugin::new());
     let db = sqlite_db().await;
-    PersistentBotRepo::with_plugins(cache, db)
+    PersistentBotRepo::new(db)
 }
 
 // ============================================================

--- a/src/bcs/crates/services/bcs-bot-store/tests/conformance_bot_control_plane_repo.rs
+++ b/src/bcs/crates/services/bcs-bot-store/tests/conformance_bot_control_plane_repo.rs
@@ -8,7 +8,6 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use bcs_bot_store::{MemoryBotRepo, PersistentBotRepo};
-use bcs_cache_local::InMemoryCachePlugin;
 use bcs_db_api::{
     DbExecuteResult, DbHealth, DbPlugin, DbResult, DbRow, DbSqlFlavor, DbStatement,
     DbTransactionStep, DbTransactionStepResult, DbValue as Value, db_get_column, db_get_column_opt,
@@ -593,11 +592,9 @@ async fn persistent_control_plane_owned_filters_and_patch_replace_descriptor_arr
 
 #[tokio::test]
 async fn persistent_control_plane_patch_returns_existing_row_when_mysql_changes_nothing() {
-    let repo = PersistentBotRepo::with_plugins_flavor_and_cache_key_prefix(
-        Arc::new(InMemoryCachePlugin::new()),
+    let repo = PersistentBotRepo::with_sql_flavor(
         Arc::new(UnchangedUpdateDb),
         DbSqlFlavor::Mysql,
-        "test:",
     );
 
     let updated = repo
@@ -874,11 +871,9 @@ async fn persistent_control_plane_concurrent_partial_patches_preserve_both_chang
         inner: db,
         snapshot_read_barrier: Barrier::new(2),
     });
-    let repo = Arc::new(PersistentBotRepo::with_plugins_flavor_and_cache_key_prefix(
-        Arc::new(InMemoryCachePlugin::new()),
+    let repo = Arc::new(PersistentBotRepo::with_sql_flavor(
         synchronized_db,
         DbSqlFlavor::Sqlite,
-        "test:",
     ));
 
     let visibility_repo = repo.clone();
@@ -1003,11 +998,9 @@ impl DbPlugin for UnchangedUpdateDb {
 
 async fn fixture() -> (PersistentBotRepo, Arc<dyn DbPlugin>) {
     let db = sqlite_db().await;
-    let repo = PersistentBotRepo::with_plugins_flavor_and_cache_key_prefix(
-        Arc::new(InMemoryCachePlugin::new()),
+    let repo = PersistentBotRepo::with_sql_flavor(
         db.clone(),
         DbSqlFlavor::Sqlite,
-        "test:",
     );
     (repo, db)
 }

--- a/src/bcs/crates/services/bcs-bot-store/tests/conformance_bot_repo.rs
+++ b/src/bcs/crates/services/bcs-bot-store/tests/conformance_bot_repo.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use bcs_bot_store::{PersistentBotRepo, MemoryBotRepo};
-use bcs_cache_local::InMemoryCachePlugin;
 use bcs_db_api::{
     DbError, DbExecuteResult, DbHealth, DbPlugin, DbRow, DbStatement, DbTransactionStep,
     DbTransactionStepResult, DbValue as Value,
@@ -16,9 +15,8 @@ use bcs_test_support::contract::repo::bot_repo_port_contract_tests;
 
 #[tokio::test]
 async fn persistent_bot_repo_passes_bot_repo_contract() {
-    let cache = Arc::new(InMemoryCachePlugin::new());
     let db = sqlite_db().await;
-    let repo = PersistentBotRepo::with_plugins(cache, db);
+    let repo = PersistentBotRepo::new(db);
 
     bot_repo_port_contract_tests(&repo).await;
 }
@@ -58,9 +56,8 @@ async fn memory_unregister_soft_deletes_bot_from_default_reads() {
 
 #[tokio::test]
 async fn persistent_bot_repo_unregister_marks_is_deleted_and_filters_default_reads() {
-    let cache = Arc::new(InMemoryCachePlugin::new());
     let db = sqlite_db().await;
-    let repo = PersistentBotRepo::with_plugins(cache, db.clone());
+    let repo = PersistentBotRepo::new(db.clone());
     repo.register_with_owner_and_token(
         "soft-delete-bot".to_string(),
         BotCapabilities {
@@ -99,12 +96,11 @@ async fn persistent_bot_repo_unregister_marks_is_deleted_and_filters_default_rea
 
 #[tokio::test]
 async fn persistent_bot_repo_list_active_fails_closed_when_tombstone_query_fails() {
-    let cache = Arc::new(InMemoryCachePlugin::new());
     let inner_db = sqlite_db().await;
     let db = Arc::new(FailActiveBotIdsQueryDb {
         inner: inner_db.clone(),
     });
-    let repo = PersistentBotRepo::with_plugins(cache, db);
+    let repo = PersistentBotRepo::new(db);
     repo.register_with_owner_and_token(
         "soft-delete-bot".to_string(),
         BotCapabilities {
@@ -154,9 +150,8 @@ async fn persistent_bot_repo_list_active_fails_closed_when_tombstone_query_fails
 
 #[tokio::test]
 async fn persistent_bot_repo_register_after_soft_delete_does_not_clear_is_deleted_column() {
-    let cache = Arc::new(InMemoryCachePlugin::new());
     let db = sqlite_db().await;
-    let repo = PersistentBotRepo::with_plugins(cache, db.clone());
+    let repo = PersistentBotRepo::new(db.clone());
     repo.register_with_owner_and_token(
         "soft-delete-bot".to_string(),
         BotCapabilities {
@@ -204,9 +199,8 @@ async fn persistent_bot_repo_register_after_soft_delete_does_not_clear_is_delete
 
 #[tokio::test]
 async fn persistent_bot_repo_passes_bot_metrics_snapshot_contract() {
-    let cache = Arc::new(InMemoryCachePlugin::new());
     let db = sqlite_db().await;
-    let repo = PersistentBotRepo::with_plugins(cache, db.clone());
+    let repo = PersistentBotRepo::new(db.clone());
 
     seed_metrics_bot(&repo).await;
     seed_metrics_human_row(db.as_ref()).await;
@@ -371,9 +365,8 @@ async fn connect_or_promote_streaming_promote_persists_real_token_to_db_survives
     // be in `bcs_bots` (not the stale MOCK), so a fresh repo built on the same DB
     // resolves the bot by the promoted token — i.e. no half-state where memory
     // holds the real token while the DB still keeps the MOCK.
-    let cache = Arc::new(InMemoryCachePlugin::new());
     let db = sqlite_db().await;
-    let repo = PersistentBotRepo::with_plugins(cache.clone(), db.clone());
+    let repo = PersistentBotRepo::new(db.clone());
 
     // provider pre-registers a plugin bot → DB holds MOCK
     let mock = mock_token();
@@ -399,7 +392,7 @@ async fn connect_or_promote_streaming_promote_persists_real_token_to_db_survives
     assert!(!bcs_service_api::is_mock_token(&promoted));
 
     // Simulate a BCS restart: a fresh repo reading the SAME DB.
-    let repo_after = PersistentBotRepo::with_plugins(cache.clone(), db);
+    let repo_after = PersistentBotRepo::new(db);
     let persisted = repo_after
         .load_token("plugin-bot:alice")
         .await
@@ -464,9 +457,8 @@ async fn connect_or_promote_streaming_refuses_real_token_connected_with_already_
 
 #[tokio::test]
 async fn persistent_repo_update_capabilities_replaces_in_memory_and_db() {
-    let cache = Arc::new(InMemoryCachePlugin::new());
     let db = sqlite_db().await;
-    let repo = PersistentBotRepo::with_plugins(cache, db.clone());
+    let repo = PersistentBotRepo::new(db.clone());
 
     repo.register(
         "update-cap-bot".to_string(),
@@ -516,8 +508,7 @@ async fn persistent_repo_update_capabilities_replaces_in_memory_and_db() {
     );
     assert_eq!(stored.capabilities.visibility, "protected");
 
-    let db_reader = PersistentBotRepo::with_plugins(
-        Arc::new(InMemoryCachePlugin::new()),
+    let db_reader = PersistentBotRepo::new(
         db,
     );
     let persisted = db_reader
@@ -532,8 +523,7 @@ async fn persistent_repo_update_capabilities_replaces_in_memory_and_db() {
 #[tokio::test]
 async fn persistent_repo_update_capabilities_updates_db_when_memory_is_absent() {
     let db = sqlite_db().await;
-    let registering_repo = PersistentBotRepo::with_plugins(
-        Arc::new(InMemoryCachePlugin::new()),
+    let registering_repo = PersistentBotRepo::new(
         db.clone(),
     );
     registering_repo
@@ -551,8 +541,7 @@ async fn persistent_repo_update_capabilities_updates_db_when_memory_is_absent() 
 
     // A separate repository instance models a pod that shares the database
     // but has never loaded this bot into its process-local registry.
-    let updating_repo = PersistentBotRepo::with_plugins(
-        Arc::new(InMemoryCachePlugin::new()),
+    let updating_repo = PersistentBotRepo::new(
         db.clone(),
     );
     updating_repo
@@ -569,8 +558,7 @@ async fn persistent_repo_update_capabilities_updates_db_when_memory_is_absent() 
         .await
         .expect("database-only capability update must succeed");
 
-    let verifying_repo = PersistentBotRepo::with_plugins(
-        Arc::new(InMemoryCachePlugin::new()),
+    let verifying_repo = PersistentBotRepo::new(
         db,
     );
     let stored = verifying_repo
@@ -597,8 +585,7 @@ async fn persistent_repo_update_capabilities_updates_db_when_memory_is_absent() 
 #[tokio::test]
 async fn persistent_repo_update_capabilities_updates_memory_without_inserting_db_row() {
     let db = sqlite_db().await;
-    let repo = PersistentBotRepo::with_plugins(
-        Arc::new(InMemoryCachePlugin::new()),
+    let repo = PersistentBotRepo::new(
         db.clone(),
     );
     repo.register(
@@ -661,9 +648,8 @@ async fn persistent_repo_update_capabilities_updates_memory_without_inserting_db
 
 #[tokio::test]
 async fn persistent_repo_update_capabilities_returns_not_found_for_unknown_bot() {
-    let cache = Arc::new(InMemoryCachePlugin::new());
     let db = sqlite_db().await;
-    let repo = PersistentBotRepo::with_plugins(cache, db.clone());
+    let repo = PersistentBotRepo::new(db.clone());
 
     let err = repo
         .update_capabilities(

--- a/src/bcs/crates/services/bcs-bot-store/tests/diagnostic_logging.rs
+++ b/src/bcs/crates/services/bcs-bot-store/tests/diagnostic_logging.rs
@@ -3,7 +3,6 @@ use std::sync::{Arc, Mutex};
 
 use bcs_bot_store::{MemoryBotRepo, PersistentBotRepo};
 use bcs_bot_store::provider::DbProviderStore;
-use bcs_cache_local::InMemoryCachePlugin;
 use bcs_db_api::{
     DbError, DbExecuteResult, DbHealth, DbPlugin, DbResult, DbRow, DbStatement,
     DbTransactionStep, DbTransactionStepResult, DbValue,
@@ -91,7 +90,7 @@ impl DbPlugin for ScriptedDb {
 }
 
 fn repository(db: Arc<ScriptedDb>) -> PersistentBotRepo {
-    PersistentBotRepo::with_plugins(Arc::new(InMemoryCachePlugin::new()), db)
+    PersistentBotRepo::new(db)
 }
 
 fn warning<'a>(events: &'a [Value], message: &str) -> &'a Value {

--- a/src/bcs/crates/services/bcs-bot-store/tests/unit/heartbeat.rs
+++ b/src/bcs/crates/services/bcs-bot-store/tests/unit/heartbeat.rs
@@ -1,0 +1,112 @@
+use super::*;
+use std::collections::BTreeMap;
+use bcs_cache_api::{CacheResult, CacheSetMode, CacheTtl};
+use bcs_db_local::LocalSqliteDbPlugin;
+
+// Any cache access is a regression, including reads that silently fall back.
+struct ForbiddenCache;
+
+#[async_trait]
+impl CachePlugin for ForbiddenCache {
+    async fn get_value(&self, _: &str) -> CacheResult<Option<Vec<u8>>> { panic!("unexpected cache GET") }
+    async fn set_value(&self, _: &str, _: Vec<u8>, _: Option<Duration>, _: CacheSetMode) -> CacheResult<bool> { panic!("unexpected cache SET") }
+    async fn delete(&self, _: &str) -> CacheResult<bool> { panic!("unexpected cache DEL") }
+    async fn expire(&self, _: &str, _: Duration) -> CacheResult<bool> { panic!("unexpected cache EXPIRE") }
+    async fn ttl(&self, _: &str) -> CacheResult<CacheTtl> { panic!("unexpected cache TTL") }
+    async fn hash_get(&self, _: &str, _: &str) -> CacheResult<Option<Vec<u8>>> { panic!("unexpected cache HGET") }
+    async fn hash_get_all(&self, _: &str) -> CacheResult<BTreeMap<String, Vec<u8>>> { panic!("unexpected cache HGETALL") }
+    async fn hash_set(&self, _: &str, _: &str, _: Vec<u8>) -> CacheResult<()> { panic!("unexpected cache HSET") }
+    async fn hash_set_many(&self, _: &str, _: BTreeMap<String, Vec<u8>>) -> CacheResult<()> { panic!("unexpected cache hash write") }
+    async fn hash_delete(&self, _: &str, _: &str) -> CacheResult<bool> { panic!("unexpected cache HDEL") }
+}
+
+async fn database() -> Arc<dyn DbPlugin> {
+    let db = Arc::new(LocalSqliteDbPlugin::new().unwrap());
+    db.execute(DbStatement::new(
+        "CREATE TABLE bcs_bots (
+            bot_uuid TEXT NOT NULL, name TEXT, bot_info TEXT, session_token TEXT,
+            created_by TEXT, visibility TEXT, status TEXT NOT NULL DEFAULT 'online',
+            actor_kind TEXT NOT NULL DEFAULT 'bot', is_deleted INTEGER NOT NULL DEFAULT 0,
+            agent_code TEXT DEFAULT NULL, env TEXT NOT NULL, registered_at TEXT,
+            updated_at TEXT, PRIMARY KEY (bot_uuid, env)
+        )",
+    )).await.unwrap();
+    db
+}
+
+fn repository(db: Arc<dyn DbPlugin>) -> PersistentBotRepo {
+    PersistentBotRepo::with_plugins_flavor_and_cache_key_prefix(
+        Arc::new(ForbiddenCache), db, DbSqlFlavor::Sqlite, "custom-prefix:",
+    )
+}
+
+async fn register(repo: &PersistentBotRepo) {
+    repo.register_with_owner_and_token(
+        "heartbeat-bot".into(),
+        BotCapabilities {
+            name: Some("Database Helper".into()),
+            summary: Some("Static SQL expertise".into()),
+            skills: vec![Skill::new("sql")],
+            visibility: "public".into(),
+            ..Default::default()
+        },
+        "owner", "heartbeat-token",
+    ).await.unwrap();
+}
+
+fn payload() -> BotDynamicStatus {
+    BotDynamicStatus {
+        status: "busy".into(), dynamic_summary: Some("ephemeral-only-marker".into()),
+        load: Some(0.9), updated_at: Some(1),
+    }
+}
+
+#[tokio::test]
+async fn heartbeat_renews_registration_without_cache_or_retained_payload() {
+    let repo = repository(database().await);
+    register(&repo).await;
+    // Renewal applies repeatedly, not only to newly registered bots.
+    for _ in 0..2 {
+        repo.bots.write().await.get_mut("heartbeat-bot").unwrap().last_heartbeat =
+            Instant::now() - BOT_EXPIRY - Duration::from_secs(1);
+        assert!(repo.list_active().await.is_empty());
+        assert!(repo.update_status("heartbeat-bot", payload()).await);
+        assert_eq!(repo.list_active().await.len(), 1);
+        assert!(!repo.bots.read().await["heartbeat-bot"].is_expired());
+    }
+    let bot = repo.get("heartbeat-bot").await.unwrap();
+    assert!(serde_json::to_value(bot).unwrap().get("dynamic_status").is_none());
+    assert!(!repo.update_status("unknown", payload()).await);
+    assert!(!repo.bots.read().await.contains_key("unknown"));
+    assert!(repo.discover("ephemeral-only-marker").await.is_empty());
+    assert_eq!(repo.discover("Static SQL").await.len(), 1);
+    assert_eq!(repo.find_by_skills(&["sql"]).await.len(), 1);
+}
+
+#[tokio::test]
+async fn database_fallback_and_reconnect_do_not_read_status_cache() {
+    let db = database().await;
+    register(&repository(db.clone())).await;
+    let cold = repository(db);
+    let bot = cold.try_get("heartbeat-bot").await.unwrap().unwrap();
+    assert_eq!(bot.capabilities.name.as_deref(), Some("Database Helper"));
+    assert!(!cold.is_connected("heartbeat-bot").await);
+    let (bot_id, token) = cold.reconnect_streaming("heartbeat-token".into()).await.unwrap();
+    assert_eq!(bot_id, "heartbeat-bot");
+    assert_eq!(token, "heartbeat-token");
+    assert!(cold.is_connected(&bot_id).await);
+    assert!(!cold.bots.read().await[&bot_id].is_expired());
+    assert!(serde_json::to_value(cold.get(&bot_id).await.unwrap()).unwrap().get("dynamic_status").is_none());
+}
+
+#[tokio::test]
+async fn deleted_bot_name_backfill_does_not_read_status_cache() {
+    let db = database().await;
+    let repo = repository(db.clone());
+    register(&repo).await;
+    assert!(repo.soft_delete("heartbeat-bot").await);
+    let cold = repository(db);
+    assert!(cold.get("heartbeat-bot").await.is_none());
+    let bot = cold.get_including_deleted("heartbeat-bot").await.unwrap();
+    assert_eq!(bot.capabilities.name.as_deref(), Some("Database Helper"));
+}

--- a/src/bcs/crates/services/bcs-bot-store/tests/unit/heartbeat.rs
+++ b/src/bcs/crates/services/bcs-bot-store/tests/unit/heartbeat.rs
@@ -1,24 +1,5 @@
 use super::*;
-use std::collections::BTreeMap;
-use bcs_cache_api::{CacheResult, CacheSetMode, CacheTtl};
 use bcs_db_local::LocalSqliteDbPlugin;
-
-// Any cache access is a regression, including reads that silently fall back.
-struct ForbiddenCache;
-
-#[async_trait]
-impl CachePlugin for ForbiddenCache {
-    async fn get_value(&self, _: &str) -> CacheResult<Option<Vec<u8>>> { panic!("unexpected cache GET") }
-    async fn set_value(&self, _: &str, _: Vec<u8>, _: Option<Duration>, _: CacheSetMode) -> CacheResult<bool> { panic!("unexpected cache SET") }
-    async fn delete(&self, _: &str) -> CacheResult<bool> { panic!("unexpected cache DEL") }
-    async fn expire(&self, _: &str, _: Duration) -> CacheResult<bool> { panic!("unexpected cache EXPIRE") }
-    async fn ttl(&self, _: &str) -> CacheResult<CacheTtl> { panic!("unexpected cache TTL") }
-    async fn hash_get(&self, _: &str, _: &str) -> CacheResult<Option<Vec<u8>>> { panic!("unexpected cache HGET") }
-    async fn hash_get_all(&self, _: &str) -> CacheResult<BTreeMap<String, Vec<u8>>> { panic!("unexpected cache HGETALL") }
-    async fn hash_set(&self, _: &str, _: &str, _: Vec<u8>) -> CacheResult<()> { panic!("unexpected cache HSET") }
-    async fn hash_set_many(&self, _: &str, _: BTreeMap<String, Vec<u8>>) -> CacheResult<()> { panic!("unexpected cache hash write") }
-    async fn hash_delete(&self, _: &str, _: &str) -> CacheResult<bool> { panic!("unexpected cache HDEL") }
-}
 
 async fn database() -> Arc<dyn DbPlugin> {
     let db = Arc::new(LocalSqliteDbPlugin::new().unwrap());
@@ -35,9 +16,7 @@ async fn database() -> Arc<dyn DbPlugin> {
 }
 
 fn repository(db: Arc<dyn DbPlugin>) -> PersistentBotRepo {
-    PersistentBotRepo::with_plugins_flavor_and_cache_key_prefix(
-        Arc::new(ForbiddenCache), db, DbSqlFlavor::Sqlite, "custom-prefix:",
-    )
+    PersistentBotRepo::with_sql_flavor(db, DbSqlFlavor::Sqlite)
 }
 
 async fn register(repo: &PersistentBotRepo) {

--- a/src/bcs/crates/services/bcs-bot/Cargo.toml
+++ b/src/bcs/crates/services/bcs-bot/Cargo.toml
@@ -33,7 +33,6 @@ bcs-user-directory-api = { workspace = true }
 
 [dev-dependencies]
 bcs-test-support = { workspace = true }
-bcs-cache-local = { workspace = true }
 bcs-db-api = { workspace = true }
 bcs-db-local = { workspace = true }
 bcs-organization = { workspace = true }

--- a/src/bcs/crates/services/bcs-bot/src/application/bot.rs
+++ b/src/bcs/crates/services/bcs-bot/src/application/bot.rs
@@ -16,7 +16,7 @@ use bcs_service_api::{
     BotRuntimeConnectOutcome, BotRuntimeConnectionService, BotRuntimeDisconnectCommand,
     BotRuntimeStatusCommand, BotRuntimeStatusOutcome, BotStatusUpdateCommand,
     BotStatusUpdateResult, BotUseCaseError, BotVisibilityCommand, BotVisibilityQueryCommand,
-    BotVisibilityQueryResult, BotVisibilityResult, ConnectionKind, BotDynamicStatus,
+    BotVisibilityQueryResult, BotVisibilityResult, ConnectionKind,
     DynamicStatusResponse, FriendCoreService, KickReason, ProviderBotBinding,
     ProviderBotDiscoverySelector, RegisteredBot, RelationCoreService, ServiceError, ServiceResult,
     SwitchDeliveryToProviderCommand, SwitchDeliveryToProviderResult,
@@ -945,7 +945,6 @@ impl Bot {
                     .map(|bot| RegisteredBot {
                         bot_uuid: bot.bot_uuid,
                         capabilities: bot.capabilities,
-                        dynamic_status: BotDynamicStatus::default(),
                         env: None,
                         created_by: None,
                         actor_kind: bot.actor_kind,
@@ -1375,11 +1374,6 @@ fn matches_query(bot: &RegisteredBot, query: &str) -> bool {
         || bot
             .capabilities
             .summary
-            .as_deref()
-            .is_some_and(|value| contains_ignore_case(value, query))
-        || bot
-            .dynamic_status
-            .dynamic_summary
             .as_deref()
             .is_some_and(|value| contains_ignore_case(value, query))
         || bot

--- a/src/bcs/crates/services/bcs-bot/src/application/onboarding.rs
+++ b/src/bcs/crates/services/bcs-bot/src/application/onboarding.rs
@@ -692,7 +692,6 @@ mod tests {
                         visibility: "protected".to_string(),
                         ..Default::default()
                     },
-                    dynamic_status: BotDynamicStatus::default(),
                     env: None,
                     created_by: Some(staff_no.to_string()),
                     actor_kind: ActorKind::Human,
@@ -784,7 +783,6 @@ mod tests {
         RegisteredBot {
             bot_uuid: bot_uuid.into(),
             capabilities,
-            dynamic_status: BotDynamicStatus::default(),
             env: None,
             created_by: None,
             actor_kind: ActorKind::Bot,

--- a/src/bcs/crates/services/bcs-bot/tests/bot_info_kv.rs
+++ b/src/bcs/crates/services/bcs-bot/tests/bot_info_kv.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use bcs_bot::BotCore;
 use bcs_bot_store::PersistentBotRepo;
-use bcs_cache_local::InMemoryCachePlugin;
 use bcs_db_api::{DbPlugin, DbStatement};
 use bcs_db_local::LocalSqliteDbPlugin;
 use bcs_service_api::port::repo::BotRepoPort;
@@ -41,9 +40,8 @@ fn test_caps() -> BotCapabilities {
 }
 
 async fn create_persistent_bot_repo() -> PersistentBotRepo {
-    let cache = Arc::new(InMemoryCachePlugin::new());
     let db = sqlite_db().await;
-    PersistentBotRepo::with_plugins(cache, db)
+    PersistentBotRepo::new(db)
 }
 
 #[tokio::test]

--- a/src/bcs/crates/services/bcs-bot/tests/bot_search_contract.rs
+++ b/src/bcs/crates/services/bcs-bot/tests/bot_search_contract.rs
@@ -8,7 +8,6 @@ use bcs_bot::{Bot, BotControlPlaneCore, BotCore};
 use bcs_config::resolve_env_str;
 use bcs_domain::edge_permission::EdgeGrant;
 use bcs_bot_store::{MemoryBotRepo, MemoryProviderStore, PersistentBotRepo};
-use bcs_cache_local::InMemoryCachePlugin;
 use bcs_db_api::{DbPlugin, DbSqlFlavor, DbStatement, DbValue as Value};
 use bcs_db_local::LocalSqliteDbPlugin;
 use bcs_service_api::{BotCapabilities, BotControlPlaneCoreService, BotQueryService, BotRegistryCoreService, BotRepoPort, BotSearchFriendshipFilter, BotUseCaseError, SearchBotsCommand, ServiceResult};
@@ -214,8 +213,7 @@ async fn seed_search_bot<R>(
 #[tokio::test]
 async fn search_bots_tc_bot_filter_keeps_only_owner_suffixed_bots() {
     let db = sqlite_db().await;
-    let cache = Arc::new(InMemoryCachePlugin::new());
-    let repo = Arc::new(PersistentBotRepo::with_plugins_flavor(cache, db.clone(), DbSqlFlavor::Sqlite));
+    let repo = Arc::new(PersistentBotRepo::with_sql_flavor(db.clone(), DbSqlFlavor::Sqlite));
     let core = Arc::new(BotCore::with_repo(repo.clone()));
     let providers = Arc::new(MemoryProviderStore::new());
     let control_plane = Arc::new(BotControlPlaneCore::new(repo.clone(), providers.clone(), providers));
@@ -311,9 +309,8 @@ async fn search_bots_applies_exact_bot_uuid_candidates() {
 
 #[tokio::test]
 async fn search_bots_excludes_soft_deleted_persistent_rows_even_if_memory_has_bot() {
-    let cache = Arc::new(InMemoryCachePlugin::new());
     let db = sqlite_db().await;
-    let repo = Arc::new(PersistentBotRepo::with_plugins_flavor(cache, db, DbSqlFlavor::Sqlite));
+    let repo = Arc::new(PersistentBotRepo::with_sql_flavor(db, DbSqlFlavor::Sqlite));
     let core = Arc::new(BotCore::with_repo(repo.clone()));
     let providers = Arc::new(MemoryProviderStore::new());
     let control_plane = Arc::new(BotControlPlaneCore::new(repo.clone(), providers.clone(), providers));

--- a/src/bcs/crates/services/bcs-bot/tests/bot_use_cases.rs
+++ b/src/bcs/crates/services/bcs-bot/tests/bot_use_cases.rs
@@ -1521,10 +1521,7 @@ async fn bot_runtime_connection_service_manages_streaming_lifecycle() {
         .get("runtime-bot")
         .await
         .expect("stored bot");
-    assert_eq!(
-        stored.dynamic_status.dynamic_summary,
-        status.dynamic_summary
-    );
+    assert!(serde_json::to_value(stored).unwrap().get("dynamic_status").is_none());
 
     service
         .disconnect_streaming(BotRuntimeDisconnectCommand {
@@ -1537,7 +1534,7 @@ async fn bot_runtime_connection_service_manages_streaming_lifecycle() {
 }
 
 #[tokio::test]
-async fn update_status_uses_dynamic_status() {
+async fn update_status_echoes_payload_without_retaining_it() {
     let fixture = RegistryFixture::new();
     let service = fixture.service();
 
@@ -1571,14 +1568,15 @@ async fn update_status_uses_dynamic_status() {
         result.status.dynamic_summary.as_deref(),
         Some("Working on a task")
     );
+    assert_eq!(result.status.load, status.load);
+    assert_eq!(result.status.updated_at, status.updated_at);
 
     let stored = fixture
         .registry
         .get("status-bot")
         .await
         .expect("stored bot");
-    assert_eq!(stored.dynamic_status.status, status.status);
-    assert_eq!(stored.dynamic_status.load, status.load);
+    assert!(serde_json::to_value(stored).unwrap().get("dynamic_status").is_none());
 }
 
 #[tokio::test]
@@ -1669,12 +1667,6 @@ async fn update_status_rejects_caller_mismatch() {
         Err(BotUseCaseError::Forbidden(message))
             if message.contains("not the owner")
     ));
-    let stored = fixture
-        .registry
-        .get("status-bot")
-        .await
-        .expect("stored bot");
-    assert_eq!(stored.dynamic_status.status, "");
 }
 
 #[tokio::test]
@@ -1995,4 +1987,25 @@ fn caps_with_skills(
             .collect(),
         ..caps(name, summary, visibility)
     }
+}
+
+#[tokio::test]
+async fn discovery_ignores_heartbeat_summary_and_keeps_static_metadata() {
+    let fixture = RegistryFixture::new();
+    register_bot(&fixture.registry, "summary-bot",
+        caps(Some("Database Helper"), Some("Static SQL expertise"), "public"), None).await;
+    fixture.registry.update_status("summary-bot", bcs_service_api::BotDynamicStatus {
+        status: "busy".into(), dynamic_summary: Some("ephemeral-only-marker".into()),
+        load: Some(1.0), updated_at: Some(123),
+    }).await;
+    let service = fixture.service();
+    let ignored = service.discover_bots(BotDiscoveryCommand {
+        q: Some("ephemeral-only-marker".into()), ..Default::default()
+    }).await.unwrap();
+    assert_eq!(ignored.count, 0);
+    let matched = service.discover_bots(BotDiscoveryCommand {
+        q: Some("Static SQL".into()), ..Default::default()
+    }).await.unwrap();
+    assert_eq!(matched.count, 1);
+    assert_eq!(matched.bots[0].bot_uuid, "summary-bot");
 }

--- a/src/bcs/crates/services/bcs-channel/src/lib.rs
+++ b/src/bcs/crates/services/bcs-channel/src/lib.rs
@@ -7205,7 +7205,6 @@ mod tests {
                 agent_code: None,
                 agent_token: None,
             },
-            dynamic_status: BotDynamicStatus::default(),
             env: Some("dev".to_string()),
             created_by: None,
             actor_kind: ActorKind::Bot,

--- a/src/bcs/crates/services/bcs-friend/tests/conformance_friend_services.rs
+++ b/src/bcs/crates/services/bcs-friend/tests/conformance_friend_services.rs
@@ -428,7 +428,6 @@ impl BotRegistryCoreService for StaticRegistry {
                     visibility: visibility.clone(),
                     ..Default::default()
                 },
-                dynamic_status: Default::default(),
                 env: None,
                 created_by: None,
                 actor_kind: *actor_kind,

--- a/src/bcs/crates/services/bcs-group/tests/management.rs
+++ b/src/bcs/crates/services/bcs-group/tests/management.rs
@@ -2809,7 +2809,6 @@ fn bot(bot_uuid: &str, name: &str, visibility: &str, created_by: Option<&str>) -
             visibility: visibility.to_string(),
             ..Default::default()
         },
-        dynamic_status: BotDynamicStatus::default(),
         env: None,
         created_by: created_by.map(str::to_string),
         actor_kind: ActorKind::Bot,
@@ -2825,7 +2824,6 @@ fn human(actor_id: &str, name: &str) -> RegisteredBot {
             visibility: "private".to_string(),
             ..Default::default()
         },
-        dynamic_status: BotDynamicStatus::default(),
         env: None,
         created_by: None,
         actor_kind: ActorKind::Human,
@@ -2852,7 +2850,6 @@ impl BotRegistryCoreService for FakeRegistry {
             RegisteredBot {
                 bot_uuid: bot_id,
                 capabilities,
-                dynamic_status: BotDynamicStatus::default(),
                 env: None,
                 created_by: None,
                 actor_kind: ActorKind::Bot,

--- a/src/bcs/crates/services/bcs-message-flow/tests/contract_a2a_chat.rs
+++ b/src/bcs/crates/services/bcs-message-flow/tests/contract_a2a_chat.rs
@@ -1645,7 +1645,6 @@ impl MemoryRegistry {
                     visibility: visibility.to_string(),
                     ..BotCapabilities::default()
                 },
-                dynamic_status: BotDynamicStatus::default(),
                 env: None,
                 created_by: created_by.map(str::to_string),
                 actor_kind: ActorKind::Bot,
@@ -1663,7 +1662,6 @@ impl BotRegistryCoreService for MemoryRegistry {
             RegisteredBot {
                 bot_uuid: bot_id,
                 capabilities,
-                dynamic_status: BotDynamicStatus::default(),
                 env: None,
                 created_by: None,
                 actor_kind: ActorKind::Bot,

--- a/src/bcs/crates/services/bcs-proposal/tests/use_cases.rs
+++ b/src/bcs/crates/services/bcs-proposal/tests/use_cases.rs
@@ -682,7 +682,6 @@ fn bot(bot_uuid: &str, name: &str, visibility: &str, created_by: Option<&str>) -
             visibility: visibility.to_string(),
             ..Default::default()
         },
-        dynamic_status: BotDynamicStatus::default(),
         env: None,
         created_by: created_by.map(str::to_string),
         actor_kind: ActorKind::Bot,
@@ -709,7 +708,6 @@ impl BotRegistryCoreService for FakeRegistry {
             RegisteredBot {
                 bot_uuid: bot_id,
                 capabilities,
-                dynamic_status: BotDynamicStatus::default(),
                 env: None,
                 created_by: None,
                 actor_kind: ActorKind::Bot,

--- a/src/bcs/crates/services/bcs-routing/src/core/router.rs
+++ b/src/bcs/crates/services/bcs-routing/src/core/router.rs
@@ -1541,7 +1541,6 @@ mod tests {
                         agent_code: None,
                         agent_token: None,
                     },
-                    dynamic_status: BotDynamicStatus::default(),
                     env: None,
                     created_by: None,
                     actor_kind: bcs_service_api::ActorKind::default(),

--- a/src/bcs/crates/services/bcs-system-message/src/dispatcher_test.rs
+++ b/src/bcs/crates/services/bcs-system-message/src/dispatcher_test.rs
@@ -1699,7 +1699,6 @@ impl BotRegistryCoreService for ProviderTargetRegistry {
                 visibility: "protected".to_string(),
                 ..BotCapabilities::default()
             },
-            dynamic_status: BotDynamicStatus::default(),
             env: None,
             created_by: self.created_by.map(str::to_string),
             actor_kind: ActorKind::Bot,

--- a/src/bcs/crates/services/bcs-system-message/src/producers/bot_joined_test.rs
+++ b/src/bcs/crates/services/bcs-system-message/src/producers/bot_joined_test.rs
@@ -165,7 +165,6 @@ async fn bot_joined_produces_context_injection_and_notification() {
                 skills: vec![Skill::new("coding")],
                 ..Default::default()
             },
-            dynamic_status: BotDynamicStatus::default(),
             env: None,
             created_by: None,
             actor_kind: ActorKind::Bot,
@@ -266,7 +265,6 @@ async fn bot_joined_emits_user_message_even_when_only_new_bot_present() {
                 skills: vec![Skill::new("coding")],
                 ..Default::default()
             },
-            dynamic_status: BotDynamicStatus::default(),
             env: None,
             created_by: None,
             actor_kind: ActorKind::Bot,

--- a/src/bcs/crates/services/bcs-system-message/src/producers/session_context_test.rs
+++ b/src/bcs/crates/services/bcs-system-message/src/producers/session_context_test.rs
@@ -37,7 +37,6 @@ impl NamedRegistry {
                             visibility: "protected".to_string(),
                             ..Default::default()
                         },
-                        dynamic_status: BotDynamicStatus::default(),
                         env: None,
                         created_by: None,
                         actor_kind: ActorKind::Bot,

--- a/src/bcs/crates/test-support/message_flow_contract_support.rs
+++ b/src/bcs/crates/test-support/message_flow_contract_support.rs
@@ -644,7 +644,6 @@ impl FakeRegistryService {
             RegisteredBot {
                 bot_uuid: id.to_string(),
                 capabilities,
-                dynamic_status: BotDynamicStatus::default(),
                 env: None,
                 created_by: None,
                 actor_kind: if id.starts_with("human_") {
@@ -722,7 +721,6 @@ impl BotRegistryCoreService for FakeRegistryService {
             RegisteredBot {
                 bot_uuid: bot_id,
                 capabilities,
-                dynamic_status: BotDynamicStatus::default(),
                 env: None,
                 created_by: None,
                 actor_kind: ActorKind::Bot,

--- a/src/bcs/docs/heartbeat-status.md
+++ b/src/bcs/docs/heartbeat-status.md
@@ -45,7 +45,10 @@ reconnect. Old `bcs:status:*` keys (or the configured prefix equivalent) expire
 using their existing TTL; no explicit deletion or migration is required.
 Other cache consumers, including election, are unaffected.
 
-Legacy `PersistentBotRepo` constructor cache and prefix arguments remain
-accepted to preserve downstream composition-root compatibility, but the
-repository neither retains nor calls the cache. OCB can adopt the public change
-without editing its repository constructor calls.
+`PersistentBotRepo::new(db)` uses the MySQL dialect;
+`PersistentBotRepo::with_sql_flavor(db, flavor)` selects a dialect explicitly.
+The old cache/prefix constructors and the unused legacy database-name argument
+are removed. The repository has no cache-plugin dependency, and its tests need
+only a database. Composition roots must use these DB-only constructors; the
+shared bootstrap and all in-repository callers are updated. OCB internal source
+has no direct constructor calls and consumes the shared bootstrap.

--- a/src/bcs/docs/heartbeat-status.md
+++ b/src/bcs/docs/heartbeat-status.md
@@ -1,0 +1,51 @@
+# Bot heartbeat state
+
+BCS accepts the existing WebSocket `bot.status` and HTTP `POST /bots/status`
+payloads, but repositories retain only `last_heartbeat` for registration liveness.
+The legacy payload fields `status`, `dynamic_summary`, `load`, and `updated_at`
+are not stored in a registration, database, or external cache. Discovery does
+not match against heartbeat descriptions; static capability matching is unchanged.
+
+## Liveness and discovery
+
+Registration and reconnection initialize the process-local timestamp. A status
+update renews it for a known in-memory registration and returns `false` for an
+unknown registration. The timestamp uses a monotonic clock; the inbound
+`updated_at` value does not control liveness.
+
+The existing expiry policy is unchanged: the persistent repository considers a
+registration expired after 300 seconds without renewal. Its memory-based active
+and discovery paths filter expired entries; detail reads may fall back to the
+database. The memory implementation retains its existing special case for
+disconnected registrations with session tokens. This change neither schedules
+`cleanup_expired()` nor changes WebSocket disconnect handling.
+
+User-facing `active`/`offline` status remains computed from the actor lifecycle
+and WebSocket connection or configured HTTP Provider delivery target. It is not
+the client's reported `idle`/`busy`/`error` state and does not use `load`.
+
+## Protocol compatibility
+
+| Surface | Behavior |
+| --- | --- |
+| WebSocket `bot.status` | Existing payload accepted; success acknowledgement remains `{"updated":true}`. |
+| `POST /bots/status` | Existing payload accepted and echoed in the response's `status` object; echoing does not retain state. |
+| `/bots/query`, `GET /bots/{id}`, other online-state views | Existing computed `dynamic_status.status` remains `active` or `offline`. |
+| `POST /providers/agentpass/resolve` diagnostic endpoint | `bot.dynamic_status` is omitted. Identity, capabilities, binding and other registration fields remain. |
+
+`RegisteredBot` no longer has a `dynamic_status` field. Rust consumers should
+remove that initializer or access, and use the online-state query services where
+they need availability. The separate inbound `BotDynamicStatus` and outbound
+`DynamicStatusResponse` types remain available for their existing protocols.
+
+## Deployment
+
+No status hashes are read or written, including during DB fallback and cold
+reconnect. Old `bcs:status:*` keys (or the configured prefix equivalent) expire
+using their existing TTL; no explicit deletion or migration is required.
+Other cache consumers, including election, are unaffected.
+
+Legacy `PersistentBotRepo` constructor cache and prefix arguments remain
+accepted to preserve downstream composition-root compatibility, but the
+repository neither retains nor calls the cache. OCB can adopt the public change
+without editing its repository constructor calls.

--- a/src/bcs/docs/observability/request-operation-logging.md
+++ b/src/bcs/docs/observability/request-operation-logging.md
@@ -45,7 +45,7 @@ wall-clock time as CPU time.
 | Area | Observations |
 | --- | --- |
 | `/bots/query` | auth, batch load, per-bot status enrichment, input/unique/returned counts, response conversion |
-| Bot repository | memory hit/miss, memory lock wait, DB load, cache read, decode, omitted-load and default-status fallbacks, partial status-write failures |
+| Bot repository | memory hit/miss, memory lock wait, DB load and omitted-load fallbacks; status heartbeats only renew process-local liveness and perform no status-cache operations |
 | chat / chat-async acceptance | Bot/human auth, run-channel/context registration, ownership/organization/reachability, target/availability, Run create/state update, credentials, security and delivery |
 | Auth chain | plugin order, skipped/no-match/success/error, plugin and elapsed chain duration |
 | Internal waits | Run-channel registry read lock, enqueue backpressure, event-delivery semaphore permit |

--- a/src/bcs/docs/plans/2026-09-11-heartbeat-only-registration.md
+++ b/src/bcs/docs/plans/2026-09-11-heartbeat-only-registration.md
@@ -1,0 +1,80 @@
+# Heartbeat-only Registration Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Accept existing status heartbeats while retaining only their process-local liveness timestamp, eliminating dynamic-status storage and discovery matching.
+
+**Architecture:** Both bot repositories retain `last_heartbeat`, connection state, identity, and capabilities, but no dynamic-status snapshot. The persistent repository no longer writes or reads status hashes. Inbound status payloads remain accepted and the HTTP update response still echoes the request; computed online status remains independent of these payloads.
+
+**Tech Stack:** Rust, Tokio, SQLite test plugin, cache plugin contract, Axum HTTP/WS adapters.
+
+## Approved behavior and propagation
+
+- Remove `status`, `dynamic_summary`, `load`, and `updated_at` from stored registration state and `RegisteredBot`; retain the inbound `BotDynamicStatus` payload type.
+- Remove dynamic-summary matching from application discovery and both repository implementations. Static names, summaries, skills, domains, scopes, visibility, and organization filters keep their semantics.
+- Keep the existing 300-second `last_heartbeat` expiry and all connection/lifecycle-based `active`/`offline` calculations. Do not add cleanup scheduling or change disconnect policy.
+- Remove status hash construction, serialization, reads, writes, and TTL refreshes. Existing keys expire naturally; no Redis cleanup commands or migrations are needed.
+- Keep existing persistent-repository constructor signatures for downstream composition roots. Legacy cache/prefix arguments are accepted but neither retained nor used. Other stores still use the shared cache normally.
+- `/providers/agentpass/resolve` serializes registration details without `bot.dynamic_status`, as explicitly authorized for this diagnostic endpoint. `POST /bots/status` retains its echo response; WS status acknowledgements remain `{ "updated": true }`.
+- Update public Rust fixtures constructing `RegisteredBot`. OCB internal sources have no dynamic-status consumers or literals; no OCB code or gitlink changes are required.
+
+## Task 1: Regressions before implementation
+
+1. Run the existing bot-store unit tests as a baseline.
+2. Add a cache implementation that fails any call and exercise real SQLite-backed registration, heartbeat, DB fallback, soft-delete enrichment, and reconnect through it.
+3. Add heartbeat-expiry tests using manually aged private registration timestamps, including a previously renewed Bot and rejection of unknown Bot heartbeats.
+4. Add repository/application discovery tests that reject a keyword present only in the inbound dynamic summary while still matching static metadata.
+5. Extend the AgentPass HTTP contract test to assert absence of dynamic state and preserve identity/capability fields; preserve HTTP status echo and computed online-state tests.
+6. Run focused tests and confirm the new expectations fail on the old implementation.
+
+## Task 2: Remove dynamic status persistence
+
+1. Remove the snapshot field from `bcs-domain::RegisteredBot` and both private registration records; update affected struct literals and obsolete snapshot assertions.
+2. Change both `update_status` implementations to refresh only `last_heartbeat`, retaining known/unknown Bot outcomes.
+3. Delete persistent status-cache helpers and their obsolete unit tests. Keep source-compatible constructors without retaining cache references.
+4. Remove dynamic-summary selector branches. Keep the wire payload and echo types.
+5. Update contract comments and current API documentation; remove obsolete cache-observation documentation caused by this change.
+
+## Task 3: Validation
+
+- `cargo test -p bcs-bot-store`
+- `cargo test -p bcs-bot`
+- `cargo test -p bcs-http`
+- `cargo test -p bcs-ws`
+- Compile affected workspace test consumers of the changed registration contract and run relevant architecture/contract gates.
+- Review the diff for leftover status-cache access, accidental changes to heartbeat expiry or computed online state, and unrelated formatting.
+- Record the actual validation results and any unavailable gate. Commit/push/PR creation follows a separate user request.
+
+## Validation results
+
+Implemented on `codex/bcs-heartbeat-only`, based on freshly fetched upstream
+`dev` at `f35e9e68edae91d3c84bfce755db1f3a9fb79244`.
+
+- Baseline bot-store unit tests: 46 passed, 5 ignored.
+- Before implementation, the new regressions failed on status HSET, fallback
+  HGETALL, retained registration payloads, dynamic-summary discovery, and the
+  AgentPass response field, confirming that they exercised the old behavior.
+- `cargo test -p bcs-bot-store -p bcs-bot -p bcs-http -p bcs-ws`:
+  933 passed, 18 ignored, no failures across unit, integration, and doc tests.
+- `cargo check --workspace --tests`: passed, including all consumers of
+  `RegisteredBot` and their test fixtures. Existing unrelated warnings remain.
+- The three SQLite-backed cache regressions were rerun after moving them to
+  `tests/unit/heartbeat.rs`: all passed. They are included as a unit-test module
+  so they can age the private monotonic heartbeat timestamp directly.
+- Independent code review and `git diff --check`: no remaining findings.
+
+The complete `scripts/ci/arch-check.sh` run was stopped during its prolonged
+workspace test enumeration; it is **not** reported as passing. Port purity,
+forbidden-symbol, store-boundary, and interceptor checks passed. Import rules,
+trait naming, and the static R25 harness/entry checks have existing findings:
+rerunning those checks on an archived clean base and comparing the final change
+found no added findings. The configuration tests passed (119 tests), but their
+gate also reports a missing explicit invalid-enum test pattern already absent
+from the unchanged baseline configuration scope.
+
+The new cache test double initially appeared in the production conformance scan
+because its file was under `src`. Keeping these unit tests under `tests/unit`
+correctly separates test implementations; the final static R25 findings match
+the clean base exactly. No architecture checks or baselines were weakened.
+
+No OCB sources or gitlink changes are needed for this implementation.

--- a/src/bcs/docs/plans/2026-09-11-heartbeat-only-registration.md
+++ b/src/bcs/docs/plans/2026-09-11-heartbeat-only-registration.md
@@ -14,14 +14,14 @@
 - Remove dynamic-summary matching from application discovery and both repository implementations. Static names, summaries, skills, domains, scopes, visibility, and organization filters keep their semantics.
 - Keep the existing 300-second `last_heartbeat` expiry and all connection/lifecycle-based `active`/`offline` calculations. Do not add cleanup scheduling or change disconnect policy.
 - Remove status hash construction, serialization, reads, writes, and TTL refreshes. Existing keys expire naturally; no Redis cleanup commands or migrations are needed.
-- Keep existing persistent-repository constructor signatures for downstream composition roots. Legacy cache/prefix arguments are accepted but neither retained nor used. Other stores still use the shared cache normally.
+- Use DB-only persistent-repository constructors: `new(db)` and `with_sql_flavor(db, flavor)`. Remove unused cache/prefix/legacy database-name arguments and the cache dependency. Update the shared bootstrap and callers; other stores still use the shared cache normally.
 - `/providers/agentpass/resolve` serializes registration details without `bot.dynamic_status`, as explicitly authorized for this diagnostic endpoint. `POST /bots/status` retains its echo response; WS status acknowledgements remain `{ "updated": true }`.
 - Update public Rust fixtures constructing `RegisteredBot`. OCB internal sources have no dynamic-status consumers or literals; no OCB code or gitlink changes are required.
 
 ## Task 1: Regressions before implementation
 
 1. Run the existing bot-store unit tests as a baseline.
-2. Add a cache implementation that fails any call and exercise real SQLite-backed registration, heartbeat, DB fallback, soft-delete enrichment, and reconnect through it.
+2. Exercise real SQLite-backed registration, heartbeat, DB fallback, soft-delete enrichment, and reconnect without constructing or injecting a cache. The initial removal was also checked with a cache implementation that failed any call; the DB-only API now removes that dependency entirely.
 3. Add heartbeat-expiry tests using manually aged private registration timestamps, including a previously renewed Bot and rejection of unknown Bot heartbeats.
 4. Add repository/application discovery tests that reject a keyword present only in the inbound dynamic summary while still matching static metadata.
 5. Extend the AgentPass HTTP contract test to assert absence of dynamic state and preserve identity/capability fields; preserve HTTP status echo and computed online-state tests.
@@ -31,7 +31,7 @@
 
 1. Remove the snapshot field from `bcs-domain::RegisteredBot` and both private registration records; update affected struct literals and obsolete snapshot assertions.
 2. Change both `update_status` implementations to refresh only `last_heartbeat`, retaining known/unknown Bot outcomes.
-3. Delete persistent status-cache helpers and their obsolete unit tests. Keep source-compatible constructors without retaining cache references.
+3. Delete persistent status-cache helpers and their obsolete unit tests. Remove unused constructor arguments and cache dependencies, and update all constructor callers.
 4. Remove dynamic-summary selector branches. Keep the wire payload and echo types.
 5. Update contract comments and current API documentation; remove obsolete cache-observation documentation caused by this change.
 
@@ -78,3 +78,22 @@ correctly separates test implementations; the final static R25 findings match
 the clean base exactly. No architecture checks or baselines were weakened.
 
 No OCB sources or gitlink changes are needed for this implementation.
+
+### DB-only constructor follow-up
+
+The constructor compatibility arguments were subsequently removed: the final
+API is `new(db)` or `with_sql_flavor(db, flavor)`. Shared bootstrap wiring and
+all callers use the new API. `bcs-bot-store` no longer depends directly on
+`bcs-cache-api` or `bcs-cache-local`; dependent test fixtures also drop their
+unused cache setup. The SQLite heartbeat regressions retain their liveness and
+fallback checks without injecting any cache implementation.
+
+- `cargo test -p bcs-bot-store -p bcs-bot -p bcs-app-group -p bcs-app-session`:
+  452 passed, 4 ignored, no failures.
+- `cargo check --workspace --tests`: passed with the DB-only constructors.
+- `cargo tree -p bcs-bot-store -e normal --depth 1`: no cache-plugin dependency.
+- `scripts/ci/check-store-boundaries.sh` and `git diff --check`: passed.
+- Constructor/dependency review found no functional issues; stale cache-related
+  comments in the integration examples were corrected.
+- OCB internal sources on the inspected `origin/dev` have no direct
+  `PersistentBotRepo` constructor calls; they use the shared bootstrap.


### PR DESCRIPTION
## Problem

Each Bot status heartbeat retained a dynamic snapshot and could issue four hash writes plus a TTL refresh. Database fallback and cold reconnection also read that snapshot from the cache. These operations add avoidable cache traffic and dependency waits: Bot availability is already derived from actor lifecycle and connection/provider state, while the heartbeat's useful retained state is its liveness timestamp.

Discovery also matched `dynamic_summary`, allowing transient heartbeat descriptions to influence search results.

## Solution

- Retain only `last_heartbeat` from status heartbeats in both repository implementations. Remove the dynamic snapshot from registration records and `RegisteredBot` while preserving identity, capabilities, connections, and lifecycle state.
- Remove all dynamic-status hash reads, writes, serialization, and TTL refreshes, including database fallback, deleted-Bot name enrichment, and cold reconnection.
- Remove dynamic-summary matching from repository and application discovery. Static capability matching and existing visibility filters retain their behavior.
- Keep the existing WebSocket and HTTP status payloads accepted. HTTP status updates still echo the payload; WebSocket acknowledgements retain their existing shape. The diagnostic `/providers/agentpass/resolve` response omits `bot.dynamic_status`.
- Simplify construction to `PersistentBotRepo::new(db)` and `with_sql_flavor(db, flavor)`. Remove unused cache, prefix, and legacy database-name arguments, update shared bootstrap and all callers, and remove unnecessary cache dependencies from the repository and its test fixtures.
- Add real SQLite-backed regressions that run without constructing or injecting a cache, plus coverage for heartbeat renewal, unknown registrations, discovery, reconnection, and HTTP compatibility. Update registration fixtures and document the revised contract.

## Validation

- Heartbeat behavior validation before the constructor cleanup: `cargo test -p bcs-bot-store -p bcs-bot -p bcs-http -p bcs-ws` — **933 passed, 18 ignored, 0 failed**.
- After the DB-only constructor cleanup: `cargo test -p bcs-bot-store -p bcs-bot -p bcs-app-group -p bcs-app-session` — **452 passed, 4 ignored, 0 failed**. The original heartbeat assertions were observed failing against the old implementation before the production changes.
- `cargo check --workspace --tests`: passed again after the DB-only constructor cleanup.
- `cargo tree -p bcs-bot-store -e normal --depth 1`: no direct cache-plugin dependency. The store-boundary check also passed.
- Independent code review and `git diff --check`: no remaining findings.
- The full `scripts/ci/arch-check.sh` umbrella was **not completed**: it was stopped during prolonged workspace test enumeration. Completed port-purity, forbidden-symbol, store-boundary, and interceptor checks passed. Import, naming, and static R25 findings were compared with the clean implementation base; the final change adds no findings. Configuration tests passed (119), while their gate reports an existing missing invalid-enum test pattern. No checks or baselines were weakened.

## Compatibility and risk

- The existing 300-second heartbeat expiry policy, disconnect handling, and computed `active`/`offline` responses remain unchanged. This does not introduce cleanup scheduling.
- **Propagation analysis:** Rust consumers constructing or accessing `RegisteredBot.dynamic_status` must remove that field; in-repository consumers and fixtures are updated. The AgentPass diagnostic endpoint intentionally stops exposing the snapshot. Other online-state responses continue using their computed status type.
- **Constructor migration:** replace `with_plugins(cache, db)` with `new(db)`; replace flavor/prefix variants with `with_sql_flavor(db, flavor)`. The previous three-argument `new` is also replaced by `new(db)`. Cache/prefix arguments are removed, not retained as compatibility placeholders. Shared bootstrap and all in-repository callers are updated; other cache consumers remain wired as before.
- No database migration or cache deletion is required. Previously written status keys can expire under their existing TTLs. Reverting this commit restores the prior snapshot behavior; new heartbeats would repopulate expired snapshots.

## Spec

- `src/bcs/docs/heartbeat-status.md`
- `src/bcs/docs/plans/2026-09-11-heartbeat-only-registration.md`

