### PR TITLE
feat(bcs): preserve safe provider headers through queued delivery

### DIFF
--- a/src/bcs/crates/bootstrap/bcs/src/config.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/config.rs
@@ -190,10 +190,14 @@ pub struct ProviderHttpConfig {
     /// Empty by default; matching is case-insensitive.
     #[serde(default)]
     pub bypass_headers: Vec<String>,
+    /// Non-sensitive routing headers explicitly approved for durable queues.
+    #[serde(default)]
+    pub queue_persistable_headers: Vec<String>,
 }
 
 impl ProviderHttpConfig {
     pub fn validate(&self) -> Result<(), String> {
+        bcs_config_api::queued_provider_headers::validate_config(&self.bypass_headers, &self.queue_persistable_headers)?;
         for raw_name in &self.bypass_headers {
             let name = raw_name.trim();
             if name.is_empty() {
@@ -1922,12 +1926,14 @@ botchat_url = "${BCS_TEST_FROM_FILE_MISSING}"
     fn provider_http_bypass_headers_parse_and_default() {
         let default_config = BcsConfig::default();
         assert!(default_config.provider_http.bypass_headers.is_empty());
+        assert!(default_config.provider_http.queue_persistable_headers.is_empty());
 
         let toml = r#"
             bots_base_dir = "/bots"
 
             [provider_http]
             bypass_headers = ["X-Sandbox-Bypass"]
+            queue_persistable_headers = ["x-sandbox-bypass"]
         "#;
         let config: BcsConfig = toml::from_str(toml).expect("parse [provider_http]");
         assert_eq!(
@@ -1956,6 +1962,7 @@ botchat_url = "${BCS_TEST_FROM_FILE_MISSING}"
             "x-bcn-protocol-version",
         ] {
             let config = ProviderHttpConfig {
+                queue_persistable_headers: Vec::new(),
                 bypass_headers: vec![name.to_string()],
             };
             assert!(

--- a/src/bcs/crates/bootstrap/bcs/src/message_delivery_wiring.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/message_delivery_wiring.rs
@@ -60,7 +60,9 @@ pub async fn wire(
     let initial = repository.load_policy().await.map_err(|_| invalid("cannot load durable delivery policy"))?;
     initial.policy.validate().map_err(|e| invalid(&e.to_string()))?;
     let durable = repository.is_durable();
-    let live = Arc::new(LiveDeliveryPolicy::new(repository.clone(), initial.clone(), !config.provider_http.bypass_headers.is_empty()));
+    config.provider_http.validate().map_err(|e| invalid(&e))?;
+    flow.queue_persistable_headers = config.provider_http.queue_persistable_headers.clone();
+    let live = Arc::new(LiveDeliveryPolicy::new(repository.clone(), initial.clone()));
     let service = ManagedMessageDelivery::new(repository).with_policy(live.clone());
     let metrics = Arc::new(crate::delivery_metrics::DeliveryMetrics::default());
     let service = service.with_instrumentation(metrics.clone());
@@ -80,9 +82,6 @@ pub async fn wire(
         }
         return Ok(flow);
     }
-    if live.provider_headers_configured && initial.policy.needs_scheduler() {
-        return Err(invalid("delivery_provider_headers_unsupported"));
-    }
     let (completion_sender, completion_receiver) = tokio::sync::watch::channel(false);
     let guard = SchedulerGuard { service: service.clone(), policy: live.clone(), completion: completion_sender };
     service.recover(chrono::Utc::now().timestamp_millis()).await.map_err(|_| invalid("message delivery startup recovery failed"))?;
@@ -91,7 +90,6 @@ pub async fn wire(
         service: service.clone(),
         preparation: Arc::new(QueuedGroupPreparation {
             flow: Arc::downgrade(&flow), deliveries: service.clone(),
-            provider_bypass_headers_configured: live.provider_headers_configured,
         }),
         transport: flow.bot_delivery.clone(),
         config: DeliveryRuntimeConfig {
@@ -149,6 +147,8 @@ mod tests {
         let admin = || CallerContext::Human(HumanActor { actor_id: "human_operator".into(), staff_no: "operator".into() });
         let mut config = crate::BcsConfig::default();
         config.metrics.enabled = false;
+        config.provider_http.bypass_headers = vec!["x-routing-zone".into()];
+        config.provider_http.queue_persistable_headers = vec!["x-routing-zone".into()];
         let mut policy = DeliveryPolicy::default();
         policy.flow_enabled.group = true;
         policy.defaults.mode = BotDeliveryMode::Enforce;
@@ -226,7 +226,7 @@ mod tests {
                 now_ms: 1,
                 expire_at_ms: None,
                 event: None,
-                targets: vec![DeliveryAdmissionTarget {
+                targets: vec![DeliveryAdmissionTarget { rejection: None,
                     target_bot_id: "bot-driver".into(),
                     kind: DeliveryType::Send,
                     max_queued: 10,

--- a/src/bcs/crates/bootstrap/bcs/tests/delivery_worker_load.rs
+++ b/src/bcs/crates/bootstrap/bcs/tests/delivery_worker_load.rs
@@ -155,7 +155,7 @@ async fn scene(name: &str, bots: usize, sessions: usize, cap: usize, ballast: bo
                     message_id: id.clone(), flow_kind: DeliveryFlowKind::Group, now_ms: now,
                     expire_at_ms: None, event: None,
                     message: NewMessage { visibility_domain: bcs_domain::MessageVisibilityDomain::Chat, audience: None, group_id: "group".into(), session_id: sid.clone(), sender_id: "human".into(), sender_type: SenderType::Human, message_type: "chat".into(), content: serde_json::json!({"text":id}), client_msg_id: Some(id), owner_bot_id: None, created_at: now as u64, run_id: String::new() },
-                    targets: vec![DeliveryAdmissionTarget { target_bot_id: format!("bot{bot:03}"), kind: DeliveryType::Send, max_queued: 10000, semantic_projection_json: serde_json::json!({"version":1}) }],
+                    targets: vec![DeliveryAdmissionTarget { rejection: None, target_bot_id: format!("bot{bot:03}"), kind: DeliveryType::Send, max_queued: 10000, semantic_projection_json: serde_json::json!({"version":1}) }],
                 }).await?;
             }
         }

--- a/src/bcs/crates/bootstrap/bcs/tests/support/reply_load.rs
+++ b/src/bcs/crates/bootstrap/bcs/tests/support/reply_load.rs
@@ -186,7 +186,7 @@ async fn reply_scene(name: &str, bots: usize, sessions: usize, offline: bool, si
                 let now = chrono::Utc::now().timestamp_millis();
                 service.admit(AdmitMessageDeliveries { display_message: None, message_id: id.clone(), flow_kind: DeliveryFlowKind::Group, now_ms: now, expire_at_ms: None, event: None,
                     message: NewMessage { visibility_domain: bcs_domain::MessageVisibilityDomain::Chat, audience: None, group_id: group.id.clone(), session_id: sid.clone(), sender_id: "human".into(), sender_type: SenderType::Human, message_type: "chat".into(), content: json!({"text":id}), client_msg_id: Some(id), owner_bot_id: None, created_at: now as u64, run_id: String::new() },
-                    targets: vec![DeliveryAdmissionTarget { target_bot_id: bot.clone(), kind: DeliveryType::Send, max_queued: 10000, semantic_projection_json: json!({"version":1}) }] }).await?;
+                    targets: vec![DeliveryAdmissionTarget { rejection: None, target_bot_id: bot.clone(), kind: DeliveryType::Send, max_queued: 10000, semantic_projection_json: json!({"version":1}) }] }).await?;
             }
         }
     }
@@ -271,7 +271,7 @@ async fn reply_scene(name: &str, bots: usize, sessions: usize, offline: bool, si
             let mut sample = output.clone(); sample.run_id = Some("verify-reply-payload".into());
             sample.state.kind = DeliveryType::Send;
             sample.state.status = bcs_domain::message_delivery::MessageDeliveryStatus::Queued;
-            let prepared = bcs_message_flow::queued_group::prepare_queued_group(&io.flows[sid], &sample, &[], false).await?;
+            let prepared = bcs_message_flow::queued_group::prepare_queued_group(&io.flows[sid], &sample, &[]).await?;
             let payload = serde_json::to_string(&prepared.command.frame)?;
             assert!(payload.contains("工具前"));
             assert!(payload.contains("工具后"));

--- a/src/bcs/crates/service-api/bcs-config-api/CONTEXT.md
+++ b/src/bcs/crates/service-api/bcs-config-api/CONTEXT.md
@@ -2,6 +2,10 @@
 
 ## Provides
 
+`queued_provider_headers` defines the explicit non-sensitive routing allowlist,
+credential-name restrictions and bounded canonical snapshots shared by bootstrap
+validation and queued application preparation. It does not acquire credentials.
+
 DeliveryPolicy's environment-level max_context_messages/max_context_bytes use
 24/131072 defaults for legacy JSON; validated positive bounded values constrain
 only each Send's appended Inject history, not ingress backlog or model tokens.

--- a/src/bcs/crates/service-api/bcs-config-api/src/lib.rs
+++ b/src/bcs/crates/service-api/bcs-config-api/src/lib.rs
@@ -16,6 +16,7 @@ use serde::{Deserialize, Serialize};
 
 pub mod bcsfuse;
 pub mod message_delivery;
+pub mod queued_provider_headers;
 pub mod mysql;
 pub mod redis;
 pub mod redis_route_type;

--- a/src/bcs/crates/service-api/bcs-config-api/src/queued_provider_headers.rs
+++ b/src/bcs/crates/service-api/bcs-config-api/src/queued_provider_headers.rs
@@ -1,0 +1,64 @@
+//! Explicit opt-in for durable, non-credential Provider routing metadata.
+use std::collections::BTreeMap;
+
+pub const MAX_HEADERS: usize = 16;
+pub const MAX_VALUE_BYTES: usize = 1024;
+pub const MAX_TOTAL_BYTES: usize = 8192;
+
+pub fn safe_name(name: &str) -> bool {
+    let name = name.to_ascii_lowercase();
+    !name.is_empty() && name.len() <= 128
+        && name.bytes().all(|b| b.is_ascii_alphanumeric() || b"!#$%&'*+-.^_`|~".contains(&b))
+        && !name.split(['-', '_']).any(|part| matches!(part,
+            "authorization" | "cookie" | "token" | "secret" | "credential" | "credentials" | "password" | "key"))
+        && !matches!(name.as_str(), "host" | "content-length" | "content-type" | "connection" | "transfer-encoding" | "bcn")
+        && !name.starts_with("bcn-") && !name.starts_with("x-bcn-")
+}
+
+/// Configuration is an operator assertion that custom values are non-secret.
+/// Never report input values in errors.
+pub fn validate_config(bypass: &[String], persistable: &[String]) -> Result<(), String> {
+    if persistable.len() > MAX_HEADERS { return Err("too many queue persistable headers".into()); }
+    for name in persistable {
+        if !safe_name(name) || !bypass.iter().any(|b| b.trim().eq_ignore_ascii_case(name)) {
+            return Err("queue persistable headers must be non-sensitive names in bypass_headers".into());
+        }
+    }
+    Ok(())
+}
+
+pub fn snapshot(headers: &[(String, String)], allowed: &[String]) -> Result<Vec<(String, String)>, &'static str> {
+    if headers.len() > MAX_HEADERS { return Err("delivery_provider_headers_unsupported"); }
+    let mut result = BTreeMap::new();
+    let mut bytes = 0usize;
+    for (name, value) in headers {
+        if !safe_name(name) || !allowed.iter().any(|a| a.eq_ignore_ascii_case(name))
+            || value.len() > MAX_VALUE_BYTES || value.bytes().any(|b| b < 32 || b == 127) {
+            return Err("delivery_provider_headers_unsupported");
+        }
+        bytes = bytes.saturating_add(name.len()).saturating_add(value.len());
+        if bytes > MAX_TOTAL_BYTES || result.insert(name.to_ascii_lowercase(), value.clone()).is_some() {
+            return Err("delivery_provider_headers_unsupported");
+        }
+    }
+    Ok(result.into_iter().collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn restricts_credentials_and_normalizes_bounded_snapshots() {
+        let names = vec!["x-routing-zone".into()];
+        validate_config(&names, &names).unwrap();
+        assert_eq!(snapshot(&[("X-Routing-Zone".into(), "blue".into())], &names).unwrap(), vec![("x-routing-zone".into(), "blue".into())]);
+        for name in ["cookie", "authorization", "x-api-key", "x-session-token", "connection"] {
+            assert!(validate_config(&[name.into()], &[name.into()]).is_err());
+            assert!(snapshot(&[(name.into(), "secret".into())], &[name.into()]).is_err());
+        }
+        assert!(validate_config(&[], &names).is_err());
+        assert!(snapshot(&[(names[0].clone(), "x".repeat(MAX_VALUE_BYTES + 1))], &names).is_err());
+        assert!(snapshot(&[(names[0].clone(), "a\r\nb".into())], &names).is_err());
+        assert!(snapshot(&[(names[0].clone(), "a".into()), (names[0].clone(), "b".into())], &names).is_err());
+    }
+}

--- a/src/bcs/crates/service-api/bcs-service-api/CONTEXT.md
+++ b/src/bcs/crates/service-api/bcs-service-api/CONTEXT.md
@@ -2,6 +2,10 @@
 
 ## Provides
 
+DeliveryAdmissionTarget carries a typed per-recipient rejection, committed as an
+unsent Failed delivery without aborting other recipients. DeliveryStatusView
+adds optional fixed admission_error codes, never arbitrary transport error text.
+
 - `CoordinationIntentPort` with authenticated consumer identity and immutable execution receipts.
 
 MessageRepoPort adds scoped run_chat_segments reconstruction with fail-closed

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/message_delivery.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/message_delivery.rs
@@ -10,6 +10,9 @@ use bcs_domain::message_delivery::PersistedMessageDelivery;
 /// nonces. State versions let clients discard reordered best-effort events.
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct DeliveryStatusView {
+    /// Stable admission error code only; never arbitrary transport errors.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub admission_error: Option<&'static str>,
     pub delivery_id: String,
     pub message_id: String,
     pub target_bot_id: String,
@@ -24,6 +27,8 @@ pub struct DeliveryStatusView {
 impl From<&PersistedMessageDelivery> for DeliveryStatusView {
     fn from(row: &PersistedMessageDelivery) -> Self {
         Self {
+            admission_error: (row.last_error_code.as_deref() == Some("delivery_provider_headers_unsupported"))
+                .then_some("delivery_provider_headers_unsupported"),
             delivery_id: row.delivery_id.clone(),
             message_id: row.source_message_id.clone(),
             target_bot_id: row.target_bot_id.clone(),

--- a/src/bcs/crates/service-api/bcs-service-api/src/port/repo/message_delivery.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/port/repo/message_delivery.rs
@@ -42,10 +42,18 @@ pub struct BoundDeliveryContexts {
 
 #[derive(Debug, Clone)]
 pub struct DeliveryAdmissionTarget {
+    /// Application rejection committed atomically with other recipients.
+    pub rejection: Option<DeliveryAdmissionRejection>,
     pub target_bot_id: String,
     pub kind: DeliveryType,
     pub max_queued: u32,
     pub semantic_projection_json: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum DeliveryAdmissionRejection { ProviderHeadersUnsupported }
+impl DeliveryAdmissionRejection {
+    pub fn code(self) -> &'static str { "delivery_provider_headers_unsupported" }
 }
 
 #[derive(Debug, Clone)]

--- a/src/bcs/crates/services/bcs-message-flow/CONTEXT.md
+++ b/src/bcs/crates/services/bcs-message-flow/CONTEXT.md
@@ -1,5 +1,12 @@
 # bcs-message-flow Context
 
+Queued Provider routing snapshots are opt-in non-sensitive headers, bounded and
+normalized by the shared config contract. Admission rejects only unsupported
+Provider recipients, without retaining rejected values or bypassing the queue.
+Send-start and scoped abort retain the original route; empty and named routes
+cannot share an ambiguous scope abort. Inject does not overwrite its carrier's
+route. Header metadata is excluded from protocol/model and public status views.
+
 Queued group preparation captures versioned routing intent without copying
 message text, attachments or credentials into deliveries. It rebuilds protocol
 frames from canonical messages, reapplies current session membership and

--- a/src/bcs/crates/services/bcs-message-flow/src/delivery_abort.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/delivery_abort.rs
@@ -133,7 +133,7 @@ pub async fn select(
                 bot_id: row.target_bot_id,
             },
             transport_owner: metadata.owner,
-            provider_bypass_headers: Vec::new(),
+            provider_bypass_headers: metadata.provider_route_headers,
             deadline_ms: now.saturating_add(60_000) as u64,
         });
         selection.owned.insert(run_id, started);

--- a/src/bcs/crates/services/bcs-message-flow/src/delivery_policy.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/delivery_policy.rs
@@ -12,13 +12,12 @@ pub struct LiveDeliveryPolicy {
     repository: Arc<dyn MessageDeliveryRepoPort>,
     updates: Arc<tokio::sync::Semaphore>,
     pub scheduler_available: Arc<AtomicBool>,
-    pub provider_headers_configured: bool,
 }
 
 impl LiveDeliveryPolicy {
-    pub fn new(repository: Arc<dyn MessageDeliveryRepoPort>, initial: DeliveryPolicyRecord, provider_headers_configured: bool) -> Self {
+    pub fn new(repository: Arc<dyn MessageDeliveryRepoPort>, initial: DeliveryPolicyRecord) -> Self {
         Self { snapshot: Arc::new(tokio::sync::RwLock::new(initial)), repository, updates: Arc::new(tokio::sync::Semaphore::new(8)),
-            scheduler_available: Arc::new(AtomicBool::new(false)), provider_headers_configured }
+            scheduler_available: Arc::new(AtomicBool::new(false)) }
     }
 
     fn human(caller: &CallerContext) -> ServiceResult<&str> {
@@ -74,9 +73,6 @@ impl LiveDeliveryPolicy {
             if current.version != expected { return Err(invalid("delivery_policy_version_conflict")); }
             if policy.needs_scheduler() && !self.scheduler_available.load(Ordering::SeqCst) {
                 return Err(invalid("delivery_scheduler_unavailable: durable storage and a healthy scheduler are required"));
-            }
-            if self.provider_headers_configured && policy.needs_scheduler() {
-                return Err(invalid("delivery_provider_headers_unsupported"));
             }
             let version = expected.checked_add(1).filter(|v| *v <= i64::MAX as u64).ok_or_else(|| invalid("delivery policy version exhausted"))?;
             let record = DeliveryPolicyRecord { version, policy, updated_by: actor.into(), updated_at_ms: chrono::Utc::now().timestamp_millis() };

--- a/src/bcs/crates/services/bcs-message-flow/src/delivery_runtime.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/delivery_runtime.rs
@@ -296,7 +296,8 @@ impl DeliveryRuntime {
                             if !matches!(selected.action, Some(DeliveryScheduleAction::Prepare { ref delivery_id, .. }) if delivery_id == &row.delivery_id) { continue; }
                             if !tokio::time::timeout(self.config.io_timeout, self.preparation.still_valid(&prepared)).await.unwrap_or(false) { continue; }
                             if prepared.command.target_bot_id() != bot || prepared.command.run_id.as_str() != row.run_id.as_deref().unwrap_or("")
-                                || !prepared.command.provider_bypass_headers.is_empty() { return Err(ManagedDeliveryError::Conflict); }
+                                || prepared.transport_context_json.get("provider_route_headers").cloned().unwrap_or_else(|| serde_json::json!([]))
+                                    != serde_json::json!(prepared.command.provider_bypass_headers) { return Err(ManagedDeliveryError::Conflict); }
                             let mut command = event(row, Event::StartSend);
                             if let Some(version) = policy_version { prepared.transport_context_json["policy_version"] = serde_json::json!(version); }
                             command.transport_context_json = Some(prepared.transport_context_json);

--- a/src/bcs/crates/services/bcs-message-flow/src/group_flow.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/group_flow.rs
@@ -1464,13 +1464,7 @@ pub async fn handle_web_send(
         primary_run_id,
         status: if active_run_ids.is_empty() {
             match &admission {
-                Some(result) if !result.deliveries.is_empty() && result.deliveries.iter().all(|d|
-                    matches!(d.state.status, bcs_domain::message_delivery::MessageDeliveryStatus::Failed | bcs_domain::message_delivery::MessageDeliveryStatus::RejectedCapacity))
-                    && result.deliveries.iter().any(|d| d.state.status == bcs_domain::message_delivery::MessageDeliveryStatus::Failed) => "failed",
-                Some(result) if result.deliveries.iter().any(|d| d.state.kind == DeliveryType::Send)
-                    && result.deliveries.iter().filter(|d| d.state.kind == DeliveryType::Send).all(|d| d.state.status == bcs_domain::message_delivery::MessageDeliveryStatus::RejectedCapacity) => "rejected_capacity",
-                Some(result) if result.deliveries.iter().all(|d| d.state.kind == DeliveryType::Inject) => "context_saved",
-                Some(_) => "queued",
+                Some(result) => queue_admission_status(result.deliveries.iter().map(|d| (d.state.kind, d.state.status))),
                 None => "started",
             }
         } else { "started" }.to_string(),
@@ -1489,6 +1483,47 @@ pub async fn handle_web_send(
             .count(),
         delivery_results,
     })
+}
+
+/// Observer context cannot make a rejected reply-producing Send look queued.
+fn queue_admission_status(deliveries: impl Iterator<Item = (DeliveryType, bcs_domain::message_delivery::MessageDeliveryStatus)>) -> &'static str {
+    use bcs_domain::message_delivery::MessageDeliveryStatus as Status;
+    let deliveries: Vec<_> = deliveries.collect();
+    let sends: Vec<_> = deliveries.iter().filter(|(kind, _)| *kind == DeliveryType::Send).collect();
+    let relevant: Vec<_> = if sends.is_empty() { deliveries.iter().collect() } else { sends };
+    if !relevant.is_empty() && relevant.iter().all(|(_, status)| matches!(status, Status::Failed | Status::RejectedCapacity)) {
+        return if relevant.iter().any(|(_, status)| *status == Status::Failed) { "failed" } else { "rejected_capacity" };
+    }
+    if !deliveries.is_empty() && deliveries.iter().all(|(kind, _)| *kind == DeliveryType::Inject) {
+        "context_saved"
+    } else {
+        "queued"
+    }
+}
+
+#[cfg(test)]
+mod queue_admission_status_tests {
+    use super::queue_admission_status;
+    use bcs_domain::{DeliveryType::{Send, Inject}, message_delivery::MessageDeliveryStatus::{Failed, RejectedCapacity, Queued, PendingContext}};
+
+    #[test]
+    fn aggregates_reply_producing_targets_without_observer_masking() {
+        for (deliveries, expected) in [
+            (vec![(Send, Failed), (Inject, PendingContext)], "failed"),
+            (vec![(Send, Failed), (Send, RejectedCapacity), (Inject, PendingContext)], "failed"),
+            (vec![(Send, Failed), (Send, Failed)], "failed"),
+            (vec![(Send, Failed), (Send, Queued)], "queued"),
+            (vec![(Send, Queued), (Inject, Failed)], "queued"),
+            (vec![(Send, Queued), (Inject, PendingContext)], "queued"),
+            (vec![(Send, RejectedCapacity), (Inject, PendingContext)], "rejected_capacity"),
+            (vec![(Send, RejectedCapacity), (Send, RejectedCapacity)], "rejected_capacity"),
+            (vec![(Inject, PendingContext)], "context_saved"),
+            (vec![(Inject, Failed)], "failed"),
+            (vec![], "queued"),
+        ] {
+            assert_eq!(queue_admission_status(deliveries.clone().into_iter()), expected, "{deliveries:?}");
+        }
+    }
 }
 
 pub async fn handle_group_chat(

--- a/src/bcs/crates/services/bcs-message-flow/src/group_flow.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/group_flow.rs
@@ -76,6 +76,7 @@ pub struct BcsMessageFlow {
     pub group_delivery_limits: BTreeMap<String, u32>,
     pub delivery_policy: Option<Arc<crate::delivery_policy::LiveDeliveryPolicy>>,
     pub delivery_queue_ttl_ms: Option<i64>,
+    pub queue_persistable_headers: Vec<String>,
     /// Retained policy for replies from already-admitted Group runs during drain.
     pub group_reply_delivery_limits: BTreeMap<String, u32>,
     pub delivery_shutdown: OnceLock<(tokio::sync::watch::Sender<bool>, tokio::sync::watch::Receiver<bool>)>,
@@ -119,6 +120,7 @@ impl BcsMessageFlow {
             delivery_policy: None,
             delivery_queue_ttl_ms: None,
             group_reply_delivery_limits: BTreeMap::new(),
+            queue_persistable_headers: Vec::new(),
             delivery_shutdown: OnceLock::new(),
             delivery_event_locks: Default::default(),
             terminal_owner: OnceLock::new(),
@@ -1462,6 +1464,9 @@ pub async fn handle_web_send(
         primary_run_id,
         status: if active_run_ids.is_empty() {
             match &admission {
+                Some(result) if !result.deliveries.is_empty() && result.deliveries.iter().all(|d|
+                    matches!(d.state.status, bcs_domain::message_delivery::MessageDeliveryStatus::Failed | bcs_domain::message_delivery::MessageDeliveryStatus::RejectedCapacity))
+                    && result.deliveries.iter().any(|d| d.state.status == bcs_domain::message_delivery::MessageDeliveryStatus::Failed) => "failed",
                 Some(result) if result.deliveries.iter().any(|d| d.state.kind == DeliveryType::Send)
                     && result.deliveries.iter().filter(|d| d.state.kind == DeliveryType::Send).all(|d| d.state.status == bcs_domain::message_delivery::MessageDeliveryStatus::RejectedCapacity) => "rejected_capacity",
                 Some(result) if result.deliveries.iter().all(|d| d.state.kind == DeliveryType::Inject) => "context_saved",
@@ -1615,7 +1620,7 @@ pub async fn handle_persistent_group_send(
         }
         let mut routed_to: Vec<_> = outcome.delivery_results.iter().filter(|r| r.success).map(|r| r.bot_uuid.clone()).collect();
         if let Some(admission) = &outcome.queue_admission {
-            routed_to.extend(admission.deliveries.iter().filter(|d| d.status != bcs_domain::message_delivery::MessageDeliveryStatus::RejectedCapacity).map(|d| d.target_bot_id.clone()));
+            routed_to.extend(admission.deliveries.iter().filter(|d| !matches!(d.status, bcs_domain::message_delivery::MessageDeliveryStatus::RejectedCapacity | bcs_domain::message_delivery::MessageDeliveryStatus::Failed)).map(|d| d.target_bot_id.clone()));
         }
         routed_to.sort(); routed_to.dedup();
         return Ok(PersistentGroupSendOutcome { queue_admission: outcome.queue_admission, message_id, routed_to, mentions: outcome.mentions });
@@ -2411,20 +2416,15 @@ pub async fn handle_chat_abort(
     }
 
     if !provider_runs.is_empty() {
-        // Empty snapshots remain valid for runs created before routing headers
-        // were persisted. Any non-empty snapshots must agree for one scoped
-        // Provider abort request to have an unambiguous route.
-        let mut header_sets = provider_runs.iter().filter_map(|context| {
-            if context.provider_bypass_headers.is_empty() {
-                return None;
-            }
+        // Empty means the default route, not a wildcard: every run in a
+        // scope-wide abort must agree, including recovered managed runs.
+        let mut header_sets = provider_runs.iter().map(|context| {
             let mut headers = context.provider_bypass_headers.clone();
             headers.sort();
-            Some(headers)
+            headers
         });
         let provider_bypass_headers = header_sets.next().unwrap_or_default();
-        let provider_headers_match = header_sets.all(|headers| headers == provider_bypass_headers)
-            && (provider_bypass_headers.is_empty() || !provider_runs.iter().any(|run| managed_abort.owned.contains_key(&run.canonical_run_id)));
+        let provider_headers_match = header_sets.all(|headers| headers == provider_bypass_headers);
         let provider_session_keys: HashSet<_> = provider_runs.iter().map(|run|
             run.downstream_session_key.clone().unwrap_or_else(|| cmd.session_id.clone())).collect();
         let expected_by_downstream: HashMap<String, ActiveBotRunContext> = provider_runs

--- a/src/bcs/crates/services/bcs-message-flow/src/managed_delivery_lock_tests.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/managed_delivery_lock_tests.rs
@@ -8,7 +8,7 @@ fn admission(id: &str, bot: &str) -> AdmitMessageDeliveries {
         now_ms: 1, expire_at_ms: None, event: None,
         message: NewMessage { visibility_domain: bcs_domain::MessageVisibilityDomain::Chat, audience: None, group_id: "group".into(), session_id: "session".into(), sender_id: "human".into(), sender_type: SenderType::Human,
             message_type: "chat".into(), content: serde_json::json!({"text":id}), client_msg_id: Some(id.into()), owner_bot_id: None, created_at: 1, run_id: String::new() },
-        targets: vec![DeliveryAdmissionTarget { target_bot_id: bot.into(), kind: DeliveryType::Send, max_queued: 100, semantic_projection_json: serde_json::json!({"version":1}) }] }
+        targets: vec![DeliveryAdmissionTarget { rejection: None, target_bot_id: bot.into(), kind: DeliveryType::Send, max_queued: 100, semantic_projection_json: serde_json::json!({"version":1}) }] }
 }
 fn transition(row: &PersistedMessageDelivery, event: Event) -> DeliveryTransitionCommand {
     DeliveryTransitionCommand { delivery_id: row.delivery_id.clone(), expected_state_version: row.state.state_version, event, now_ms: 2,

--- a/src/bcs/crates/services/bcs-message-flow/src/message_delivery.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/message_delivery.rs
@@ -37,7 +37,7 @@ fn valid(state: MessageDeliveryState) -> bool {
             !state.may_have_been_sent
                 && matches!(
                     state.status,
-                    PendingContext | Bound | Consumed | DiscardedContext | Cancelled | Expired
+                    PendingContext | Bound | Consumed | DiscardedContext | Cancelled | Expired | Failed
                 )
         }
         DeliveryType::Send => match state.status {

--- a/src/bcs/crates/services/bcs-message-flow/src/queued_admission.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/queued_admission.rs
@@ -225,6 +225,17 @@ pub(crate) async fn commit_routed_reply(
         .or_else(|| event.bcs_session_id.clone())
         .filter(|s| !s.is_empty())
         .ok_or_else(|| ServiceError::InternalError("queue reply Session missing".into()))?;
+    let provider_bypass_headers = if let Some(row) = &original {
+        let context: crate::queued_group::QueuedTransportContext = serde_json::from_value(row.transport_context_json.clone()
+            .ok_or_else(|| ServiceError::InternalError("original queue transport missing".into()))?)
+            .map_err(|_| ServiceError::InternalError("invalid original queue transport metadata".into()))?;
+        context.relay_route_headers.unwrap_or(context.provider_route_headers)
+    } else if let Some(contexts) = &flow.bot_run_context {
+        contexts.find_active_run(&event.run_id).await?
+            .filter(|context| context.scope.bot_id == event.bot_id && context.scope.group_id == group.id
+                && context.scope.session_id == session_id)
+            .map(|context| context.provider_bypass_headers).unwrap_or_default()
+    } else { Vec::new() };
     let command = WebSendCommand {
         caller: bcs_service_api::CallerContext::Public,
         group_id: group.id.clone(),
@@ -239,7 +250,7 @@ pub(crate) async fn commit_routed_reply(
         source_im_message_id: None,
         channel_sender_identity: None,
         sender_conn_id: None,
-        provider_bypass_headers: Vec::new(),
+        provider_bypass_headers,
     };
     let mut targets = Vec::new();
     for (target, context, limit) in selected {
@@ -254,7 +265,7 @@ pub(crate) async fn commit_routed_reply(
         )
         .await?
         .with_reply_context(context, forward_hop, strip_mentions);
-        targets.push(DeliveryAdmissionTarget {
+        targets.push(DeliveryAdmissionTarget { rejection: projection.admission_rejection,
             target_bot_id: target.bot_uuid,
             kind: target.delivery_type,
             max_queued: limit,
@@ -366,7 +377,8 @@ pub(crate) async fn commit_routed_reply(
     let rows = crate::storage_retry::retry(crate::storage_retry::shutdown(flow), "relay_admission_lookup",
         crate::storage_retry::managed_storage, || service.lookup(bcs_service_api::port::repo::message_delivery::DeliveryLookup::Message(reply_message_id.clone())))
         .await.map_err(|_| ServiceError::InternalError("queue relay admission lookup failed".into()))?;
-    let relayed = fresh && rows.iter().any(|row| row.state.status != bcs_domain::message_delivery::MessageDeliveryStatus::RejectedCapacity);
+    let relayed = fresh && rows.iter().any(|row| !matches!(row.state.status,
+        bcs_domain::message_delivery::MessageDeliveryStatus::RejectedCapacity | bcs_domain::message_delivery::MessageDeliveryStatus::Failed));
     Ok(Some(QueuedReply { target_ids, relayed }))
 }
 
@@ -460,9 +472,10 @@ pub async fn prepare_group_admission(
             sender_owner.clone(),
         )
         .await?;
+        let rejection = projection.admission_rejection;
         let mut projection = serde_json::to_value(projection)?;
         if let Some(policy) = &policy { projection["policy_version"] = serde_json::json!(policy.version); }
-        targets.push(DeliveryAdmissionTarget {
+        targets.push(DeliveryAdmissionTarget { rejection,
             target_bot_id: target.bot_uuid.clone(),
             kind: target.delivery_type,
             max_queued: limit,

--- a/src/bcs/crates/services/bcs-message-flow/src/queued_group.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/queued_group.rs
@@ -61,6 +61,11 @@ pub struct QueuedGroupProjection {
     reply_context: Option<bcs_protocol::GroupContext>,
     #[serde(default)]
     forward_hop: Option<u32>,
+    /// Internal transport metadata; never part of model context or history.
+    #[serde(default)]
+    provider_route_headers: Vec<(String, String)>,
+    #[serde(skip)]
+    pub(crate) admission_rejection: Option<bcs_service_api::port::repo::message_delivery::DeliveryAdmissionRejection>,
 }
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -72,12 +77,16 @@ pub struct QueuedTransportContext {
     pub downstream_session_key: String,
     #[serde(default)]
     pub downstream_run_id: Option<String>,
+    #[serde(default)]
+    pub provider_route_headers: Vec<(String, String)>,
+    /// Causal routing metadata also crosses WS runs without entering their frames.
+    #[serde(default)]
+    pub relay_route_headers: Option<Vec<(String, String)>>,
 }
 
 pub struct QueuedGroupPreparation {
     pub flow: std::sync::Weak<BcsMessageFlow>,
     pub deliveries: Arc<dyn ManagedMessageDeliveryService>,
-    pub provider_bypass_headers_configured: bool,
 }
 
 #[async_trait::async_trait]
@@ -121,7 +130,6 @@ impl ManagedDeliveryPreparationService for QueuedGroupPreparation {
             delivery,
             &contexts.rows,
             contexts.total,
-            self.provider_bypass_headers_configured,
         )
         .await
     }
@@ -172,7 +180,7 @@ impl ManagedDeliveryPreparationService for QueuedGroupPreparation {
             }
             _ => false,
         };
-        if !matches_owner || !command.provider_bypass_headers.is_empty() {
+        if !matches_owner || command.provider_bypass_headers != transport.provider_route_headers {
             return Err(invalid("queue original transport owner mismatch"));
         }
         // Preparation may outlive a Provider mutation or WS reconnect. Resolve
@@ -226,7 +234,7 @@ impl ManagedDeliveryPreparationService for QueuedGroupPreparation {
                     bot_id: delivery.target_bot_id.clone(),
                 },
                 transport_owner: transport.owner,
-                provider_bypass_headers: Vec::new(),
+                provider_bypass_headers: transport.provider_route_headers,
                 deadline_ms,
             })
             .await?;
@@ -347,11 +355,14 @@ impl QueuedGroupProjection {
         if command.session_id.as_deref().is_none_or(|s| s.is_empty()) {
             return Err(invalid("queue admission requires a canonical session"));
         }
-        if !command.provider_bypass_headers.is_empty() {
-            return Err(invalid(
-                "queue admission does not retain Provider bypass headers",
-            ));
-        }
+        let is_provider = flow.registry.resolve_delivery_target(&target.bot_uuid).await?.is_http_provider();
+        // WS does not consume Provider-only headers. Preserve only explicitly
+        // approved routing metadata for a later Bot relay, never credentials.
+        let headers: Vec<_> = command.provider_bypass_headers.iter().filter(|(name, _)|
+            is_provider || flow.queue_persistable_headers.iter().any(|a| a.eq_ignore_ascii_case(name))).cloned().collect();
+        let header_snapshot = bcs_config_api::queued_provider_headers::snapshot(&headers, &flow.queue_persistable_headers);
+        let admission_rejection = header_snapshot.as_ref().err().map(|_| bcs_service_api::port::repo::message_delivery::DeliveryAdmissionRejection::ProviderHeadersUnsupported);
+        let provider_route_headers = header_snapshot.unwrap_or_default();
         let participant = group
             .participants
             .iter()
@@ -360,6 +371,8 @@ impl QueuedGroupProjection {
         let snapshot = crate::protocol_context::group_context_input(group);
         Ok(Self {
             policy_version: None,
+            provider_route_headers,
+            admission_rejection,
             version: 1,
             reply_context: None,
             forward_hop: None,
@@ -439,9 +452,8 @@ pub async fn prepare_queued_group(
     flow: &BcsMessageFlow,
     row: &PersistedMessageDelivery,
     contexts: &[PersistedMessageDelivery],
-    provider_bypass_headers_configured: bool,
 ) -> ServiceResult<PreparedManagedDelivery> {
-    prepare_queued_group_bounded(flow, row, contexts, contexts.len() as u64, provider_bypass_headers_configured).await
+    prepare_queued_group_bounded(flow, row, contexts, contexts.len() as u64).await
 }
 
 async fn prepare_queued_group_bounded(
@@ -449,7 +461,6 @@ async fn prepare_queued_group_bounded(
     row: &PersistedMessageDelivery,
     contexts: &[PersistedMessageDelivery],
     total: u64,
-    provider_bypass_headers_configured: bool,
 ) -> ServiceResult<PreparedManagedDelivery> {
     let projection = QueuedGroupProjection::decode(row).map_err(|e| invalid(&e))?;
     let repo = flow
@@ -534,11 +545,9 @@ async fn prepare_queued_group_bounded(
         .registry
         .resolve_delivery_target(&row.target_bot_id)
         .await?;
-    if delivery_target.is_http_provider() && provider_bypass_headers_configured {
-        return Err(invalid(
-            "Provider queue cannot enforce with bypass headers configured",
-        ));
-    }
+    let relay_route_headers = bcs_config_api::queued_provider_headers::snapshot(&projection.provider_route_headers, &flow.queue_persistable_headers)
+        .map_err(invalid)?;
+    let provider_route_headers = if delivery_target.is_http_provider() { relay_route_headers.clone() } else { Vec::new() };
     let connection_id = match &delivery_target {
         BotDeliveryTarget::WebSocket { .. } => Some(
             flow.bot_delivery
@@ -676,6 +685,8 @@ async fn prepare_queued_group_bounded(
         },
     };
     let transport = QueuedTransportContext {
+        provider_route_headers: provider_route_headers.clone(),
+        relay_route_headers: Some(relay_route_headers),
         version: 1,
         owner,
         connection_id,
@@ -692,7 +703,7 @@ async fn prepare_queued_group_bounded(
             frame,
             delivery_kind: BotDeliveryKind::Send,
             provider_transport: Default::default(),
-            provider_bypass_headers: Vec::new(),
+            provider_bypass_headers: provider_route_headers,
         },
         transport_context_json: transport_json,
     })

--- a/src/bcs/crates/services/bcs-message-flow/tests/bounded_context.rs
+++ b/src/bcs/crates/services/bcs-message-flow/tests/bounded_context.rs
@@ -12,7 +12,7 @@ fn admission(id: &str, text: serde_json::Value, kind: DeliveryType) -> AdmitMess
         display_message: None,
         message_id: id.into(), flow_kind: DeliveryFlowKind::Group, now_ms: 1,
         expire_at_ms: None, event: None,
-        targets: vec![DeliveryAdmissionTarget { target_bot_id: "bot".into(), kind, max_queued: 100, semantic_projection_json: serde_json::json!({"version":1}) }],
+        targets: vec![DeliveryAdmissionTarget { rejection: None, target_bot_id: "bot".into(), kind, max_queued: 100, semantic_projection_json: serde_json::json!({"version":1}) }],
         message: NewMessage { visibility_domain: bcs_domain::MessageVisibilityDomain::Chat, audience: None, group_id: "g".into(), session_id: "s".into(), sender_id: "human".into(), sender_type: SenderType::Human,
             message_type: "chat".into(), client_msg_id: Some(id.into()), owner_bot_id: None, created_at: 1, run_id: String::new(),
             content: serde_json::json!({"text":text,"attachments":[{"attachment_id":id,"type":"image","file_name":"image.png","url":"https://example.invalid/image"}]}) },

--- a/src/bcs/crates/services/bcs-message-flow/tests/conformance_queued_group.rs
+++ b/src/bcs/crates/services/bcs-message-flow/tests/conformance_queued_group.rs
@@ -76,7 +76,7 @@ async fn queue_status_respects_participant_message_audience() {
                 sender_id: "bot-driver".into(), sender_type: SenderType::Bot, message_type: "chat".into(),
                 content: json!({"text":id}), client_msg_id: Some(id.into()), owner_bot_id: None,
                 created_at: 100, run_id: id.into(), visibility_domain: MessageVisibilityDomain::ManagerWorker, audience: Some(audience) },
-            targets: vec![DeliveryAdmissionTarget { target_bot_id: "bot-observer".into(), kind: DeliveryType::Inject,
+            targets: vec![DeliveryAdmissionTarget { rejection: None, target_bot_id: "bot-observer".into(), kind: DeliveryType::Inject,
                 max_queued: 10, semantic_projection_json: json!({"version":1}) }],
         }).await.unwrap();
         let result = flow.query_message_deliveries(DeliveryStatusQuery {
@@ -95,7 +95,7 @@ async fn conformance_live_group_admission_uses_defaults_and_blocks_drain_bypass(
     let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
     let group = support.group.get("group-1").await.unwrap();
     let repo = Arc::new(bcs_message_store::MemoryMessageRepo::new());
-    let live = Arc::new(LiveDeliveryPolicy::new(repo.clone(), Default::default(), false));
+    let live = Arc::new(LiveDeliveryPolicy::new(repo.clone(), Default::default()));
     live.scheduler_available.store(true, std::sync::atomic::Ordering::SeqCst);
     let service = Arc::new(ManagedMessageDelivery::new(repo.clone()).with_policy(live.clone()));
     let mut flow = BcsMessageFlow::new(support.group.clone(), support.routing.clone(), support.registry.clone(), support.bot_delivery.clone(), support.frontend_delivery.clone())
@@ -235,7 +235,7 @@ async fn conformance_queued_group_preparation_and_ingress() {
             now_ms: 1,
             expire_at_ms: None,
             event: None,
-            targets: vec![DeliveryAdmissionTarget {
+            targets: vec![DeliveryAdmissionTarget { rejection: None,
                 target_bot_id: "bot-driver".into(),
                 kind: DeliveryType::Send,
                 max_queued: 10,
@@ -290,7 +290,6 @@ async fn conformance_queued_group_preparation_and_ingress() {
     let preparer = QueuedGroupPreparation {
         flow: Arc::downgrade(&flow),
         deliveries: service.clone(),
-        provider_bypass_headers_configured: false,
     };
     bcs_test_support::contract::application::message_delivery::managed_delivery_preparation_service_contract_tests(&preparer, &row).await.unwrap();
     let mut prepared = preparer.prepare(&row).await.unwrap();

--- a/src/bcs/crates/services/bcs-message-flow/tests/contract_bot_event.rs
+++ b/src/bcs/crates/services/bcs-message-flow/tests/contract_bot_event.rs
@@ -82,7 +82,7 @@ async fn queued_im_hints_aggregate_targets_and_do_not_replay_on_restart() {
         display_message: None,
         message_id: "im-queue".into(), flow_kind: DeliveryFlowKind::Group, now_ms: now - 3_000, expire_at_ms: None, event: None,
         targets: [("bot-driver", DeliveryType::Send), ("bot-observer", DeliveryType::Send), ("context-only", DeliveryType::Inject)].into_iter()
-            .map(|(bot, kind)| DeliveryAdmissionTarget { target_bot_id: bot.into(), kind, max_queued: 10, semantic_projection_json: json!({"version":1}) }).collect(),
+            .map(|(bot, kind)| DeliveryAdmissionTarget { rejection: None, target_bot_id: bot.into(), kind, max_queued: 10, semantic_projection_json: json!({"version":1}) }).collect(),
         message: NewMessage { visibility_domain: MessageVisibilityDomain::Chat, audience: None, group_id: "group-1".into(), session_id: "group-1:im-original".into(), sender_id: "human_1".into(), sender_type: SenderType::Human,
             message_type: "chat".into(), content: json!({"text":"hello","source_im_message_id":"im-original"}), client_msg_id: None, owner_bot_id: None, created_at: (now - 3_000) as u64, run_id: String::new() },
     }).await.unwrap();

--- a/src/bcs/crates/services/bcs-message-flow/tests/contract_message_flow.rs
+++ b/src/bcs/crates/services/bcs-message-flow/tests/contract_message_flow.rs
@@ -3800,7 +3800,7 @@ async fn chat_abort_provider_sends_one_scope_request_for_parallel_runs() {
             },
         )
         .await;
-        if canonical == "bcs-run-2" {
+        {
             let mut context = run_context
                 .find_active_run(canonical)
                 .await

--- a/src/bcs/crates/services/bcs-message-flow/tests/delivery_policy.rs
+++ b/src/bcs/crates/services/bcs-message-flow/tests/delivery_policy.rs
@@ -42,7 +42,7 @@ impl MessageDeliveryRepoPort for SlowPolicyRepo {
 #[tokio::test]
 async fn disconnected_management_request_still_finishes_commit_and_publication() {
     let repo = Arc::new(SlowPolicyRepo { inner: MemoryMessageRepo::new(), started: Default::default(), release: Default::default() });
-    let live = Arc::new(LiveDeliveryPolicy::new(repo.clone(), Default::default(), false));
+    let live = Arc::new(LiveDeliveryPolicy::new(repo.clone(), Default::default()));
     let request_live = live.clone();
     let request = tokio::spawn(async move { request_live.replace(admin(), 0, DeliveryPolicy::default()).await });
     tokio::time::timeout(std::time::Duration::from_secs(1), repo.started.notified()).await.unwrap();
@@ -57,7 +57,7 @@ async fn disconnected_management_request_still_finishes_commit_and_publication()
 #[tokio::test]
 async fn policy_management_auth_cas_and_live_publication() {
     let repo = Arc::new(MemoryMessageRepo::new());
-    let live = LiveDeliveryPolicy::new(repo.clone(), DeliveryPolicyRecord::default(), false);
+    let live = LiveDeliveryPolicy::new(repo.clone(), DeliveryPolicyRecord::default());
     assert!(live.get(CallerContext::Public).await.is_err());
     assert!(live.replace(CallerContext::Public, 0, DeliveryPolicy::default()).await.is_err());
     for caller in [
@@ -91,8 +91,8 @@ async fn policy_management_auth_cas_and_live_publication() {
 }
 
 #[tokio::test]
-async fn provider_headers_and_unready_flows_are_rejected() {
-    let live = LiveDeliveryPolicy::new(Arc::new(MemoryMessageRepo::new()), Default::default(), true);
+async fn unready_flows_are_rejected_but_group_activation_is_allowed() {
+    let live = LiveDeliveryPolicy::new(Arc::new(MemoryMessageRepo::new()), Default::default());
     live.scheduler_available.store(true, Ordering::SeqCst);
     let mut policy = DeliveryPolicy::default();
     policy.flow_enabled.state_machine = true;
@@ -100,5 +100,5 @@ async fn provider_headers_and_unready_flows_are_rejected() {
     let mut policy = DeliveryPolicy::default();
     policy.flow_enabled.group = true;
     policy.defaults.mode = BotDeliveryMode::Enforce;
-    assert!(live.replace(admin(), 0, policy).await.is_err());
+    assert!(live.replace(admin(), 0, policy).await.is_ok());
 }

--- a/src/bcs/crates/services/bcs-message-flow/tests/delivery_policy_audit.rs
+++ b/src/bcs/crates/services/bcs-message-flow/tests/delivery_policy_audit.rs
@@ -20,7 +20,7 @@ async fn policy_audit_records_human_versions_fields_and_both_outcomes() {
     tracing::subscriber::set_global_default(subscriber).unwrap();
     async {
         let caller = || CallerContext::Human(HumanActor { actor_id: "human_audit_operator".into(), staff_no: "audit_operator".into() });
-        let live = LiveDeliveryPolicy::new(Arc::new(MemoryMessageRepo::new()), Default::default(), false);
+        let live = LiveDeliveryPolicy::new(Arc::new(MemoryMessageRepo::new()), Default::default());
         let mut policy = DeliveryPolicy::default();
         policy.defaults.max_queued = 50;
         live.replace(caller(), 0, policy.clone()).await.unwrap();

--- a/src/bcs/crates/services/bcs-message-flow/tests/delivery_runtime.rs
+++ b/src/bcs/crates/services/bcs-message-flow/tests/delivery_runtime.rs
@@ -247,7 +247,7 @@ fn command(id: &str, session: &str) -> AdmitMessageDeliveries {
             created_at: 1,
             run_id: String::new(),
         },
-        targets: vec![DeliveryAdmissionTarget {
+        targets: vec![DeliveryAdmissionTarget { rejection: None,
             target_bot_id: "bot".into(),
             kind: DeliveryType::Send,
             max_queued: 10,
@@ -364,7 +364,7 @@ async fn live_policy_enables_empty_scheduler_recalculates_interval_and_drains_of
     use bcs_service_api::{HumanActor, CallerContext};
     let admin = || CallerContext::Human(HumanActor { actor_id: "human_operator".into(), staff_no: "operator".into() });
     let repo = Arc::new(MemoryMessageRepo::new());
-    let live = Arc::new(LiveDeliveryPolicy::new(repo.clone(), Default::default(), false));
+    let live = Arc::new(LiveDeliveryPolicy::new(repo.clone(), Default::default()));
     live.scheduler_available.store(true, std::sync::atomic::Ordering::SeqCst);
     let service = Arc::new(ManagedMessageDelivery::new(repo).with_policy(live.clone()));
     let io = Arc::new(RecordingIo { service: service.clone(), sent: Default::default(), aborts: Default::default(), fail_send: false, fail_registration: false });
@@ -486,7 +486,7 @@ async fn lowering_live_limits_preserves_existing_work_and_only_blocks_new_capaci
     use bcs_service_api::{HumanActor, CallerContext};
     let admin = || CallerContext::Human(HumanActor { actor_id: "human_operator".into(), staff_no: "operator".into() });
     let repo = Arc::new(MemoryMessageRepo::new());
-    let live = Arc::new(LiveDeliveryPolicy::new(repo.clone(), Default::default(), false));
+    let live = Arc::new(LiveDeliveryPolicy::new(repo.clone(), Default::default()));
     live.scheduler_available.store(true, std::sync::atomic::Ordering::SeqCst);
     let mut policy = DeliveryPolicy::default();
     policy.flow_enabled.group = true;

--- a/src/bcs/crates/services/bcs-message-flow/tests/managed_delivery.rs
+++ b/src/bcs/crates/services/bcs-message-flow/tests/managed_delivery.rs
@@ -18,7 +18,7 @@ fn admit(id: &str, kind: DeliveryType) -> AdmitMessageDeliveries {
         now_ms: 100,
         expire_at_ms: None,
         event: None,
-        targets: vec![DeliveryAdmissionTarget {
+        targets: vec![DeliveryAdmissionTarget { rejection: None,
             target_bot_id: "bot".into(),
             kind,
             max_queued: 20,
@@ -64,7 +64,7 @@ async fn send_start_rechecks_cross_session_capacity_under_mutation_lock() -> Res
     let repo = Arc::new(MemoryMessageRepo::new());
     let mut initial = DeliveryPolicyRecord::default();
     initial.policy.flow_enabled.group = true; initial.policy.defaults.mode = BotDeliveryMode::Enforce; initial.policy.defaults.max_running = 1;
-    let policy = Arc::new(bcs_message_flow::delivery_policy::LiveDeliveryPolicy::new(repo.clone(), initial, false));
+    let policy = Arc::new(bcs_message_flow::delivery_policy::LiveDeliveryPolicy::new(repo.clone(), initial));
     let service = ManagedMessageDelivery::new(repo).with_policy(policy);
     let mut a = admit("race-a", DeliveryType::Send); a.message.session_id = "a".into();
     let mut b = admit("race-b", DeliveryType::Send); b.message.session_id = "b".into();

--- a/src/bcs/crates/services/bcs-message-flow/tests/queued_provider_headers.rs
+++ b/src/bcs/crates/services/bcs-message-flow/tests/queued_provider_headers.rs
@@ -1,0 +1,143 @@
+use std::sync::Arc;
+use bcs_message_flow::{BcsMessageFlow, MemoryBotRunContextStore, managed_delivery::ManagedMessageDelivery, queued_group::QueuedGroupPreparation};
+use bcs_service_api::{CallerContext, GroupCoreService, HumanActor, ManagedDeliveryPreparationService, ManagedMessageDeliveryService, MessageFlowService, WebSendCommand};
+use bcs_domain::{DeliveryType, message_delivery::MessageDeliveryStatus as Status};
+use serde_json::json;
+#[path = "support/session.rs"] mod session;
+#[path = "../../../test-support/message_flow_contract_support.rs"] mod support;
+
+fn command(id: &str, name: &str, value: &str) -> WebSendCommand {
+    WebSendCommand {
+        caller: CallerContext::Human(HumanActor { actor_id: "human_1".into(), staff_no: "1".into() }),
+        group_id: "group-1".into(), session_id: Some("group-1:headers".into()), from_actor_id: "human_1".into(),
+        from_name: None, message: "hello".into(), mentions: vec!["bot-driver".into()], attachments: None,
+        thinking: None, idempotency_key: Some(id.into()), source_im_message_id: None, channel_sender_identity: None,
+        sender_conn_id: None, provider_bypass_headers: vec![(name.into(), value.into())],
+    }
+}
+
+async fn fixture() -> (support::FlowTestSupport, Arc<BcsMessageFlow>, Arc<ManagedMessageDelivery>) {
+    let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
+    support.registry.set_delivery_target("bot-driver", support::FakeRegistryService::provider_target("bot-driver")).await;
+    let group = support.group.get("group-1").await.unwrap();
+    let repo = Arc::new(bcs_message_store::MemoryMessageRepo::new());
+    let service = Arc::new(ManagedMessageDelivery::new(repo.clone()));
+    let mut flow = BcsMessageFlow::new(support.group.clone(), support.routing.clone(), support.registry.clone(), support.bot_delivery.clone(), support.frontend_delivery.clone())
+        .with_message_repo(repo).with_managed_deliveries(service.clone())
+        .with_bot_run_context(Arc::new(MemoryBotRunContextStore::new()))
+        .with_group_delivery_limits(std::collections::BTreeMap::from([("bot-driver".into(),10),("bot-observer".into(),10)]))
+        .with_session_management(Arc::new(session::StaticSessionManagement::new(session::test_session("group-1:headers","group-1",group.participants))));
+    flow.queue_persistable_headers = vec!["x-routing-zone".into()];
+    (support, Arc::new(flow), service)
+}
+
+#[tokio::test]
+async fn rejects_only_provider_target_without_persisting_unsupported_values() {
+    let (support, flow, service) = fixture().await;
+    let result = flow.handle_web_send(command("reject", "cookie", "do-not-persist")).await.unwrap();
+    let view = result.queue_admission.unwrap();
+    let provider = view.deliveries.iter().find(|d| d.target_bot_id == "bot-driver").unwrap();
+    assert_eq!(provider.status, Status::Failed);
+    assert_eq!(provider.admission_error, Some("delivery_provider_headers_unsupported"));
+    assert_eq!(view.deliveries.iter().find(|d| d.target_bot_id == "bot-observer").unwrap().status, Status::PendingContext);
+    let rows = service.snapshot(None).await.unwrap();
+    for row in rows {
+        assert!(!row.semantic_projection_json.to_string().contains("do-not-persist"));
+    }
+    assert!(support.bot_delivery.frames().await.is_empty());
+    assert!(!serde_json::to_string(&view).unwrap().contains("do-not-persist"));
+}
+
+#[tokio::test]
+async fn persists_route_per_send_restores_abort_and_relay_without_model_leakage() {
+    use bcs_service_api::{DeliveryTransitionCommand, ChatAbortCommand, BotEventCommand, ChatEventState};
+    use bcs_service_api::core::message_delivery::DeliveryLifecycleEvent as Event;
+    for provider in [true, false] {
+    let (support, flow, service) = fixture().await;
+    if !provider {
+        support.registry.set_delivery_target("bot-driver", bcs_service_api::BotDeliveryTarget::WebSocket { bot_id: "bot-driver".into() }).await;
+    }
+    // A pending Inject may carry another routing snapshot but cannot replace
+    // the carrier's route when both are composed into one model request.
+    let mut injected = command("inject", "x-routing-zone", "context-zone");
+    injected.mentions = vec!["bot-observer".into()];
+    flow.handle_web_send(injected).await.unwrap();
+    let view = flow.handle_web_send(command("send", "X-Routing-Zone", "carrier-zone")).await.unwrap().queue_admission.unwrap();
+    let row = service.snapshot(None).await.unwrap().into_iter().find(|d| d.source_message_id == view.message_id && d.state.kind == DeliveryType::Send).unwrap();
+    let preparer = QueuedGroupPreparation { flow: Arc::downgrade(&flow), deliveries: service.clone() };
+    let mut prepared = preparer.prepare(&row).await.unwrap();
+    let expected = vec![("x-routing-zone".into(), "carrier-zone".into())];
+    let transport_headers = if provider { expected.clone() } else { Vec::new() };
+    assert_eq!(prepared.command.provider_bypass_headers, transport_headers);
+    let frame = serde_json::to_string(&prepared.command.frame).unwrap();
+    assert!(!frame.contains("carrier-zone") && !frame.contains("context-zone"));
+    assert!(!serde_json::to_string(&view).unwrap().contains("carrier-zone"));
+    let started = service.transition(DeliveryTransitionCommand {
+        delivery_id: row.delivery_id.clone(), expected_state_version: row.state.state_version,
+        event: Event::StartSend, now_ms: chrono::Utc::now().timestamp_millis(), request_id: None, actor_id: None, reply: None,
+        transport_context_json: Some(prepared.transport_context_json.clone()), deadline_at_ms: Some(i64::MAX),
+    }).await.unwrap();
+    if let bcs_protocol::BcsFrame::Request(frame) = &mut prepared.command.frame { frame.id = started.request_id.clone().unwrap(); }
+    preparer.before_send(&started, &prepared.command).await.unwrap();
+    let active = flow.bot_run_context.as_ref().unwrap().find_active_run(started.run_id.as_deref().unwrap()).await.unwrap().unwrap();
+    assert_eq!(active.provider_bypass_headers, transport_headers);
+    let mut mismatched = prepared.command.clone();
+    mismatched.provider_bypass_headers = vec![("x-routing-zone".into(), "incorrect-zone".into())];
+    assert!(preparer.before_send(&started, &mismatched).await.is_err());
+    // Recover abort from durable transport, not an active-run cache or the
+    // cancelling caller. Exact Provider abort remains unsupported.
+    if provider {
+    assert!(preparer.prepare_abort(&started).await.is_err());
+    flow.bot_run_context.as_ref().unwrap().remove_active_run(&active.scope, started.run_id.as_deref().unwrap()).await.unwrap();
+    flow.handle_chat_abort(ChatAbortCommand {
+        caller: CallerContext::Human(HumanActor { actor_id: "human_1".into(), staff_no: "1".into() }),
+        group_id: "group-1".into(), session_id: "group-1:headers".into(), bot_id: "bot-driver".into(), run_id: None,
+    }).await.unwrap();
+    assert_eq!(support.bot_delivery.aborts().await[0].provider_bypass_headers, expected);
+    }
+    support.registry.set_delivery_target("bot-observer", support::FakeRegistryService::provider_target("bot-observer")).await;
+    flow.handle_bot_event(BotEventCommand { bot_id: "bot-driver".into(), run_id: started.run_id.unwrap(), group_id: "group-1".into(),
+        event_type: "chat".into(), state: ChatEventState::Final, bcs_session_id: Some("group-1:headers".into()),
+        event_payload: json!({"message":{"role":"assistant","content":[{"type":"text","text":"@Observer check this"}]}}),
+    }).await.unwrap();
+    let reply = service.snapshot(None).await.unwrap().into_iter().find(|d| d.target_bot_id == "bot-observer" && d.state.kind == DeliveryType::Send && d.source_session_seq > row.source_session_seq).unwrap();
+    assert_eq!(reply.semantic_projection_json["provider_route_headers"], json!(expected));
+    }
+}
+
+#[tokio::test]
+async fn configuration_tightening_fails_instead_of_sending_without_route() {
+    let (_, mut flow, service) = fixture().await;
+    let view = flow.handle_web_send(command("tighten", "x-routing-zone", "original-zone")).await.unwrap().queue_admission.unwrap();
+    let row = service.snapshot(None).await.unwrap().into_iter().find(|d| d.source_message_id == view.message_id && d.state.kind == DeliveryType::Send).unwrap();
+    Arc::get_mut(&mut flow).unwrap().queue_persistable_headers.clear();
+    let preparer = QueuedGroupPreparation { flow: Arc::downgrade(&flow), deliveries: service };
+    assert!(preparer.prepare(&row).await.is_err());
+    // Old persisted rows without headers remain readable and use default route.
+    let mut old = row;
+    old.semantic_projection_json.as_object_mut().unwrap().remove("provider_route_headers");
+    assert!(preparer.prepare(&old).await.unwrap().command.provider_bypass_headers.is_empty());
+}
+
+#[tokio::test]
+async fn scope_abort_rejects_default_and_named_route_mix() {
+    let (support, flow, _) = fixture().await;
+    for (id, headers) in [("default", Vec::new()), ("named", vec![("x-routing-zone".into(), "blue".into())])] {
+        flow.bot_run_context.as_ref().unwrap().put_context(bcs_service_api::BotRunContext {
+            run_id: id.into(), bot_id: "bot-driver".into(), group_id: "group-1".into(),
+            bcs_session_id: Some("group-1:headers".into()), deadline_ms: u64::MAX, terminal: false,
+        }).await;
+        flow.bot_run_context.as_ref().unwrap().register_active_run(bcs_service_api::ActiveBotRunContext {
+            canonical_run_id: id.into(), downstream_run_id: id.into(), downstream_session_key: Some("group-1:headers".into()),
+            scope: bcs_service_api::BotRunScope { group_id: "group-1".into(), session_id: "group-1:headers".into(), bot_id: "bot-driver".into() },
+            transport_owner: bcs_service_api::BotRunTransportOwner::HttpProvider { provider_id: "provider-1".into(), provider_bot_ref: "bot-driver".into() },
+            provider_bypass_headers: headers, deadline_ms: u64::MAX,
+        }).await.unwrap();
+    }
+    let outcome = flow.handle_chat_abort(bcs_service_api::ChatAbortCommand {
+        caller: CallerContext::Human(HumanActor { actor_id: "human_1".into(), staff_no: "1".into() }),
+        group_id: "group-1".into(), session_id: "group-1:headers".into(), bot_id: "bot-driver".into(), run_id: None,
+    }).await.unwrap();
+    assert!(outcome.aborted_run_ids.is_empty());
+    assert!(support.bot_delivery.aborts().await.is_empty(), "never choose one route arbitrarily");
+}

--- a/src/bcs/crates/services/bcs-message-flow/tests/queued_provider_headers.rs
+++ b/src/bcs/crates/services/bcs-message-flow/tests/queued_provider_headers.rs
@@ -35,6 +35,7 @@ async fn fixture() -> (support::FlowTestSupport, Arc<BcsMessageFlow>, Arc<Manage
 async fn rejects_only_provider_target_without_persisting_unsupported_values() {
     let (support, flow, service) = fixture().await;
     let result = flow.handle_web_send(command("reject", "cookie", "do-not-persist")).await.unwrap();
+    assert_eq!(result.status, "failed", "accepted observer context cannot produce a reply");
     let view = result.queue_admission.unwrap();
     let provider = view.deliveries.iter().find(|d| d.target_bot_id == "bot-driver").unwrap();
     assert_eq!(provider.status, Status::Failed);
@@ -46,6 +47,26 @@ async fn rejects_only_provider_target_without_persisting_unsupported_values() {
     }
     assert!(support.bot_delivery.frames().await.is_empty());
     assert!(!serde_json::to_string(&view).unwrap().contains("do-not-persist"));
+}
+
+#[tokio::test]
+async fn accepted_send_targets_keep_queued_or_legacy_started_status() {
+    for legacy in [false, true] {
+        let (_, mut flow, _) = fixture().await;
+        if legacy {
+            Arc::get_mut(&mut flow).unwrap().group_delivery_limits.remove("bot-observer");
+        }
+        let mut request = command("partial", "cookie", "do-not-persist");
+        request.mentions.push("bot-observer".into());
+        let result = flow.handle_web_send(request).await.unwrap();
+        assert_eq!(result.status, if legacy { "started" } else { "queued" });
+        assert_eq!(result.active_run_ids.is_empty(), !legacy);
+        let view = result.queue_admission.unwrap();
+        assert_eq!(view.deliveries.iter().find(|d| d.target_bot_id == "bot-driver").unwrap().status, Status::Failed);
+        if !legacy {
+            assert_eq!(view.deliveries.iter().find(|d| d.target_bot_id == "bot-observer").unwrap().status, Status::Queued);
+        }
+    }
 }
 
 #[tokio::test]

--- a/src/bcs/crates/services/bcs-message-flow/tests/run_reply.rs
+++ b/src/bcs/crates/services/bcs-message-flow/tests/run_reply.rs
@@ -69,11 +69,11 @@ async fn terminal_storage_faults_preserve_reply_and_publish_after_commit_even_if
             message: NewMessage { visibility_domain: bcs_domain::MessageVisibilityDomain::Chat, audience: None, group_id: "group-1".into(), session_id: "group-1:retry".into(), sender_id: "human".into(),
                 sender_type: SenderType::Human, message_type: "chat".into(), content: json!({"text":"question"}),
                 client_msg_id: Some("input".into()), owner_bot_id: None, created_at: 1, run_id: String::new() },
-            flow_kind: DeliveryFlowKind::Group, targets: vec![DeliveryAdmissionTarget { target_bot_id: "bot-driver".into(), kind: DeliveryType::Send,
+            flow_kind: DeliveryFlowKind::Group, targets: vec![DeliveryAdmissionTarget { rejection: None, target_bot_id: "bot-driver".into(), kind: DeliveryType::Send,
                 max_queued: 100, semantic_projection_json: json!({"version":1}) }], now_ms: 1, expire_at_ms: None, event: None }).await.unwrap().deliveries.remove(0);
         let started = service.transition(DeliveryTransitionCommand { delivery_id: input.delivery_id.clone(), expected_state_version: 1,
             event: bcs_service_api::core::message_delivery::DeliveryLifecycleEvent::StartSend, now_ms: 2, request_id: None, actor_id: None,
-            reply: None, transport_context_json: Some(json!({"version":1,"kind":"websocket"})), deadline_at_ms: Some(i64::MAX) }).await.unwrap();
+            reply: None, transport_context_json: Some(json!({"version":1,"owner":{"kind":"web_socket"},"connection_id":"test","downstream_session_key":"session"})), deadline_at_ms: Some(i64::MAX) }).await.unwrap();
         let mut terminal = BotEventCommand { bot_id: "bot-driver".into(), run_id: started.run_id.clone().unwrap(), group_id: "group-1".into(),
             bcs_session_id: Some("group-1:retry".into()), state: ChatEventState::Delta, event_type: "chat".into(), event_payload: json!({"delta_text":"保留的正文"}) };
         flow.handle_bot_event(terminal.clone()).await.unwrap();
@@ -138,12 +138,12 @@ async fn mixed_final_modes_reconstruct_one_reply_and_preserve_visible_history() 
             message_id: format!("input-{index}"), message: NewMessage { visibility_domain: bcs_domain::MessageVisibilityDomain::Chat, audience: None, group_id: "group-1".into(), session_id: "group-1:reply".into(),
                 sender_id: "human".into(), sender_type: SenderType::Human, message_type: "chat".into(), content: json!({"text":"question"}),
                 client_msg_id: Some(format!("input-{index}")), owner_bot_id: None, created_at: 1, run_id: String::new() },
-            flow_kind: DeliveryFlowKind::Group, targets: vec![DeliveryAdmissionTarget { target_bot_id: "bot-driver".into(), kind: DeliveryType::Send,
+            flow_kind: DeliveryFlowKind::Group, targets: vec![DeliveryAdmissionTarget { rejection: None, target_bot_id: "bot-driver".into(), kind: DeliveryType::Send,
                 max_queued: 100, semantic_projection_json: json!({"version":1}) }], now_ms: 1, expire_at_ms: None, event: None }).await.unwrap();
         let input = &source.deliveries[0];
         let started = service.transition(DeliveryTransitionCommand { delivery_id: input.delivery_id.clone(), expected_state_version: 1,
             event: bcs_service_api::core::message_delivery::DeliveryLifecycleEvent::StartSend, now_ms: 2, request_id: None, actor_id: None,
-            reply: None, transport_context_json: Some(json!({"version":1,"kind":"websocket"})), deadline_at_ms: Some(i64::MAX) }).await.unwrap();
+            reply: None, transport_context_json: Some(json!({"version":1,"owner":{"kind":"web_socket"},"connection_id":"test","downstream_session_key":"session"})), deadline_at_ms: Some(i64::MAX) }).await.unwrap();
         let run = started.run_id.as_ref().unwrap();
         let event = |state, event_type: &str, payload| BotEventCommand { bot_id: "bot-driver".into(), run_id: run.clone(), group_id: "group-1".into(),
             bcs_session_id: Some("group-1:reply".into()), state, event_type: event_type.into(), event_payload: payload };

--- a/src/bcs/crates/services/bcs-message-store/CONTEXT.md
+++ b/src/bcs/crates/services/bcs-message-store/CONTEXT.md
@@ -2,6 +2,10 @@
 
 ## Provides
 
+Application-supplied admission rejections commit as unsent Failed rows (Send or
+Inject), with a fixed last_error_code, alongside other admitted recipients.
+Stores do not inspect Header values or decide Header policy.
+
 Opt-in `bcs_reply_profile` DEBUG timing separates delivery_writer wait from
 hold time. A held-writer span lets the isolated load test attribute SQLite SQL
 category timings/counts to the critical section without logging SQL or payloads.

--- a/src/bcs/crates/services/bcs-message-store/src/delivery.rs
+++ b/src/bcs/crates/services/bcs-message-store/src/delivery.rs
@@ -284,7 +284,9 @@ pub(crate) fn plan_admission(
                     && d.state.status == Status::Queued
             })
             .count());
-        let status = if target.kind == DeliveryType::Inject {
+        let status = if target.rejection.is_some() {
+            Status::Failed
+        } else if target.kind == DeliveryType::Inject {
             Status::PendingContext
         } else if queued >= target.max_queued as usize {
             Status::RejectedCapacity
@@ -320,7 +322,7 @@ pub(crate) fn plan_admission(
             submitted_at_ms: None,
             accepted_at_ms: None,
             run_deadline_at_ms: None,
-            terminal_at_ms: (status == Status::RejectedCapacity).then_some(command.now_ms),
+            terminal_at_ms: matches!(status, Status::RejectedCapacity | Status::Failed).then_some(command.now_ms),
             bound_to_delivery_id: None,
             cancel_requested_at_ms: None,
             cancel_requested_by: None,
@@ -328,7 +330,7 @@ pub(crate) fn plan_admission(
             abort_request_id: None,
             abort_started_at_ms: None,
             cancel_deadline_at_ms: None,
-            last_error_code: None,
+            last_error_code: target.rejection.map(|r| r.code().to_owned()),
             semantic_projection_json: target.semantic_projection_json.clone(),
             transport_context_json: None,
             context_selection_json: None,

--- a/src/bcs/crates/services/bcs-message-store/tests/conformance_delivery_repo.rs
+++ b/src/bcs/crates/services/bcs-message-store/tests/conformance_delivery_repo.rs
@@ -117,7 +117,7 @@ async fn pooled_file_sqlite_preserves_contract_and_concurrent_capacity() -> Resu
             created_at: 100, run_id: String::new(),
         },
         flow_kind: DeliveryFlowKind::Group, now_ms: 100, expire_at_ms: None, event: None,
-        targets: vec![DeliveryAdmissionTarget {
+        targets: vec![DeliveryAdmissionTarget { rejection: None,
             target_bot_id: "capacity-bot".into(), kind, max_queued: 3,
             semantic_projection_json: serde_json::json!({"version":1}),
         }],

--- a/src/bcs/crates/test-support/bcs-test-support/src/contract/application/message_delivery.rs
+++ b/src/bcs/crates/test-support/bcs-test-support/src/contract/application/message_delivery.rs
@@ -21,7 +21,7 @@ pub async fn managed_message_delivery_service_contract_tests<
             now_ms: 1,
             expire_at_ms: None,
             event: None,
-            targets: vec![DeliveryAdmissionTarget {
+            targets: vec![DeliveryAdmissionTarget { rejection: None,
                 target_bot_id: "bot".into(),
                 kind: DeliveryType::Send,
                 max_queued: 10,

--- a/src/bcs/crates/test-support/bcs-test-support/src/contract/repo/message_delivery.rs
+++ b/src/bcs/crates/test-support/bcs-test-support/src/contract/repo/message_delivery.rs
@@ -30,7 +30,7 @@ fn command(id: &str, targets: &[(&str, DeliveryType)]) -> AdmitMessageDeliveries
         },
         targets: targets
             .iter()
-            .map(|(bot, kind)| DeliveryAdmissionTarget {
+            .map(|(bot, kind)| DeliveryAdmissionTarget { rejection: None,
                 target_bot_id: (*bot).into(),
                 kind: *kind,
                 max_queued: 1,
@@ -326,5 +326,21 @@ async fn run_reply_contract<T: MessageDeliveryRepoPort + MessageRepoPort>(repo: 
     let segments = repo.run_chat_segments(&summary.message.session_id, "reply-bot", "shared-run").await?;
     assert_eq!(segments.iter().map(|m| m.content.as_str().unwrap()).collect::<Vec<_>>(), vec!["before", "after"]);
     assert!(repo.run_chat_segments("other-session", "reply-bot", "shared-run").await?.is_empty());
+    let mut rejected = command("header-rejection", &[("header-send", DeliveryType::Send), ("header-context", DeliveryType::Inject), ("accepted", DeliveryType::Send)]);
+    rejected.targets[0].rejection = Some(DeliveryAdmissionRejection::ProviderHeadersUnsupported);
+    rejected.targets[1].rejection = Some(DeliveryAdmissionRejection::ProviderHeadersUnsupported);
+    rejected.targets[2].semantic_projection_json = serde_json::json!({"version":1,"provider_route_headers":[["x-routing-zone","blue"]]});
+    let admitted = repo.admit(rejected.clone()).await?;
+    for row in &admitted.deliveries[..2] {
+        assert_eq!(row.state.status, Status::Failed);
+        assert!(!row.state.may_have_been_sent);
+        assert_eq!(row.last_error_code.as_deref(), Some("delivery_provider_headers_unsupported"));
+        assert_eq!(row.terminal_at_ms, Some(100));
+        assert!(repo.lookup(DeliveryLookup::BotPending(row.target_bot_id.clone())).await?.is_empty());
+    }
+    let accepted = &admitted.deliveries[2];
+    assert_eq!(accepted.state.status, Status::Queued);
+    assert_eq!(repo.get_delivery(&accepted.delivery_id).await?.unwrap().semantic_projection_json, rejected.targets[2].semantic_projection_json);
+    assert!(repo.admit(rejected).await?.duplicate);
     Ok(())
 }

--- a/src/bcs/docs/message-delivery-service-api.md
+++ b/src/bcs/docs/message-delivery-service-api.md
@@ -195,8 +195,22 @@ TTL / safe_retry 可为 null，分别表示不自动过期、不自动安全重�
 持久群普通 Bot 消息、IM 入站及其回复路由。system callback、task、Direct A2A、
 state-machine 保留原路径；误开启未就绪类型返回 queue_flow_not_ready。
 
-provider_http.bypass_headers 非空时首版拒绝开启队列策略，避免默认策略覆盖未来 Provider
-Bot 后产生无法持久化的 header 依赖；不保存 header 明文。
+`provider_http.queue_persistable_headers`（默认空）是 `bypass_headers` 的子集，
+用于显式批准可明文持久化的非敏感路由 Header。名称大小写无关；最多 16 个、单值
+1024 字节、名称和值总计 8192 字节，禁止重复名称、控制字符和已知凭证类名称。
+自定义字段是否含敏感信息仍需部署者评审；Cookie/Authorization 不支持持久化。
+不再因透传白名单非空全局禁止 enforce。实际 HTTP Provider 目标携带未批准 Header 时，
+在准入事务中仅将该目标记为 `failed`，响应中的 `admission_error` 为
+`delivery_provider_headers_unsupported`；不保存其值、不回滚其他目标、不退回老链路。
+WebSocket 目标不使用 Provider Header，队列关闭的目标保留原行为。
+允许值只存 delivery 内部投影 `provider_route_headers`，send-start 固化到 transport context；
+旧记录缺字段按空处理。Worker、恢复后的 scope abort 和受管 Bot 回复接力复用原运行快照。
+transport context 的 `relay_route_headers` 保留因果路由，`provider_route_headers` 只记录
+实际 HTTP 路由；受管 WS 中间跳只保留前者，不把 Header 放入 WS frame，避免接力丢失 lane。
+Inject 不覆盖承载 Send 的路由；配置收紧导致未发请求失败，不静默删除 Header 改路由。
+scope abort 要求全部原运行路由（包括空路由）一致，精确 Provider abort 仍不支持。
+Header 值不进入消息正文、模型、History、状态响应或日志。无需数据库 DDL 迁移；
+回滚旧二进制前必须排空新增 Header 投影的队列，否则旧版本无法读取这些字段。
 附件存于 bcs_messages.content.attachments，实际发送重新读取 canonical 消息；
 历史、事件和状态不暴露保留的签名 URL。本轮不处理排队期间 URL 过期。
 

--- a/src/bcs/docs/plans/2026-09-04-bcs-message-congestion-control-design.md
+++ b/src/bcs/docs/plans/2026-09-04-bcs-message-congestion-control-design.md
@@ -57,7 +57,7 @@
   Workbench UI 明确后置，是否仍混入了前端实现或页面验收要求。
 - 是否接受首版无 outbox、外部 IM 状态提示可能漏发；ChatRun 查询校准及业务回调的
   既有恢复/人工处理边界是否明确。
-- Provider bypass header TODO 是否阻塞对应 Bot 的生产启用。
+- Provider 路由 Header 持久化白名单是否仅含非敏感字段，以及敏感凭证拒绝边界。
 - 按业务类型灰度时，是否接受限流/顺序只约束受管请求；关闭类型共享 Bot/Session 时的
   上下文边界和 Provider scope Abort 风险是否已明确。
 - Direct A2A/state-machine 未就绪时拒绝启用、类型停用前 drain，以及已入队请求的所有权是否明确。
@@ -1264,7 +1264,7 @@ policy_json 包含 flow_enabled、defaults、bots、queue_ttl_ms、safe_retry、
 
 - GET /admin/message-delivery/policy：读取完整生效记录。
 - PUT 同一路径：提交 expected_version + 完整 policy，不是任意 JSON merge patch。
-- PUT 校验继承后的每个策略、就绪类型、调度能力及 Provider header 限制。
+- PUT 校验继承后的每个策略、就绪类型、调度能力；实际 Provider header 在逐目标准入时校验。
 - DB CAS 匹配预期版本、递增版本并保存操作者/时间；写失败不发布。
 - 进程内写锁跨越事务提交和快照发布；准入在提交前复核策略，prepared send 在 send-start
   前复核策略版本，旧版本准备结果不能绕过新 pause/限额。
@@ -1305,8 +1305,8 @@ SQLite/MySQL/OceanBase 持久化模式下，默认 off 也启动空闲调度器�
 再通过 API 开启。策略更新本身不迁移旧 ChatRun、不重新发送历史、不回填已直发 inject。
 未接入类型仍走原路径，不承诺其与队列之间共同限流/有序；不能开一个标志代替消息持久化接入。
 
-provider_http.bypass_headers 非空时首版保守拒绝开启队列策略，防止默认策略覆盖未来
-Provider Bot 后才发现不能恢复 header。后续再评审按 Bot capability 或加密 run context。
+非敏感 Provider 路由 Header 通过独立持久化允许列表接入，逐目标准入失败不回滚其他目标；
+敏感凭证继续拒绝，具体规则见第 17.3 节。
 
 ### 14.3 动态调整、停用与 drain
 
@@ -1603,7 +1603,7 @@ MySQL/OceanBase、Bot 引擎/IM 账号及 Singlebox 全链路验收仍须单独�
   不承诺与受管消息全局 FIFO，旧 inject 不回填重放。
 - 停用某类型不联动关闭其他类型；已有跨类型 inject 绑定、查询和取消可继续处理。
 - 热更新关闭但有积压时拒绝切换；重启配置已关闭时仍恢复旧 delivery，并阻止新直发越过。
-- Provider header 非空时禁止启用，不能默默丢弃。
+- 未批准的 Provider header 按目标拒绝；批准路由字段完整恢复，不能默默丢弃。
 - 当前开启业务类型的全部子入口都进入统一准入；关闭类型保留原路径。后续分别开启
   Direct A2A/state-machine 的验收独立进行，不要求二者同时迁移或同时启用。
 
@@ -1661,22 +1661,30 @@ inject 积压治理需要结合真实消息量、下游上下文窗口和压缩�
 替代语义处理。后续评审需明确何时压缩、如何保留原始消息及因果关系、摘要如何绑定到 send，
 以及如何避免重放已消费的上下文；这些不是首版实现要求。
 
-### 17.3 Provider bypass header TODO
+### 17.3 Provider 路由 Header 与敏感凭证边界
 
-当前仓库 example/local 配置未启用 `provider_http.bypass_headers`；实际部署是否非空仍需核实。
-队列延迟和 BCS 重启会让仅存于入站 HTTP 请求中的 header 丢失，现有 Abort 又需要沿用原始
-Provider routing header。因此它仍是明确的生产启用门槛，而不是单实例就可以忽略的问题。
+`provider_http.queue_persistable_headers` 默认空，必须是 `bypass_headers` 子集；部署者明确
+批准其中的值属于非敏感路由信息。公共默认不预设内部环境 Header。标准凭证和 token/key/
+secret 等名称禁止加入；自定义名字仍需评审其实际内容，不能仅凭名字保证无敏感信息。
 
-首版规则：
+- Header 名大小写归一化，最多 16 个、单值 1024 字节、总计 8192 字节；拒绝重复名和控制字符。
+- 不再全局禁止 enforce。实际 Provider 投递携带未批准值时，仅该 delivery 原子写为 failed，
+  `last_error_code` 与公开 `admission_error` 为固定 `delivery_provider_headers_unsupported`；
+  不保存拒绝值、不回滚其他目标、不绕过队列。Inject 的准入失败同样是未发送的终态。
+- 允许值只进入内部 delivery 投影，send-start 固化到原运行 transport context；不进入
+  bcs_messages、模型、History、状态响应或日志。旧数据缺字段默认空，无需新表或 DDL。
+- 每条 Send 使用自己的路由；Inject 不覆盖承载 Send 的 Header。受管 Bot 回复从父 run
+  持久化上下文继承，不采信任意回调 HTTP Header。
+  WS 中间跳仅保留已批准的内部因果路由，不放入 WS frame；实际 Provider Header 与接力
+  路由分别使用 transport context 的 provider_route_headers / relay_route_headers。
+- Worker 发送前重新校验允许列表；收紧配置不能静默删除原值后发送到默认路由。
+- scoped abort 使用原运行 Header，包括重启后的恢复。全部运行的 Header（包括空值）必须
+  一致，否则明确拒绝歧义取消；精确 Provider abort 仍不支持，不扩大取消范围。
+- Bot off 或未就绪类型沿用原路径，不宣称拥有 durable queue/恢复能力。
+- 回滚旧二进制前需排空含新投影字段的队列；旧版 deny_unknown_fields 无法解析新记录。
 
-- 不持久化 header 明文，不写入 delivery、消息来源元数据或日志。
-- 实际 allowlist 非空的 Provider Bot 不允许开启 enforce，返回明确兼容性错误。
-- Bot off 或类型关闭的请求可以沿用原路径，但不能宣称拥有本方案的 durable queue/恢复能力。
-- 已选择受管路径的请求不允许因 header 缺失临时 bypass 调度器、改写 flow_kind 或切换 transport owner。
-- 即使 allowlist 原先为空，运行中配置变为非空也必须阻止新的队列发送，先完成兼容性评审。
-
-后续另行评审：run-scoped AEAD 加密上下文，或明确拒绝需要延迟透传 header 的请求。
-不在本次首版顺带实现凭据存储系统。
+后续单独评审敏感凭证：优先服务认证/委托 Token，必要时使用加密凭证引用。
+本次不实现 Cookie 持久化、凭证刷新或通用凭据存储系统。
 
 ### 17.4 实现前需要确认的事项
 


### PR DESCRIPTION
## Problem
Queued Provider delivery currently rejects every request when any bypass header is configured. Non-sensitive routing metadata must survive queue delay, restart, cancellation and Bot relay without being added to model context or message history.

## Solution
- Add opt-in `provider_http.queue_persistable_headers`, a case-insensitive subset of `bypass_headers`. Reject credential/control headers; bound snapshots to 16 headers, 1 KiB per value and 8 KiB total.
- Validate actual target/request headers at admission, persist only approved routing metadata in existing delivery JSON, and reject only unsupported targets with a stable admission error. Never silently strip an unsupported Provider route or bypass the queue.
- Snapshot actual transport headers at send-start, verify the prepared command against the snapshot, and restore the original route for recovery/scope abort. Mixed default/named-route scope aborts are rejected rather than selecting an arbitrary route.
- Carry explicitly allowed causal routing metadata through managed Bot relays, including WebSocket intermediates, without putting it in WS/model frames. Inject context does not override its carrier Send route.
- Remove the configuration-wide enforce prohibition; keep sensitive credentials unsupported. Add repository/flow/config contracts and update the Chinese design.

## Validation
- `cargo test -p bcs-message-flow -p bcs-message-store -p bcs-config-api --release`: 495 passed, including SQLite/Memory repository contracts and routed-header cases.
- `cargo test -p bcs --release --lib provider_http`: 2 passed.
- `cargo test -p bcs --release --lib message_delivery_wiring`: 4 passed, rerun after implementation.
- A temporary schema harness validated the downstream deployment's actual Provider configuration against the new public config type: 1 passed; harness removed.
- `git diff --check`: passed.
- Full `arch-check.sh` did not pass: existing dependency/import/name/conformance-harness gate failures were reported; baseline checks reproduced import/name/harness failures on unmodified dev. The gate's workspace debug discovery build was stopped under disk pressure and only task-generated debug artifacts were cleaned. No gate was weakened.
- Full Singlebox E2E and live OceanBase/Provider verification were not run locally.
- Rebased onto latest dev before push. Commit/push used `--no-verify` as requested.

## Compatibility and risk
No SQL migration: new metadata uses existing delivery JSON, and old rows missing header fields resolve to an empty route. Queued rows fail safely if an allowlist is tightened before send; already-started abort uses its original transport snapshot. Custom allowlist values remain an operator assertion that they contain no secrets.

Deploy the public runtime before adding the new config field in downstream overlays. Downgrading to an older binary requires draining deliveries containing the new metadata first because old projection parsers reject unknown fields. This PR does not add encrypted credential storage or broaden Provider cancellation semantics.

## Spec
- `src/bcs/docs/message-delivery-service-api.md`
- `src/bcs/docs/plans/2026-09-04-bcs-message-congestion-control-design.md`
