### PR TITLE
refactor(apply): drop the legacy bare-string source road

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/entry_delivery.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/entry_delivery.py
@@ -162,7 +162,7 @@ class FetchedEntry:
     #: The address these bytes are filed under, in one of three shapes
     #: depending on the road that produced them::
     #:
-    #:     "https://example.com/tools/qc-v2.zip"       # inline URL road
+    #:     "https://example.com/tools/qc-v2.zip"       # the API install road
     #:     "oss://team-artifacts/tools/qc/v2.tgz"      # object store road
     #:     "git+https://code.example.com/team/content.git@<40-hex sha>:kb"
     #:
@@ -308,8 +308,8 @@ class EntryDelivery(Protocol):
     ``single``; ``cli_tools`` alone calls ``digest``; and all four call
     ``note``, ``receipt_url``, ``auth`` and ``needs_receipt``.
 
-    Created by: ``apply/source_fetchers`` (both fetchers) and
-    ``apply/entry_fetch.fetch_declared`` on the legacy inline-URL road.
+    Created by: ``apply/source_fetchers`` (both fetchers), and by
+    ``cli_tools/service`` around a ``fetch`` on the API-driven install road.
     Consumed by: every fetching materialiser — ``skills``, ``resources``,
     ``identity``, ``cli_tools``.
 
@@ -433,9 +433,9 @@ class EntryDelivery(Protocol):
 class BlobDelivery(EntryDelivery):
     """One object's bytes, however they were acquired.
 
-    The object-store road, the legacy inline-URL road, and every ``keep_last``
-    fallback — including a git one, whose stored bytes arrive here as a
-    canonical tree blob rather than as a checkout::
+    The object-store road, the API install road's plain URL, and every
+    ``keep_last`` fallback — including a git one, whose stored bytes arrive
+    here as a canonical tree blob rather than as a checkout::
 
         BlobDelivery(fetched=FetchedEntry(
             content=b"PK\x03\x04...",

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/entry_fetch.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/entry_fetch.py
@@ -8,10 +8,13 @@ content store so delivery and audit share one copy.
 **The four entry points**, and which is which:
 
 ``fetch(ctx, *, source_url=…)``
-    Called by :meth:`EntryFetcher.fetch_declared` on the legacy bare-string
-    ``source:`` road, and by nothing else in this package. Its ``source_url``
-    is a plain ``https://…`` URL, never ``oss://`` and never ``git+…``. Files
-    a receipt. Charges the budget on a real fetch, not on a store hit.
+    Called by the ``cli_tools`` service's API-driven install
+    (``cli_tools/service.py::_acquire``, the ``decl.entry is None`` branch),
+    where a caller hands the platform a plain URL with no manifest and no
+    ``sources`` map — and by nothing in this package, because no manifest
+    road reaches it. Its ``source_url`` is a plain ``https://…`` URL, never
+    ``oss://`` and never ``git+…``. Files a receipt. Charges the budget on a
+    real fetch, not on a store hit.
 
 ``fetch_declared(ctx, *, entry=…)``
     The front door every fetching materialiser calls. Takes no URL at all: it
@@ -33,9 +36,9 @@ content store so delivery and audit share one copy.
 **Three ``source_url`` shapes exist**, and which method sees which matters::
 
     "https://example.com/tools/qc-v2.zip"
-        the inline bare-string source, and the ONLY shape ``fetch`` ever
-        takes as its ``source_url=`` argument. Never ``oss://``, never
-        ``git+…``.
+        the plain URL the API-driven install hands over, and the ONLY shape
+        ``fetch`` ever takes as its ``source_url=`` argument. Never
+        ``oss://``, never ``git+…``.
 
     "oss://team-artifacts/tools/qc/v2.tgz"
         built by ``source_fetchers.object_receipt_url`` inside
@@ -101,7 +104,7 @@ and inline-source roads resolve through the apply's source session, and the git
 road returns a :class:`GitEntrySource` — the tree is the entry's to
 interpret (a file? a package?) — while its canonical, entry-level bytes are
 filed with the store via :meth:`file_bytes`, so audit and ``keep_last`` read
-the same receipts the URL roads always have.
+the same receipts every fetching road files.
 
 **Dispatch is on the declared protocol**, read through the one parser the
 ``PUT`` validator also uses. It used to be on which key a source mapping
@@ -118,7 +121,6 @@ from typing import TYPE_CHECKING, Any, Mapping, Optional, Protocol, runtime_chec
 
 
 from agentclaw.community.core.bot_config_manifest.apply.entry_delivery import (
-    BlobDelivery,
     EntryDelivery,
     EntryFetchError,
     FetchedEntry,
@@ -297,9 +299,10 @@ class EntryFetcher:
     ) -> FetchedEntry:
         """Acquire one entry's bytes over HTTPS. Raises :class:`EntryFetchError`.
 
-        ``source_url`` is a plain ``https://…`` URL — the legacy bare-string
-        ``source:`` spelling, which the schema now refuses at ``PUT`` but which
-        stored documents still carry. It is never ``oss://`` and never
+        ``source_url`` is a plain ``https://…`` URL — the address the
+        API-driven ``cli_tools`` install hands over, which is the only caller
+        left: no manifest entry reaches this method, because a manifest names
+        its source as a declaration. It is never ``oss://`` and never
         ``git+…``; those roads have their own entry points. ``${BOT_*}`` is
         substituted here, so the argument may still contain placeholders::
 
@@ -501,12 +504,13 @@ class EntryFetcher:
 
             {"name": "qc", "source": {"protocol": "oss",
                                       "bucket": "team-artifacts",
-                                      "key": "qc/v2.tgz"}}
+                                      "key": "qc/v2.tgz",
+                                      "auth": "oss-prod"}}
                 # an inline declaration. Needs a source session.
 
             {"path": "data/kb.zip", "source": "https://example.com/kb.zip"}
-                # the legacy bare string: straight to ``fetch``, no session
-                # needed.
+                # NOT a road: ``source`` is a declaration object, so this is
+                # refused here, the way ``PUT`` refuses it.
 
         ``category`` is a :class:`FetchCategory` value as a string, e.g.
         ``"resources_file"``; it is coerced to the enum here, so a misspelling
@@ -524,40 +528,41 @@ class EntryFetcher:
         what keeps the roads from drifting — two fetchers each deciding what
         ``keep_last`` means would both look correct and disagree.
 
-        One road never reaches a fetcher: a bare-string ``source`` is a URL
-        with no declaration to parse, so it goes straight to :meth:`fetch`.
-        The schema now **refuses** that spelling at ``PUT``, so no new document
-        can take it. It survives here for the documents already stored under
-        the old grammar, which an apply still has to be able to read; delete it
-        only once those are known to be gone.
+        **Every source that reaches here is a declaration**, and there is no
+        road around that: ``source`` is a Mapping carrying a ``protocol``, or
+        ``from`` names one under the apply's ``sources``. A ``source`` of any
+        other type — a URL written as a plain string, the spelling the ``PUT``
+        validator refuses (§2.2 — declare ``protocol: git`` or
+        ``protocol: oss``) — is refused here too, so both surfaces answer a
+        stored document the same way.
         """
         expired = ctx.budget.expired() if ctx.budget is not None else None
         if expired is not None:
             raise EntryFetchError(expired)
 
         # The entry's own inline ``source:`` — the alternative to naming a
-        # declared one with ``from:``. Three shapes reach here, and the type
-        # is the dispatch::
+        # declared one with ``from:``. One shape reaches here, a declaration
+        # object, and its ``protocol`` is the dispatch::
         #
-        #     source: {protocol: git, url: ..., ref: v1.2.0}   # Mapping
-        #     source: {protocol: oss, bucket: b, key: k}       # Mapping
-        #     source: "https://example.com/x.zip"              # str, legacy
+        #     source: {protocol: git, url: ..., ref: v1.2.0}
+        #     source: {protocol: oss, bucket: b, key: k}
         #
         # ``None`` when the entry used ``from:`` or inline ``content:``.
         inline = entry.get("source")
-        # Only the roads that read the session require one: a ``from`` name
-        # is looked up in ``session.sources`` and a git road checks out
-        # through it. The inline-URL road never touches it, and refusing it
-        # over a missing session would break the URL-only applies (and
-        # their rigs) that W5 shipped — the message says who it is for.
-        needs_session = isinstance(entry.get("from"), str) or isinstance(
+        # Every road that reaches a fetcher reads the session — a ``from``
+        # name is looked up in ``session.sources``, and a declared source is
+        # acquired through it — so the requirement is exactly "this entry
+        # declares a source". An entry that declares none is refused below on
+        # its own terms rather than blamed on the missing session, and the
+        # message says who builds one, for the rig that arrives without it.
+        declares_source = isinstance(entry.get("from"), str) or isinstance(
             inline, Mapping
         )
         session = ctx.source_session
-        if needs_session and session is None:
+        if declares_source and session is None:
             raise EntryFetchError(
-                "this apply carries no source session: a 'from' or git "
-                "source needs one (the apply service builds it per apply)"
+                "this apply carries no source session: a declared 'from' or "
+                "'source' needs one (the apply service builds it per apply)"
             )
 
         keep_last = entry.get("on_fetch_failure", "keep_last") == "keep_last"
@@ -572,23 +577,14 @@ class EntryFetcher:
                     f"'from' names source {name!r}, which is not declared "
                     "under 'sources'"
                 )
-        elif isinstance(inline, str):
-            return BlobDelivery(
-                self.fetch(
-                    ctx,
-                    source_url=inline,
-                    digest=entry.get("digest"),
-                    auth=entry.get("auth"),
-                    category=category,
-                    keep_last=keep_last,
-                    entry_identity=entry_identity,
-                )
-            )
         elif isinstance(inline, Mapping):
             raw = inline
         else:
             raise EntryFetchError(
-                "an entry must name one of 'from', 'source' or 'content'"
+                "an entry must name one of 'from', 'source' or 'content', "
+                "and 'source' is a declaration object carrying a 'protocol' "
+                "(declare 'protocol: git' or 'protocol: oss') — a URL written "
+                "as a plain string is not one"
             )
         assert raw is not None
 
@@ -933,7 +929,7 @@ def declared_protocol(
     ==============================================  ====================
     ``entry``                                       Answer
     ==============================================  ====================
-    ``{"source": "https://example.com/kb.zip"}``    ``SourceKind.OSS``
+    ``{"source": "https://example.com/kb.zip"}``    ``None``
     ``{"source": {"protocol": "oss", "bucket":      ``SourceKind.OSS``
     "b", "key": "k", "auth": "a"}}``
     ``{"source": {"protocol": "git", "url":         ``SourceKind.GIT``
@@ -947,10 +943,9 @@ def declared_protocol(
     ``{"content": "inline text"}``                  ``None``
     ==============================================  ====================
 
-    A bare-string ``source`` answers ``OSS`` because that legacy road is served
-    by the object-store side of the pipeline, even though it fetches over
-    HTTPS. Anything that does not parse cleanly answers ``None``, which is why
-    an incomplete declaration reads the same as an absent one here.
+    Anything that is not a parseable declaration answers ``None`` — a
+    ``source`` that is not a Mapping at all reads the same here as an
+    incomplete one, and the same as an absent one.
 
     Called by: ``materialisers/resources``, which validates an archive's
     ``unpack`` before spending a fetch that a missing one guarantees to waste,
@@ -959,13 +954,12 @@ def declared_protocol(
 
     Read through the same parser the ``PUT`` validator and ``fetch_declared``
     use, so a fourth derivation cannot appear. ``None`` means "cannot say from
-    the declaration alone"; the caller then falls through to the fetch, which
-    raises the real error with the real message.
+    the declaration alone" — anything that is not a parseable declaration
+    (a malformed source, an undeclared one, a ``source`` that is not a
+    Mapping at all) answers ``None``; the caller then falls through to the
+    fetch, which raises the real error with the real message.
     """
-    inline = entry.get("source")
-    if isinstance(inline, str):
-        return SourceKind.OSS
-    raw: Any = inline
+    raw: Any = entry.get("source")
     if isinstance(entry.get("from"), str):
         session = ctx.source_session
         raw = (getattr(session, "sources", None) or {}).get(entry["from"])

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/cli_tools.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/cli_tools.py
@@ -14,10 +14,13 @@ the command as it will be invoked. Both source spellings are accepted, and a
           digest: sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b...
           version: "2.1.0"           # a label only; never decides convergence
 
-        # an inline source
+        # an inline source: a declaration object, like every source
         - name: mycli
-          source: https://x/mycli
-          digest: sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b...
+          source:
+            protocol: git
+            url: https://code.example.com/team/tools.git
+            ref: v1.0.0
+          subpath: bin/mycli
 
         # over git the resolved commit SHA is the pin, so 'digest' is
         # refused rather than required
@@ -25,8 +28,8 @@ the command as it will be invoked. Both source spellings are accepted, and a
           from: content
           subpath: bin/tool
 
-An entry reaches ``resolve`` as the raw mapping, e.g. ``{"name": "mycli",
-"source": "https://x/mycli", "digest": "sha256:…"}``.
+An entry reaches ``resolve`` as the raw mapping, e.g. ``{"name": "qc",
+"from": "artifacts", "key": "qc/v2.tgz", "digest": "sha256:…"}``.
 
 This materialiser fetches nothing, verifies nothing, stores nothing and
 delivers nothing. It translates: manifest entries into ``CliToolDecl``s on the
@@ -258,11 +261,12 @@ class CliToolsMaterialiser(Materialiser):
                 )
                 continue
 
-            # Substituted into BOTH halves, so the address the report shows and
-            # the entry the acquisition reads are one string. The fetch funnel
-            # substitutes again on its own road, which is harmless (the result
-            # is a fixed point) and is what covers a ``from``-named source's
-            # URL — a value this materialiser never sees.
+            # ``source_url`` is the declared address the report echoes, and it
+            # is what the API-driven install road hands to the transport, so
+            # it is substituted here. The entry itself is carried through
+            # untouched: the fetch funnel substitutes again on its own road,
+            # which is what covers a ``from``-named source's URL — a value
+            # this materialiser never sees.
             substituted = placeholders.resolve(
                 decl.source_url,
                 engine_type=ctx.engine_type,
@@ -270,8 +274,6 @@ class CliToolsMaterialiser(Materialiser):
                 tenant=ctx.tenant,
             )
             resolved_entry = dict(entry)
-            if isinstance(resolved_entry.get("source"), str):
-                resolved_entry["source"] = substituted
             intents.append(
                 Intent(
                     name,

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/identity.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/identity.py
@@ -12,9 +12,13 @@ inline body and a fetched one are accepted::
           content: |
             # rules
 
-        # an inline source, the legacy bare-string spelling
+        # an inline source: a declaration object, like every source
         - type: SOUL.md
-          source: https://content.example/identity/soul.md
+          source:
+            protocol: oss
+            bucket: team-artifacts
+            key: identity/soul.md
+            auth: oss-prod
 
         # a named source: the entry's subpath must name ONE file, because
         # this category delivers a single body per entry
@@ -23,7 +27,8 @@ inline body and a fetched one are accepted::
           subpath: okr.md
 
 An entry reaches ``resolve`` as the raw mapping, e.g. ``{"type": "SOUL.md",
-"source": "https://content.example/identity/soul.md"}``.
+"source": {"protocol": "oss", "bucket": "team-artifacts",
+"key": "identity/soul.md", "auth": "oss-prod"}}``.
 
 The area this overwrites is the bot's identity
 file set, minus ``MEMORY.md`` / ``IDENTITY.md`` — engine-generated runtime
@@ -49,8 +54,8 @@ IdentityService exposes no delete, and inventing one in apply would give the
 identity area two removal semantics where every reader of the area sees one.
 A reserved name never receives even an empty write.
 
-Fetch (for ``source`` entries — inline URL, or a ``from``/git source via W7's
-``fetch_declared``) happens in ``resolve`` through
+Fetch (for ``source`` entries — a declared ``source``, or a ``from`` name,
+both through W7's ``fetch_declared``) happens in ``resolve`` through
 :class:`~agentclaw.community.core.bot_config_manifest.apply.entry_fetch.EntryFetcher`;
 a failure aborts the whole category before the first write — §3.2's
 all-or-nothing, by construction, never by discipline. The bytes are decoded

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/skills.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/skills.py
@@ -12,14 +12,18 @@ Both source spellings are accepted::
           subpath: quality-check     # selects a subtree, then re-packed
           on_fetch_failure: keep_last
 
-        # an inline source; the legacy bare-string spelling shown here is
-        # what the tests drive, and is still readable from stored documents
+        # an inline source: a declaration object, like every source
         - name: quality-check
-          source: https://content.example/skills/quality-check.zip
+          source:
+            protocol: oss
+            bucket: team-artifacts
+            key: skills/quality-check.zip
+            auth: oss-prod
           digest: sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b...
 
 An entry reaches ``resolve`` as the raw mapping, e.g.
-``{"name": "quality-check", "source": "https://…/quality-check.zip",
+``{"name": "quality-check", "source": {"protocol": "oss", "bucket":
+"team-artifacts", "key": "skills/quality-check.zip", "auth": "oss-prod"},
 "digest": "sha256:…"}``.
 
 The area is the one the all-or-nothing rule names: the bot's **active** skill
@@ -372,12 +376,7 @@ class SkillsMaterialiser(Materialiser):
                         self._build_package,
                         entry=entry,
                         delivery=delivery,
-                        source_url=delivery.source_url()
-                        or (
-                            entry["source"]
-                            if isinstance(entry.get("source"), str)
-                            else ""
-                        ),
+                        source_url=delivery.source_url() or "",
                     )
             except _PackageRefusal as exc:
                 failures.append(ResolveFailure(name, str(exc)))

--- a/src/backend/tests/community/core/bot_config_manifest/apply/_fakes.py
+++ b/src/backend/tests/community/core/bot_config_manifest/apply/_fakes.py
@@ -299,6 +299,85 @@ class FakeCredentials:
         )
 
 
+# ── the declared object-source rig ──────────────────────────────────────────
+# A ``source`` is a declaration: ``{protocol: oss, bucket, key, auth}`` or
+# ``{protocol: git, ...}``. The object road is the one a consumer test reaches
+# for when what it is really pinning is the *fetch* — pinning, keep_last,
+# budget, receipts — so these constants and helpers give every such test one
+# bucket, one credential and one spelling of the declaration.
+
+#: The bucket the rigs seed. A document names it; the endpoint never appears
+#: in a document, which is the whole security property of this road.
+OSS_BUCKET = "manifest-fixtures"
+#: The credential name a declared source carries — ``auth`` is mandatory on
+#: this road, since the endpoint is a property of the credential row.
+OSS_AUTH = "oss-cred"
+OSS_ENDPOINT = "https://oss-cn-shanghai.aliyuncs.com"
+#: Deliberately short and with no provider prefix. Nothing on this road
+#: validates a key id's shape — the store fake compares it as an opaque
+#: string — while anything token-shaped, or merely 12+ characters with a
+#: little entropy, trips ``scripts/ci/check_secrets.py`` on the field name
+#: alone and blocks every push that touches this line.
+OSS_ACCESS_KEY_ID = "fake-ak"
+
+
+class FakeObjectCredentials(FakeCredentials):
+    """:class:`FakeCredentials` plus the half only the object road reads.
+
+    The base fake's binding answers the two header seams; an ``oss`` source
+    also asks it for an :class:`ObjectStoreTarget`, and *that* is where the
+    endpoint and the key pair come from — never from the document.
+    """
+
+    def binding(self, *, name: str):
+        binding = super().binding(name=name)
+        binding.object_store_target = lambda bucket: ObjectStoreTarget(
+            endpoint=OSS_ENDPOINT,
+            bucket=bucket,
+            access_key_id=OSS_ACCESS_KEY_ID,
+            secret_access_key="fake-sk",  # short, for the reason above
+            region="cn-shanghai",
+        )
+        return binding
+
+
+def oss_source(
+    key: str, *, bucket: str = OSS_BUCKET, auth: str | None = OSS_AUTH
+) -> dict[str, Any]:
+    """The declared ``source`` an entry carries to read one object."""
+    decl: dict[str, Any] = {"protocol": "oss", "bucket": bucket, "key": key}
+    if auth is not None:
+        decl["auth"] = auth
+    return decl
+
+
+def seeded_object_store(objects: dict[str, bytes] | None = None) -> FakeObjectStore:
+    """A store holding ``key → bytes`` under :data:`OSS_BUCKET`, readable by
+    the key pair :class:`FakeObjectCredentials` presents."""
+    store = FakeObjectStore()
+    for key, body in (objects or {}).items():
+        store.put(OSS_BUCKET, key, body, access_key_id=OSS_ACCESS_KEY_ID)
+    return store
+
+
+def declared_session(**kwargs):
+    """The per-apply source session a declared source needs.
+
+    Every entry that reaches a fetcher carries one — the ``from`` road reads
+    ``sources`` out of it and the git road checks out through it — so a rig
+    driving a declared source hands the context one even when the object road
+    it takes never looks inside.
+    """
+    from agentclaw.community.core.bot_config_manifest.apply.source_session import (
+        SourceSession,
+    )
+
+    kwargs.setdefault("sources", {})
+    kwargs.setdefault("baselines", {})
+    kwargs.setdefault("git", None)
+    return SourceSession(**kwargs)
+
+
 class FakeIdentityService:
     """Stands in for ``IdentityService``: files held, writes counted.
 
@@ -386,9 +465,11 @@ class FakeIdentityService:
 
 
 def identity_rig(files: dict[str, str] | None = None):
-    """A materialiser over fakes: (materialiser, identity fake, fetcher fake).
+    """A materialiser over fakes: (materialiser, identity fake, object store,
+    content store).
 
-    The fetched URL ``SOUL_URL`` serves ``SOUL_BODY`` for identity tests.
+    The declared source :data:`SOUL_SOURCE` reads :data:`SOUL_KEY` out of the
+    seeded bucket and serves :data:`SOUL_BODY`.
     """
     from agentclaw.community.core.bot_config_manifest.apply.entry_fetch import (
         EntryFetcher,
@@ -398,13 +479,19 @@ def identity_rig(files: dict[str, str] | None = None):
     )
 
     identity = FakeIdentityService(files)
-    fetcher = FakeGuardedFetcher(responses={SOUL_URL: fetched_object(SOUL_BODY)})
+    objects = seeded_object_store({SOUL_KEY: SOUL_BODY})
     content = FakeManifestContent()
-    pipeline = EntryFetcher(fetcher, content, FakeCredentials(), FakeObjectStore())
-    return IdentityMaterialiser(identity, pipeline), identity, fetcher, content
+    pipeline = EntryFetcher(
+        FakeGuardedFetcher(responses={}),
+        content,
+        FakeObjectCredentials(),
+        objects,
+    )
+    return IdentityMaterialiser(identity, pipeline), identity, objects, content
 
 
-SOUL_URL = "https://content.example/identity/soul.md"
+SOUL_KEY = "identity/soul.md"
+SOUL_SOURCE = oss_source(SOUL_KEY)
 SOUL_BODY = b"# team charter\nServe the customer honestly.\n"
 
 

--- a/src/backend/tests/community/core/bot_config_manifest/apply/test_apply_engine.py
+++ b/src/backend/tests/community/core/bot_config_manifest/apply/test_apply_engine.py
@@ -35,9 +35,6 @@ from agentclaw.community.core.bot_config_manifest.capabilities import (
 from agentclaw.community.core.bot_config_manifest.apply.entry_fetch import (
     EntryFetcher,
 )
-from agentclaw.community.core.bot_config_manifest.fetch.guarded_fetcher import (
-    FetchFailedError,
-)
 
 from ._fakes import (
     FakeActivationService,
@@ -51,7 +48,6 @@ from ._fakes import (
     FakeResourceFileService,
     FakeSkillUploadService,
     FakeStartupScriptService,
-    fetched_object,
     make_context,
     real_validator,
 )
@@ -772,14 +768,19 @@ async def test_a_fetching_document_applies_all_four_categories_in_order():
     the partial delivery.
     """
     from ._fakes import (
+        FakeObjectCredentials,
+        OSS_AUTH,
+        OSS_BUCKET,
         SOUL_BODY as _SOUL_BODY,
-        SOUL_URL as _SOUL_URL,
+        SOUL_KEY as _SOUL_KEY,
         build_skill_zip,
+        declared_session,
+        seeded_object_store,
     )
 
     qc_zip = build_skill_zip("quality-check")
-    qc_url = "https://content.example/skills/quality-check.zip"
-    rules_url = "https://content.example/identity/rules.md"
+    qc_key = "skills/quality-check.zip"
+    rules_key = "identity/rules.md"
     import hashlib
 
     qc_digest = "sha256:" + hashlib.sha256(qc_zip).hexdigest()
@@ -787,14 +788,9 @@ async def test_a_fetching_document_applies_all_four_categories_in_order():
     uploads = FakeSkillUploadService()
     activation = FakeActivationService()
     reader = FakeCapabilityReader()
-    fetcher = FakeGuardedFetcher(
-        responses={
-            _SOUL_URL: fetched_object(_SOUL_BODY, url=_SOUL_URL),
-            qc_url: fetched_object(qc_zip, url=qc_url, content_type="application/zip"),
-            # identity rules fetch: the source is gone — a real outage shape.
-        },
-        failures={rules_url: FetchFailedError("source answered 404")},
-    )
+    objects = seeded_object_store({_SOUL_KEY: _SOUL_BODY, qc_key: qc_zip})
+    # identity rules fetch: its bucket is unreachable — a real outage shape.
+    objects.make_unavailable("rules-bucket", "source answered 404")
     engine = ApplyOrchestrator(
         build_materialisers(
             script_service=FakeStartupScriptService(),
@@ -805,8 +801,11 @@ async def test_a_fetching_document_applies_all_four_categories_in_order():
             capability_reader=reader,
             package_validator=real_validator(),
             entry_fetcher=EntryFetcher(
-                fetcher, FakeManifestContent(), FakeCredentials()
-            , FakeObjectStore()),
+                FakeGuardedFetcher(responses={}),
+                FakeManifestContent(),
+                FakeObjectCredentials(),
+                objects,
+            ),
             resource_service=FakeResourceFileService(),
             cli_tool_service=object(),
         ),
@@ -819,17 +818,31 @@ async def test_a_fetching_document_applies_all_four_categories_in_order():
 manifest:
   identity:
     - type: SOUL.md
-      source: "{_SOUL_URL}"
+      source:
+        protocol: oss
+        bucket: "{OSS_BUCKET}"
+        key: "{_SOUL_KEY}"
+        auth: "{OSS_AUTH}"
     - type: RULES.md
-      source: "{rules_url}"
+      source:
+        protocol: oss
+        bucket: rules-bucket
+        key: "{rules_key}"
+        auth: "{OSS_AUTH}"
   skills:
     - name: quality-check
-      source: "{qc_url}"
+      source:
+        protocol: oss
+        bucket: "{OSS_BUCKET}"
+        key: "{qc_key}"
+        auth: "{OSS_AUTH}"
       digest: "{qc_digest}"
 script:
   body: "echo hi"
 """,
-        ctx=make_context(engine_type="openclaw"),
+        ctx=make_context(
+            engine_type="openclaw", source_session=declared_session()
+        ),
     )
 
     # identity aborted on the failed RULES fetch — nothing written there;

--- a/src/backend/tests/community/core/bot_config_manifest/apply/test_cli_tools_materialiser.py
+++ b/src/backend/tests/community/core/bot_config_manifest/apply/test_cli_tools_materialiser.py
@@ -51,6 +51,16 @@ def _elf() -> bytes:
 _TOOL = _elf()
 _DIGEST = "sha256:" + hashlib.sha256(_TOOL).hexdigest()
 
+#: The object source a plain ``_entry()`` names. A cli_tools entry declares a
+#: source the way every other category does; the endpoint and the key pair
+#: come off the credential the source names, never out of the document.
+_OBJECT_SOURCE = {
+    "protocol": "oss",
+    "bucket": "tool-artifacts",
+    "key": "bin/",
+    "auth": "oss-cred",
+}
+
 
 def _ctx(**kwargs) -> ApplyContext:
     base = dict(
@@ -61,6 +71,8 @@ def _ctx(**kwargs) -> ApplyContext:
             is_teclaw=lambda e: (e or "") == "teclaw",
         ),
         apply_id="ap1",
+        # A declared source resolves against the apply's source session.
+        source_session=SimpleNamespace(sources={"tools": _OBJECT_SOURCE}),
     )
     base.update(kwargs)
     return ApplyContext(**base)
@@ -81,7 +93,7 @@ def _service(*, content=_TOOL, digest=_DIGEST, delivery=None):
 
 
 def _entry(**kwargs) -> dict:
-    base = {"name": "mycli", "source": "https://x/mycli", "digest": _DIGEST}
+    base = {"name": "mycli", "from": "tools", "key": "mycli", "digest": _DIGEST}
     base.update(kwargs)
     return base
 
@@ -146,13 +158,27 @@ def test_the_apply_context_is_carried_whole_into_the_service() -> None:
 
 
 @pytest.mark.asyncio
-async def test_a_placeholder_in_a_source_is_substituted_before_the_fetch() -> None:
-    service, _, _, fetcher = _service()
+async def test_a_placeholder_in_a_declared_address_is_substituted() -> None:
+    """The address the report echoes — and the one the API-driven install road
+    hands the transport — carries the substitution this materialiser performs.
+    The fetch funnel substitutes again on its own road, over the source's own
+    fields, which is what covers a ``from``-named source."""
+    service, _, _, _ = _service()
     mat = CliToolsMaterialiser(service)
-    await _apply(
-        mat, _ctx(), [_entry(**{"source": "https://x/${BOT_ENGINE_TYPE}/mycli"})]
+    resolved = await mat.resolve(
+        _ctx(source_session=SimpleNamespace(sources={})),
+        [{
+            "name": "mycli",
+            "source": {
+                "protocol": "git",
+                "url": "https://x/${BOT_ENGINE_TYPE}/tools.git",
+                "ref": "v1.0.0",
+            },
+            "subpath": "bin/mycli",
+        }],
     )
-    assert fetcher.calls[0]["source_url"] == "https://x/openclaw/mycli"
+    assert resolved.ok, resolved.failures
+    assert resolved.intents[0].value.source_url == "https://x/openclaw/tools.git"
 
 
 # ── convergence ───────────────────────────────────────────────────────────
@@ -364,7 +390,7 @@ async def test_the_digest_belt_still_refuses_an_unpinned_object_store_tool() -> 
     service, _, _, _ = _service()
     mat = CliToolsMaterialiser(service)
     resolved = await mat.resolve(
-        _git_ctx(), [{"name": "mycli", "source": "https://x/mycli"}]
+        _ctx(), [{"name": "mycli", "from": "tools", "key": "mycli"}]
     )
     assert not resolved.ok
     assert "requires a 'digest'" in resolved.failures[0].reason

--- a/src/backend/tests/community/core/bot_config_manifest/apply/test_entry_fetch.py
+++ b/src/backend/tests/community/core/bot_config_manifest/apply/test_entry_fetch.py
@@ -21,9 +21,11 @@ from agentclaw.community.core.bot_config_manifest.fetch.object_store import (
 )
 from tests.community.core.bot_config_manifest.apply._fakes import FakeObjectStore
 from agentclaw.community.core.bot_config_manifest.apply.entry_fetch import (
+    declared_protocol,
     EntryFetchError,
     EntryFetcher,
 )
+from agentclaw.community.core.bot_config_manifest.support_matrix import SourceKind
 from agentclaw.community.core.bot_config_manifest.apply.source_session import (
     SourceSession,
 )
@@ -1074,3 +1076,53 @@ def test_an_oss_source_without_auth_is_refused_before_any_read(objects_rig):
     assert objects.calls == []  # refused before the store was touched
 
 
+
+
+# --- 'source' is a declaration, and nothing else ----------------------------
+
+
+def test_a_source_written_as_a_plain_url_string_is_refused(rig):
+    """The supported set is exactly three roads — inline ``content``, a
+    declared ``oss`` object, a declared ``git`` repository — and a ``source``
+    naming a URL directly is none of them.
+
+    The ``PUT`` validator has refused that spelling for some time; the apply
+    pipeline kept a read-side branch for documents already stored under the
+    old grammar, and there are none left. The refusal names the shape the
+    author has to write instead, because the entry it is refusing was
+    written by a person, not produced by the platform.
+    """
+    _, fetcher, _, pipeline = rig
+    ctx = make_context(source_session=_session(_ScriptedGit()))
+    with pytest.raises(EntryFetchError) as raised:
+        pipeline.fetch_declared(
+            ctx,
+            entry={"source": "https://example.com/x.zip"},
+            category="skills",
+        )
+    reason = raised.value.reason
+    assert "declaration object" in reason and "protocol" in reason
+    assert "protocol: git" in reason and "protocol: oss" in reason
+    # Refused at the front door: no transport was asked for those bytes.
+    assert fetcher.requests == []
+
+
+def test_declared_protocol_cannot_answer_for_a_source_that_is_not_a_declaration():
+    """``declared_protocol`` answers from the declaration or not at all.
+
+    It used to call a string ``source`` ``OSS``, which was the legacy road's
+    classification. ``None`` — "cannot say from the declaration alone" — is
+    what the callers already handle: they fall through to the fetch, which
+    raises the real error with the real message rather than a rule derived
+    from a shape nothing supports.
+    """
+    ctx = make_context()
+    assert declared_protocol(ctx, {"source": "https://example.com/x.zip"}) is None
+    assert declared_protocol(ctx, {"content": "inline text"}) is None
+    assert (
+        declared_protocol(
+            ctx,
+            {"source": {"protocol": "oss", "bucket": "b", "key": "k", "auth": "c"}},
+        )
+        is SourceKind.OSS
+    )

--- a/src/backend/tests/community/core/bot_config_manifest/apply/test_identity_materialiser.py
+++ b/src/backend/tests/community/core/bot_config_manifest/apply/test_identity_materialiser.py
@@ -28,22 +28,33 @@ from agentclaw.community.core.bot_config_manifest.apply.source_session import (
     SourceSession,
 )
 from agentclaw.community.core.bot_config_manifest.fetch.guarded_fetcher import (
-    FetchFailedError,
     FetchRefusedError,
 )
 
+from agentclaw.community.core.bot_config_manifest.apply.source_fetchers import (
+    object_receipt_url,
+)
+
 from ._fakes import (
-    FakeCredentials,
     FakeGuardedFetcher,
     FakeIdentityService,
     FakeManifestContent,
+    FakeObjectCredentials,
+    OSS_BUCKET,
+    declared_session,
     fetched_object,
     identity_rig,
     make_context,
+    oss_source,
+    seeded_object_store,
     SOUL_BODY,
-    SOUL_URL,
+    SOUL_KEY,
+    SOUL_SOURCE,
 )
-from tests.community.core.bot_config_manifest.apply._fakes import FakeObjectStore
+
+#: The W11 identity the seeded object's bytes are filed under — what a
+#: pre-filed keep_last copy is keyed by.
+SOUL_RECEIPT = object_receipt_url(OSS_BUCKET, SOUL_KEY)
 
 
 def _run(coro):
@@ -56,6 +67,8 @@ def _ctx(**kwargs):
     # turn every RULES/SOUL test into a legality test.
     kwargs.setdefault("engine_type", "openclaw")
     kwargs.setdefault("owner_id", "u_owner")
+    # Every declared source is resolved against the apply's source session.
+    kwargs.setdefault("source_session", declared_session())
     return make_context(**kwargs)
 
 
@@ -69,7 +82,7 @@ async def _apply(materialiser, ctx, entries):
     return resolved, plan, written
 
 
-DECLARED = {"type": "SOUL.md", "source": SOUL_URL}
+DECLARED = {"type": "SOUL.md", "source": SOUL_SOURCE}
 
 
 # ── resolve: entries, both source forms ─────────────────────────────────────
@@ -95,40 +108,37 @@ def test_an_inline_content_entry_materialises():
 
 
 def test_a_sourced_entry_fetches_then_writes():
-    materialiser, identity, fetcher, _ = identity_rig()
+    materialiser, identity, objects, _ = identity_rig()
     result, plan, written = _run(_apply(materialiser, _ctx(), [DECLARED]))
     assert result.ok
     assert [e.outcome.value for e in written] == ["created"]
-    assert fetcher.requests[0].url == SOUL_URL
+    assert objects.calls[0][1] == SOUL_KEY
     assert identity.writes[0]["file_type"] == "SOUL.md"
     assert identity.writes[0]["content"] == SOUL_BODY.decode("utf-8")
 
 
 def test_placeholder_substitution_reaches_the_identity_fetch():
-    materialiser, identity, fetcher, _ = identity_rig()
-    substituted = "https://content.example/identity/dev/soul.md"
-    fetcher.responses[substituted] = fetcher.responses.pop(SOUL_URL)
+    """A per-env key prefix is the whole reason the placeholders exist, so
+    the substitution has to land in the address the store is asked for."""
+    materialiser, identity, objects, _ = identity_rig()
+    substituted = "identity/dev/soul.md"
+    objects.put(OSS_BUCKET, substituted, SOUL_BODY, access_key_id=None)
 
     result, _, _ = _run(
         _apply(
             materialiser,
             _ctx(),
-            [
-                {
-                    "type": "SOUL.md",
-                    "source": "https://content.example/identity/${BOT_ENV}/soul.md",
-                }
-            ],
+            [{"type": "SOUL.md", "source": oss_source("identity/${BOT_ENV}/soul.md")}],
         )
     )
     assert result.ok
-    assert fetcher.requests[0].url == substituted
+    assert objects.calls[0][1] == substituted
 
 
 def test_a_non_utf8_identity_source_fails_the_entry():
-    materialiser, identity, fetcher, _ = identity_rig()
+    materialiser, identity, objects, _ = identity_rig()
     binary = bytes([0xFF, 0xFE, 0x00, 0x01])
-    fetcher.responses[SOUL_URL] = fetched_object(binary, url=SOUL_URL)
+    objects.put(OSS_BUCKET, SOUL_KEY, binary)
 
     resolved = _run(materialiser.resolve(_ctx(), [DECLARED]))
     assert not resolved.ok
@@ -200,21 +210,27 @@ def test_an_entry_without_either_source_form_is_refused():
 
 def test_one_failed_fetch_aborts_the_whole_category_no_writes():
     identity = FakeIdentityService()
-    ok_url = "https://content.example/identity/rules.md"
-    failing = FakeGuardedFetcher(
-        responses={ok_url: fetched_object(b"# rules", url=ok_url)},
-        failures={SOUL_URL: FetchFailedError("source answered 404")},
-    )
+    ok_key = "identity/rules.md"
+    objects = seeded_object_store({ok_key: b"# rules"})
+    # The second entry reads a bucket the store cannot reach — a transport
+    # failure with nothing filed to fall back to.
+    objects.make_unavailable("down-bucket", "source answered 404")
     materialiser = IdentityMaterialiser(
-        identity, EntryFetcher(failing, FakeManifestContent(), FakeCredentials(), FakeObjectStore())
+        identity,
+        EntryFetcher(
+            FakeGuardedFetcher(responses={}),
+            FakeManifestContent(),
+            FakeObjectCredentials(),
+            objects,
+        ),
     )
 
     resolved = _run(
         materialiser.resolve(
             _ctx(),
             [
-                {"type": "RULES.md", "source": ok_url},
-                {"type": "SOUL.md", "source": SOUL_URL},
+                {"type": "RULES.md", "source": oss_source(ok_key)},
+                {"type": "SOUL.md", "source": oss_source(SOUL_KEY, bucket="down-bucket")},
             ],
         )
     )
@@ -231,15 +247,20 @@ def test_keep_last_reuses_the_platform_copy_when_the_source_is_down():
     content = FakeManifestContent()
     # A prior apply fetched and filed the bytes; since then, the source died.
     content.store(
-        fetched_object(SOUL_BODY, url=SOUL_URL, content_type="text/markdown"),
+        fetched_object(SOUL_BODY, url=SOUL_RECEIPT, content_type="text/markdown"),
         scope=None,
-        source_url=SOUL_URL,
+        source_url=SOUL_RECEIPT,
     )
-    failing = FakeGuardedFetcher(
-        failures={SOUL_URL: FetchFailedError("source transport failed")}
-    )
+    objects = seeded_object_store({SOUL_KEY: SOUL_BODY})
+    objects.make_unavailable(OSS_BUCKET, "source transport failed")
     materialiser = IdentityMaterialiser(
-        identity, EntryFetcher(failing, content, FakeCredentials(), FakeObjectStore())
+        identity,
+        EntryFetcher(
+            FakeGuardedFetcher(responses={}),
+            content,
+            FakeObjectCredentials(),
+            objects,
+        ),
     )
 
     result, plan, written = _run(
@@ -249,7 +270,7 @@ def test_keep_last_reuses_the_platform_copy_when_the_source_is_down():
             [
                 {
                     "type": "SOUL.md",
-                    "source": SOUL_URL,
+                    "source": SOUL_SOURCE,
                     "on_fetch_failure": "keep_last",
                 },
                 {"type": "RULES.md", "content": "# rules"},
@@ -262,15 +283,15 @@ def test_keep_last_reuses_the_platform_copy_when_the_source_is_down():
 
 
 def test_a_declared_digest_that_the_source_no_longer_matches_fails():
-    materialiser, identity, fetcher, _ = identity_rig()
+    materialiser, identity, objects, _ = identity_rig()
     other = "sha256:" + "1" * 64
     resolved = _run(
         materialiser.resolve(
-            _ctx(), [{"type": "SOUL.md", "source": SOUL_URL, "digest": other}]
+            _ctx(), [{"type": "SOUL.md", "source": SOUL_SOURCE, "digest": other}]
         )
     )
     assert not resolved.ok  # the pin disagrees with what is actually served
-    assert "digest mismatch" in resolved.failures[0].reason
+    assert other in resolved.failures[0].reason
     assert identity.writes == []
 
 
@@ -363,15 +384,20 @@ def test_an_omitted_on_fetch_failure_defaults_to_keep_last():
     identity = FakeIdentityService()
     content = FakeManifestContent()
     content.store(
-        fetched_object(SOUL_BODY, url=SOUL_URL, content_type="text/markdown"),
+        fetched_object(SOUL_BODY, url=SOUL_RECEIPT, content_type="text/markdown"),
         scope=None,
-        source_url=SOUL_URL,
+        source_url=SOUL_RECEIPT,
     )
-    failing = FakeGuardedFetcher(
-        failures={SOUL_URL: FetchFailedError("source transport failed")}
-    )
+    objects = seeded_object_store({SOUL_KEY: SOUL_BODY})
+    objects.make_unavailable(OSS_BUCKET, "source transport failed")
     materialiser = IdentityMaterialiser(
-        identity, EntryFetcher(failing, content, FakeCredentials(), FakeObjectStore())
+        identity,
+        EntryFetcher(
+            FakeGuardedFetcher(responses={}),
+            content,
+            FakeObjectCredentials(),
+            objects,
+        ),
     )
 
     result, _, written = _run(
@@ -385,7 +411,7 @@ def test_the_receipts_link_the_apply_and_the_entry():
     """The linkage the W11 columns exist for: a fetch filed from an apply
     carries the apply key and the entry's identity, so "what did apply X
     fetch" and "what was fetched for this entry" are reads, not guesses."""
-    materialiser, identity, fetcher, content = identity_rig()
+    materialiser, identity, objects, content = identity_rig()
     ctx = _ctx(apply_id="apply-4")
     _run(_apply(materialiser, ctx, [DECLARED]))
     call = content.store_calls[0]

--- a/src/backend/tests/community/core/bot_config_manifest/apply/test_resources_materialiser.py
+++ b/src/backend/tests/community/core/bot_config_manifest/apply/test_resources_materialiser.py
@@ -58,12 +58,23 @@ def _run(coro):
     return asyncio.run(coro)
 
 
+#: The bucket the fetch cases read. A resources entry names a declared
+#: source; ``key`` is the object, and the stub addresses it the way the real
+#: object road files it — ``oss://<bucket>/<key>``.
+_BUCKET = "cdn"
+
+
+def _src(key: str, **extra) -> dict:
+    """The declared ``source`` an entry carries to read one object."""
+    return {"protocol": "oss", "bucket": _BUCKET, "key": key, "auth": "oss-cred", **extra}
+
+
 class _StubEntryFetcher:
     """``EntryFetcher``'s test double, every call recorded.
 
-    URLs ending in ``gone`` stand in for unreachable sources. With
-    ``fixed_body``, every URL serves the same bytes (an archive); without it,
-    the URL's own ``bytes-of-<url>``. It answers in the pipeline's own
+    Addresses ending in ``gone`` stand in for unreachable sources. With
+    ``fixed_body``, every address serves the same bytes (an archive); without
+    it, the address's own ``bytes-of-<address>``. It answers in the pipeline's own
     currency — a real :class:`FetchedEntry` — because the materialiser
     consumes ``.content``; a stub answering in the transport's
     ``FetchedObject`` shape would pass collection and fail on the first real
@@ -131,8 +142,9 @@ class _StubEntryFetcher:
         ``from`` name or an inline ``source`` object resolves through
         ``sources`` on the apply context, and a git protocol answers with a
         tree rather than bytes — which is the branch the materialiser has to
-        get right. Anything else falls through to the URL road's ``fetch``,
-        so every existing case still exercises the code it always did.
+        get right. A ``source`` that is not a declaration object is refused
+        here exactly as the real door refuses it, so the double cannot serve
+        a spelling production no longer accepts.
         """
         if getattr(self, "declared_override", None) is not None:
             return BlobDelivery(self.declared_override)
@@ -148,6 +160,11 @@ class _StubEntryFetcher:
                 )
         elif isinstance(entry.get("source"), dict):
             decl = dict(entry["source"])
+        else:
+            raise EntryFetchError(
+                "an entry must name one of 'from', 'source' or 'content', "
+                "and 'source' is a declaration object carrying a 'protocol'"
+            )
 
         if decl is not None and decl.get("protocol") == "git":
             key = decl["url"]
@@ -173,7 +190,7 @@ class _StubEntryFetcher:
                 )
             )
 
-        url = decl["url"] if decl is not None else entry.get("source")
+        url = decl.get("url") or f"oss://{decl.get('bucket')}/{decl.get('key')}"
         return BlobDelivery(
             self.fetch(
                 ctx,
@@ -319,28 +336,28 @@ def test_fake_resource_service_records_uploads_and_deletes():
     )
 
 
-# --- file entries: URL fetch and inline content (Task 2) ---
+# --- file entries: a declared fetch and inline content (Task 2) ---
 
 
-def test_file_entry_from_url_resolves_to_intent_bytes():
+def test_file_entry_from_a_declared_source_resolves_to_intent_bytes():
     svc = FakeResourceFileService()
     stub = _StubEntryFetcher()
     m = ResourcesMaterialiser(svc, stub)
     ctx = make_context(engine_type="claude_code")
     resolved = _run(
-        m.resolve(ctx, [{"path": "data/a.md", "source": "https://x/a.bin"}])
+        m.resolve(ctx, [{"path": "data/a.md", "source": _src("a.bin")}])
     )
     assert resolved.ok
     assert [i.identity for i in resolved.intents] == ["data/a.md"]
-    assert resolved.intents[0].value == b"bytes-of-https://x/a.bin"
+    assert resolved.intents[0].value == b"bytes-of-oss://cdn/a.bin"
     # The funnel saw the entry's own identity under the file form's own
     # category — the W11 apply/entry linkage — with keep_last as the
     # declared default.
     assert stub.calls == [
         {
-            "source_url": "https://x/a.bin",
+            "source_url": "oss://cdn/a.bin",
             "digest": None,
-            "auth": None,
+            "auth": "oss-cred",
             "category": "resources_file",
             "keep_last": True,
             "entry_identity": "data/a.md",
@@ -368,8 +385,8 @@ def test_fetch_failure_aborts_whole_category():
         m.resolve(
             ctx,
             [
-                {"path": "data/a.md", "source": "https://x/a.bin"},
-                {"path": "data/gone.md", "source": "https://x/gone"},
+                {"path": "data/a.md", "source": _src("a.bin")},
+                {"path": "data/gone.md", "source": _src("gone")},
             ],
         )
     )
@@ -401,7 +418,7 @@ def test_dir_entry_expands_members_under_path():
                     "path": "wrap/",
                     "unpack": "tar.gz",
                     "strip_components": 1,
-                    "source": "https://x/tree.tgz",
+                    "source": _src("tree.tgz"),
                 }
             ],
         )
@@ -427,7 +444,7 @@ def test_bad_archive_is_a_resolve_failure_and_nothing_reaches_the_bot():
     resolved = _run(
         m.resolve(
             ctx,
-            [{"path": "wrap/", "unpack": "tar.gz", "source": "https://x/tree.tgz"}],
+            [{"path": "wrap/", "unpack": "tar.gz", "source": _src("tree.tgz")}],
         )
     )
     assert not resolved.ok
@@ -440,7 +457,7 @@ def test_dir_unpack_missing_is_rejected_at_resolve():
     m = ResourcesMaterialiser(svc, _StubEntryFetcher(_tgz({"a.txt": b"x"})))
     ctx = make_context(engine_type="claude_code")
     resolved = _run(
-        m.resolve(ctx, [{"path": "wrap/", "source": "https://x/tree.tgz"}])
+        m.resolve(ctx, [{"path": "wrap/", "source": _src("tree.tgz")}])
     )
     assert not resolved.ok
     assert "unpack" in resolved.failures[0].reason
@@ -457,9 +474,9 @@ def test_nested_paths_abort_category():
                 {
                     "path": "wrap/",
                     "unpack": "tar.gz",
-                    "source": "https://x/t.tgz",
+                    "source": _src("t.tgz"),
                 },
-                {"path": "wrap/inner.txt", "source": "https://x/i.txt"},
+                {"path": "wrap/inner.txt", "source": _src("i.txt")},
             ],
         )
     )
@@ -478,8 +495,8 @@ def test_plan_classifies_present_as_updated_and_new_as_created():
         m.resolve(
             ctx,
             [
-                {"path": "data/a.md", "source": "https://x/a.bin"},
-                {"path": "data/new.md", "source": "https://x/new.bin"},
+                {"path": "data/a.md", "source": _src("a.bin")},
+                {"path": "data/new.md", "source": _src("new.bin")},
             ],
         )
     )
@@ -512,7 +529,7 @@ def test_plan_addresses_the_bot_owner_not_the_manifest_storage_key():
         engine_type="claude_code",
     )
     resolved = _run(
-        m.resolve(ctx, [{"path": "data/a.md", "source": "https://x/a.bin"}])
+        m.resolve(ctx, [{"path": "data/a.md", "source": _src("a.bin")}])
     )
     assert resolved.ok, [f.reason for f in resolved.failures]
     _run(m.plan(ctx, resolved.intents))
@@ -549,12 +566,12 @@ def test_declared_trees_report_as_removals_not_member_rows():
                 {
                     "path": "established/",
                     "unpack": "tar.gz",
-                    "source": "https://x/old.tgz",
+                    "source": _src("old.tgz"),
                 },
                 {
                     "path": "fresh/",
                     "unpack": "tar.gz",
-                    "source": "https://x/new.tgz",
+                    "source": _src("new.tgz"),
                 },
             ],
         )
@@ -593,7 +610,7 @@ def test_write_replaces_the_tree_then_uploads_every_member():
     plan, results = _write_through(
         m,
         ctx,
-        [{"path": "wrap/", "unpack": "tar.gz", "source": "https://x/t.tgz"}],
+        [{"path": "wrap/", "unpack": "tar.gz", "source": _src("t.tgz")}],
     )
     # One delete per declared tree, first: the replace removes everything
     # under "wrap/" — including files the new archive no longer ships and
@@ -627,7 +644,7 @@ def test_write_deletes_the_declared_tree_without_the_trailing_slash():
     m = ResourcesMaterialiser(svc, _StubEntryFetcher(archive))
     ctx = make_context(engine_type="claude_code")
     _write_through(
-        m, ctx, [{"path": "wrap/", "unpack": "tar.gz", "source": "https://x/t"}]
+        m, ctx, [{"path": "wrap/", "unpack": "tar.gz", "source": _src("t")}]
     )
     assert [c["path"] for c in svc.delete_calls] == ["wrap"]
 
@@ -650,7 +667,7 @@ def test_a_silently_failed_tree_delete_fails_its_members():
         m,
         ctx,
         [
-            {"path": "tools/", "unpack": "tar.gz", "source": "https://x/t.tgz"},
+            {"path": "tools/", "unpack": "tar.gz", "source": _src("t.tgz")},
             {"path": "notes/r.md", "content": "# rules"},
         ],
     )
@@ -677,7 +694,7 @@ def test_a_failed_delete_of_an_absent_tree_is_not_a_failure():
     plan, results = _write_through(
         m,
         ctx,
-        [{"path": "tools/", "unpack": "tar.gz", "source": "https://x/t.tgz"}],
+        [{"path": "tools/", "unpack": "tar.gz", "source": _src("t.tgz")}],
     )
     assert [r.outcome.value for r in results] == ["created"]
     assert svc.writes == {("tools", "a.md"): b"A"}
@@ -695,7 +712,7 @@ def test_write_addresses_the_bot_owner():
         engine_type="claude_code",
     )
     _write_through(
-        m, ctx, [{"path": "wrap/", "unpack": "tar.gz", "source": "https://x/t"}]
+        m, ctx, [{"path": "wrap/", "unpack": "tar.gz", "source": _src("t")}]
     )
     assert svc.delete_calls == [
         {
@@ -733,7 +750,7 @@ def test_write_is_player_setup_convergent():
         _write_through(
             m,
             ctx,
-            [{"path": "wrap/", "unpack": "tar.gz", "source": "https://x/t.tgz"}],
+            [{"path": "wrap/", "unpack": "tar.gz", "source": _src("t.tgz")}],
         )
     assert svc.writes == {("wrap", "a.txt"): b"AAA"}
     assert svc.deleted == ["wrap", "wrap"]
@@ -753,7 +770,7 @@ def test_write_failure_yields_failed_entry_per_member():
     plan, results = _write_through(
         m,
         ctx,
-        [{"path": "wrap/", "unpack": "tar.gz", "source": "https://x/t.tgz"}],
+        [{"path": "wrap/", "unpack": "tar.gz", "source": _src("t.tgz")}],
     )
     outcomes = {(r.identity, r.outcome.value) for r in results}
     assert ("wrap/b.txt", "failed") in outcomes
@@ -839,11 +856,11 @@ def test_each_form_fetches_under_its_own_category():
         m.resolve(
             ctx,
             [
-                {"path": "data/a.md", "source": "https://x/a.bin"},
+                {"path": "data/a.md", "source": _src("a.bin")},
                 {
                     "path": "tools/",
                     "unpack": "tar.gz",
-                    "source": "https://x/t.tgz",
+                    "source": _src("t.tgz"),
                 },
             ],
         )
@@ -882,7 +899,7 @@ def test_keep_last_fallback_surfaces_as_the_entries_note():
     m = ResourcesMaterialiser(svc, _FallingBack())
     ctx = make_context(engine_type="claude_code")
     resolved = _run(
-        m.resolve(ctx, [{"path": "data/a.md", "source": "https://x/a.bin"}])
+        m.resolve(ctx, [{"path": "data/a.md", "source": _src("a.bin")}])
     )
     assert resolved.ok, [f.reason for f in resolved.failures]
     assert (
@@ -910,7 +927,7 @@ def test_write_carries_the_note_onto_the_report_row():
     m = ResourcesMaterialiser(svc, _FallingBack())
     ctx = make_context(engine_type="claude_code")
     plan, results = _write_through(
-        m, ctx, [{"path": "data/a.md", "source": "https://x/a.bin"}]
+        m, ctx, [{"path": "data/a.md", "source": _src("a.bin")}]
     )
     assert [r.note for r in results] == ["fell back (keep_last)"]
 
@@ -934,7 +951,7 @@ def test_an_archive_member_the_chain_would_refuse_fails_at_resolve():
     resolved = _run(
         m.resolve(
             ctx,
-            [{"path": "tools/", "unpack": "tar.gz", "source": "https://x/t.tgz"}],
+            [{"path": "tools/", "unpack": "tar.gz", "source": _src("t.tgz")}],
         )
     )
     # The whole category aborts (§3.2): one undeliverable member means the
@@ -991,7 +1008,7 @@ def test_strip_components_of_the_wrong_type_is_a_resolve_failure():
                     "path": "tools/",
                     "unpack": "tar.gz",
                     "strip_components": "one",
-                    "source": "https://x/t.tgz",
+                    "source": _src("t.tgz"),
                 }
             ],
         )
@@ -1024,7 +1041,7 @@ def test_a_failed_tree_replacement_fails_its_members_in_composed_words():
             {
                 "path": "tools/",
                 "unpack": "tar.gz",
-                "source": "https://x/t.tgz",
+                "source": _src("t.tgz"),
             },
             {"path": "notes/r.md", "content": "# rules"},
         ],
@@ -1067,7 +1084,7 @@ _DOCUMENT = {
             {
                 "path": "wrap/",
                 "unpack": "tar.gz",
-                "source": "https://x/t.tgz",
+                "source": _src("t.tgz"),
             },
             {"path": "notes/r.md", "content": "# rules"},
         ]
@@ -1139,7 +1156,7 @@ def test_an_empty_archive_still_audits_the_tree_removal():
                         {
                             "path": "gone/",
                             "unpack": "tar.gz",
-                            "source": "https://x/empty.tgz",
+                            "source": _src("empty.tgz"),
                         }
                     ]
                 },
@@ -1158,7 +1175,7 @@ def test_an_empty_archive_still_audits_the_tree_removal():
                         {
                             "path": "gone/",
                             "unpack": "tar.gz",
-                            "source": "https://x/empty.tgz",
+                            "source": _src("empty.tgz"),
                         }
                     ]
                 },
@@ -1204,7 +1221,7 @@ def test_a_refused_member_blames_the_declared_entry_in_the_report():
                         {
                             "path": "tools/",
                             "unpack": "tar.gz",
-                            "source": "https://x/t.tgz",
+                            "source": _src("t.tgz"),
                         },
                         {"path": "notes/r.md", "content": "# rules"},
                     ]
@@ -1248,7 +1265,7 @@ def test_routed_bots_address_the_runtime_engine_workspace():
         engine_type="claude_code", bot={"template_type": "applicationCoding"}
     )
     _write_through(
-        m, ctx, [{"path": "wrap/", "unpack": "tar.gz", "source": "https://x/t"}]
+        m, ctx, [{"path": "wrap/", "unpack": "tar.gz", "source": _src("t")}]
     )
     assert svc.delete_calls[0]["engine_type"] == "aicoding"
     assert all(c["engine_type"] == "aicoding" for c in svc.upload_calls)
@@ -1269,7 +1286,7 @@ def test_unrouted_bots_keep_the_active_engine():
         m = ResourcesMaterialiser(svc, _StubEntryFetcher(archive))
         ctx = make_context(engine_type="claude_code", bot=overlay)
         _write_through(
-            m, ctx, [{"path": "wrap/", "unpack": "tar.gz", "source": "https://x/t"}]
+            m, ctx, [{"path": "wrap/", "unpack": "tar.gz", "source": _src("t")}]
         )
         assert svc.delete_calls[0]["engine_type"] == "claude_code"
 
@@ -1277,7 +1294,7 @@ def test_unrouted_bots_keep_the_active_engine():
     m = ResourcesMaterialiser(svc, _StubEntryFetcher(archive))
     ctx = make_context(engine_type="openclaw")
     _write_through(
-        m, ctx, [{"path": "wrap/", "unpack": "tar.gz", "source": "https://x/t"}]
+        m, ctx, [{"path": "wrap/", "unpack": "tar.gz", "source": _src("t")}]
     )
     assert svc.delete_calls[0]["engine_type"] == "openclaw"
 
@@ -1291,7 +1308,7 @@ def test_an_engineless_bot_record_falls_back_to_the_context_engine():
     m = ResourcesMaterialiser(svc, _StubEntryFetcher(archive))
     ctx = make_context(engine_type="openclaw", bot={"active_engine": None})
     _write_through(
-        m, ctx, [{"path": "wrap/", "unpack": "tar.gz", "source": "https://x/t"}]
+        m, ctx, [{"path": "wrap/", "unpack": "tar.gz", "source": _src("t")}]
     )
     assert svc.delete_calls[0]["engine_type"] == "openclaw"
 
@@ -1334,7 +1351,7 @@ def test_duplicate_declared_paths_abort_the_category():
             ctx,
             [
                 {"path": "data/a.md", "content": "first"},
-                {"path": "data/a.md", "source": "https://x/a"},
+                {"path": "data/a.md", "source": _src("a")},
             ],
         )
     )
@@ -1357,7 +1374,7 @@ def test_an_unknown_unpack_kind_is_refused():
                 {
                     "path": "wrap/",
                     "unpack": "tgz",
-                    "source": "https://x/t.tgz",
+                    "source": _src("t.tgz"),
                 }
             ],
         )
@@ -1444,7 +1461,7 @@ def test_an_unhashable_unpack_kind_is_refused_not_raised():
                 {
                     "path": "wrap/",
                     "unpack": ["zip"],
-                    "source": "https://x/t.tgz",
+                    "source": _src("t.tgz"),
                 }
             ],
         )
@@ -1456,8 +1473,8 @@ def test_an_unhashable_unpack_kind_is_refused_not_raised():
 # --- resources over git (defect D1) -----------------------------------------
 #
 # The category that could not name a source. Every case below is a shape the
-# URL road already had and ``resources`` could not reach, plus the one shape
-# only git gives: a tree that arrives as a tree.
+# object road already had and ``resources`` could not reach, plus the one
+# shape only git gives: a tree that arrives as a tree.
 
 _REPO = "https://code.example.com/team/content.git"
 
@@ -1765,7 +1782,7 @@ def test_a_real_archive_still_takes_the_unpack_road():
             make_context(engine_type="claude_code"),
             [{
                 "path": "data/kb/",
-                "source": "https://cdn.example.com/kb.tgz",
+                "source": _src("kb.tgz"),
                 "unpack": "tar.gz",
                 "strip_components": 1,
             }],
@@ -1786,7 +1803,7 @@ def test_an_oss_directory_entry_is_refused_before_the_network_is_touched():
     resolved = _run(
         m.resolve(
             make_context(engine_type="claude_code"),
-            [{"path": "data/kb/", "source": "https://cdn.example.com/kb.zip"}],
+            [{"path": "data/kb/", "source": _src("kb.zip")}],
         )
     )
     assert not resolved.ok
@@ -1803,7 +1820,7 @@ def test_an_invalid_strip_components_is_also_refused_before_the_fetch():
             make_context(engine_type="claude_code"),
             [{
                 "path": "data/kb/",
-                "source": "https://cdn.example.com/kb.zip",
+                "source": _src("kb.zip"),
                 "unpack": "zip",
                 "strip_components": -1,
             }],

--- a/src/backend/tests/community/core/bot_config_manifest/apply/test_skills_materialiser.py
+++ b/src/backend/tests/community/core/bot_config_manifest/apply/test_skills_materialiser.py
@@ -28,6 +28,9 @@ from agentclaw.community.core.bot_config_manifest.apply.entry_fetch import (
 from agentclaw.community.core.bot_config_manifest.apply.source_session import (
     SourceSession,
 )
+from agentclaw.community.core.bot_config_manifest.apply.source_fetchers import (
+    object_receipt_url,
+)
 from agentclaw.community.core.bot_config_manifest.fetch.guarded_fetcher import (
     FetchFailedError,
 )
@@ -35,20 +38,28 @@ from agentclaw.community.core.bot_config_manifest.fetch.guarded_fetcher import (
 from ._fakes import (
     FakeActivationService,
     FakeCapabilityReader,
-    FakeCredentials,
     FakeGuardedFetcher,
     FakeManifestContent,
+    FakeObjectCredentials,
     FakeSkillUploadService,
+    OSS_BUCKET,
     build_skill_tgz,
     build_skill_zip,
+    declared_session,
     fetched_object,
     make_context,
+    oss_source,
     real_validator,
+    seeded_object_store,
     skill_asset,
 )
-from tests.community.core.bot_config_manifest.apply._fakes import FakeObjectStore
 
-QC_URL = "https://content.example/skills/quality-check.zip"
+#: The object every skills fixture is declared against. A skills entry names
+#: a declared source; the key's own suffix is what ``_archive_kind`` reads.
+QC_KEY = "skills/quality-check.zip"
+#: The W11 identity bytes read out of the bucket are filed under — what a
+#: pre-filed receipt (a keep_last copy, a dry run's leftover) is keyed by.
+QC_RECEIPT = object_receipt_url(OSS_BUCKET, QC_KEY)
 
 
 def _run(coro):
@@ -58,6 +69,9 @@ def _run(coro):
 def _ctx(**kwargs):
     kwargs.setdefault("engine_type", "openclaw")
     kwargs.setdefault("owner_id", "u_owner")
+    # Every declared source is resolved against the apply's source session,
+    # so a rig that declares one hands the context one.
+    kwargs.setdefault("source_session", declared_session())
     return make_context(**kwargs)
 
 
@@ -81,10 +95,13 @@ def skill_rig(
     packages: dict[str, bytes] | None = None,
     assets: list | None = None,
     member_ids: set[int] | None = None,
-    fetch_failures: dict[str, Exception] | None = None,
-    content_types: dict[str, str] | None = None,
 ) -> tuple:
-    """(materialiser, uploads, activation, reader, fetcher, content)."""
+    """(materialiser, uploads, activation, reader, objects, content).
+
+    ``packages`` seeds the bucket a declared ``oss`` source reads: object key
+    → the package's bytes. A source that has died is modelled on the store
+    (``objects.make_unavailable``), which is the road a skills entry takes.
+    """
     from agentclaw.community.core.bot_config_manifest.apply.materialisers.skills import (
         SkillsMaterialiser,
     )
@@ -92,29 +109,29 @@ def skill_rig(
     uploads = FakeSkillUploadService()
     activation = FakeActivationService()
     reader = FakeCapabilityReader(assets=assets, member_ids=member_ids)
-    types = content_types or {}
-    fetcher = FakeGuardedFetcher(
-        responses={
-            url: fetched_object(
-                body, url=url, content_type=types.get(url, "application/zip")
-            )
-            for url, body in (packages or {}).items()
-        },
-        failures=fetch_failures or {},
-    )
+    objects = seeded_object_store(packages)
     content = FakeManifestContent()
-    pipeline = EntryFetcher(fetcher, content, FakeCredentials(), FakeObjectStore())
+    pipeline = EntryFetcher(
+        FakeGuardedFetcher(responses={}),
+        content,
+        FakeObjectCredentials(),
+        objects,
+    )
     materialiser = SkillsMaterialiser(
         uploads, activation, reader, real_validator(), pipeline
     )
-    return materialiser, uploads, activation, reader, fetcher, content
+    return materialiser, uploads, activation, reader, objects, content
 
 
 QZ = build_skill_zip("quality-check")
 
 
-def _declared(name: str = "quality-check", url: str = QC_URL, digest: str | None = None):
-    entry = {"name": name, "source": url, "digest": digest or _digest_of(QZ)}
+def _declared(name: str = "quality-check", key: str = QC_KEY, digest: str | None = None):
+    entry = {
+        "name": name,
+        "source": oss_source(key),
+        "digest": digest or _digest_of(QZ),
+    }
     return entry
 
 
@@ -122,8 +139,8 @@ def _declared(name: str = "quality-check", url: str = QC_URL, digest: str | None
 
 
 def test_a_declared_skill_uploads_the_validated_package_and_activates():
-    materialiser, uploads, activation, _, fetcher, _ = skill_rig(
-        packages={QC_URL: QZ}
+    materialiser, uploads, activation, _, objects, _ = skill_rig(
+        packages={QC_KEY: QZ}
     )
     result, plan, written = _run(
         _apply(materialiser, _ctx(), [_declared()])
@@ -142,8 +159,8 @@ def test_a_declared_skill_uploads_the_validated_package_and_activates():
 
 
 def test_the_second_apply_of_an_unchanged_document_performs_no_writes():
-    materialiser, uploads, activation, reader, fetcher, content = skill_rig(
-        packages={QC_URL: QZ}
+    materialiser, uploads, activation, reader, objects, content = skill_rig(
+        packages={QC_KEY: QZ}
     )
     entries = [_declared()]
     _run(_apply(materialiser, _ctx(), entries))
@@ -158,7 +175,7 @@ def test_the_second_apply_of_an_unchanged_document_performs_no_writes():
     assert [e.outcome.value for e in second] == ["unchanged"]
     assert len(uploads.uploads) == 1  # zero further uploads
     assert activation.writes == 1  # and zero further activations
-    assert len(fetcher.requests) == 1  # only the first apply hit the network;
+    assert len(objects.calls) == 1  # only the first apply hit the store;
     # the second was answered by the platform's own copy of the pinned bytes
 
 
@@ -167,48 +184,54 @@ def test_an_inactive_same_name_skill_is_reinstated_as_created():
     ACTIVE set) does not contain it, so it is classed for creation — the
     upload service's same-name replace handles the row, the activation makes
     it active."""
-    materialiser, uploads, activation, _, _, _ = skill_rig(packages={QC_URL: QZ})
+    materialiser, uploads, activation, _, _, _ = skill_rig(packages={QC_KEY: QZ})
     result, plan, written = _run(_apply(materialiser, _ctx(), [_declared()]))
     assert [e.outcome.value for e in written] == ["created"]
     assert uploads.uploads and activation.skill_activations
 
 
 def test_one_failed_fetch_aborts_the_whole_category_no_writes():
-    other_url = "https://content.example/skills/order-lookup.zip"
+    other_key = "skills/order-lookup.zip"
     other = build_skill_zip("order-lookup")
-    materialiser, uploads, activation, _, fetcher, _ = skill_rig(
-        packages={QC_URL: QZ, other_url: other},
-        fetch_failures={other_url: FetchFailedError("source answered 404")},
+    materialiser, uploads, activation, _, objects, _ = skill_rig(
+        packages={QC_KEY: QZ, other_key: other},
     )
+    # The second entry's source is a bucket the store cannot reach — the
+    # transport failure, not a refusal, and nothing is filed to fall back to.
+    objects.make_unavailable("down-bucket", "source transport failed")
     resolved = _run(
         materialiser.resolve(
             _ctx(),
             [
                 _declared(),
-                _declared(name="order-lookup", url=other_url, digest=_digest_of(other)),
+                {
+                    "name": "order-lookup",
+                    "source": oss_source(other_key, bucket="down-bucket"),
+                    "digest": _digest_of(other),
+                },
             ],
         )
     )
     assert not resolved.ok
     failures = {f.identity: f.reason for f in resolved.failures}
-    assert "source answered 404" in failures["order-lookup"]
+    assert "source transport failed" in failures["order-lookup"]
     assert uploads.uploads == []
     assert activation.writes == 0
 
 
 def test_a_digest_that_the_source_no_longer_matches_fails_the_entry():
     stale_pin = "sha256:" + "1" * 64
-    materialiser, uploads, _, _, _, _ = skill_rig(packages={QC_URL: QZ})
+    materialiser, uploads, _, _, _, _ = skill_rig(packages={QC_KEY: QZ})
     resolved = _run(
         materialiser.resolve(_ctx(), [_declared(digest=stale_pin)])
     )
-    assert not resolved.ok
-    assert "digest mismatch" in resolved.failures[0].reason
+    assert not resolved.ok  # the pin disagrees with what is actually served
+    assert stale_pin in resolved.failures[0].reason
     assert uploads.uploads == []
 
 
 def test_the_packages_own_name_must_equal_the_declared_name():
-    materialiser, uploads, _, _, _, _ = skill_rig(packages={QC_URL: QZ})
+    materialiser, uploads, _, _, _, _ = skill_rig(packages={QC_KEY: QZ})
     resolved = _run(
         materialiser.resolve(_ctx(), [_declared(name="different-name")])
     )
@@ -239,8 +262,8 @@ def test_a_tar_gz_source_with_a_subpath_flattens_to_the_skill():
             ("pkg/README", b"wrapper readme the subtree must drop"),
         ]
     )
-    url = "https://content.example/skills/qc.tar.gz"
-    materialiser, uploads, activation, _, _, _ = skill_rig(packages={url: archive})
+    key = "skills/qc.tar.gz"
+    materialiser, uploads, activation, _, _, _ = skill_rig(packages={key: archive})
     result, plan, written = _run(
         _apply(
             materialiser,
@@ -248,7 +271,7 @@ def test_a_tar_gz_source_with_a_subpath_flattens_to_the_skill():
             [
                 {
                     "name": "quality-check",
-                    "source": url,
+                    "source": oss_source(key),
                     "digest": _digest_of(archive),
                     "subpath": "pkg/quality-check",
                 }
@@ -263,16 +286,16 @@ def test_a_tar_gz_source_with_a_subpath_flattens_to_the_skill():
         assert ziparchive.namelist() == ["SKILL.md"]
 
 
-def test_a_declared_unpack_overrides_an_unhelpful_url():
-    url = "https://content.example/skills/get-package"
-    materialiser, uploads, _, _, _, _ = skill_rig(packages={url: QZ})
+def test_a_declared_unpack_overrides_an_unhelpful_key():
+    key = "skills/get-package"
+    materialiser, uploads, _, _, _, _ = skill_rig(packages={key: QZ})
     resolved = _run(
         materialiser.resolve(
             _ctx(),
             [
                 {
                     "name": "quality-check",
-                    "source": url,
+                    "source": oss_source(key),
                     "digest": _digest_of(QZ),
                     "unpack": "zip",
                 }
@@ -283,22 +306,22 @@ def test_a_declared_unpack_overrides_an_unhelpful_url():
     assert resolved.intents[0].identity == "quality-check"
 
 
-def test_a_zip_url_is_detected_from_its_suffix_without_unpack():
-    url = "https://content.example/skills/anything.zip"
-    materialiser, _, _, _, _, _ = skill_rig(packages={url: QZ})
+def test_a_zip_key_is_detected_from_its_suffix_without_unpack():
+    key = "skills/anything.zip"
+    materialiser, _, _, _, _, _ = skill_rig(packages={key: QZ})
     resolved = _run(
-        materialiser.resolve(_ctx(), [_declared(url=url)])
+        materialiser.resolve(_ctx(), [_declared(key=key)])
     )
     assert resolved.ok
 
 
 def test_an_undetectable_archive_kind_fails_with_a_readable_reason():
-    url = "https://content.example/skills/get-package"
-    materialiser, uploads, _, _, _, _ = skill_rig(
-        packages={url: QZ}, content_types={url: "text/plain"}
-    )
+    # Nothing names the shape: the key carries no archive suffix, the object
+    # road serves no content type, and the entry declares no ``unpack``.
+    key = "skills/get-package"
+    materialiser, uploads, _, _, _, _ = skill_rig(packages={key: QZ})
     resolved = _run(
-        materialiser.resolve(_ctx(), [_declared(url=url)])
+        materialiser.resolve(_ctx(), [_declared(key=key)])
     )
     assert not resolved.ok
     assert "unpack" in resolved.failures[0].reason
@@ -307,15 +330,15 @@ def test_an_undetectable_archive_kind_fails_with_a_readable_reason():
 
 def test_a_subpath_that_selects_nothing_fails():
     archive = build_skill_tgz([("other/SKILL.md", _manifest_bytes("other"))])
-    url = "https://content.example/skills/qc.tar.gz"
-    materialiser, _, _, _, _, _ = skill_rig(packages={url: archive})
+    key = "skills/qc.tar.gz"
+    materialiser, _, _, _, _, _ = skill_rig(packages={key: archive})
     resolved = _run(
         materialiser.resolve(
             _ctx(),
             [
                 {
                     "name": "quality-check",
-                    "source": url,
+                    "source": oss_source(key),
                     "digest": _digest_of(archive),
                     "subpath": "pkg/quality-check",
                 }
@@ -331,10 +354,10 @@ def test_an_oversized_package_fails_at_resolve_not_mid_write():
         "quality-check",
         extra=[("big.bin", b"x" * (10 * 1024 * 1024 + 1))],
     )
-    url = "https://content.example/skills/qc.zip"
-    materialiser, uploads, activation, _, _, _ = skill_rig(packages={url: huge})
+    key = "skills/qc.zip"
+    materialiser, uploads, activation, _, _, _ = skill_rig(packages={key: huge})
     resolved = _run(
-        materialiser.resolve(_ctx(), [_declared(url=url, digest=_digest_of(huge))])
+        materialiser.resolve(_ctx(), [_declared(key=key, digest=_digest_of(huge))])
     )
     assert not resolved.ok  # the package limit is the upload's, asked up front
     assert uploads.uploads == []
@@ -376,7 +399,7 @@ def test_a_declared_name_matching_a_set_governed_skill_fails_at_resolve():
     materialiser, uploads, activation, reader, _, _ = skill_rig(
         assets=[skill_asset(12, "quality-check")],
         member_ids={12},
-        packages={QC_URL: QZ},
+        packages={QC_KEY: QZ},
     )
     resolved = _run(materialiser.resolve(_ctx(), [_declared()]))
     assert not resolved.ok
@@ -391,7 +414,7 @@ def test_a_declared_name_matching_a_non_local_active_skill_fails():
     # before any bytes spend, because install would refuse it mid-write.
     materialiser, uploads, _, _, _, _ = skill_rig(
         assets=[skill_asset(9, "quality-check", git_path="git://default/x")],
-        packages={QC_URL: QZ},
+        packages={QC_KEY: QZ},
     )
     resolved = _run(materialiser.resolve(_ctx(), [_declared()]))
     assert not resolved.ok
@@ -408,7 +431,7 @@ def test_undeclared_members_of_the_area_are_removed_by_name():
             skill_asset(11, "some-other-skill"),
             skill_asset(12, "quality-check"),
         ],
-        packages={QC_URL: QZ},
+        packages={QC_KEY: QZ},
     )
     _, plan, written = _run(_apply(materialiser, _ctx(), [_declared()]))
     assert [e.outcome.value for e in written] == ["updated"]
@@ -463,15 +486,15 @@ def test_an_unpinned_skill_source_defaults_to_keep_last():
     """Omitted ``on_fetch_failure`` means ``keep_last`` (schema §2): a source
     that has since died still delivers the platform's own copy, and the
     entry materialises from it."""
-    materialiser, uploads, activation, reader, fetcher, content = skill_rig(
-        packages={QC_URL: QZ}
+    materialiser, uploads, activation, reader, objects, content = skill_rig(
+        packages={QC_KEY: QZ}
     )
     # First apply with an unpinned entry (no digest declared on identity-style
-    # freedom is not allowed for skills — the validator pins URL sources — so
-    # pin it and file the receipt, then kill the source).
+    # freedom is not allowed for skills — the validator pins declared sources
+    # — so pin it and file the receipt, then kill the source).
     entries = [_declared()]
     _run(_apply(materialiser, _ctx(), entries))
-    fetcher.failures[QC_URL] = FetchFailedError("source transport failed")
+    objects.make_unavailable(OSS_BUCKET, "source transport failed")
     qc_id = uploads.rows["quality-check"]["id"]
     reader.assets = (skill_asset(qc_id, "quality-check"),)
 
@@ -481,8 +504,8 @@ def test_an_unpinned_skill_source_defaults_to_keep_last():
 
 
 def test_the_receipts_link_the_apply_and_the_entry():
-    materialiser, uploads, activation, reader, fetcher, content = skill_rig(
-        packages={QC_URL: QZ}
+    materialiser, uploads, activation, reader, objects, content = skill_rig(
+        packages={QC_KEY: QZ}
     )
     _run(_apply(materialiser, _ctx(apply_id="apply-7"), [_declared()]))
     call = content.store_calls[0]
@@ -500,8 +523,8 @@ def test_a_dry_run_receipt_is_not_installation_evidence():
     UNCHANGED here would mean D2 silently never lands while the report says
     SUCCEEDED."""
     old_zip = build_skill_zip("quality-check", extra=[("v1.txt", b"old")])
-    materialiser, uploads, activation, reader, fetcher, content = skill_rig(
-        packages={QC_URL: QZ}
+    materialiser, uploads, activation, reader, objects, content = skill_rig(
+        packages={QC_KEY: QZ}
     )
     # World: installed and active is D1 (the OLD package).
     uploads.rows["quality-check"] = {"id": 12, "name": "quality-check"}
@@ -509,9 +532,9 @@ def test_a_dry_run_receipt_is_not_installation_evidence():
     reader.assets = (skill_asset(12, "quality-check"),)
     # The dry run's fetch of D2 filed its receipt…
     content.store(
-        fetched_object(QZ, url=QC_URL, content_type="application/zip"),
+        fetched_object(QZ, url=QC_RECEIPT, content_type="application/zip"),
         scope=None,
-        source_url=QC_URL,
+        source_url=QC_RECEIPT,
     )
 
     _, plan, written = _run(_apply(materialiser, _ctx(), [_declared()]))
@@ -528,14 +551,14 @@ def test_a_receipt_left_behind_by_an_aborted_write_is_not_evidence():
     """Apply #1's resolve filed this entry's receipt, its write stage then
     aborted (the category's other half failed): apply #2 must still WRITE,
     not read the leftover receipt as 'already installed'."""
-    materialiser, uploads, activation, reader, fetcher, content = skill_rig(
-        packages={QC_URL: QZ}
+    materialiser, uploads, activation, reader, objects, content = skill_rig(
+        packages={QC_KEY: QZ}
     )
     # The leftover receipt from the aborted apply…
     content.store(
-        fetched_object(QZ, url=QC_URL, content_type="application/zip"),
+        fetched_object(QZ, url=QC_RECEIPT, content_type="application/zip"),
         scope=None,
-        source_url=QC_URL,
+        source_url=QC_RECEIPT,
     )
     # …an active name (installed with the *older* package, because abort #1
     # never reached this entry's write)…
@@ -553,8 +576,8 @@ def test_an_unreadable_installed_package_is_treated_as_unknown():
     """Unreadable ≠ equal: a name whose installed package cannot be read back
     (or holds bytes that no longer form a package) must be classed for a
     full write, never guessed into UNCHANGED."""
-    materialiser, uploads, activation, reader, fetcher, content = skill_rig(
-        packages={QC_URL: QZ}
+    materialiser, uploads, activation, reader, objects, content = skill_rig(
+        packages={QC_KEY: QZ}
     )
     uploads.rows["quality-check"] = {"id": 12, "name": "quality-check"}
     # Installed bytes that are NOT this package: digest differs on purpose —
@@ -574,8 +597,8 @@ def test_a_deactivation_conflict_mid_write_reports_partially_written():
     partially-written semantics rather than pretending the area is whole.
     The engine's write-raise path classifies it; this drives it through the
     materialiser with W2's conflict shape the fake models."""
-    materialiser, uploads, activation, reader, fetcher, content = skill_rig(
-        packages={QC_URL: QZ},
+    materialiser, uploads, activation, reader, objects, content = skill_rig(
+        packages={QC_KEY: QZ},
     )
     # The area holds one direct skill the document does not declare…
     reader.assets = (skill_asset(31, "stale-skill"),)

--- a/src/backend/tests/community/core/bot_config_manifest/cli_tools/_fakes.py
+++ b/src/backend/tests/community/core/bot_config_manifest/cli_tools/_fakes.py
@@ -247,11 +247,13 @@ class FakeEntryFetcher:
 
         A manifest-sourced declaration comes through here rather than through
         ``fetch``, so the double resolves the entry the way the real fetcher
-        does — an inline URL, a ``from`` name against the session's ``sources``,
-        or a git source answering with a tree — and records the *resolved*
-        address. A double that just forwarded to ``fetch`` would have kept
-        passing while a source name went on the wire as a URL, which is the
-        defect this door closes.
+        does — a ``from`` name against the session's ``sources`` or an inline
+        declaration object, a git source answering with a tree and an object
+        source with its bucket address — and records the *resolved* address. A
+        double that just forwarded to ``fetch`` would have kept passing while
+        a source name went on the wire as a URL, which is the defect this door
+        closes. A ``source`` that is not a declaration object is refused here
+        exactly as the real door refuses it.
         """
         decl = None
         if isinstance(entry.get("from"), str):
@@ -265,8 +267,34 @@ class FakeEntryFetcher:
                 )
         elif isinstance(entry.get("source"), Mapping):
             decl = entry["source"]
+        else:
+            raise EntryFetchError(
+                "an entry must name one of 'from', 'source' or 'content', "
+                "and 'source' is a declaration object carrying a 'protocol'"
+            )
 
-        if decl is not None and decl.get("protocol") == "git":
+        if decl.get("protocol") == "oss":
+            key = "/".join(
+                part.strip("/")
+                for part in (decl.get("key"), entry.get("key"))
+                if part
+            )
+            self.calls.append(
+                {
+                    "source_url": f"oss://{decl.get('bucket')}/{key}",
+                    "digest": entry.get("digest"),
+                    "auth": decl.get("auth"),
+                    "category": category,
+                    "entry_identity": entry_identity,
+                }
+            )
+            if self.error is not None:
+                raise self.error
+            return BlobDelivery(
+                FakeFetchedEntry(self.content, self.digest or entry.get("digest") or "")
+            )
+
+        if decl.get("protocol") == "git":
             self.calls.append(
                 {
                     "source_url": decl["url"],
@@ -282,9 +310,9 @@ class FakeEntryFetcher:
         return BlobDelivery(
             self.fetch(
                 ctx,
-                source_url=(decl or {}).get("url") or entry.get("source"),
+                source_url=decl.get("url"),
                 digest=entry.get("digest"),
-                auth=(decl or {}).get("auth", entry.get("auth")),
+                auth=decl.get("auth", entry.get("auth")),
                 category=category,
                 keep_last=(
                     entry.get("on_fetch_failure", "keep_last") == "keep_last"

--- a/src/backend/tests/community/core/bot_config_manifest/creation/test_first_artifact.py
+++ b/src/backend/tests/community/core/bot_config_manifest/creation/test_first_artifact.py
@@ -67,25 +67,26 @@ from agentclaw.community.kernel.bot_config import StoreRef
 
 from ..apply._fakes import (
     FakeActivationService,
-    FakeCredentials,
     FakeGitClient,
     FakeGuardedFetcher,
     FakeManifestContent,
     FakeMcpAuth,
+    FakeObjectCredentials,
     FakeStartupScriptService,
+    OSS_AUTH,
+    OSS_BUCKET,
     build_skill_zip,
-    fetched_object,
     real_validator,
+    seeded_object_store,
 )
 from ..managed_files._fakes import FakeObjectStorage
 from ..managed_files.test_skill_port import FakeSkillRepository, LiveCapabilityReader
 from tests.community.core.config_compose.test_collector import _reader_over, _registry_over
-from tests.community.core.bot_config_manifest.apply._fakes import FakeObjectStore
 
 _OWNER = "u_owner"
 _BOT = "b_first"
 _ENTITY = _OWNER
-_QC_URL = "https://example.test/skills/quality-check.zip"
+_QC_KEY = "skills/quality-check.zip"
 _QZ = build_skill_zip("quality-check", extra=[("scripts/run.sh", b"echo ok\n")])
 _DOCUMENT = f"""schema_version: 1
 manifest:
@@ -97,7 +98,11 @@ manifest:
       content: 'Q: ?'
   skills:
     - name: quality-check
-      source: {_QC_URL}
+      source:
+        protocol: oss
+        bucket: "{OSS_BUCKET}"
+        key: "{_QC_KEY}"
+        auth: "{OSS_AUTH}"
 """
 _BASE = "teclaw/dev/bolt_data"
 _REF_ROOT = f"staff_{_OWNER}/{_BOT}_manifest/teclaw"
@@ -185,10 +190,11 @@ def _build(db):
 
     def fetcher():
         return EntryFetcher(
-            FakeGuardedFetcher(responses={_QC_URL: fetched_object(_QZ, url=_QC_URL, content_type="application/zip")}),
+            FakeGuardedFetcher(responses={}),
             FakeManifestContent(),
-            FakeCredentials(),
-        FakeObjectStore(),)
+            FakeObjectCredentials(),
+            seeded_object_store({_QC_KEY: _QZ}),
+        )
 
     def platform_ports() -> MaterialiserPorts:
         return MaterialiserPorts(

--- a/src/backend/tests/community/core/bot_config_manifest/managed_files/test_skill_port.py
+++ b/src/backend/tests/community/core/bot_config_manifest/managed_files/test_skill_port.py
@@ -29,21 +29,23 @@ from agentclaw.community.core.bot_config_manifest.managed_files.ports import (
 
 from tests.community.core.bot_config_manifest.apply._fakes import (
     FakeActivationService,
-    FakeCredentials,
     FakeGuardedFetcher,
     FakeManifestContent,
+    FakeObjectCredentials,
+    OSS_BUCKET,
     build_skill_zip,
-    fetched_object,
+    declared_session,
     make_context,
+    oss_source,
     real_validator,
+    seeded_object_store,
 )
 
 from ._fakes import FakeObjectStorage
-from tests.community.core.bot_config_manifest.apply._fakes import FakeObjectStore
 
 _BASE = "teclaw/dev/bolt_data"
 _SCOPE = ManagedFileScope(entity_type="staff", entity_id="u_owner", bot_id="b_1")
-QC_URL = "https://example.test/skills/quality-check.zip"
+QC_KEY = "skills/quality-check.zip"
 QZ = build_skill_zip("quality-check", extra=[("scripts/run.sh", b"echo ok\n")])
 QZ_V2 = build_skill_zip("quality-check", extra=[("scripts/run.sh", b"echo v2\n")])
 
@@ -109,6 +111,8 @@ class LiveCapabilityReader:
 
 
 def _rig(packages: dict[str, bytes]):
+    """``packages`` is object key → package bytes, seeded into the bucket the
+    declared ``oss`` source reads."""
     oss = FakeObjectStorage()
     store = ManagedFilesStore(
         object_storage=oss, store_base=lambda: _BASE
@@ -120,17 +124,17 @@ def _rig(packages: dict[str, bytes]):
         validator=real_validator(),
         skill_repository=skills,
     )
-    fetcher = FakeGuardedFetcher(
-        responses={
-            url: fetched_object(body, url=url, content_type="application/zip")
-            for url, body in packages.items()
-        }
+    objects = seeded_object_store(packages)
+    pipeline = EntryFetcher(
+        FakeGuardedFetcher(responses={}),
+        FakeManifestContent(),
+        FakeObjectCredentials(),
+        objects,
     )
-    pipeline = EntryFetcher(fetcher, FakeManifestContent(), FakeCredentials(), FakeObjectStore())
     materialiser = SkillsMaterialiser(
         port, activation, LiveCapabilityReader(skills, activation), real_validator(), pipeline
     )
-    return materialiser, store, oss, skills, activation, fetcher
+    return materialiser, store, oss, skills, activation, objects
 
 
 async def _apply(materialiser, ctx, entries):
@@ -142,11 +146,20 @@ async def _apply(materialiser, ctx, entries):
 
 
 def _ctx():
-    return make_context(engine_type="teclaw", owner_id="u_owner")
+    return make_context(
+        engine_type="teclaw",
+        owner_id="u_owner",
+        # A declared source resolves against the apply's source session.
+        source_session=declared_session(),
+    )
 
 
-def _declared(url: str = QC_URL, body: bytes = QZ):
-    return {"name": "quality-check", "source": url, "digest": _digest_of(body)}
+def _declared(key: str = QC_KEY, body: bytes = QZ):
+    return {
+        "name": "quality-check",
+        "source": oss_source(key),
+        "digest": _digest_of(body),
+    }
 
 
 def _indexed(store) -> list[tuple[str, str]]:
@@ -157,7 +170,7 @@ def _indexed(store) -> list[tuple[str, str]]:
 
 
 def test_a_declared_skill_is_unpacked_into_the_store_and_recorded() -> None:
-    materialiser, store, oss, skills, activation, _ = _rig({QC_URL: QZ})
+    materialiser, store, oss, skills, activation, _ = _rig({QC_KEY: QZ})
 
     plan, written = _run(_apply(materialiser, _ctx(), [_declared()]))
 
@@ -188,7 +201,7 @@ def test_a_declared_skill_is_unpacked_into_the_store_and_recorded() -> None:
 
 
 def test_the_second_apply_is_unchanged_and_writes_nothing() -> None:
-    materialiser, store, oss, skills, activation, _ = _rig({QC_URL: QZ})
+    materialiser, store, oss, skills, activation, _ = _rig({QC_KEY: QZ})
     _run(_apply(materialiser, _ctx(), [_declared()]))
     puts_before = list(oss.puts)
 
@@ -201,12 +214,12 @@ def test_the_second_apply_is_unchanged_and_writes_nothing() -> None:
 
 
 def test_a_changed_package_is_replaced_in_place() -> None:
-    materialiser, store, oss, skills, activation, fetcher = _rig({QC_URL: QZ})
+    materialiser, store, oss, skills, activation, objects = _rig({QC_KEY: QZ})
     _run(_apply(materialiser, _ctx(), [_declared()]))
     created_id = skills.creates[0]["id"]
 
     # The same URL now serves a new package (a moved pin).
-    fetcher.responses[QC_URL] = fetched_object(QZ_V2, url=QC_URL, content_type="application/zip")
+    objects.put(OSS_BUCKET, QC_KEY, QZ_V2)
     plan, written = _run(_apply(materialiser, _ctx(), [_declared(body=QZ_V2)]))
 
     assert [e.outcome.value for e in written] == ["updated"]
@@ -238,7 +251,7 @@ def test_a_stale_member_of_a_replaced_package_is_dropped_from_the_store() -> Non
 
 
 def test_removal_deactivates_record_only() -> None:
-    materialiser, store, oss, skills, activation, _ = _rig({QC_URL: QZ})
+    materialiser, store, oss, skills, activation, _ = _rig({QC_KEY: QZ})
     _run(_apply(materialiser, _ctx(), [_declared()]))
 
     plan, written = _run(_apply(materialiser, _ctx(), []))


### PR DESCRIPTION
## Problem

A manifest entry used to be allowed to name its source as a plain HTTPS URL string:

```yaml
skills:
  - name: summarize
    source: "https://cdn.example.com/summarize.zip"     # the old spelling
```

That spelling was replaced by declared sources (`source: {protocol: git|oss, ...}` or `from: <name>`), and the PUT validator has refused it for some time (`schema/entries.py`, violation code `invalid_source`). The apply pipeline kept a read-side branch so documents stored under the old grammar could still be applied. There are no such documents left in any environment, so that branch — and everything that existed only to serve it — is dead weight that still has to be reasoned about by anyone reading the fetch funnel.

The supported set after this change is exactly three roads: `content` (inline text), `oss` (declared object), `git` (declared repository). There is no fourth road.

## Solution

### Source changes

| File | Change |
| --- | --- |
| `apply/entry_fetch.py` | Deleted `fetch_declared`'s `elif isinstance(inline, str)` branch. A `source` that is not a Mapping now falls into the final `else` and raises `EntryFetchError` naming the declaration-object form. Renamed `needs_session` → `declares_source` and rewrote its comment: with the string road gone the flag is exactly "this entry declares a source", and the only case that skips it is the no-source entry refused on its own terms two lines later. Kept the rig-friendly hint in the message (`the apply service builds it per apply`), and `source_session` stays optional on `FetchContext`. Removed the now-unused `BlobDelivery` import. |
| `apply/entry_fetch.py` (`declared_protocol`) | Removed the `if isinstance(inline, str): return SourceKind.OSS` first branch. A string `source` now answers `None` — "cannot say from the declaration alone" — which both callers already handle by falling through to the real fetch and its real error. |
| `apply/materialisers/cli_tools.py` | Removed the `if isinstance(resolved_entry.get("source"), str): resolved_entry["source"] = substituted` rewrite. Trimmed the surrounding comment so it no longer describes substituting "BOTH halves": `decl.source_url` is still substituted (the report echoes it, and the API-driven install road hands it to the transport), and the entry is now carried through untouched. |
| `apply/materialisers/skills.py` | Simplified `_build_package(source_url=...)` to `delivery.source_url() or ""`. `_archive_kind` still fails readably on an empty URL — declared `unpack` wins, then the URL suffix (no match on `""`), then the served content type, then `_PackageRefusal("cannot tell how to unpack this skill source: …")`. |
| `apply/entry_delivery.py`, `apply/materialisers/identity.py` | Docs only: the places that named "the legacy inline-URL road" or showed the string spelling in a worked example. See **Docs carried through the `dev` merge** below. |

`EntryFetcher.fetch`, `EntryFetcher._fetch`, `GuardedFetcher`, `FetchContext`, `scope_of`, `schema/entries.py`'s refusal, and the `content:` branches in `identity.py` / `resources.py` / `skills.py` are untouched.

**`EntryFetcher.fetch` was kept.** Its remaining caller is `cli_tools/service.py::_acquire`, in the `decl.entry is None` branch — the API-driven install, where a caller hands the platform a plain URL with no manifest and no `sources` map. That road is not part of the manifest grammar. A consequence worth stating: after this change the guarded HTTPS transport is no longer reachable *from a manifest document at all*, only from that API road.

### Docs carried through the `dev` merge

This branch was opened on `31381df7`; `dev` has since landed three `docs(apply)` commits that added worked examples and entry-point tables across the fetch pipeline, several of which describe the removed road as live. Merging `dev` in (commit `f3417b9`) conflicted on `entry_fetch.py` and `outcomes.py`. Resolved by keeping this branch's removal and carrying it into the newly arrived text:

- `entry_fetch.py` — the module's entry-point table now says `fetch` is called by the cli_tools API-driven install rather than by `fetch_declared`; the `https://…` `source_url` shape is that road's; the `fetch_declared` example block marks a string `source` as refused rather than as a third road; `declared_protocol`'s table row for a string `source` answers `None` instead of `SourceKind.OSS`.
- `entry_delivery.py` — "the legacy inline-URL road" → the API install road, in the three places it names one.
- `materialisers/identity.py`, `skills.py`, `cli_tools.py` — the inline `source:` examples now show a declaration object. (The cli_tools one shows an inline **git** source rather than `oss`, for the reason in "Out of scope" below.)
- `outcomes.py` — took `dev`'s rewritten `SourceResolution` docstring wholesale; it drops the pre-W7 "sources are inline URLs only" note this branch had edited, so the file leaves the diff entirely.

### Tests

Converted (the subject was the fetch — pinning, keep_last, convergence, receipts, the pre-fetch gate — and the string spelling was just the shortest way to reach it). Each moved to an equivalent `source: {protocol: oss, bucket, key, auth}` declaration over the in-memory object store, with the assertion preserved:

| File | What changed |
| --- | --- |
| `apply/_fakes.py` | New shared rig: `OSS_BUCKET` / `OSS_AUTH` / `OSS_ACCESS_KEY_ID`, `FakeObjectCredentials` (the base fake plus `object_store_target`), `oss_source()`, `seeded_object_store()`, `declared_session()`. `identity_rig` now serves `SOUL_KEY` out of a seeded bucket and returns the object store in place of the guarded fetcher; `SOUL_URL` → `SOUL_KEY` + `SOUL_SOURCE`. |
| `apply/test_identity_materialiser.py` | 8 tests converted. Source-down cases model the outage on the store (`make_unavailable`, a genuine transport failure) rather than on a URL transport; keep_last receipts are keyed by `oss://bucket/key`. |
| `apply/test_skills_materialiser.py` | ~20 tests converted via `skill_rig` + `_declared`. Fixture URLs became object keys, so `_archive_kind`'s suffix detection is still exercised (`skills/anything.zip`, `skills/qc.tar.gz`, `skills/get-package`). Dropped `skill_rig`'s `fetch_failures` and `content_types` params — the object road models failure on the store and serves no content type. |
| `apply/test_resources_materialiser.py` | 41 entry declarations converted through a local `_src()` helper. Two assertions that named the fetched address moved to `oss://cdn/a.bin`. `_StubEntryFetcher` now refuses a non-declaration `source` exactly as the real door does, and addresses an object decl the way the real road files it. |
| `apply/test_cli_tools_materialiser.py` | `_entry()` now names a declared source with `from: tools` (see the note below on why not an inline `oss` object). `test_the_digest_belt_still_refuses_an_unpinned_object_store_tool` now spells its object source the way one is spelled. |
| `apply/test_apply_engine.py` | The four-category integration document now declares `oss` sources; the failing identity entry reads an unreachable bucket. |
| `creation/test_first_artifact.py` | The first-artifact document's skill entry now declares an `oss` source. |
| `managed_files/test_skill_port.py` | `_rig` seeds object keys; `_declared` names a declared source. |
| `cli_tools/_fakes.py` | `FakeEntryFetcher.fetch_declared` refuses a non-declaration `source` and grew an `oss` branch recording the bucket address — the double was mirroring a dispatch that no longer exists. |

Rewritten because the subject *was* the removed road:

- `test_a_placeholder_in_a_source_is_substituted_before_the_fetch` (cli_tools) asserted the entry-rewrite this PR removes. Replaced with `test_a_placeholder_in_a_declared_address_is_substituted`, which pins the half that survives: the materialiser substitutes `decl.source_url` (the address the report echoes and the API road uses), while the fetch funnel substitutes the source's own fields on its own road. End-to-end substitution through a real fetcher is now covered by the converted `test_placeholder_substitution_reaches_the_identity_fetch`, which asserts the substituted **key** reached the store.

No test was deleted outright — every one had a live subject on a surviving road.

Added:

- `test_a_source_written_as_a_plain_url_string_is_refused` — `fetch_declared` with `source: "https://example.com/x.zip"` raises `EntryFetchError`, the message names the declaration-object form (`protocol: git` / `protocol: oss`), and no transport was asked for those bytes.
- `test_declared_protocol_cannot_answer_for_a_source_that_is_not_a_declaration` — a string `source` answers `None`, a parseable object still answers `SourceKind.OSS`.

Two assertions could not be kept literally, both because the message genuinely differs by road: a digest mismatch on the object road reads `the object's bytes are …, the entry declared …` rather than the transport's `digest mismatch`. Those tests now match on the declared digest; their subject (a disagreeing pin fails the entry, nothing is written) is unchanged.

## Validation

```
cd src/backend
uv run --no-sync python -m pytest -q -o addopts="" -W ignore \
  tests/community/core/bot_config_manifest/
```

**1061 passed**, both before and after the `dev` merge (baseline on the original parent commit: 1059 — the two new regression tests account for the difference).

Wider sweep of everything that touches the manifest — `tests/community/architecture`, `di`, `core/bot_management`, `core/config_compose`, `core/service_bot`, `core/resources`, `endpoints`: **4757 passed, 2 failed**. Both failures are `test_bot_build_service_skill_artifact.py::test_pool_build_uses_the_versioned_filesystem_snapshot_when_runtime_cannot_write_nfs[openclaw|claude_code]`, failing with `exec: rsync: not found`. Verified pre-existing by stashing this branch's changes and re-running them on the parent commit — they fail identically there. `rsync` is not installed in this container. (That sweep predates the `dev` merge; the manifest suite was re-run after it.)

Gates, re-run after the merge:

```
git status --short          # uv.lock is not listed
grep -rn 'isinstance(inline, str)' .../apply/entry_fetch.py    # no output
grep -rn 'bare.URL\|legacy\|inline URL' .../apply/             # no output
ruff check --select F401,F811,F821 <changed files>             # All checks passed
```

The three surviving `isinstance(inline, str)` hits under `apply/` are all `inline = entry.get("content")` — the inline **content** road, deliberately kept. Two `"source": "https://…"` strings remain in `entry_fetch.py`: both are the deliberate *this is refused* example, one in `fetch_declared`'s road table and one in `declared_protocol`'s answer table.

Not run: anything requiring `rsync` or live network/object-store access.

## Compatibility and risk

No contract, schema, config, or migration change. The PUT validator already refused this spelling, so no document a client can create today is affected; the change is only to what a *stored* document can still be applied as. A document stored under the old grammar — believed to be none — would now fail its entry at apply with a message naming the declaration-object form, instead of fetching. Rollback is a plain revert.

## Out of scope, noted

- **`cli_tools/declarations.py::_declared_address`** keeps an `or inline` fallback (and the docstring line "An inline URL is itself") that only a string `source` can reach. It is now unreachable in any useful sense — `from_entry`'s only caller is the cli_tools materialiser, and a string `source` is refused at the front door moments later — but removing it would change `CliToolDecl.from_entry`'s contract and three vocabulary tests in `cli_tools/test_service.py`, which is outside this PR. Worth a follow-up.
- **A cli_tools entry cannot currently declare an *inline* `oss` source.** `_declared_address` derives the address from `source["url"]`, which an object declaration does not carry, so `decl.source_url` comes back empty and the materialiser refuses the entry with "a cli_tools entry must name a source". This is pre-existing, and is why the converted cli_tools tests name their object source with `from:` rather than inline, and why that module's inline-source example shows a git source. Same follow-up as above.
- **`apply/materialisers/skills.py`** still accepts `str` in its pre-fetch guard `isinstance(entry.get("source"), (str, dict))`. Left deliberately: a string source falls through to `fetch_declared` and gets the specific "declaration object carrying a 'protocol'" error, instead of the generic "a skills entry must declare 'source' or 'from'". Narrowing it to `dict` would give authors of old documents a worse message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W2PuopGbXE88PbPSv8cXSj