### PR TITLE
refactor(apply): give each fetch road one home and rename the dispatcher

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/README.md
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/README.md
@@ -19,7 +19,7 @@ that travel the manual-upload road (`SkillPackageValidator`, then
 `upload_local_skill`, then direct activation) — and `identity` — the file set
 minus the reserved names, written through the router's own
 `IdentityService` path. The one funnel they fetch through is
-`apply/entry_fetch.py`: substitute, consult the platform's copy, fetch under
+`apply/source_resolver.py`: substitute, consult the platform's copy, fetch under
 a named credential, file the receipt. W6 adds `resources` — files and
 archived directory trees, written through `ResourceFileService`'s one
 dispatcher chain, directory entries replacing their declared tree in full.
@@ -336,7 +336,7 @@ effect now" is the tempting bug, and the one this boundary exists to prevent.
 everything that can fail before touching the bot into `resolve`, and a fetch is
 exactly that kind of failure: one failed fetch aborts its whole category with
 zero writes, by construction rather than by discipline. The pipeline every
-fetching category runs is `apply/entry_fetch.py` — substitute ``${BOT_*}``
+fetching category runs is `apply/source_resolver.py` — substitute ``${BOT_*}``
 *before* prefix authorization, consult W11's newest receipt for the source
 (pinned entries are served from the store: content addressing makes those bytes
 *the* declared bytes, and unpinned entries re-fetch so an apply converges to the
@@ -600,7 +600,7 @@ provides:
   - Materialiser
   - APPLY_ORDER
   - build_materialisers
-  - EntryFetcher
+  - DeclaredSourceResolver
   - FetchedEntry
   - EntryFetchError
   - scope_of
@@ -690,7 +690,7 @@ consumes:
 consumed_by:
   - "adapters/http/openapi_v1/bots — the public read/replace/clear/capabilities surface, and the create-with-manifest pair (W13), which reaches the seam and never the task queue"
   - "core.bot_management create_flow — submission calls the creation seam (preflight, persist, start the job); the dependency runs one way, so the seam is handed its job operations at construction rather than importing them"
-  - "the apply orchestration (`apply/`, W4 #1472 + W5 #1473) — di/modules/manifest_fetch_module.py constructor-injects the transport_allowlist and the content store root (read via the W2/W11 pure parsers over config_module's seam) and holds the one EntryFetcher over the fetcher, the store, and W3's credentials"
+  - "the apply orchestration (`apply/`, W4 #1472 + W5 #1473) — di/modules/manifest_fetch_module.py constructor-injects the transport_allowlist and the content store root (read via the W2/W11 pure parsers over config_module's seam) and holds the one DeclaredSourceResolver over the fetcher, the store, and W3's credentials"
   - "adapters/http/openapi_v1/source_credentials — the public tenant credential register/rotate/read/delete surface (OPEN admission; app-operated — the edge requires an app credential, owner-app guarded)"
 internal_dependencies:
   - agentclaw.community.core.base

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/budget.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/budget.py
@@ -12,9 +12,8 @@ Created by: ``services/config_manifest_apply_service`` (both the apply and the
 dry-run path) as ``ApplyFetchBudget(deadline=time.monotonic() +
 APPLY_BUDGET_S, total_bytes=APPLY_FETCH_TOTAL_LIMIT)`` — 300 seconds and
 500 MiB, from ``fetch/limits.py``.
-Consumed by: ``apply/entry_fetch.EntryFetcher`` (``fetch``,
-``fetch_declared``, ``acquire_object``, ``file_bytes``) and
-``apply/source_fetchers.GitSourceFetcher.fetch``.
+Consumed by: ``apply/entry_fetch.EntryFetcher.fetch_declared``, both fetchers
+in ``apply/source_fetchers``, and ``apply/entry_delivery.GitDelivery.file``.
 
 Deliberately mutable: it is a ledger threaded through an immutable context,
 the way a run's writes are a ledger threaded through an immutable bot id.
@@ -48,15 +47,15 @@ class ApplyFetchBudget:
 
     What a ``charge`` looks like on each road:
 
-    * object store and HTTPS URL — ``ctx.budget.charge(fetched.size_bytes)``
-      in ``entry_fetch.fetch``, and ``charge(len(content))`` in
-      ``acquire_object``: the bytes that came over the wire.
+    * object store — ``charge(len(content))`` in
+      ``source_fetchers.ObjectStoreFetcher._acquire``: the bytes that came
+      over the wire.
     * git — ``ctx.budget.charge(checkout.tree_bytes)`` in
       ``source_fetchers.GitSourceFetcher.fetch``: the whole tree's declared
       size, charged only when *this* call did the fetching.
     * canonical bytes filed back — ``charge(len(content))`` in
-      ``entry_fetch.file_bytes``, so a git entry's canonical form is on the
-      ledger too.
+      ``entry_delivery.GitDelivery.file``, so a git entry's canonical form is
+      on the ledger too.
 
     What is deliberately **not** charged:
 

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/budget.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/budget.py
@@ -12,7 +12,7 @@ Created by: ``services/config_manifest_apply_service`` (both the apply and the
 dry-run path) as ``ApplyFetchBudget(deadline=time.monotonic() +
 APPLY_BUDGET_S, total_bytes=APPLY_FETCH_TOTAL_LIMIT)`` — 300 seconds and
 500 MiB, from ``fetch/limits.py``.
-Consumed by: ``apply/entry_fetch.EntryFetcher.fetch_declared``, both fetchers
+Consumed by: ``apply/source_resolver.DeclaredSourceResolver.resolve``, both fetchers
 in ``apply/source_fetchers``, and ``apply/entry_delivery.GitDelivery.file``.
 
 Deliberately mutable: it is a ledger threaded through an immutable context,

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/context.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/context.py
@@ -67,7 +67,7 @@ class ApplyContext:
 
     Created by: ``services/config_manifest_apply_service._context``.
     Consumed by: every materialiser stage, ``apply/orchestrator``, and the
-    fetch pipeline through the narrower ``entry_fetch.FetchContext`` protocol.
+    fetch pipeline through the narrower ``source_resolver.FetchContext`` protocol.
 
     ``owner_id`` and ``actor_id`` differ on a shared bot: the bot is resolved as
     the *owner's*, while the actor is whoever is applying. Materialisers that
@@ -130,7 +130,8 @@ class ApplyContext:
     #: git checkout cache. Mutable by design inside the frozen context, for the
     #: same reason as ``budget``: the alternative is state on a DI-singleton
     #: fetcher, which would leak across applies. ``None`` for callers that run
-    #: no ``from``/git pipeline; ``fetch_declared`` refuses such entries loudly
+    #: no ``from``/git pipeline; the declared-source resolver refuses such
+    #: entries loudly
     #: rather than fetching anonymously.
     source_session: Optional[SourceSession] = None
 

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/delivery.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/delivery.py
@@ -37,7 +37,7 @@ from agentclaw.community.core.ports.activation_port import (
     ActivationPort,
 )
 from agentclaw.community.core.bot_config_manifest.apply.context import ApplyContext
-from agentclaw.community.core.bot_config_manifest.apply.entry_fetch import EntryFetcher
+from agentclaw.community.core.bot_config_manifest.apply.source_resolver import DeclaredSourceResolver
 from agentclaw.community.core.ports.identity_file_port import (
     IdentityFilePort,
 )
@@ -120,7 +120,7 @@ class MaterialiserPorts:
     upload_service: SkillPackageUploadPort
     capability_reader: BotCapabilityStateReaderProtocol
     package_validator: SkillPackageValidator
-    entry_fetcher: EntryFetcher
+    entry_fetcher: DeclaredSourceResolver
     resource_service: ResourceFilePort
     #: W9. One field for a whole category, because the service already holds
     #: the family's delivery port — so the ``cli_tools`` materialiser takes one

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/entry_delivery.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/entry_delivery.py
@@ -20,12 +20,17 @@ first place, and it survives intact:
     what "the entry's bytes" are (a file? a package? a canonical zip?) is a
     *category* question the fetch layer must not answer.
 
-**Reads are pure — nothing here files a receipt.** That is deliberate, and
-``skills`` is why: its deliverable is a *canonical zip* that only exists after
-validation, so the bytes worth a receipt are not the bytes that arrived. Filing
-therefore belongs to whoever decides what the receipt stands for, which is the
-caller. :meth:`EntryDelivery.receipt_url` and :meth:`EntryDelivery.auth` are
-here so that caller can file under the right identity on either road.
+**Reads are pure, and filing is never automatic.** ``skills`` is why: its
+deliverable is a *canonical zip* that only exists after validation, so the
+bytes worth a receipt are not the bytes that arrived. Deciding what the
+receipt stands for therefore belongs to the caller, and it stays the caller's:
+no read here writes anything.
+
+What a delivery *can* do is file on instruction. :meth:`EntryDelivery.file`
+takes the bytes the caller has decided are the deliverable and puts them under
+the right identity for the road that served them — which means the caller
+states what the receipt is *for* without having to know which road that was,
+or whether one is owed at all.
 
 **One discriminator survives, and it is not a type check.** ``skills`` runs two
 validators by design — a fetched zip with no ``subpath`` goes byte-for-byte
@@ -42,17 +47,31 @@ two copies of one grammar drift, and the document is the one users read.
 """
 from __future__ import annotations
 
+import hashlib
 import tempfile
 from abc import abstractmethod
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional, Protocol, runtime_checkable
 
+from agentclaw.community.core.bot_config_manifest.apply.fetch_context import (
+    FetchContext,
+    scope_of,
+)
+from agentclaw.community.core.bot_config_manifest.content.errors import (
+    ContentStoreError,
+    ContentStoreFault,
+)
+from agentclaw.community.core.bot_config_manifest.content.service_protocol import (
+    ManifestContentServiceProtocol,
+)
 from agentclaw.community.core.bot_config_manifest.fetch.git_source import (
     GitCheckout,
     git_receipt_url,
 )
 from agentclaw.community.core.bot_config_manifest.fetch.guarded_fetcher import (
+    FetchedObject,
     FetchRefusedError,
 )
 from agentclaw.community.core.bot_config_manifest.fetch.unpack import (
@@ -133,8 +152,8 @@ class FetchedEntry:
             ),
         )
 
-    Created by: ``apply/entry_fetch.EntryFetcher`` — ``fetch``,
-    ``acquire_object`` and ``_git_keep_last``.
+    Created by: ``apply/source_fetchers`` — ``ObjectStoreFetcher._acquire``
+    and ``GitSourceFetcher._keep_last``.
     Consumed by: ``apply/entry_delivery.BlobDelivery``, which is the only thing
     that wraps one.
     """
@@ -291,22 +310,20 @@ class EntryDelivery(Protocol):
                          fallback reason
     ``digest()``         the content digest      ``None``; git declares no
                                                  digest
-    ``receipt_url()``    ``https://…`` or        ``git+…@<sha>:<subpath>``
-                         ``oss://…``
-    ``auth()``           ``None``; the fetch     the credential name
-                         already filed it
+    ``file()``           nothing to write; the   the bytes filed under
+                         fetch filed on its way  ``git+…@<sha>:<subpath>``,
+                         past                    under the source's credential
     ``source_url()``     the fetched URL         the repository URL
     ``content_type()``   what the source said    ``None``
     ``from_store()``     ``True`` on a store     always ``False``
                          hit
-    ``needs_receipt()``  ``False``               ``True``
     ===================  ======================  =========================
 
     Which category asks which: ``skills`` alone calls ``is_tree``,
     ``source_url``, ``content_type`` and ``from_store``; ``resources`` calls
     ``members``; ``resources``, ``identity`` and ``cli_tools`` call
     ``single``; ``cli_tools`` alone calls ``digest``; and all four call
-    ``note``, ``receipt_url``, ``auth`` and ``needs_receipt``.
+    ``note`` and ``file``.
 
     Created by: ``apply/source_fetchers`` (both fetchers), and by
     ``cli_tools/service`` around a ``fetch`` on the API-driven install road.
@@ -377,16 +394,29 @@ class EntryDelivery(Protocol):
         ...
 
     @abstractmethod
-    def receipt_url(self) -> Optional[str]:
-        """The W11 identity to file this entry's bytes under."""
-        ...
+    def file(
+        self,
+        ctx: FetchContext,
+        content: bytes,
+        *,
+        category: str,
+        entry_identity: Optional[str],
+        content_type: Optional[str] = None,
+    ) -> str:
+        """File ``content`` as this entry's deliverable and return its digest.
+        No-op on a road that filed on the way past.
 
-    @abstractmethod
-    def auth(self) -> Optional[str]:
-        """The credential **name** the acquisition rode, for the receipt.
+        All four fetching categories call it, unconditionally, with whatever
+        they decided the entry delivers — a tree canonicalised, one file out
+        of it, a validated zip. The delivery knows the rest: which identity
+        the bytes are filed under, which credential name rides with them, and
+        whether a write is owed at all. That last one used to be the caller's
+        question (``needs_receipt`` then ``receipt_url`` then ``auth``), which
+        made every caller re-derive the road it had deliberately stopped
+        asking about.
 
-        Never a value. The lineage's answer to "which credential served this"
-        is the same on both roads because both thread this.
+        Raises :class:`EntryFetchError` on a store fault, so a filing that
+        fails is this entry's failure and not the category's.
         """
         ...
 
@@ -415,19 +445,6 @@ class EntryDelivery(Protocol):
         """
         ...
 
-    @abstractmethod
-    def needs_receipt(self) -> bool:
-        """Does the caller still owe this delivery's bytes to the store?
-
-        All four fetching categories ask. ``False`` on the object road: the
-        fetch filed what arrived on its way past, so a second write would be
-        one entry with two receipts and ``keep_last`` reading whichever it
-        found. ``True`` on the git road, where a checkout is not bytes and
-        only the caller knows which bytes this entry actually delivers — the
-        tree canonicalised, one file out of it, or a validated zip.
-        """
-        ...
-
 
 @dataclass(frozen=True)
 class BlobDelivery(EntryDelivery):
@@ -445,10 +462,9 @@ class BlobDelivery(EntryDelivery):
             source_url="oss://team-artifacts/tools/qc/v2.tgz",
         ))
 
-    Differs from :class:`GitDelivery` in four answers: ``is_tree`` is
-    ``False``, ``digest`` is a real content address, ``needs_receipt`` is
-    ``False`` (the fetch already filed these bytes) and ``auth`` is ``None``
-    (there is no second write for a credential name to ride on).
+    Differs from :class:`GitDelivery` in three answers: ``is_tree`` is
+    ``False``, ``digest`` is a real content address, and ``file`` writes
+    nothing — the fetch already filed these bytes, credential and all.
     """
 
     #: The bytes and their provenance. Every method here is a read of this.
@@ -489,14 +505,28 @@ class BlobDelivery(EntryDelivery):
     def digest(self) -> Optional[str]:
         return self.fetched.digest
 
-    def receipt_url(self) -> Optional[str]:
-        return self.fetched.source_url
+    def file(
+        self,
+        ctx: FetchContext,
+        content: bytes,
+        *,
+        category: str,
+        entry_identity: Optional[str],
+        content_type: Optional[str] = None,
+    ) -> str:
+        """Nothing to write, and the digest these bytes are already filed under.
 
-    def auth(self) -> Optional[str]:
-        # Nothing downstream re-files these bytes (``needs_receipt`` is False),
-        # so there is no second write for a credential name to ride on: the
-        # fetch already filed the receipt, credential and all.
-        return None
+        The object road filed what it read on its way past, and a ``keep_last``
+        hit is by definition already in the store — so a write here would be
+        one entry with two receipts and ``keep_last`` reading whichever it
+        found. There is no second write for a credential name to ride on
+        either, which is why this road never carried one.
+
+        The answer is this delivery's own digest rather than a hash of
+        ``content``: the receipt this entry answers for is the one the fetch
+        filed, and computing a second address would name bytes no receipt has.
+        """
+        return self.fetched.digest
 
     def source_url(self) -> Optional[str]:
         return self.fetched.source_url
@@ -506,9 +536,6 @@ class BlobDelivery(EntryDelivery):
 
     def from_store(self) -> bool:
         return self.fetched.from_store
-
-    def needs_receipt(self) -> bool:
-        return False
 
 
 @dataclass(frozen=True)
@@ -527,16 +554,20 @@ class GitDelivery(EntryDelivery):
             file_limit=104857600,
         ))
 
-    Differs from :class:`BlobDelivery` in four answers: ``is_tree`` is
+    Differs from :class:`BlobDelivery` in three answers: ``is_tree`` is
     ``True``, ``digest`` is ``None`` (the schema refuses ``digest`` on a git
-    source, so there is nothing for the pin belt to compare), ``needs_receipt``
-    is ``True`` (a checkout is not bytes, and only the caller knows which bytes
-    this entry delivers) and ``auth`` is the credential name, because those
-    bytes are still owed to the store.
+    source, so there is nothing for the pin belt to compare) and ``file``
+    really writes — a checkout is not bytes, only the caller knows which bytes
+    this entry delivers, and the source's credential name rides with them.
     """
 
     #: The checkout and the entry's view into it.
     source: GitEntrySource
+    #: W11's store, to file the caller's deliverable with. Held by the
+    #: delivery rather than reached back through the pipeline: this is the one
+    #: road that still owes the store a write, so this is where the store
+    #: belongs.
+    store: ManifestContentServiceProtocol
 
     def is_tree(self) -> bool:
         return True
@@ -568,11 +599,58 @@ class GitDelivery(EntryDelivery):
         # nothing here for the pin belt to compare and ``None`` says so.
         return None
 
-    def receipt_url(self) -> Optional[str]:
-        return self.source.receipt_url()
+    def file(
+        self,
+        ctx: FetchContext,
+        content: bytes,
+        *,
+        category: str,
+        entry_identity: Optional[str],
+        content_type: Optional[str] = None,
+    ) -> str:
+        """File entry-level bytes the wire never fetched — the git road's
+        canonical form (a package's canonical zip, a single file's bytes)
+        — so audit and ``keep_last`` read the same store everyone else does.
 
-    def auth(self) -> Optional[str]:
-        return self.source.auth
+        The identity is this delivery's own :meth:`GitEntrySource.receipt_url`,
+        the ``git+…@<sha>:<subpath>`` one, and the source's credential **name**
+        rides with it into the W11 lineage exactly as the object road's store
+        call threads its own — so a git-sourced receipt answers "which named
+        credential distributed this content" the same way an object-sourced
+        one answers it::
+
+            delivery.file(ctx,
+                          b"acm-tree-v1\n5:a.txt2:hi...",
+                          category="resources_archive",
+                          entry_identity="data/prices/")
+            # -> "sha256:2c26b46b68ffc68ff99b453c1d30413413422d70..."
+
+        Returns the content digest. Raises :class:`EntryFetchError` on a
+        store fault; the charge against the apply budget keeps the ledger
+        honest about what the entry cost, disk-read or not.
+        """
+        source_url = self.source.receipt_url()
+        digest = "sha256:" + hashlib.sha256(content).hexdigest()
+        obj = FetchedObject(
+            bytes=content, sha256=digest, url=source_url,
+            content_type=content_type,
+            fetched_at=datetime.now(timezone.utc), size_bytes=len(content),
+        )
+        try:
+            self.store.store(
+                obj, scope=scope_of(ctx), source_url=source_url,
+                credential_name=self.source.auth,
+                modifier=ctx.actor_id, apply_id=ctx.apply_id,
+                category=category, entry_identity=entry_identity,
+            )
+        except (ContentStoreError, ContentStoreFault) as exc:
+            raise EntryFetchError(
+                "the bytes could not be filed with the platform's store: "
+                f"{exc}"
+            ) from exc
+        if ctx.budget is not None:
+            ctx.budget.charge(len(content))
+        return digest
 
     def source_url(self) -> Optional[str]:
         return self.source.source_url
@@ -582,9 +660,6 @@ class GitDelivery(EntryDelivery):
 
     def from_store(self) -> bool:
         return False
-
-    def needs_receipt(self) -> bool:
-        return True
 
 
 # ── the shared mechanics ─────────────────────────────────────────────────────

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/entry_delivery.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/entry_delivery.py
@@ -1,8 +1,8 @@
 """What a source delivered, and how a category reads it.
 
-One return type for the fetch layer. ``fetch_declared`` used to answer with
-``FetchedEntry | GitEntrySource`` and every consumer opened with "which one did
-I get?" — eight ``isinstance`` sites across four files, all asking that question
+One return type for the fetch layer. The declared-source front door used to
+answer with ``FetchedEntry | GitEntrySource`` and every consumer opened with
+"which one did I get?" — eight ``isinstance`` sites across four files, all asking that question
 to answer a different one: *what did this entry deliver?*
 
 :class:`EntryDelivery` is that question's home. Two implementations satisfy it:

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/entry_fetch.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/entry_fetch.py
@@ -5,19 +5,10 @@ entry's declared source, consult the platform's own copy before the network,
 read it through the protocol's own transport under a named credential, and file
 the result with the content store so delivery and audit share one copy.
 
-**The two entry points**, and which is which:
-
-``fetch_declared(ctx, *, entry=…)``
-    The front door every fetching materialiser calls. Takes no URL at all: it
-    reads the entry, resolves the declaration and dispatches on its
-    ``protocol``. Files a receipt and charges the budget through whichever road
-    it picked.
-
-``file_bytes(ctx, *, content=…, source_url=…)``
-    Called by the ``resources``, ``skills`` and ``cli_tools`` materialisers for
-    the git road's canonical bytes. Its ``source_url`` is the caller's own
-    receipt identity, normally a ``git+…`` one. Files a receipt and always
-    charges, because the caller is declaring what the entry cost.
+**One entry point**, ``fetch_declared(ctx, *, entry=…)``: the front door
+every fetching materialiser calls. It takes no URL at all — it reads the
+entry, resolves the declaration and dispatches on its ``protocol``. A receipt
+is filed and the budget charged through whichever road it picked.
 
 **What each road does with the source it was handed lives in
 ``apply/source_fetchers.py``**, and so does the policy it runs under: the two
@@ -38,8 +29,9 @@ W7 is the declared-source front door, :meth:`fetch_declared`: the ``from``
 and inline-source roads resolve through the apply's source session, and the git
 road returns a :class:`GitEntrySource` — the tree is the entry's to
 interpret (a file? a package?) — while its canonical, entry-level bytes are
-filed with the store via :meth:`file_bytes`, so audit and ``keep_last`` read
-the same receipts the object road files on its way past.
+filed with the store by the delivery itself, on the materialiser's
+instruction, so audit and ``keep_last`` read the same receipts the object road
+files on its way past.
 
 **Dispatch is on the declared protocol**, read through the one parser the
 ``PUT`` validator also uses. It used to be on which key a source mapping
@@ -55,8 +47,6 @@ declare is now an object with a ``protocol``.
 """
 from __future__ import annotations
 
-import hashlib
-from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Mapping, Optional
 
 
@@ -74,15 +64,8 @@ from agentclaw.community.core.bot_config_manifest.apply.source_fetchers import (
     DeclaredFetch,
     build_fetchers,
 )
-from agentclaw.community.core.bot_config_manifest.content.errors import (
-    ContentStoreError,
-    ContentStoreFault,
-)
 from agentclaw.community.core.bot_config_manifest.fetch.limits import (
     FetchCategory,
-)
-from agentclaw.community.core.bot_config_manifest.fetch.guarded_fetcher import (
-    FetchedObject,
 )
 from agentclaw.community.core.bot_config_manifest.schema.sources import (
     parse_source,
@@ -105,9 +88,9 @@ class EntryFetcher:
     """Fetches one manifest entry's bytes on a bot's behalf.
 
     The one funnel every fetching category goes through: ``skills``,
-    ``resources``, ``identity`` and ``cli_tools``. Two public entry points,
-    tabulated in this module's docstring; ``fetch_declared`` is the one a
-    materialiser normally calls.
+    ``resources``, ``identity`` and ``cli_tools``. One public entry point,
+    :meth:`fetch_declared`; it holds no collaborators of its own, only the
+    table of roads it dispatches to.
 
     Composed once per apply — the transport is stateless per hop, so there is
     nothing to hold between entries — and handed to every materialiser that
@@ -121,10 +104,6 @@ class EntryFetcher:
         credentials: SourceCredentialServiceProtocol,
         objects: AliyunObjectStore,
     ) -> None:
-        # Kept because the front door itself still reads it — see
-        # :meth:`file_bytes`. The roads read their own copy of it, handed to
-        # them below.
-        self._content = content
         # Bound once, from this pipeline's three collaborators: the fetchers
         # are strategies over the same store, the same credentials and the
         # same object-store client, so every road files receipts under one
@@ -280,65 +259,6 @@ class EntryFetcher:
                 name=name,
             )
         )
-
-    def file_bytes(
-        self,
-        ctx: FetchContext,
-        *,
-        content: bytes,
-        source_url: str,
-        category: str,
-        entry_identity: Optional[str] = None,
-        content_type: Optional[str] = None,
-        credential_name: Optional[str] = None,
-    ) -> str:
-        """File entry-level bytes the wire never fetched — the git road's
-        canonical form (a package's canonical zip, a single file's bytes)
-        — so audit and ``keep_last`` read the same store everyone else does.
-
-        ``source_url`` is the caller's own receipt identity, normally the
-        ``git+…`` one from ``GitDelivery.receipt_url()``::
-
-            file_bytes(ctx,
-                       content=b"acm-tree-v1\n5:a.txt2:hi...",
-                       source_url=("git+https://code.example.com/team/"
-                                   "content.git@4f2a9c1b...:kb"),
-                       category="resources_archive",
-                       entry_identity="data/prices/",
-                       credential_name="git-prod")
-            # -> "sha256:2c26b46b68ffc68ff99b453c1d30413413422d70..."
-
-        ``credential_name`` threads the acquisition's auth into the W11
-        lineage exactly as the object road's store call does, so a git-sourced
-        receipt answers "which named credential distributed this content"
-        the same way an object-sourced one answers it.
-
-        Returns the content digest. Raises :class:`EntryFetchError` on a
-        store fault; the charge against the apply budget keeps the ledger
-        honest about what the entry cost, disk-read or not.
-        """
-        digest = "sha256:" + hashlib.sha256(content).hexdigest()
-        obj = FetchedObject(
-            bytes=content, sha256=digest, url=source_url,
-            content_type=content_type,
-            fetched_at=datetime.now(timezone.utc), size_bytes=len(content),
-        )
-        try:
-            self._content.store(
-                obj, scope=scope_of(ctx), source_url=source_url,
-                credential_name=credential_name,
-                modifier=ctx.actor_id, apply_id=ctx.apply_id,
-                category=category, entry_identity=entry_identity,
-            )
-        except (ContentStoreError, ContentStoreFault) as exc:
-            raise EntryFetchError(
-                "the bytes could not be filed with the platform's store: "
-                f"{exc}"
-            ) from exc
-        if ctx.budget is not None:
-            ctx.budget.charge(len(content))
-        return digest
-
 
 
 def declared_protocol(

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/entry_fetch.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/entry_fetch.py
@@ -5,7 +5,7 @@ entry's declared source, consult the platform's own copy before the network,
 read it through the protocol's own transport under a named credential, and file
 the result with the content store so delivery and audit share one copy.
 
-**The three entry points**, and which is which:
+**The two entry points**, and which is which:
 
 ``fetch_declared(ctx, *, entry=…)``
     The front door every fetching materialiser calls. Takes no URL at all: it
@@ -13,33 +13,17 @@ the result with the content store so delivery and audit share one copy.
     ``protocol``. Files a receipt and charges the budget through whichever road
     it picked.
 
-``acquire_object(ctx, *, target=…, key=…)``
-    Called by ``source_fetchers.ObjectStoreFetcher``. Takes an
-    ``ObjectStoreTarget`` and a key rather than a URL, and builds the
-    ``oss://`` receipt identity itself. Files a receipt. Charges the budget on
-    a real read.
-
 ``file_bytes(ctx, *, content=…, source_url=…)``
     Called by the ``resources``, ``skills`` and ``cli_tools`` materialisers for
     the git road's canonical bytes. Its ``source_url`` is the caller's own
     receipt identity, normally a ``git+…`` one. Files a receipt and always
     charges, because the caller is declaring what the entry cost.
 
-**Two ``source_url`` shapes exist**, and both are receipt identities rather
-than fetchable URLs — the address bytes are *filed* under, never an address
-this module dials::
-
-    "oss://team-artifacts/tools/qc/v2.tgz"
-        built by ``source_fetchers.object_receipt_url`` inside
-        ``acquire_object``. The endpoint is deliberately absent: it comes off
-        the credential row, not off the document.
-
-    "git+https://code.example.com/team/content.git@<40-hex sha>:kb/faq.csv"
-        built by ``fetch/git_source.git_receipt_url``. Keyed on the resolved
-        sha, and ends in a bare colon when there is no subpath.
-
-``FetchedEntry.source_url`` and every receipt ``source_url`` is one of the two,
-because they are written by whichever road ran.
+**What each road does with the source it was handed lives in
+``apply/source_fetchers.py``**, and so does the policy it runs under: the two
+receipt-identity shapes, pinned vs unpinned, which failures ``keep_last`` may
+answer for, and the translation of every store fault into
+:class:`EntryFetchError`. This module picks the road; it does not drive one.
 
 Fetch lives here **and only here** — the registry's contract says ``resolve``
 is where a category's failures are collected before anything is written, and a
@@ -49,45 +33,6 @@ Because the fetch belongs to ``resolve``, a ``dry_run`` may perform one (it
 still writes **nothing to the bot** — the store it files with is the
 platform's own record of what a bot was served, true whether or not the apply
 proceeds).
-
-Pinned vs unpinned is a declared-digest question, and it decides the
-store-first vs read-first policy:
-
-* **pinned** (the entry declares a ``digest``) — a receipt for this bot and
-  source address *matching the declaration* is the bytes, by content
-  addressing: no network is consulted to acquire what the platform already
-  holds. A source that has since moved is irrelevant — the declaration asks
-  for the pinned bytes, and a re-read of them would only fail the pin.
-* **unpinned** — the entry wants whatever is there *now*; every apply
-  re-reads so it converges to the source, and ``keep_last`` exists for the
-  day that read fails.
-
-``keep_last`` (on a real read failure) reads the latest receipt: bytes that
-are entitled to be reused when the declaration pinned nothing, and bytes that
-must match the pin when it did — a receipt that disagrees with a declared
-digest is not "last", it is stale, and supplying it would silently pin bytes
-the declaration never named.
-
-**Which failures may fall back is fixed by what they are a statement about,
-and the ruling is:** the source was reachable and could not serve — an
-unreachable object store, a git fetch that failed — may fall back; a refusal
-may not. A refusal (an object the document names that is not there, a
-credential the store will not accept, an object past the category's cap) is a
-statement about the document's or the credential's *configuration*, while
-keep_last exists for statements about the source's *availability*. Masking a
-refusal with stored bytes would answer SUCCEEDED to a document the platform
-just refused; the same ruling keeps a deleted credential name loud —
-configuration drift is for the author to fix, not for the stored copy to
-absorb.
-
-**Every interaction with the content store — lookup, both reads, the
-re-file after a read — is translated here** into :class:`EntryFetchError`:
-a store-side fault answers as that ENTRY's failure with the store's own
-message, never as an unrelated exception escaping resolve to abort the
-whole category under a wrapped surprise. The one leniency: a pinned
-store-hit whose blob has gone missing falls through to the source —
-the pin is byte-provable, so a re-read re-filed with the store heals the
-address and nobody upstream learns anything happened.
 
 W7 is the declared-source front door, :meth:`fetch_declared`: the ``from``
 and inline-source roads resolve through the apply's source session, and the git
@@ -112,7 +57,7 @@ from __future__ import annotations
 
 import hashlib
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any, Mapping, Optional, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Mapping, Optional
 
 
 from agentclaw.community.core.bot_config_manifest.apply.entry_delivery import (
@@ -121,28 +66,19 @@ from agentclaw.community.core.bot_config_manifest.apply.entry_delivery import (
     FetchedEntry,
     GitEntrySource,
 )
+from agentclaw.community.core.bot_config_manifest.apply.fetch_context import (
+    FetchContext,
+    scope_of,
+)
 from agentclaw.community.core.bot_config_manifest.apply.source_fetchers import (
     DeclaredFetch,
     build_fetchers,
-    object_receipt_url,
-)
-from agentclaw.community.core.bot_config_manifest.apply.source_session import (
-    SourceSession,
 )
 from agentclaw.community.core.bot_config_manifest.content.errors import (
-    ContentMissingError,
     ContentStoreError,
     ContentStoreFault,
 )
-from agentclaw.community.core.bot_config_manifest.content.models import (
-    ContentScope,
-)
-from agentclaw.community.core.bot_config_manifest.fetch.git_source import (
-    GitSourceSpec,
-    git_receipt_url,
-)
 from agentclaw.community.core.bot_config_manifest.fetch.limits import (
-    FETCH_ENTRY_LIMITS,
     FetchCategory,
 )
 from agentclaw.community.core.bot_config_manifest.fetch.guarded_fetcher import (
@@ -153,16 +89,10 @@ from agentclaw.community.core.bot_config_manifest.schema.sources import (
 )
 from agentclaw.community.core.bot_config_manifest.fetch.object_store import (
     AliyunObjectStore,
-    ObjectFetchStatus,
-    ObjectStoreTarget,
 )
 from agentclaw.community.core.bot_config_manifest.support_matrix import SourceKind
-from agentclaw.community.log import get_logger
 
 if TYPE_CHECKING:
-    from agentclaw.community.core.bot_config_manifest.apply.budget import (
-        ApplyFetchBudget,
-    )
     from agentclaw.community.core.bot_config_manifest.content.service_protocol import (
         ManifestContentServiceProtocol,
     )
@@ -170,74 +100,12 @@ if TYPE_CHECKING:
         SourceCredentialServiceProtocol,
     )
 
-logger = get_logger()
-
-
-@runtime_checkable
-class FetchContext(Protocol):
-    """Exactly what a fetch reads off its caller's context, and nothing more.
-
-    Nine attributes, no methods. ``ApplyContext`` satisfies it structurally and
-    is the usual one; the ``cli_tools`` service passes its own object, because
-    it is called by an HTTP route as well as by a materialiser and both must
-    fetch through *this* funnel.
-
-    A minimal satisfying value::
-
-        ctx.bot_id        == "bot_42"
-        ctx.entity_id     == "ent_7"
-        ctx.env           == "prod"
-        ctx.tenant        == "acme"
-        ctx.engine_type   == "claude_code"
-        ctx.actor_id      == "usr_collaborator"
-        ctx.apply_id      == "ap_01HZX8"   # or None
-        ctx.budget        == ApplyFetchBudget(...)   # or None
-        ctx.source_session == SourceSession(...)     # or None
-
-    The first six are read for the store scope, placeholder substitution and
-    the receipt's ``modifier``. The last three are legitimately ``None`` for a
-    caller that is not an apply: an unbudgeted single install files a receipt
-    with no apply linkage, which is what that column's nullability means.
-
-    Declaring the seam rather than annotating ``"ApplyContext"`` while a second
-    type is passed keeps the dependency honest: a maintainer who adds a
-    ``ctx.something`` read below adds it here too, and the other caller fails
-    to type-check instead of failing at apply time.
-    """
-
-    bot_id: str
-    #: Storage key for the bot; one axis of the content store's scope.
-    entity_id: str
-    env: str
-    tenant: str
-    engine_type: str
-    #: Who is fetching. Lands on the receipt as ``modifier``.
-    actor_id: str
-    #: Stamped into every receipt this fetch files. ``None`` off the apply path.
-    apply_id: Optional[str]
-    budget: Optional[ApplyFetchBudget]
-    source_session: Optional[SourceSession]
-
-
-def scope_of(ctx: FetchContext) -> ContentScope:
-    """The store scope for the bot an apply runs against::
-
-        scope_of(ctx)
-        # -> ContentScope(env="prod", entity_id="ent_7", bot_id="bot_42")
-
-    Three axes, all read straight off the context. Every receipt this pipeline
-    reads and every one it writes is filed under this scope, so they are one
-    log. Called by ``fetch``, ``acquire_object``, ``file_bytes`` and
-    ``_git_keep_last``.
-    """
-    return ContentScope(env=ctx.env, entity_id=ctx.entity_id, bot_id=ctx.bot_id)
-
 
 class EntryFetcher:
     """Fetches one manifest entry's bytes on a bot's behalf.
 
     The one funnel every fetching category goes through: ``skills``,
-    ``resources``, ``identity`` and ``cli_tools``. Four public entry points,
+    ``resources``, ``identity`` and ``cli_tools``. Two public entry points,
     tabulated in this module's docstring; ``fetch_declared`` is the one a
     materialiser normally calls.
 
@@ -259,7 +127,7 @@ class EntryFetcher:
         # rigs driving only the git road need not assemble a store — but
         # the composition root always binds one, so the type said "may be
         # absent" about a value that never is, and bought a ``None`` branch
-        # in ``acquire_object`` that production could not reach. Rigs pass
+        # in the object road that production could not reach. Rigs pass
         # ``FakeObjectStore()``; it costs them one line and buys everyone an
         # honest signature.
         self._objects = objects
@@ -408,213 +276,6 @@ class EntryFetcher:
                 session=session,
                 name=name,
             )
-        )
-
-    def _git_keep_last(
-        self,
-        ctx: FetchContext,
-        *,
-        session: SourceSession,
-        spec: GitSourceSpec,
-        display: str,
-        keep_last: bool,
-    ) -> Optional[FetchedEntry]:
-        """``keep_last`` for the git road: the receipt of the *last-resolved*
-        SHA, when there was one.
-
-        Looks the baseline up by ``display`` and reads the receipt filed under
-        ``git+<url>@<baseline sha>:<subpath>``. Answers ``None`` — meaning
-        "no fallback, let the failure stand" — in three cases: ``keep_last`` is
-        off, the source has no baseline (a first-time source has no stored copy
-        entitled to answer for it), or no receipt exists at that address.
-
-        On a hit the :class:`FetchedEntry` carries ``from_store=True`` and a
-        ``fallback_reason``, which is what the report's note comes from.
-        """
-        if not keep_last:
-            return None
-        baseline = session.baseline(display)
-        if baseline is None:
-            return None
-        target = git_receipt_url(spec.url, baseline, spec.subpath)
-        try:
-            receipt = self._content.latest_receipt(
-                scope_of(ctx), source_url=target
-            )
-            if receipt is None:
-                return None
-            return FetchedEntry(
-                content=self._content.read(receipt.digest),
-                digest=receipt.digest,
-                from_store=True,
-                content_type=receipt.content_type,
-                source_url=target,
-                # The failure is named, never quoted: the git road's transport
-                # error text is report-safe on its own ("git fetch failed"),
-                # and re-embedding it here would just restate the same words —
-                # the reason keep_last fired stays one clean sentence.
-                fallback_reason=(
-                    "delivered from the platform's stored copy (keep_last): "
-                    "the git fetch failed"
-                ),
-            )
-        except (ContentStoreError, ContentStoreFault) as exc:
-            raise EntryFetchError(str(exc)) from exc
-
-    def acquire_object(
-        self,
-        ctx: FetchContext,
-        *,
-        target: ObjectStoreTarget,
-        key: str,
-        digest: Optional[str],
-        auth: Optional[str],
-        category: str,
-        keep_last: bool,
-        entry_identity: Optional[str],
-    ) -> FetchedEntry:
-        """One object out of a tenant-named bucket, through the object store.
-
-        Takes the resolved ``ObjectStoreTarget`` (bucket plus the endpoint and
-        key pair off the credential row) and the already-composed, already
-        substituted ``key``. The address it files under is built here::
-
-            acquire_object(ctx,
-                           target=ObjectStoreTarget(bucket="team-artifacts",
-                                                    ...),
-                           key="tools/qc/v2.tgz",
-                           digest=None,
-                           auth="oss-prod",
-                           category="cli_tools",
-                           keep_last=True,
-                           entry_identity="qc")
-            # -> FetchedEntry(...,
-            #        source_url="oss://team-artifacts/tools/qc/v2.tgz")
-
-        ``content_type`` is always ``None`` on this road: the store client
-        reports none.
-
-        The shape the module docstring's policy describes — pinned fast path,
-        acquire, ``keep_last``, file — over the object store's transport, where
-        four of the guarded fetcher's six protections are gone *because they
-        have nothing left to guard*: there is no tenant-supplied URL to
-        shape-check, no host to resolve and pin, and no redirect to
-        re-validate, since the endpoint comes off the credential row and the
-        store client owns the wire. The two that survive are the two that were
-        never about a URL: the byte cap (enforced inside the client, while
-        streaming) and the content address computed here.
-        """
-        expired = ctx.budget.expired() if ctx.budget is not None else None
-        if expired is not None:
-            raise EntryFetchError(expired)
-
-        address = object_receipt_url(target.bucket, key)
-        scope = scope_of(ctx)
-        try:
-            receipt = self._content.latest_receipt(scope, source_url=address)
-        except (ContentStoreError, ContentStoreFault) as exc:
-            raise EntryFetchError(str(exc)) from exc
-
-        if digest is not None and receipt is not None and receipt.digest == digest:
-            # Content addressing makes the stored bytes *the* declared bytes,
-            # so the store is the strictly more available source of the same
-            # truth — the ruling the module docstring records.
-            try:
-                return FetchedEntry(
-                    content=self._content.read(digest),
-                    digest=digest,
-                    from_store=True,
-                    content_type=receipt.content_type,
-                    source_url=address,
-                )
-            except ContentMissingError:
-                logger.warning(
-                    "[manifest.object_store] the pinned blob is missing; "
-                    "re-reading to heal the platform's copy, digest=%s",
-                    digest,
-                )
-            except (ContentStoreError, ContentStoreFault) as exc:
-                raise EntryFetchError(
-                    "the platform's copy of the pinned content could not be "
-                    f"read: {exc}"
-                ) from exc
-
-        limit = FETCH_ENTRY_LIMITS.get(category, FETCH_ENTRY_LIMITS["resources_file"])
-        result = self._objects.get(target, key, byte_limit=limit)
-
-        if result.is_refusal:
-            # NOT_FOUND, DENIED, TOO_LARGE — the document or the credential is
-            # wrong. keep_last must not mask any of them: a denied credential
-            # quietly serving last apply's bytes for a year is exactly the
-            # outcome that ruling exists to prevent.
-            raise EntryFetchError(result.detail)
-
-        if result.status is not ObjectFetchStatus.FOUND:
-            # UNAVAILABLE: the store could not be reached, which is what
-            # keep_last is for.
-            if keep_last and receipt is not None and (
-                digest is None or receipt.digest == digest
-            ):
-                try:
-                    return FetchedEntry(
-                        content=self._content.read(receipt.digest),
-                        digest=receipt.digest,
-                        from_store=True,
-                        content_type=receipt.content_type,
-                        source_url=address,
-                        fallback_reason=(
-                            "delivered from the platform's stored copy "
-                            f"(keep_last): {result.detail}"
-                        ),
-                    )
-                except (ContentStoreError, ContentStoreFault) as read_exc:
-                    raise EntryFetchError(
-                        f"{result.detail}; the keep_last fallback copy could "
-                        f"not be read: {read_exc}"
-                    ) from read_exc
-            raise EntryFetchError(result.detail)
-
-        content = result.content or b""
-        computed = "sha256:" + hashlib.sha256(content).hexdigest()
-        if digest is not None and computed != digest:
-            # The pin, checked here rather than in the client: a transport has
-            # no business knowing what a manifest digest is, and this is the
-            # one place both roads agree on what "the declared bytes" means.
-            raise EntryFetchError(
-                f"the object's bytes are {computed}, the entry declared {digest}"
-            )
-
-        fetched = FetchedObject(
-            bytes=content,
-            sha256=computed,
-            size_bytes=len(content),
-            url=address,
-            content_type=None,
-            fetched_at=datetime.now(timezone.utc),
-        )
-        try:
-            self._content.store(
-                fetched,
-                scope=scope,
-                source_url=address,
-                credential_name=auth,
-                modifier=ctx.actor_id,
-                apply_id=ctx.apply_id,
-                category=category,
-                entry_identity=entry_identity,
-            )
-        except (ContentStoreError, ContentStoreFault) as exc:
-            raise EntryFetchError(
-                "the fetched bytes could not be filed with the platform's "
-                f"store: {exc}"
-            ) from exc
-        if ctx.budget is not None:
-            ctx.budget.charge(len(content))
-        return FetchedEntry(
-            content=content,
-            digest=computed,
-            from_store=False,
-            source_url=address,
         )
 
     def file_bytes(

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/entry_fetch.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/entry_fetch.py
@@ -121,20 +121,23 @@ class EntryFetcher:
         credentials: SourceCredentialServiceProtocol,
         objects: AliyunObjectStore,
     ) -> None:
+        # Kept because the front door itself still reads it — see
+        # :meth:`file_bytes`. The roads read their own copy of it, handed to
+        # them below.
         self._content = content
-        self._credentials = credentials
-        # Required, not defaulted. It was ``Optional[...] = None`` so that
-        # rigs driving only the git road need not assemble a store — but
-        # the composition root always binds one, so the type said "may be
-        # absent" about a value that never is, and bought a ``None`` branch
-        # in the object road that production could not reach. Rigs pass
+        # Bound once, from this pipeline's three collaborators: the fetchers
+        # are strategies over the same store, the same credentials and the
+        # same object-store client, so every road files receipts under one
+        # policy and W11's lineage cannot answer differently by protocol.
+        #
+        # ``objects`` is required, not defaulted. It was ``Optional[...] =
+        # None`` so that rigs driving only the git road need not assemble a
+        # store — but the composition root always binds one, so the type said
+        # "may be absent" about a value that never is, and bought a ``None``
+        # branch in the object road that production could not reach. Rigs pass
         # ``FakeObjectStore()``; it costs them one line and buys everyone an
         # honest signature.
-        self._objects = objects
-        # Bound once, to this pipeline: the fetchers are strategies over these
-        # same collaborators, so every road files receipts under one policy
-        # and W11's lineage cannot answer differently by protocol.
-        self._fetchers = build_fetchers(self)
+        self._fetchers = build_fetchers(content, credentials, objects)
 
     def fetch_declared(
         self,

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/entry_fetch.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/entry_fetch.py
@@ -199,27 +199,19 @@ class EntryFetcher:
             )
 
         keep_last = entry.get("on_fetch_failure", "keep_last") == "keep_last"
-        name: Optional[str] = None
-        raw: Optional[Mapping[str, Any]] = None
-
-        if isinstance(entry.get("from"), str):
-            name = entry["from"]
-            raw = session.sources.get(name)
-            if raw is None:
+        name, raw = _raw_declaration(ctx, entry)
+        if raw is None:
+            if name is not None:
                 raise EntryFetchError(
                     f"'from' names source {name!r}, which is not declared "
                     "under 'sources'"
                 )
-        elif isinstance(inline, Mapping):
-            raw = inline
-        else:
             raise EntryFetchError(
                 "an entry must name one of 'from', 'source' or 'content', "
                 "and 'source' is a declaration object carrying a 'protocol' "
                 "(declare 'protocol: git' or 'protocol: oss') — a URL written "
                 "as a plain string is not one"
             )
-        assert raw is not None
 
         # The one place a stored declaration is read. The PUT validator parses
         # through the same pure function, so a document that was accepted
@@ -261,6 +253,43 @@ class EntryFetcher:
         )
 
 
+def _raw_declaration(
+    ctx: FetchContext, entry: Mapping[str, Any]
+) -> tuple[Optional[str], Any]:
+    """The declaration an entry names, unparsed, and the name it named it by::
+
+        _raw_declaration(ctx, {"from": "content", "subpath": "faq.csv"})
+        # -> ("content", {"protocol": "git", "url": "https://..."})
+
+        _raw_declaration(ctx, {"source": {"protocol": "oss", ...}})
+        # -> (None, {"protocol": "oss", ...})
+
+        _raw_declaration(ctx, {"content": "inline text"})
+        # -> (None, None)
+
+    Two callers, one lookup: :meth:`EntryFetcher.fetch_declared` and
+    :func:`declared_protocol`. They used to each spell out "a ``from`` name in
+    ``session.sources``, else the entry's own ``source`` mapping", which is two
+    places for one rule to be true in — and the two of them must agree, because
+    the second exists precisely to predict what the first will do.
+
+    **A ``from`` name's value comes back exactly as ``sources`` holds it**,
+    Mapping or not, while an inline ``source`` that is not a Mapping comes back
+    as ``None``. That asymmetry is the callers' existing behaviour and worth
+    keeping: a *declared* source that does not parse deserves the parser's
+    reason rather than "which is not declared under 'sources'", while an entry
+    whose ``source`` is a bare URL string has declared nothing at all. Each
+    caller narrows on its own terms.
+    """
+    from_name = entry["from"] if isinstance(entry.get("from"), str) else None
+    if from_name is not None:
+        return from_name, (getattr(ctx.source_session, "sources", None) or {}).get(
+            from_name
+        )
+    inline = entry.get("source")
+    return None, inline if isinstance(inline, Mapping) else None
+
+
 def declared_protocol(
     ctx: FetchContext, entry: Mapping[str, Any]
 ) -> Optional[SourceKind]:
@@ -295,15 +324,14 @@ def declared_protocol(
     applies.
 
     Read through the same parser the ``PUT`` validator and ``fetch_declared``
-    use, so a fourth derivation cannot appear.
+    use, and off the same lookup ``fetch_declared`` uses
+    (:func:`_raw_declaration`), so a fourth derivation cannot appear and this
+    cannot drift from the road it predicts.
     """
-    raw: Any = entry.get("source")
-    if isinstance(entry.get("from"), str):
-        session = ctx.source_session
-        raw = (getattr(session, "sources", None) or {}).get(entry["from"])
+    _, raw = _raw_declaration(ctx, entry)
     if not isinstance(raw, Mapping):
         return None
-    decl, _ = parse_source(raw)
+    decl, _violations = parse_source(raw)
     return None if decl is None else decl.protocol
 
 

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/fetch_context.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/fetch_context.py
@@ -1,0 +1,89 @@
+"""What a fetch reads off its caller, and the store scope it derives.
+
+Two names, held apart from every road that uses them. The dispatcher, both
+protocol fetchers and the deliveries each read the caller's context and file
+under one scope, so whichever of those modules held them would be imported by
+the rest — and the fetch package would close a cycle around it.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional, Protocol, runtime_checkable
+
+from agentclaw.community.core.bot_config_manifest.apply.source_session import (
+    SourceSession,
+)
+from agentclaw.community.core.bot_config_manifest.content.models import (
+    ContentScope,
+)
+
+if TYPE_CHECKING:
+    from agentclaw.community.core.bot_config_manifest.apply.budget import (
+        ApplyFetchBudget,
+    )
+
+
+@runtime_checkable
+class FetchContext(Protocol):
+    """Exactly what a fetch reads off its caller's context, and nothing more.
+
+    Nine attributes, no methods. ``ApplyContext`` satisfies it structurally and
+    is the usual one; the ``cli_tools`` service passes its own object, because
+    it is called by an HTTP route as well as by a materialiser and both must
+    fetch through *this* funnel.
+
+    A minimal satisfying value::
+
+        ctx.bot_id        == "bot_42"
+        ctx.entity_id     == "ent_7"
+        ctx.env           == "prod"
+        ctx.tenant        == "acme"
+        ctx.engine_type   == "claude_code"
+        ctx.actor_id      == "usr_collaborator"
+        ctx.apply_id      == "ap_01HZX8"   # or None
+        ctx.budget        == ApplyFetchBudget(...)   # or None
+        ctx.source_session == SourceSession(...)     # or None
+
+    The first six are read for the store scope, placeholder substitution and
+    the receipt's ``modifier``. The last three are legitimately ``None`` for a
+    caller that is not an apply: an unbudgeted single install files a receipt
+    with no apply linkage, which is what that column's nullability means.
+
+    Declaring the seam rather than annotating ``"ApplyContext"`` while a second
+    type is passed keeps the dependency honest: a maintainer who adds a
+    ``ctx.something`` read below adds it here too, and the other caller fails
+    to type-check instead of failing at apply time.
+    """
+
+    bot_id: str
+    #: Storage key for the bot; one axis of the content store's scope.
+    entity_id: str
+    env: str
+    tenant: str
+    engine_type: str
+    #: Who is fetching. Lands on the receipt as ``modifier``.
+    actor_id: str
+    #: Stamped into every receipt this fetch files. ``None`` off the apply path.
+    apply_id: Optional[str]
+    budget: Optional[ApplyFetchBudget]
+    source_session: Optional[SourceSession]
+
+
+def scope_of(ctx: FetchContext) -> ContentScope:
+    """The store scope for the bot an apply runs against::
+
+        scope_of(ctx)
+        # -> ContentScope(env="prod", entity_id="ent_7", bot_id="bot_42")
+
+    Three axes, all read straight off the context. Every receipt this pipeline
+    reads and every one it writes is filed under this scope, so they are one
+    log. Called by ``source_fetchers.ObjectStoreFetcher._acquire``,
+    ``source_fetchers.GitSourceFetcher._keep_last`` and
+    ``entry_delivery.GitDelivery.file``.
+    """
+    return ContentScope(env=ctx.env, entity_id=ctx.entity_id, bot_id=ctx.bot_id)
+
+
+__all__ = [
+    "FetchContext",
+    "scope_of",
+]

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/__init__.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/__init__.py
@@ -21,7 +21,7 @@ Module             ``identity`` from  ``Intent.value``
 =================  =================  ====================================
 
 ``script`` and ``mcp`` fetch nothing. ``identity``, ``skills`` and
-``resources`` fetch in ``resolve``, through the one ``EntryFetcher`` funnel.
+``resources`` fetch in ``resolve``, through the one ``DeclaredSourceResolver`` funnel.
 ``cli_tools`` is the exception: it fetches in ``write``, because the service
 it translates for owns fetching for both of its callers.
 

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/cli_tools.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/cli_tools.py
@@ -93,7 +93,7 @@ from agentclaw.community.core.bot_config_manifest.cli_tools.models import (
 from agentclaw.community.core.bot_config_manifest.cli_tools.service import (
     CliToolService,
 )
-from agentclaw.community.core.bot_config_manifest.apply.entry_fetch import (
+from agentclaw.community.core.bot_config_manifest.apply.source_resolver import (
     declared_protocol,
 )
 from agentclaw.community.core.bot_config_manifest.support_matrix import SourceKind

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/identity.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/identity.py
@@ -233,19 +233,17 @@ class IdentityMaterialiser(Materialiser):
 
             def _read_and_file() -> bytes:
                 body = delivery.single()
-                if delivery.needs_receipt():
-                    # The one file's bytes go through the same store the
-                    # object road files with — auth included, so the
-                    # lineage's answer to "which credential served this" is
-                    # the same on both roads.
-                    self._fetcher.file_bytes(
-                        ctx,
-                        content=body,
-                        source_url=delivery.receipt_url(),
-                        category=_FETCH_CATEGORY,
-                        entry_identity=file_type,
-                        credential_name=delivery.auth(),
-                    )
+                # The one file's bytes go through the same store the object
+                # road files with — auth included, so the lineage's answer to
+                # "which credential served this" is the same on both roads.
+                # Unconditional: a road that filed on the way past writes
+                # nothing here, and the caller no longer has to ask which.
+                delivery.file(
+                    ctx,
+                    body,
+                    category=_FETCH_CATEGORY,
+                    entry_identity=file_type,
+                )
                 return body
 
             try:

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/identity.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/identity.py
@@ -55,8 +55,8 @@ identity area two removal semantics where every reader of the area sees one.
 A reserved name never receives even an empty write.
 
 Fetch (for ``source`` entries — a declared ``source``, or a ``from`` name,
-both through W7's ``fetch_declared``) happens in ``resolve`` through
-:class:`~agentclaw.community.core.bot_config_manifest.apply.entry_fetch.EntryFetcher`;
+both through W7's declared-source door) happens in ``resolve`` through
+:class:`~agentclaw.community.core.bot_config_manifest.apply.source_resolver.DeclaredSourceResolver`;
 a failure aborts the whole category before the first write — §3.2's
 all-or-nothing, by construction, never by discipline. The bytes are decoded
 to text here rather than in the fetch pipeline because "is this UTF-8" is a
@@ -68,9 +68,9 @@ import asyncio
 from typing import TYPE_CHECKING, Any, Optional, Sequence
 
 from agentclaw.community.core.bot_config_manifest.fetch.limits import FetchCategory
-from agentclaw.community.core.bot_config_manifest.apply.entry_fetch import (
+from agentclaw.community.core.bot_config_manifest.apply.source_resolver import (
     EntryFetchError,
-    EntryFetcher,
+    DeclaredSourceResolver,
 )
 from agentclaw.community.core.bot_config_manifest.apply.outcomes import (
     EntryOutcome,
@@ -136,9 +136,11 @@ class IdentityMaterialiser(Materialiser):
 
     construct = ManifestCategory.IDENTITY
 
-    def __init__(self, identity_service: Any, fetcher: "EntryFetcher") -> None:
+    def __init__(
+        self, identity_service: Any, resolver: "DeclaredSourceResolver"
+    ) -> None:
         self._identity = identity_service
-        self._fetcher = fetcher
+        self._resolver = resolver
 
     async def resolve(
         self, ctx: "ApplyContext", entries: Sequence[dict[str, Any]]
@@ -221,7 +223,7 @@ class IdentityMaterialiser(Materialiser):
                 # which the adapter awaits inline; a hung source must not
                 # park every concurrent request.
                 delivery = await asyncio.to_thread(
-                    self._fetcher.fetch_declared,
+                    self._resolver.resolve,
                     ctx,
                     entry=entry,
                     category=_FETCH_CATEGORY,

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/resources.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/resources.py
@@ -88,7 +88,7 @@ from agentclaw.community.core.bot_config_manifest.apply.entry_delivery import (
     archive_refusal,
     canonical_tree_bytes,
 )
-from agentclaw.community.core.bot_config_manifest.apply.entry_fetch import (
+from agentclaw.community.core.bot_config_manifest.apply.source_resolver import (
     declared_protocol,
 )
 from agentclaw.community.core.bot_config_manifest.apply.outcomes import (
@@ -185,9 +185,9 @@ class ResourcesMaterialiser(Materialiser):
 
     construct = ManifestCategory.RESOURCES
 
-    def __init__(self, resource_service: Any, fetcher: Any) -> None:
+    def __init__(self, resource_service: Any, resolver: Any) -> None:
         self._resources = resource_service
-        self._fetcher = fetcher
+        self._resolver = resolver
 
     async def resolve(
         self, ctx: ApplyContext, entries: Sequence[dict[str, Any]]
@@ -349,7 +349,8 @@ class ResourcesMaterialiser(Materialiser):
     ):
         """One entry's content through the W2/W3/W11 funnel.
 
-        ``fetch_declared``, not ``fetch``: this is the whole of defect D1. The
+        ``DeclaredSourceResolver.resolve``, not ``fetch``: this is the whole of
+        defect D1. The
         URL-only call this replaced is why ``resources`` was the one fetching
         category that could not name a source — not just git, but ``from:``
         pointing at anything, since a named source has no ``source:`` URL for
@@ -366,7 +367,7 @@ class ResourcesMaterialiser(Materialiser):
         source.
         """
         return await asyncio.to_thread(
-            self._fetcher.fetch_declared,
+            self._resolver.resolve,
             ctx,
             entry=entry,
             category=category,

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/resources.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/resources.py
@@ -263,20 +263,19 @@ class ResourcesMaterialiser(Materialiser):
                 if isinstance(members, str):
                     failures.append(ResolveFailure(path, members))
                     continue
-                if delivery.needs_receipt():
-                    # The members are filed as **one canonical blob** under the
-                    # tree's receipt URL — the same shape the skills
-                    # materialiser files a package as, and for the same reason:
-                    # §2.8's audit and ``keep_last`` read one receipt per entry,
-                    # and a receipt per member would make a 5000-file tree 5000
-                    # rows describing one delivery.
-                    try:
-                        await asyncio.to_thread(
-                            self._file_tree, ctx, delivery, members, path
-                        )
-                    except EntryFetchError as exc:
-                        failures.append(ResolveFailure(path, exc.reason))
-                        continue
+                # The members are filed as **one canonical blob** under the
+                # tree's receipt URL — the same shape the skills materialiser
+                # files a package as, and for the same reason: §2.8's audit and
+                # ``keep_last`` read one receipt per entry, and a receipt per
+                # member would make a 5000-file tree 5000 rows describing one
+                # delivery.
+                try:
+                    await asyncio.to_thread(
+                        self._file_tree, ctx, delivery, members, path
+                    )
+                except EntryFetchError as exc:
+                    failures.append(ResolveFailure(path, exc.reason))
+                    continue
                 note = delivery.note()
                 # The declared-tree marker intent rides first so plan routes
                 # the tree into ``removals`` and write replaces it before
@@ -326,10 +325,9 @@ class ResourcesMaterialiser(Materialiser):
                     ctx, entry, path, _FETCH_CATEGORY_FILE
                 )
                 data = await asyncio.to_thread(delivery.single)
-                if delivery.needs_receipt():
-                    await asyncio.to_thread(
-                        self._file_one, ctx, delivery, data, path
-                    )
+                await asyncio.to_thread(
+                    self._file_one, ctx, delivery, data, path
+                )
             except EntryFetchError as exc:
                 failures.append(ResolveFailure(str(path), exc.reason))
                 continue
@@ -384,18 +382,17 @@ class ResourcesMaterialiser(Materialiser):
     ) -> None:
         """File a delivered tree with the store, as one canonical blob.
 
-        Only the roads that still owe a receipt reach here — the object road
-        filed what arrived inside the fetch. The credential name rides along,
-        so the lineage answers "which credential served this" identically on
-        both roads.
+        Unconditional, and the delivery decides what that means: the object
+        road filed what arrived inside the fetch and writes nothing again,
+        while the git road files these bytes under its own receipt identity
+        with the source's credential name riding along — so the lineage
+        answers "which credential served this" identically on both roads.
         """
-        self._fetcher.file_bytes(
+        delivery.file(
             ctx,
-            content=canonical_tree_bytes(members),
-            source_url=delivery.receipt_url(),
+            canonical_tree_bytes(members),
             category=_FETCH_CATEGORY_ARCHIVE,
             entry_identity=path,
-            credential_name=delivery.auth(),
         )
 
     def _file_one(
@@ -406,13 +403,11 @@ class ResourcesMaterialiser(Materialiser):
         path: str,
     ) -> None:
         """File one delivered file with the store. Same rule as the tree's."""
-        self._fetcher.file_bytes(
+        delivery.file(
             ctx,
-            content=data,
-            source_url=delivery.receipt_url(),
+            data,
             category=_FETCH_CATEGORY_FILE,
             entry_identity=path,
-            credential_name=delivery.auth(),
         )
 
     def _entry_failure(

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/skills.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/skills.py
@@ -72,8 +72,8 @@ from agentclaw.community.core.bot_config_manifest.apply.entry_delivery import (
     EntryDelivery,
     EntryFetchError,
 )
-from agentclaw.community.core.bot_config_manifest.apply.entry_fetch import (
-    EntryFetcher,
+from agentclaw.community.core.bot_config_manifest.apply.source_resolver import (
+    DeclaredSourceResolver,
 )
 from agentclaw.community.core.bot_config_manifest.apply.outcomes import (
     EntryOutcome,
@@ -244,13 +244,13 @@ class SkillsMaterialiser(Materialiser):
         activation_service: ActivationPort,
         capability_reader: BotCapabilityStateReaderProtocol,
         validator: SkillPackageValidator,
-        fetcher: EntryFetcher,
+        resolver: DeclaredSourceResolver,
     ) -> None:
         self._uploads = upload_service
         self._activation = activation_service
         self._reader = capability_reader
         self._validator = validator
-        self._fetcher = fetcher
+        self._resolver = resolver
 
     async def resolve(
         self, ctx: "ApplyContext", entries: Sequence[dict[str, Any]]
@@ -343,7 +343,7 @@ class SkillsMaterialiser(Materialiser):
                 # materialiser's note; a dry run must not park the server on
                 # a hung source.
                 delivery = await asyncio.to_thread(
-                    self._fetcher.fetch_declared,
+                    self._resolver.resolve,
                     ctx,
                     entry=entry,
                     category=_FETCH_CATEGORY,

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/skills.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/skills.py
@@ -566,19 +566,16 @@ class SkillsMaterialiser(Materialiser):
         if isinstance(files, str):
             raise _PackageRefusal(files)
         validated = self._validate(self._validator.validate_directory, files)
-        if delivery.needs_receipt():
-            try:
-                self._fetcher.file_bytes(
-                    ctx,
-                    content=validated.canonical_zip,
-                    source_url=delivery.receipt_url(),
-                    category=_FETCH_CATEGORY,
-                    entry_identity=name,
-                    content_type="application/zip",
-                    credential_name=delivery.auth(),
-                )
-            except EntryFetchError as exc:
-                raise _PackageRefusal(str(exc)) from exc
+        try:
+            delivery.file(
+                ctx,
+                validated.canonical_zip,
+                category=_FETCH_CATEGORY,
+                entry_identity=name,
+                content_type="application/zip",
+            )
+        except EntryFetchError as exc:
+            raise _PackageRefusal(str(exc)) from exc
         return _SkillPackage(
             validated.name,
             validated.canonical_zip,

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/registry.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/registry.py
@@ -55,7 +55,7 @@ if TYPE_CHECKING:  # pragma: no cover — the registry stays import-light; see b
     from agentclaw.community.core.ports.activation_port import (
         ActivationPort,
     )
-    from agentclaw.community.core.bot_config_manifest.apply.entry_fetch import EntryFetcher
+    from agentclaw.community.core.bot_config_manifest.apply.source_resolver import DeclaredSourceResolver
     from agentclaw.community.core.ports.identity_file_port import (
         IdentityFilePort,
     )
@@ -345,7 +345,7 @@ def build_materialisers(
     upload_service: SkillPackageUploadPort,
     capability_reader: BotCapabilityStateReaderProtocol,
     package_validator: SkillPackageValidator,
-    entry_fetcher: EntryFetcher,
+    entry_fetcher: DeclaredSourceResolver,
     resource_service: ResourceFilePort,
     cli_tool_service: CliToolService,
 ) -> dict[ApplyConstruct, Materialiser]:

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/source_fetchers.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/source_fetchers.py
@@ -10,11 +10,13 @@ Adding a protocol is a class and a row; the branch has no third arm to grow.
 fetcher raises at import rather than ``KeyError``-ing at apply time, in front
 of a bot, with the apply lock held.
 
-Each fetcher holds the :class:`~...entry_fetch.EntryFetcher` that owns it —
-its transport, its content store, its credentials. They are strategies over
-one pipeline's collaborators, not independent pipelines: two fetchers that
-each built their own store would file receipts under two policies, and W11's
-lineage would answer differently depending on which road served an entry.
+Each fetcher is handed the collaborators its own road needs — the content
+store and W3's credentials, plus the object-store client on the road that has
+one. They are strategies over **one apply's** collaborators, not independent
+pipelines: :func:`build_fetchers` binds them all from the same three, so two
+fetchers cannot each end up with their own store, filing receipts under two
+policies while W11's lineage answers differently depending on which road
+served an entry.
 
 **Two ``source_url`` shapes exist**, both built here, and both are receipt
 identities rather than fetchable URLs — the address bytes are *filed* under,
@@ -82,7 +84,7 @@ from abc import abstractmethod
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, Mapping, Optional, Protocol, runtime_checkable
+from typing import Any, Mapping, Optional, Protocol, runtime_checkable
 
 import httpx
 
@@ -101,6 +103,9 @@ from agentclaw.community.core.bot_config_manifest.apply.fetch_context import (
 from agentclaw.community.core.bot_config_manifest.apply.source_session import (
     SourceSession,
 )
+from agentclaw.community.core.bot_config_manifest.content.service_protocol import (
+    ManifestContentServiceProtocol,
+)
 from agentclaw.community.core.bot_config_manifest.content.errors import (
     ContentMissingError,
     ContentStoreError,
@@ -108,6 +113,9 @@ from agentclaw.community.core.bot_config_manifest.content.errors import (
 )
 from agentclaw.community.core.bot_config_manifest.credentials.errors import (
     CredentialError,
+)
+from agentclaw.community.core.bot_config_manifest.credentials.service_protocol import (
+    SourceCredentialServiceProtocol,
 )
 from agentclaw.community.core.bot_config_manifest.credentials.policy import (
     PrefixAuthorizationError,
@@ -126,6 +134,7 @@ from agentclaw.community.core.bot_config_manifest.fetch.limits import (
     FetchCategory,
 )
 from agentclaw.community.core.bot_config_manifest.fetch.object_store import (
+    AliyunObjectStore,
     ObjectFetchStatus,
     ObjectStoreTarget,
 )
@@ -136,11 +145,6 @@ from agentclaw.community.core.bot_config_manifest.schema._support import (
 from agentclaw.community.core.bot_config_manifest.schema.sources import SourceDecl
 from agentclaw.community.core.bot_config_manifest.support_matrix import SourceKind
 from agentclaw.community.log import get_logger
-
-if TYPE_CHECKING:
-    from agentclaw.community.core.bot_config_manifest.apply.entry_fetch import (
-        EntryFetcher,
-    )
 
 logger = get_logger()
 
@@ -298,8 +302,15 @@ class ObjectStoreFetcher(SourceFetcher):
     delivered; git delivers a tree, an object store delivers an object.
     """
 
-    def __init__(self, owner: EntryFetcher) -> None:
-        self._owner = owner
+    def __init__(
+        self,
+        content: ManifestContentServiceProtocol,
+        credentials: SourceCredentialServiceProtocol,
+        objects: AliyunObjectStore,
+    ) -> None:
+        self._content = content
+        self._credentials = credentials
+        self._objects = objects
 
     def fetch(self, request: DeclaredFetch) -> EntryDelivery:
         decl, entry = request.decl, request.entry
@@ -325,7 +336,7 @@ class ObjectStoreFetcher(SourceFetcher):
                 "the key pair come from the named credential"
             )
         try:
-            target = self._owner._credentials.binding(
+            target = self._credentials.binding(
                 name=decl.auth
             ).object_store_target(substitute(request.ctx, decl.bucket or ""))
         except CredentialError as exc:
@@ -393,7 +404,7 @@ class ObjectStoreFetcher(SourceFetcher):
         address = object_receipt_url(target.bucket, key)
         scope = scope_of(ctx)
         try:
-            receipt = self._owner._content.latest_receipt(
+            receipt = self._content.latest_receipt(
                 scope, source_url=address
             )
         except (ContentStoreError, ContentStoreFault) as exc:
@@ -405,7 +416,7 @@ class ObjectStoreFetcher(SourceFetcher):
             # truth — the ruling the module docstring records.
             try:
                 return FetchedEntry(
-                    content=self._owner._content.read(digest),
+                    content=self._content.read(digest),
                     digest=digest,
                     from_store=True,
                     content_type=receipt.content_type,
@@ -430,7 +441,7 @@ class ObjectStoreFetcher(SourceFetcher):
         # to raise on rather than to paper over with the file cap. The git
         # road's ``file_limit=`` line reads the table the same way.
         limit = FETCH_ENTRY_LIMITS[category]
-        result = self._owner._objects.get(target, key, byte_limit=limit)
+        result = self._objects.get(target, key, byte_limit=limit)
 
         if result.is_refusal:
             # NOT_FOUND, DENIED, TOO_LARGE — the document or the credential is
@@ -447,7 +458,7 @@ class ObjectStoreFetcher(SourceFetcher):
             ):
                 try:
                     return FetchedEntry(
-                        content=self._owner._content.read(receipt.digest),
+                        content=self._content.read(receipt.digest),
                         digest=receipt.digest,
                         from_store=True,
                         content_type=receipt.content_type,
@@ -483,7 +494,7 @@ class ObjectStoreFetcher(SourceFetcher):
             fetched_at=datetime.now(timezone.utc),
         )
         try:
-            self._owner._content.store(
+            self._content.store(
                 fetched,
                 scope=scope,
                 source_url=address,
@@ -526,8 +537,13 @@ class GitSourceFetcher(SourceFetcher):
     masked, a *failure* is the transport and may be.
     """
 
-    def __init__(self, owner: EntryFetcher) -> None:
-        self._owner = owner
+    def __init__(
+        self,
+        content: ManifestContentServiceProtocol,
+        credentials: SourceCredentialServiceProtocol,
+    ) -> None:
+        self._content = content
+        self._credentials = credentials
 
     def fetch(self, request: DeclaredFetch) -> EntryDelivery:
         ctx, decl, entry = request.ctx, request.decl, request.entry
@@ -564,7 +580,7 @@ class GitSourceFetcher(SourceFetcher):
         try:
             headers: dict[str, str] = {}
             if auth:
-                binding = self._owner._credentials.binding(name=auth)
+                binding = self._credentials.binding(name=auth)
                 binding.reauthorize(httpx.URL(spec.url))
                 headers = dict(binding.headers_for(httpx.URL(spec.url)))
             checkout, fresh = session.checkout(
@@ -666,13 +682,13 @@ class GitSourceFetcher(SourceFetcher):
             return None
         target = git_receipt_url(spec.url, baseline, spec.subpath)
         try:
-            receipt = self._owner._content.latest_receipt(
+            receipt = self._content.latest_receipt(
                 scope_of(ctx), source_url=target
             )
             if receipt is None:
                 return None
             return FetchedEntry(
-                content=self._owner._content.read(receipt.digest),
+                content=self._content.read(receipt.digest),
                 digest=receipt.digest,
                 from_store=True,
                 content_type=receipt.content_type,
@@ -721,18 +737,31 @@ if _UNSERVED:
     )
 
 
-def build_fetchers(owner: EntryFetcher) -> Mapping[SourceKind, SourceFetcher]:
-    """The table, bound to one pipeline's collaborators::
+def build_fetchers(
+    content: ManifestContentServiceProtocol,
+    credentials: SourceCredentialServiceProtocol,
+    objects: AliyunObjectStore,
+) -> Mapping[SourceKind, SourceFetcher]:
+    """The table above, bound to one apply's collaborators::
 
         {
-            SourceKind.OSS: ObjectStoreFetcher(owner),
-            SourceKind.GIT: GitSourceFetcher(owner),
+            SourceKind.OSS: ObjectStoreFetcher(content, credentials, objects),
+            SourceKind.GIT: GitSourceFetcher(content, credentials),
         }
+
+    One row per :data:`FETCHER_TYPES` key, spelled out rather than built by
+    comprehension, because the two roads do not take the same collaborators:
+    only the object road reaches a store client. The table above is still the
+    record of *which* protocols are served, and still what the import-time
+    check holds exhaustive; this binds them.
 
     Called once per :class:`~...entry_fetch.EntryFetcher`, in its constructor.
     """
     return MappingProxyType(
-        {kind: cls(owner) for kind, cls in FETCHER_TYPES.items()}
+        {
+            SourceKind.OSS: ObjectStoreFetcher(content, credentials, objects),
+            SourceKind.GIT: GitSourceFetcher(content, credentials),
+        }
     )
 
 

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/source_fetchers.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/source_fetchers.py
@@ -16,14 +16,71 @@ one pipeline's collaborators, not independent pipelines: two fetchers that
 each built their own store would file receipts under two policies, and W11's
 lineage would answer differently depending on which road served an entry.
 
+**Two ``source_url`` shapes exist**, both built here, and both are receipt
+identities rather than fetchable URLs — the address bytes are *filed* under,
+never an address a fetcher dials::
+
+    "oss://team-artifacts/tools/qc/v2.tgz"
+        built by :func:`object_receipt_url` inside
+        :meth:`ObjectStoreFetcher._acquire`. The endpoint is deliberately
+        absent: it comes off the credential row, not off the document.
+
+    "git+https://code.example.com/team/content.git@<40-hex sha>:kb/faq.csv"
+        built by ``fetch/git_source.git_receipt_url``. Keyed on the resolved
+        sha, and ends in a bare colon when there is no subpath.
+
+``FetchedEntry.source_url`` and every receipt ``source_url`` is one of the two,
+because they are written by whichever road ran.
+
+Pinned vs unpinned is a declared-digest question, and it decides the
+store-first vs read-first policy:
+
+* **pinned** (the entry declares a ``digest``) — a receipt for this bot and
+  source address *matching the declaration* is the bytes, by content
+  addressing: no network is consulted to acquire what the platform already
+  holds. A source that has since moved is irrelevant — the declaration asks
+  for the pinned bytes, and a re-read of them would only fail the pin.
+* **unpinned** — the entry wants whatever is there *now*; every apply
+  re-reads so it converges to the source, and ``keep_last`` exists for the
+  day that read fails.
+
+``keep_last`` (on a real read failure) reads the latest receipt: bytes that
+are entitled to be reused when the declaration pinned nothing, and bytes that
+must match the pin when it did — a receipt that disagrees with a declared
+digest is not "last", it is stale, and supplying it would silently pin bytes
+the declaration never named.
+
+**Which failures may fall back is fixed by what they are a statement about,
+and the ruling is:** the source was reachable and could not serve — an
+unreachable object store, a git fetch that failed — may fall back; a refusal
+may not. A refusal (an object the document names that is not there, a
+credential the store will not accept, an object past the category's cap) is a
+statement about the document's or the credential's *configuration*, while
+keep_last exists for statements about the source's *availability*. Masking a
+refusal with stored bytes would answer SUCCEEDED to a document the platform
+just refused; the same ruling keeps a deleted credential name loud —
+configuration drift is for the author to fix, not for the stored copy to
+absorb.
+
+**Every interaction with the content store — lookup, both reads, the
+re-file after a read — is translated here** into :class:`EntryFetchError`:
+a store-side fault answers as that ENTRY's failure with the store's own
+message, never as an unrelated exception escaping resolve to abort the
+whole category under a wrapped surprise. The one leniency: a pinned
+store-hit whose blob has gone missing falls through to the source —
+the pin is byte-provable, so a re-read re-filed with the store heals the
+address and nobody upstream learns anything happened.
+
 Grammar reference: ``docs/bot-config-manifest/manifest-schema.zh-CN.md``
 — §2.2 (``protocol``), §5 (per-entry limits). Cite a section rather than restating the grammar here;
 two copies of one grammar drift, and the document is the one users read.
 """
 from __future__ import annotations
 
+import hashlib
 from abc import abstractmethod
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Mapping, Optional, Protocol, runtime_checkable
 
@@ -33,11 +90,21 @@ from agentclaw.community.core.bot_config_manifest.apply.entry_delivery import (
     BlobDelivery,
     EntryDelivery,
     EntryFetchError,
+    FetchedEntry,
     GitDelivery,
     GitEntrySource,
 )
+from agentclaw.community.core.bot_config_manifest.apply.fetch_context import (
+    FetchContext,
+    scope_of,
+)
 from agentclaw.community.core.bot_config_manifest.apply.source_session import (
     SourceSession,
+)
+from agentclaw.community.core.bot_config_manifest.content.errors import (
+    ContentMissingError,
+    ContentStoreError,
+    ContentStoreFault,
 )
 from agentclaw.community.core.bot_config_manifest.credentials.errors import (
     CredentialError,
@@ -47,8 +114,10 @@ from agentclaw.community.core.bot_config_manifest.credentials.policy import (
 )
 from agentclaw.community.core.bot_config_manifest.fetch.git_source import (
     GitSourceSpec,
+    git_receipt_url,
 )
 from agentclaw.community.core.bot_config_manifest.fetch.guarded_fetcher import (
+    FetchedObject,
     FetchFailedError,
     FetchRefusedError,
 )
@@ -56,18 +125,24 @@ from agentclaw.community.core.bot_config_manifest.fetch.limits import (
     FETCH_ENTRY_LIMITS,
     FetchCategory,
 )
+from agentclaw.community.core.bot_config_manifest.fetch.object_store import (
+    ObjectFetchStatus,
+    ObjectStoreTarget,
+)
 from agentclaw.community.core.bot_config_manifest.schema import placeholders
 from agentclaw.community.core.bot_config_manifest.schema._support import (
     relative_path_refusal,
 )
 from agentclaw.community.core.bot_config_manifest.schema.sources import SourceDecl
 from agentclaw.community.core.bot_config_manifest.support_matrix import SourceKind
+from agentclaw.community.log import get_logger
 
 if TYPE_CHECKING:
     from agentclaw.community.core.bot_config_manifest.apply.entry_fetch import (
         EntryFetcher,
-        FetchContext,
     )
+
+logger = get_logger()
 
 
 @dataclass(frozen=True)
@@ -256,7 +331,7 @@ class ObjectStoreFetcher(SourceFetcher):
         except CredentialError as exc:
             raise EntryFetchError(str(exc)) from exc
         return BlobDelivery(
-            self._owner.acquire_object(
+            self._acquire(
                 request.ctx,
                 target=target,
                 key=key,
@@ -266,6 +341,170 @@ class ObjectStoreFetcher(SourceFetcher):
                 keep_last=request.keep_last,
                 entry_identity=request.entry_identity,
             )
+        )
+
+    def _acquire(
+        self,
+        ctx: FetchContext,
+        *,
+        target: ObjectStoreTarget,
+        key: str,
+        digest: Optional[str],
+        auth: Optional[str],
+        category: FetchCategory,
+        keep_last: bool,
+        entry_identity: Optional[str],
+    ) -> FetchedEntry:
+        """One object out of a tenant-named bucket, through the object store.
+
+        Takes the resolved ``ObjectStoreTarget`` (bucket plus the endpoint and
+        key pair off the credential row) and the already-composed, already
+        substituted ``key``. The address it files under is built here::
+
+            _acquire(ctx,
+                     target=ObjectStoreTarget(bucket="team-artifacts",
+                                              ...),
+                     key="tools/qc/v2.tgz",
+                     digest=None,
+                     auth="oss-prod",
+                     category=FetchCategory.CLI_TOOLS,
+                     keep_last=True,
+                     entry_identity="qc")
+            # -> FetchedEntry(...,
+            #        source_url="oss://team-artifacts/tools/qc/v2.tgz")
+
+        ``content_type`` is always ``None`` on this road: the store client
+        reports none.
+
+        The shape the module docstring's policy describes — pinned fast path,
+        acquire, ``keep_last``, file — over the object store's transport, where
+        four of the guarded fetcher's six protections are gone *because they
+        have nothing left to guard*: there is no tenant-supplied URL to
+        shape-check, no host to resolve and pin, and no redirect to
+        re-validate, since the endpoint comes off the credential row and the
+        store client owns the wire. The two that survive are the two that were
+        never about a URL: the byte cap (enforced inside the client, while
+        streaming) and the content address computed here.
+        """
+        expired = ctx.budget.expired() if ctx.budget is not None else None
+        if expired is not None:
+            raise EntryFetchError(expired)
+
+        address = object_receipt_url(target.bucket, key)
+        scope = scope_of(ctx)
+        try:
+            receipt = self._owner._content.latest_receipt(
+                scope, source_url=address
+            )
+        except (ContentStoreError, ContentStoreFault) as exc:
+            raise EntryFetchError(str(exc)) from exc
+
+        if digest is not None and receipt is not None and receipt.digest == digest:
+            # Content addressing makes the stored bytes *the* declared bytes,
+            # so the store is the strictly more available source of the same
+            # truth — the ruling the module docstring records.
+            try:
+                return FetchedEntry(
+                    content=self._owner._content.read(digest),
+                    digest=digest,
+                    from_store=True,
+                    content_type=receipt.content_type,
+                    source_url=address,
+                )
+            except ContentMissingError:
+                logger.warning(
+                    "[manifest.object_store] the pinned blob is missing; "
+                    "re-reading to heal the platform's copy, digest=%s",
+                    digest,
+                )
+            except (ContentStoreError, ContentStoreFault) as exc:
+                raise EntryFetchError(
+                    "the platform's copy of the pinned content could not be "
+                    f"read: {exc}"
+                ) from exc
+
+        # Total, not ``.get`` with a fallback: ``category`` is the
+        # ``FetchCategory`` the front door already coerced, and
+        # ``FETCH_ENTRY_LIMITS`` is bound to that enum by the limits module's
+        # own assertion — so every member has a cap and a missing one is a bug
+        # to raise on rather than to paper over with the file cap. The git
+        # road's ``file_limit=`` line reads the table the same way.
+        limit = FETCH_ENTRY_LIMITS[category]
+        result = self._owner._objects.get(target, key, byte_limit=limit)
+
+        if result.is_refusal:
+            # NOT_FOUND, DENIED, TOO_LARGE — the document or the credential is
+            # wrong. keep_last must not mask any of them: a denied credential
+            # quietly serving last apply's bytes for a year is exactly the
+            # outcome that ruling exists to prevent.
+            raise EntryFetchError(result.detail)
+
+        if result.status is not ObjectFetchStatus.FOUND:
+            # UNAVAILABLE: the store could not be reached, which is what
+            # keep_last is for.
+            if keep_last and receipt is not None and (
+                digest is None or receipt.digest == digest
+            ):
+                try:
+                    return FetchedEntry(
+                        content=self._owner._content.read(receipt.digest),
+                        digest=receipt.digest,
+                        from_store=True,
+                        content_type=receipt.content_type,
+                        source_url=address,
+                        fallback_reason=(
+                            "delivered from the platform's stored copy "
+                            f"(keep_last): {result.detail}"
+                        ),
+                    )
+                except (ContentStoreError, ContentStoreFault) as read_exc:
+                    raise EntryFetchError(
+                        f"{result.detail}; the keep_last fallback copy could "
+                        f"not be read: {read_exc}"
+                    ) from read_exc
+            raise EntryFetchError(result.detail)
+
+        content = result.content or b""
+        computed = "sha256:" + hashlib.sha256(content).hexdigest()
+        if digest is not None and computed != digest:
+            # The pin, checked here rather than in the client: a transport has
+            # no business knowing what a manifest digest is, and this is the
+            # one place both roads agree on what "the declared bytes" means.
+            raise EntryFetchError(
+                f"the object's bytes are {computed}, the entry declared {digest}"
+            )
+
+        fetched = FetchedObject(
+            bytes=content,
+            sha256=computed,
+            size_bytes=len(content),
+            url=address,
+            content_type=None,
+            fetched_at=datetime.now(timezone.utc),
+        )
+        try:
+            self._owner._content.store(
+                fetched,
+                scope=scope,
+                source_url=address,
+                credential_name=auth,
+                modifier=ctx.actor_id,
+                apply_id=ctx.apply_id,
+                category=category,
+                entry_identity=entry_identity,
+            )
+        except (ContentStoreError, ContentStoreFault) as exc:
+            raise EntryFetchError(
+                "the fetched bytes could not be filed with the platform's "
+                f"store: {exc}"
+            ) from exc
+        if ctx.budget is not None:
+            ctx.budget.charge(len(content))
+        return FetchedEntry(
+            content=content,
+            digest=computed,
+            from_store=False,
+            source_url=address,
         )
 
 
@@ -338,7 +577,7 @@ class GitSourceFetcher(SourceFetcher):
         except FetchRefusedError as exc:
             raise EntryFetchError(str(exc)) from exc
         except FetchFailedError as exc:
-            fallback = self._owner._git_keep_last(
+            fallback = self._keep_last(
                 ctx,
                 session=session,
                 spec=spec,
@@ -398,6 +637,57 @@ class GitSourceFetcher(SourceFetcher):
                 file_limit=FETCH_ENTRY_LIMITS[request.category],
             )
         )
+
+    def _keep_last(
+        self,
+        ctx: FetchContext,
+        *,
+        session: SourceSession,
+        spec: GitSourceSpec,
+        display: str,
+        keep_last: bool,
+    ) -> Optional[FetchedEntry]:
+        """``keep_last`` for the git road: the receipt of the *last-resolved*
+        SHA, when there was one.
+
+        Looks the baseline up by ``display`` and reads the receipt filed under
+        ``git+<url>@<baseline sha>:<subpath>``. Answers ``None`` — meaning
+        "no fallback, let the failure stand" — in three cases: ``keep_last`` is
+        off, the source has no baseline (a first-time source has no stored copy
+        entitled to answer for it), or no receipt exists at that address.
+
+        On a hit the :class:`FetchedEntry` carries ``from_store=True`` and a
+        ``fallback_reason``, which is what the report's note comes from.
+        """
+        if not keep_last:
+            return None
+        baseline = session.baseline(display)
+        if baseline is None:
+            return None
+        target = git_receipt_url(spec.url, baseline, spec.subpath)
+        try:
+            receipt = self._owner._content.latest_receipt(
+                scope_of(ctx), source_url=target
+            )
+            if receipt is None:
+                return None
+            return FetchedEntry(
+                content=self._owner._content.read(receipt.digest),
+                digest=receipt.digest,
+                from_store=True,
+                content_type=receipt.content_type,
+                source_url=target,
+                # The failure is named, never quoted: the git road's transport
+                # error text is report-safe on its own ("git fetch failed"),
+                # and re-embedding it here would just restate the same words —
+                # the reason keep_last fired stays one clean sentence.
+                fallback_reason=(
+                    "delivered from the platform's stored copy (keep_last): "
+                    "the git fetch failed"
+                ),
+            )
+        except (ContentStoreError, ContentStoreFault) as exc:
+            raise EntryFetchError(str(exc)) from exc
 
 
 #: Which fetcher **class** serves which protocol — the types, not instances::

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/source_fetchers.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/source_fetchers.py
@@ -651,7 +651,13 @@ class GitSourceFetcher(SourceFetcher):
                 # assertion, so every member has a cap and a missing one is a
                 # bug to raise on rather than to paper over with the file cap.
                 file_limit=FETCH_ENTRY_LIMITS[request.category],
-            )
+            ),
+            # The one road that still owes the store a write: a checkout is
+            # not bytes, so what this entry delivers is the caller's to decide
+            # and the delivery's to file. Handed the same store this fetcher
+            # reads ``keep_last`` receipts from, so one entry's read and its
+            # write cannot end up on two policies.
+            self._content,
         )
 
     def _keep_last(

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/source_fetchers.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/source_fetchers.py
@@ -1,6 +1,6 @@
 """One fetcher per protocol, and the table that picks between them.
 
-The front door (``entry_fetch.fetch_declared``) does the work that is the same
+The front door (``source_resolver.resolve``) does the work that is the same
 on every road — budget, session, ``keep_last``, and parsing the declaration
 once — then looks the protocol up in :data:`FETCHER_TYPES` and calls it.
 Adding a protocol is a class and a row; the branch has no third arm to grow.
@@ -225,7 +225,7 @@ class DeclaredFetch:
     An **inline** source differs in exactly one field: ``name`` is ``None`` and
     ``decl`` is parsed from the entry's own ``source:`` mapping.
 
-    Created by: ``apply/entry_fetch.EntryFetcher.fetch_declared``, the only
+    Created by: ``apply/source_resolver.DeclaredSourceResolver.resolve``, the only
     place one is built.
     Consumed by: :meth:`SourceFetcher.fetch` — that is, both fetchers below.
 
@@ -761,7 +761,7 @@ def build_fetchers(
     record of *which* protocols are served, and still what the import-time
     check holds exhaustive; this binds them.
 
-    Called once per :class:`~...entry_fetch.EntryFetcher`, in its constructor.
+    Called once per :class:`~...source_resolver.DeclaredSourceResolver`, in its constructor.
     """
     return MappingProxyType(
         {

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/source_resolver.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/source_resolver.py
@@ -1,14 +1,17 @@
 """One entry's fetch, from a declared source to materialisable bytes.
 
-The second half of ``resolve`` for every fetch-consuming category: resolve the
-entry's declared source, consult the platform's own copy before the network,
-read it through the protocol's own transport under a named credential, and file
-the result with the content store so delivery and audit share one copy.
+The second half of a **materialiser's** ``resolve`` for every fetch-consuming
+category: resolve the entry's declared source, consult the platform's own copy
+before the network, read it through the protocol's own transport under a named
+credential, and file the result with the content store so delivery and audit
+share one copy.
 
-**One entry point**, ``fetch_declared(ctx, *, entry=…)``: the front door
-every fetching materialiser calls. It takes no URL at all — it reads the
-entry, resolves the declaration and dispatches on its ``protocol``. A receipt
-is filed and the budget charged through whichever road it picked.
+**One entry point**, :meth:`DeclaredSourceResolver.resolve` — the front door
+every fetching materialiser calls, and the reason this module's one class is
+named for resolving a declaration rather than for fetching. It takes no URL at
+all: it reads the entry, resolves the declaration and dispatches on its
+``protocol``. A receipt is filed and the budget charged through whichever road
+it picked.
 
 **What each road does with the source it was handed lives in
 ``apply/source_fetchers.py``**, and so does the policy it runs under: the two
@@ -16,16 +19,18 @@ receipt-identity shapes, pinned vs unpinned, which failures ``keep_last`` may
 answer for, and the translation of every store fault into
 :class:`EntryFetchError`. This module picks the road; it does not drive one.
 
-Fetch lives here **and only here** — the registry's contract says ``resolve``
-is where a category's failures are collected before anything is written, and a
-fetch is exactly that kind of failure. Materialisers translate :class:`EntryFetchError`
+Fetch lives here **and only here** — the registry's contract says a
+materialiser's ``resolve`` is where a category's failures are collected before
+anything is written, and a fetch is exactly that kind of failure. Materialisers
+translate :class:`EntryFetchError`
 into their ``ResolveFailure`` currency; nothing about the transport leaks out.
-Because the fetch belongs to ``resolve``, a ``dry_run`` may perform one (it
+Because the fetch belongs to that phase, a ``dry_run`` may perform one (it
 still writes **nothing to the bot** — the store it files with is the
 platform's own record of what a bot was served, true whether or not the apply
 proceeds).
 
-W7 is the declared-source front door, :meth:`fetch_declared`: the ``from``
+W7 is the declared-source front door, :meth:`DeclaredSourceResolver.resolve`:
+the ``from``
 and inline-source roads resolve through the apply's source session, and the git
 road returns a :class:`GitEntrySource` — the tree is the entry's to
 interpret (a file? a package?) — while its canonical, entry-level bytes are
@@ -84,13 +89,15 @@ if TYPE_CHECKING:
     )
 
 
-class EntryFetcher:
-    """Fetches one manifest entry's bytes on a bot's behalf.
+class DeclaredSourceResolver:
+    """Resolves one manifest entry's declared source, and dispatches to it.
 
     The one funnel every fetching category goes through: ``skills``,
     ``resources``, ``identity`` and ``cli_tools``. One public entry point,
-    :meth:`fetch_declared`; it holds no collaborators of its own, only the
-    table of roads it dispatches to.
+    :meth:`resolve`; it holds no collaborators of its own, only the table of
+    roads it dispatches to — which is the whole of what it does, and what it
+    is named for. The bytes are the roads' business, in
+    ``apply/source_fetchers.py``.
 
     Composed once per apply — the transport is stateless per hop, so there is
     nothing to hold between entries — and handed to every materialiser that
@@ -118,7 +125,7 @@ class EntryFetcher:
         # honest signature.
         self._fetchers = build_fetchers(content, credentials, objects)
 
-    def fetch_declared(
+    def resolve(
         self,
         ctx: FetchContext,
         *,
@@ -267,7 +274,7 @@ def _raw_declaration(
         _raw_declaration(ctx, {"content": "inline text"})
         # -> (None, None)
 
-    Two callers, one lookup: :meth:`EntryFetcher.fetch_declared` and
+    Two callers, one lookup: :meth:`DeclaredSourceResolver.resolve` and
     :func:`declared_protocol`. They used to each spell out "a ``from`` name in
     ``session.sources``, else the entry's own ``source`` mapping", which is two
     places for one rule to be true in — and the two of them must agree, because
@@ -293,7 +300,7 @@ def _raw_declaration(
 def declared_protocol(
     ctx: FetchContext, entry: Mapping[str, Any]
 ) -> Optional[SourceKind]:
-    """Which protocol :meth:`EntryFetcher.fetch_declared` will take, **without
+    """Which protocol :meth:`DeclaredSourceResolver.resolve` will take, **without
     fetching anything**.
 
     ==============================================  ====================
@@ -323,8 +330,8 @@ def declared_protocol(
     and ``materialisers/cli_tools``, which asks whether the digest rule
     applies.
 
-    Read through the same parser the ``PUT`` validator and ``fetch_declared``
-    use, and off the same lookup ``fetch_declared`` uses
+    Read through the same parser the ``PUT`` validator and ``resolve``
+    use, and off the same lookup ``resolve`` uses
     (:func:`_raw_declaration`), so a fourth derivation cannot appear and this
     cannot drift from the road it predicts.
     """
@@ -338,7 +345,7 @@ def declared_protocol(
 __all__ = [
     "declared_protocol",
     "EntryFetchError",
-    "EntryFetcher",
+    "DeclaredSourceResolver",
     "FetchContext",
     "FetchedEntry",
     "GitEntrySource",

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/source_session.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/source_session.py
@@ -48,9 +48,9 @@ class SourceSession:
     Created by: ``services/config_manifest_apply_service``, at ``start_apply``
     and ``dry_run``, and closed in every terminal path including launch
     failure.
-    Consumed by: ``apply/source_fetchers.GitSourceFetcher.fetch`` and
-    ``apply/entry_fetch`` (``fetch_declared``, ``_git_keep_last``,
-    ``declared_protocol``).
+    Consumed by: ``apply/source_fetchers`` (``GitSourceFetcher.fetch``,
+    ``GitSourceFetcher._keep_last``) and ``apply/entry_fetch``
+    (``fetch_declared``, ``declared_protocol``).
     """
 
     #: The stored document's top-level ``sources`` map, verbatim and frozen at

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/source_session.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/source_session.py
@@ -49,13 +49,13 @@ class SourceSession:
     and ``dry_run``, and closed in every terminal path including launch
     failure.
     Consumed by: ``apply/source_fetchers`` (``GitSourceFetcher.fetch``,
-    ``GitSourceFetcher._keep_last``) and ``apply/entry_fetch``
-    (``fetch_declared``, ``declared_protocol``).
+    ``GitSourceFetcher._keep_last``) and ``apply/source_resolver``
+    (``resolve``, ``declared_protocol``).
     """
 
     #: The stored document's top-level ``sources`` map, verbatim and frozen at
     #: apply start: declared name → the raw declaration mapping, unparsed.
-    #: ``fetch_declared`` looks an entry's ``from`` name up here and hands the
+    #: ``resolve`` looks an entry's ``from`` name up here and hands the
     #: value to ``parse_source``::
     #:
     #:     {

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/cli_tools/README.md
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/cli_tools/README.md
@@ -22,7 +22,7 @@ code never reaches the feature through the platform's own HTTP endpoints.
 - `declarations.py` — `CliToolDecl` / `CliToolOutcome` / `CliToolDrift`: what a
   caller declares and what one operation reports back.
 - `context.py` — `CliToolContext`: who and what an operation runs as. It also
-  satisfies `apply/entry_fetch.py`'s `FetchContext`, which is what lets an
+  satisfies `apply/fetch_context.py`'s `FetchContext`, which is what lets an
   HTTP-driven install fetch through the same funnel a manifest apply does.
 - `verify.py` — `verify_amd64_elf` and `select_subpath`. The digest answers
   "are these the bytes you asked for"; these answer "can this machine run

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/cli_tools/context.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/cli_tools/context.py
@@ -11,7 +11,7 @@ operation needs: ``owner_id`` resolves the bot and its device binding,
 is carried but read by nobody here: the family difference lives in *which*
 delivery port the strategy bound, never in a branch inside one.
 
-It also satisfies ``apply/entry_fetch.py``'s :class:`FetchContext`, which is
+It also satisfies ``apply/source_resolver.py``'s :class:`FetchContext`, which is
 what lets an HTTP-driven install fetch through the *same* funnel a manifest
 apply does. ``apply_id``, ``budget`` and ``source_session`` are the three
 fields only an apply has, and they are ``None`` for the API caller: an

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/cli_tools/declarations.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/cli_tools/declarations.py
@@ -59,7 +59,8 @@ class CliToolDecl:
 
     **Where the bytes come from is not one of its fields.** There are two
     roads and each carries its own payload: a manifest entry goes through
-    ``fetch_declared`` — see :attr:`entry` — and an upload arrives as bytes the
+    ``DeclaredSourceResolver.resolve`` — see :attr:`entry` — and an upload
+    arrives as bytes the
     caller already holds. Neither is a URL this type could hold, and holding
     one is precisely how a source *name* once went on the wire as though it
     were an address.
@@ -80,8 +81,9 @@ class CliToolDecl:
     keep_last: bool = True
     #: The manifest entry this was read from — **the manifest road's payload**.
     #:
-    #: Present ⇒ the acquisition goes through ``fetch_declared``, which is the
-    #: only thing that can resolve a ``from`` name or a ``protocol: git``
+    #: Present ⇒ the acquisition goes through
+    #: ``DeclaredSourceResolver.resolve``, which is the only thing that can
+    #: resolve a ``from`` name or a ``protocol: git``
     #: source. ``CliToolService.install`` requires it, because that method *is*
     #: the manifest road; the upload road has its own entry point and carries
     #: bytes instead, so a decl built for it leaves this ``None`` and never

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/cli_tools/service.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/cli_tools/service.py
@@ -10,7 +10,7 @@ checks that matter — the digest, the architecture, whether a failed placement
 still writes a row.
 
 **Two doors, one pipeline.** A manifest entry is resolved through
-``fetch_declared``; an upload arrives with its bytes already in hand. From
+``resolve``; an upload arrives with its bytes already in hand. From
 there they are the same call:
 
     [acquire] → digest → unpack → select subpath → verify ELF → md5
@@ -48,8 +48,8 @@ from typing import Callable, Mapping, Optional, Sequence
 from agentclaw.community.core.bot_config_manifest.apply.entry_delivery import (
     EntryFetchError,
 )
-from agentclaw.community.core.bot_config_manifest.apply.entry_fetch import (
-    EntryFetcher,
+from agentclaw.community.core.bot_config_manifest.apply.source_resolver import (
+    DeclaredSourceResolver,
 )
 from agentclaw.community.core.bot_config_manifest.cli_tools.context import (
     CliToolContext,
@@ -108,12 +108,12 @@ class CliToolService:
         repo: BotCliToolRepositoryProtocol,
         store: CliToolStore,
         delivery: CliToolDeliveryPort,
-        entry_fetcher: EntryFetcher,
+        entry_fetcher: DeclaredSourceResolver,
     ) -> None:
         self._repo = repo
         self._store = store
         self._delivery = delivery
-        self._fetcher = entry_fetcher
+        self._resolver = entry_fetcher
 
     # ── reads ────────────────────────────────────────────────────────────
 
@@ -163,8 +163,9 @@ class CliToolService:
         """**The manifest road.** Acquire, verify, store, record and deliver.
 
         ``decl.entry`` is the manifest entry, and it is required: this method's
-        first act is to resolve that entry through ``fetch_declared``, the same
-        door every other fetching category uses. A declaration with no entry
+        first act is to resolve that entry through
+        ``DeclaredSourceResolver.resolve``, the same door every other fetching
+        category uses. A declaration with no entry
         names no source, so it is refused rather than half-acquired — the
         upload road is :meth:`install_upload`, which carries its bytes.
 
@@ -736,8 +737,8 @@ class CliToolService:
     ) -> tuple[bytes, bool]:
         """The manifest entry's bytes, and whether its ``subpath`` is spent.
 
-        One door: ``fetch_declared``, the same one every other fetching
-        category uses, and the only one that resolves a ``from`` name or a
+        One door: ``DeclaredSourceResolver.resolve``, the same one every other
+        fetching category uses, and the only one that resolves a ``from`` name or a
         ``protocol: git`` source. There is no second road to pick between —
         reading an address off the declaration instead is what used to put a
         source *name* on the wire as though it were a URL: accepted at ``PUT``,
@@ -749,7 +750,7 @@ class CliToolService:
         must not look for an archive member of the same name.
         """
         delivery = await asyncio.to_thread(
-            self._fetcher.fetch_declared,
+            self._resolver.resolve,
             ctx,
             entry=decl.entry,
             category=FETCH_CATEGORY,

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/cli_tools/service.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/cli_tools/service.py
@@ -756,20 +756,19 @@ class CliToolService:
             entry_identity=decl.name,
         )
         data = await asyncio.to_thread(delivery.single)
-        if delivery.needs_receipt():
-            # A tree's bytes are not filed by the fetch — only the caller
-            # knows which of them this entry delivers, and here that is the
-            # one file the composed subpath named. Auth included, so the
-            # lineage answers "which credential served this" on both roads.
-            await asyncio.to_thread(
-                self._fetcher.file_bytes,
-                ctx,
-                content=data,
-                source_url=delivery.receipt_url(),
-                category=FETCH_CATEGORY,
-                entry_identity=decl.name,
-                credential_name=delivery.auth(),
-            )
+        # A tree's bytes are not filed by the fetch — only the caller knows
+        # which of them this entry delivers, and here that is the one file the
+        # composed subpath named. The delivery files them under its own
+        # identity, auth included, so the lineage answers "which credential
+        # served this" on both roads; the road that already filed writes
+        # nothing, which is why this is no longer a question the service asks.
+        await asyncio.to_thread(
+            delivery.file,
+            ctx,
+            data,
+            category=FETCH_CATEGORY,
+            entry_identity=decl.name,
+        )
         return data, delivery.is_tree()
 
     @staticmethod

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/services/config_manifest_apply_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/services/config_manifest_apply_service.py
@@ -63,8 +63,8 @@ from agentclaw.community.core.bot_config_manifest.apply.apply_task import (
     build_apply_task_payload,
     phases_from_payload,
 )
-from agentclaw.community.core.bot_config_manifest.apply.entry_fetch import (
-    EntryFetcher,
+from agentclaw.community.core.bot_config_manifest.apply.source_resolver import (
+    DeclaredSourceResolver,
 )
 from agentclaw.community.core.ports.identity_file_port import (
     IdentityFilePort,
@@ -212,7 +212,7 @@ class BotConfigManifestApplyService(BotConfigManifestApplyServiceProtocol):
         upload_service_provider: Callable[[], LocalSkillUploadServiceProtocol],
         capability_reader_provider: Callable[[], BotCapabilityStateReaderProtocol],
         package_validator_provider: Callable[[], SkillPackageValidator],
-        entry_fetcher_provider: Callable[[], EntryFetcher],
+        entry_fetcher_provider: Callable[[], DeclaredSourceResolver],
         resource_service_provider: Callable[[], ResourceFilePort],
         cli_tool_service_factory: Callable[[str], "CliToolService"],
         git_client_provider: Callable[[], GitSourceClient],

--- a/src/backend/src/agentclaw/community/di/modules/bot_management_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/bot_management_module.py
@@ -103,7 +103,7 @@ from agentclaw.community.core.bot_config_manifest.creation import (
 from agentclaw.community.core.bot_config_manifest.services.config_manifest_apply_service import (
     BotConfigManifestApplyService,
 )
-from agentclaw.community.core.bot_config_manifest.apply.entry_fetch import EntryFetcher
+from agentclaw.community.core.bot_config_manifest.apply.source_resolver import DeclaredSourceResolver
 from agentclaw.community.core.bot_config_manifest.cli_tools.service import CliToolPurger, CliToolServiceFactory
 from agentclaw.community.core.ports.identity_file_port import (
     IdentityFilePort,
@@ -728,7 +728,7 @@ class BotManagementModule(Module):
         upload_service_provider: Callable[[], LocalSkillUploadServiceProtocol],
         capability_reader_provider: Callable[[], BotCapabilityStateReaderProtocol],
         package_validator_provider: Callable[[], SkillPackageValidator],
-        entry_fetcher_provider: Callable[[], EntryFetcher],
+        entry_fetcher_provider: Callable[[], DeclaredSourceResolver],
         # W6's resources materialiser and W7's git transport, from the same
         # module and lazy for the same reason.
         resource_service_provider: Callable[[], ResourceFilePort],

--- a/src/backend/src/agentclaw/community/di/modules/manifest_fetch_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/manifest_fetch_module.py
@@ -20,8 +20,8 @@ from typing import Callable
 
 from injector import Injector, Module, inject, provider, singleton
 
-from agentclaw.community.core.bot_config_manifest.apply.entry_fetch import (
-    EntryFetcher,
+from agentclaw.community.core.bot_config_manifest.apply.source_resolver import (
+    DeclaredSourceResolver,
 )
 from agentclaw.community.core.bot_config_manifest.credentials.service import (
     SourceCredentialService,
@@ -281,7 +281,7 @@ class ManifestFetchModule(Module):
         content: ManifestContentServiceProtocol,
         credentials: SourceCredentialServiceProtocol,
         objects: AliyunObjectStore,
-    ) -> EntryFetcher:
+    ) -> DeclaredSourceResolver:
         """The one fetch funnel the fetch-consuming materialisers share.
 
         One instance over three singletons: the store, W3's credentials, and
@@ -292,7 +292,7 @@ class ManifestFetchModule(Module):
         two roads that remain reach their sources through the object store and
         through git.
         """
-        return EntryFetcher(content, credentials, objects)
+        return DeclaredSourceResolver(content, credentials, objects)
 
     @singleton
     @provider
@@ -402,9 +402,9 @@ class ManifestFetchModule(Module):
     @inject
     def manifest_entry_fetcher_factory(
         self, injector: Injector
-    ) -> Callable[[], EntryFetcher]:
+    ) -> Callable[[], DeclaredSourceResolver]:
         """The lazy lookup the apply service's registry wiring asks for."""
-        return lambda: injector.get(EntryFetcher)
+        return lambda: injector.get(DeclaredSourceResolver)
 
     @singleton
     @provider
@@ -443,7 +443,7 @@ class ManifestFetchModule(Module):
         self,
         injector: Injector,
         object_storage: ObjectStoragePlugin,
-        entry_fetcher_provider: Callable[[], EntryFetcher],
+        entry_fetcher_provider: Callable[[], DeclaredSourceResolver],
     ) -> CliToolServiceFactory:
         """W9: the one component both callers install a CLI tool through.
 
@@ -632,7 +632,7 @@ class ManifestFetchModule(Module):
         mcp_auth_service_provider: Callable[[], MCPAuthServiceProtocol],
         capability_reader_provider: Callable[[], BotCapabilityStateReaderProtocol],
         package_validator_provider: Callable[[], SkillPackageValidator],
-        entry_fetcher_provider: Callable[[], EntryFetcher],
+        entry_fetcher_provider: Callable[[], DeclaredSourceResolver],
         cli_tool_service_factory: CliToolServiceFactory,
     ) -> TeclawPlatformBindings:
         """The store-backed ports and the closing redeliver (W8, spec D-7).

--- a/src/backend/tests/community/architecture/test_no_data_infra_vendor_in_core.py
+++ b/src/backend/tests/community/architecture/test_no_data_infra_vendor_in_core.py
@@ -68,6 +68,10 @@ _TERM_ALLOWLIST_FILES = {
     # takes, exactly as it names ``GuardedFetcher``.
     "core/bot_config_manifest/fetch/object_store.py": "manifest oss road — Aliyun-native transport (oss2)",
     "core/bot_config_manifest/apply/source_resolver.py": "manifest oss road — constructor-injects AliyunObjectStore",
+    # Same rationale one layer down: the dispatcher hands the store to the
+    # object road's own fetcher, which names the class it takes for the same
+    # reason its owner did.
+    "core/bot_config_manifest/apply/source_fetchers.py": "manifest oss road — ObjectStoreFetcher takes AliyunObjectStore",
 }
 
 

--- a/src/backend/tests/community/architecture/test_no_data_infra_vendor_in_core.py
+++ b/src/backend/tests/community/architecture/test_no_data_infra_vendor_in_core.py
@@ -67,7 +67,7 @@ _TERM_ALLOWLIST_FILES = {
     # product name in its import line too). Its consumer names the class it
     # takes, exactly as it names ``GuardedFetcher``.
     "core/bot_config_manifest/fetch/object_store.py": "manifest oss road — Aliyun-native transport (oss2)",
-    "core/bot_config_manifest/apply/entry_fetch.py": "manifest oss road — constructor-injects AliyunObjectStore",
+    "core/bot_config_manifest/apply/source_resolver.py": "manifest oss road — constructor-injects AliyunObjectStore",
 }
 
 

--- a/src/backend/tests/community/core/bot_config_manifest/apply/_fakes.py
+++ b/src/backend/tests/community/core/bot_config_manifest/apply/_fakes.py
@@ -471,8 +471,8 @@ def identity_rig(files: dict[str, str] | None = None):
     The declared source :data:`SOUL_SOURCE` reads :data:`SOUL_KEY` out of the
     seeded bucket and serves :data:`SOUL_BODY`.
     """
-    from agentclaw.community.core.bot_config_manifest.apply.entry_fetch import (
-        EntryFetcher,
+    from agentclaw.community.core.bot_config_manifest.apply.source_resolver import (
+        DeclaredSourceResolver,
     )
     from agentclaw.community.core.bot_config_manifest.apply.materialisers.identity import (
         IdentityMaterialiser,
@@ -481,7 +481,7 @@ def identity_rig(files: dict[str, str] | None = None):
     identity = FakeIdentityService(files)
     objects = seeded_object_store({SOUL_KEY: SOUL_BODY})
     content = FakeManifestContent()
-    pipeline = EntryFetcher(content, FakeObjectCredentials(), objects)
+    pipeline = DeclaredSourceResolver(content, FakeObjectCredentials(), objects)
     return IdentityMaterialiser(identity, pipeline), identity, objects, content
 
 

--- a/src/backend/tests/community/core/bot_config_manifest/apply/test_apply_engine.py
+++ b/src/backend/tests/community/core/bot_config_manifest/apply/test_apply_engine.py
@@ -32,8 +32,8 @@ from agentclaw.community.core.bot_config_manifest.capabilities import (
     ManifestCategory,
     ManifestSection,
 )
-from agentclaw.community.core.bot_config_manifest.apply.entry_fetch import (
-    EntryFetcher,
+from agentclaw.community.core.bot_config_manifest.apply.source_resolver import (
+    DeclaredSourceResolver,
 )
 
 from ._fakes import (
@@ -77,7 +77,7 @@ def _engine(scripts=None, activations=None, auth=None):
 def _dummy_entry_fetcher():
     """The engine tests never declare skills/identity sources, so the fetcher
     the registry holds for them can be a never-called placeholder."""
-    return EntryFetcher(FakeManifestContent(), FakeCredentials(), FakeObjectStore())
+    return DeclaredSourceResolver(FakeManifestContent(), FakeCredentials(), FakeObjectStore())
 
 
 async def _apply(engine, document, *, ctx=None, dry_run=False, phases=None):
@@ -797,7 +797,7 @@ async def test_a_fetching_document_applies_all_four_categories_in_order():
             upload_service=uploads,
             capability_reader=reader,
             package_validator=real_validator(),
-            entry_fetcher=EntryFetcher(FakeManifestContent(), FakeObjectCredentials(), objects),
+            entry_fetcher=DeclaredSourceResolver(FakeManifestContent(), FakeObjectCredentials(), objects),
             resource_service=FakeResourceFileService(),
             cli_tool_service=object(),
         ),

--- a/src/backend/tests/community/core/bot_config_manifest/apply/test_apply_service_lifecycle.py
+++ b/src/backend/tests/community/core/bot_config_manifest/apply/test_apply_service_lifecycle.py
@@ -55,8 +55,8 @@ from agentclaw.community.core.repository.implementations.bot.config_manifest_app
     BotConfigManifestApplyRepository,
 )
 
-from agentclaw.community.core.bot_config_manifest.apply.entry_fetch import (
-    EntryFetcher,
+from agentclaw.community.core.bot_config_manifest.apply.source_resolver import (
+    DeclaredSourceResolver,
 )
 from ._fakes import (
     FakeActivationService,
@@ -201,7 +201,7 @@ def world():
         upload_service_provider=lambda: FakeSkillUploadService(),
         capability_reader_provider=lambda: FakeCapabilityReader(),
         package_validator_provider=lambda: real_validator(),
-        entry_fetcher_provider=lambda: EntryFetcher(
+        entry_fetcher_provider=lambda: DeclaredSourceResolver(
             FakeManifestContent(), FakeCredentials(), FakeObjectStore()
         ),
         # W6's materialiser: this suite's document declares no resources,

--- a/src/backend/tests/community/core/bot_config_manifest/apply/test_apply_service_uses_strategy.py
+++ b/src/backend/tests/community/core/bot_config_manifest/apply/test_apply_service_uses_strategy.py
@@ -19,7 +19,7 @@ from agentclaw.community.core.bot_config_manifest.apply.delivery import (
     MaterialiserPorts,
     TeclawDelivery,
 )
-from agentclaw.community.core.bot_config_manifest.apply.entry_fetch import EntryFetcher
+from agentclaw.community.core.bot_config_manifest.apply.source_resolver import DeclaredSourceResolver
 from agentclaw.community.core.bot_config_manifest.apply.order import ApplyPhase
 from agentclaw.community.core.bot_config_manifest.apply.outcomes import ApplyStatus
 from agentclaw.community.core.bot_config_manifest.repository.apply_models import (  # noqa: F401
@@ -147,7 +147,7 @@ def _world(*, bot, platform_managed, platform_activation=None, redeliver=None):
             upload_service=FakeSkillUploadService(),
             capability_reader=FakeCapabilityReader(),
             package_validator=real_validator(),
-            entry_fetcher=EntryFetcher(
+            entry_fetcher=DeclaredSourceResolver(
                 FakeManifestContent(), FakeCredentials(), FakeObjectStore()
             ),
             resource_service=FakeResourceFileService(),
@@ -165,7 +165,7 @@ def _world(*, bot, platform_managed, platform_activation=None, redeliver=None):
         upload_service_provider=lambda: FakeSkillUploadService(),
         capability_reader_provider=lambda: FakeCapabilityReader(),
         package_validator_provider=lambda: real_validator(),
-        entry_fetcher_provider=lambda: EntryFetcher(
+        entry_fetcher_provider=lambda: DeclaredSourceResolver(
             FakeManifestContent(), FakeCredentials(), FakeObjectStore()
         ),
         resource_service_provider=lambda: FakeResourceFileService(),

--- a/src/backend/tests/community/core/bot_config_manifest/apply/test_apply_task.py
+++ b/src/backend/tests/community/core/bot_config_manifest/apply/test_apply_task.py
@@ -63,8 +63,8 @@ from agentclaw.community.core.repository.implementations.bot.config_manifest_app
 )
 from agentclaw.community.core.task_queue.types import Complete
 
-from agentclaw.community.core.bot_config_manifest.apply.entry_fetch import (
-    EntryFetcher,
+from agentclaw.community.core.bot_config_manifest.apply.source_resolver import (
+    DeclaredSourceResolver,
 )
 from ._fakes import (
     FakeActivationService,
@@ -181,7 +181,7 @@ def _service(db, *, scripts, manifests=None, queue=None):
         upload_service_provider=lambda: FakeSkillUploadService(),
         capability_reader_provider=lambda: FakeCapabilityReader(),
         package_validator_provider=lambda: real_validator(),
-        entry_fetcher_provider=lambda: EntryFetcher(
+        entry_fetcher_provider=lambda: DeclaredSourceResolver(
             FakeManifestContent(), FakeCredentials(), FakeObjectStore()
         ),
         # W6's resources materialiser and W7's git transport: unreached by

--- a/src/backend/tests/community/core/bot_config_manifest/apply/test_cli_tools_materialiser.py
+++ b/src/backend/tests/community/core/bot_config_manifest/apply/test_cli_tools_materialiser.py
@@ -37,7 +37,7 @@ from ..cli_tools._fakes import (
     elf,
     FakeCliToolRepo,
     FakeDelivery,
-    FakeEntryFetcher,
+    FakeDeclaredSourceResolver,
     FakeObjectStorage,
 )
 
@@ -82,7 +82,7 @@ def _service(*, content=_TOOL, digest=_DIGEST, delivery=None):
     oss = FakeObjectStorage()
     repo = FakeCliToolRepo()
     delivery = delivery if delivery is not None else FakeDelivery()
-    fetcher = FakeEntryFetcher(content=content, digest=digest)
+    fetcher = FakeDeclaredSourceResolver(content=content, digest=digest)
     service = CliToolService(
         repo=repo,
         store=CliToolStore(object_storage=oss, store_base=lambda: _BASE),
@@ -149,7 +149,7 @@ async def test_the_materialiser_adds_no_fetch_of_its_own() -> None:
     source = inspect.getsource(
         inspect.getmodule(CliToolsMaterialiser)
     )
-    for forbidden in ("entry_fetcher", "EntryFetcher", "unpack_archive", "verify_amd64"):
+    for forbidden in ("entry_fetcher", "DeclaredSourceResolver", "unpack_archive", "verify_amd64"):
         assert forbidden not in source, f"the materialiser names {forbidden!r}"
 
 

--- a/src/backend/tests/community/core/bot_config_manifest/apply/test_entry_delivery.py
+++ b/src/backend/tests/community/core/bot_config_manifest/apply/test_entry_delivery.py
@@ -244,7 +244,7 @@ def test_a_blob_files_nothing_and_answers_with_its_own_digest():
     the delivery's own rather than a hash of the caller's bytes — the receipt
     this entry answers for is the one already in the store — so the caller's
     bytes here are deliberately *different* ones, and the answer is still the
-    fetch's digest. ``test_entry_fetch`` pins the same property end to end:
+    fetch's digest. ``test_source_resolver`` pins the same property end to end:
     one fetch, one receipt, `file` adds none.
     """
     delivery = _blob(b"body", digest="sha256:feed")

--- a/src/backend/tests/community/core/bot_config_manifest/apply/test_entry_delivery.py
+++ b/src/backend/tests/community/core/bot_config_manifest/apply/test_entry_delivery.py
@@ -28,6 +28,8 @@ from agentclaw.community.core.bot_config_manifest.fetch.guarded_fetcher import (
     FetchRefusedError,
 )
 
+from ._fakes import FakeManifestContent, make_context
+
 
 def _blob(content: bytes = b"body", **kw) -> BlobDelivery:
     return BlobDelivery(
@@ -58,6 +60,7 @@ def _git(
     moved_from: str | None = None,
     auth: str | None = None,
     refuse: str | None = None,
+    store=None,
 ) -> GitDelivery:
     def _read(subpath=None, file_limit=None):
         if refuse is not None:
@@ -76,7 +79,10 @@ def _git(
             subpath=subpath,
             moved_from=moved_from,
             auth=auth,
-        )
+        ),
+        # The store the git road is handed when its fetcher builds the
+        # delivery: this is the road that still owes a write.
+        store if store is not None else FakeManifestContent(),
     )
 
 
@@ -94,15 +100,23 @@ def test_both_implementations_satisfy_the_protocol(delivery):
 
 
 def test_the_two_roads_disagree_on_exactly_the_two_questions_that_differ():
-    """``is_tree`` and ``needs_receipt`` are the whole discriminating surface.
+    """``is_tree`` and what ``file`` does are the whole discriminating surface.
 
-    Everything else is answered on both roads. If a third question ever needs
-    asking, this is where it becomes visible as a design decision rather than
-    an ``isinstance`` sneaking back in.
+    Everything else is answered on both roads. ``needs_receipt`` used to be the
+    second question and it was the caller's to ask; now the delivery answers it
+    by *acting* — the git road writes, the object road does not — and the only
+    question left on the seam is the one ``skills`` genuinely needs. If a third
+    ever needs asking, this is where it becomes visible as a design decision
+    rather than an ``isinstance`` sneaking back in.
     """
-    blob, git = _blob(), _git()
-    assert (blob.is_tree(), blob.needs_receipt()) == (False, False)
-    assert (git.is_tree(), git.needs_receipt()) == (True, True)
+    blob, git = _blob(), _git(store=FakeManifestContent())
+    ctx = make_context()
+    assert blob.is_tree() is False
+    assert git.is_tree() is True
+
+    blob.file(ctx, b"body", category="skills", entry_identity="s1")
+    git.file(ctx, b"body", category="skills", entry_identity="s1")
+    assert git.store.store_calls and not hasattr(blob, "store")
 
 
 # ── BlobDelivery ─────────────────────────────────────────────────────────────
@@ -161,8 +175,6 @@ def test_the_blob_road_answers_the_remaining_questions_off_its_payload():
     assert delivery.content_type() == "application/zip"
     assert delivery.note() == "stood in (keep_last)"
     assert delivery.source_url() == "https://content.example/x.zip"
-    # No second write is owed, so no credential name rides one.
-    assert delivery.auth() is None
 
 
 # ── GitDelivery ──────────────────────────────────────────────────────────────
@@ -198,11 +210,54 @@ def test_a_moved_ref_becomes_the_note_and_names_both_shas():
     assert note is not None and "b" * 40 in note and "c" * 40 in note
 
 
-def test_a_tree_carries_its_receipt_identity_and_credential_name():
-    delivery = _git(auth="ci-token", subpath="pkg")
-    assert delivery.auth() == "ci-token"
-    receipt = delivery.receipt_url()
-    assert "c" * 40 in receipt and "pkg" in receipt
+def test_a_tree_files_under_its_receipt_identity_and_credential_name():
+    """What the caller used to assemble out of ``receipt_url`` and ``auth``,
+    the delivery now puts on the receipt row itself."""
+    content = FakeManifestContent()
+    delivery = _git(auth="ci-token", subpath="pkg", store=content)
+
+    digest = delivery.file(
+        make_context(apply_id="apply-1"),
+        b"canonical-zip",
+        category="skills",
+        entry_identity="s1",
+        content_type="application/zip",
+    )
+
+    import hashlib
+
+    assert digest == "sha256:" + hashlib.sha256(b"canonical-zip").hexdigest()
+    call = content.store_calls[-1]
+    assert call["credential_name"] == "ci-token"
+    assert "c" * 40 in call["source_url"] and "pkg" in call["source_url"]
+    assert call["apply_id"] == "apply-1"
+    assert call["entry_identity"] == "s1"
+
+
+def test_a_blob_files_nothing_and_answers_with_its_own_digest():
+    """The object road filed what it read on its way past, so a second write
+    would be one entry with two receipts and ``keep_last`` reading whichever it
+    found.
+
+    Structural, not merely observed: this road holds no store to write
+    through, which is the strongest form the statement takes. The digest is
+    the delivery's own rather than a hash of the caller's bytes — the receipt
+    this entry answers for is the one already in the store — so the caller's
+    bytes here are deliberately *different* ones, and the answer is still the
+    fetch's digest. ``test_entry_fetch`` pins the same property end to end:
+    one fetch, one receipt, `file` adds none.
+    """
+    delivery = _blob(b"body", digest="sha256:feed")
+
+    digest = delivery.file(
+        make_context(),
+        b"some-other-bytes",
+        category="skills",
+        entry_identity="s1",
+    )
+
+    assert digest == "sha256:feed"
+    assert not hasattr(delivery, "store")
 
 
 def test_a_tree_offers_no_digest_for_the_pin_belt_to_compare():

--- a/src/backend/tests/community/core/bot_config_manifest/apply/test_entry_fetch.py
+++ b/src/backend/tests/community/core/bot_config_manifest/apply/test_entry_fetch.py
@@ -448,7 +448,7 @@ def test_the_funnel_requires_a_category_by_keyword():
         assert category.default is inspect.Parameter.empty
 
 
-# --- the W7 declared-source front door: fetch_declared / file_bytes ---
+# --- the W7 declared-source front door: fetch_declared ---
 
 GIT_URL = "https://git.corp/repo.git"
 _FAKE_SHA = "a" * 40
@@ -723,12 +723,35 @@ def test_git_credentials_reach_the_transport_as_headers(rig):
     assert git.headers == [{"X-Custom-Auth": "payload-of-ci-token"}]
 
 
-def test_file_bytes_files_canonical_entry_bytes_with_the_store(rig):
+def _git_delivery(pipeline, ctx, *, subpath="pkg", auth=None):
+    """The delivery the git road hands back for a source named ``"app"``.
+
+    Built by ``GitSourceFetcher`` rather than by hand, so the store it files
+    through is the one the fetcher bound it to — which is the whole of what
+    replaced the caller reaching for ``receipt_url`` and ``auth``.
+    """
+    return pipeline.fetch_declared(
+        ctx, entry={"from": "app"}, category="skills", entry_identity="s1"
+    )
+
+
+def _git_source_ctx(*, subpath="pkg", auth=None, **kwargs):
+    source = {"protocol": "git", "url": GIT_URL, "ref": "main", "subpath": subpath}
+    if auth is not None:
+        source["auth"] = auth
+    return make_context(
+        source_session=_session(_ScriptedGit(), sources={"app": source}),
+        **kwargs,
+    )
+
+
+def test_a_git_delivery_files_canonical_entry_bytes_with_the_store(rig):
     content, _, pipeline = rig
-    ctx = make_context(apply_id="apply-1")
-    digest = pipeline.file_bytes(
-        ctx, content=b"canonical-zip",
-        source_url=git_receipt_url(GIT_URL, _FAKE_SHA, "pkg"),
+    ctx = _git_source_ctx(apply_id="apply-1")
+    delivery = _git_delivery(pipeline, ctx)
+
+    digest = delivery.file(
+        ctx, b"canonical-zip",
         category="skills", entry_identity="s1",
         content_type="application/zip",
     )
@@ -906,21 +929,45 @@ def test_entry_level_auth_on_an_inline_git_source_is_refused(rig):
         )
 
 
-def test_file_bytes_files_the_credential_name_on_git_receipts(rig):
+def test_a_git_delivery_files_the_credential_name_on_git_receipts(rig):
     content, _, pipeline = rig
-    ctx = make_context(apply_id="apply-1")
-    pipeline.file_bytes(
-        ctx, content=b"canonical-zip",
-        source_url=git_receipt_url(GIT_URL, _FAKE_SHA, "pkg"),
-        category="skills", entry_identity="s1", credential_name="ci-token",
+    ctx = _git_source_ctx(auth="ci-token", apply_id="apply-1")
+    delivery = _git_delivery(pipeline, ctx)
+
+    delivery.file(
+        ctx, b"canonical-zip", category="skills", entry_identity="s1",
     )
     # The lineage answers "which named credential distributed this content"
-    # identically on the URL and git roads.
+    # identically on the object and git roads — and the caller no longer
+    # threads the name, because the source the delivery came from carries it.
     assert content.store_calls[-1]["credential_name"] == "ci-token"
 
 
+def test_the_object_road_files_once_and_its_delivery_adds_nothing(objects_rig):
+    """The other half of the seam's filing rule, end to end.
+
+    The fetch filed what it read on its way past, so the caller's
+    unconditional ``file`` must not make a second receipt for one entry —
+    ``keep_last`` would then read whichever it found first.
+    """
+    content, objects, pipeline = objects_rig
+    objects.put("b", "k", BODY, access_key_id=_OBJ_AK)
+    ctx = _oss_ctx()
+
+    delivery = pipeline.fetch_declared(
+        ctx, entry={"from": "s"}, category="identity", entry_identity="soul"
+    )
+    assert len(content.store_calls) == 1
+
+    digest = delivery.file(
+        ctx, delivery.single(), category="identity", entry_identity="soul"
+    )
+    assert len(content.store_calls) == 1
+    assert digest == DIGEST
+
+
 def test_the_git_road_carries_the_auth_and_the_category_limit(rig):
-    _, _, pipeline = rig
+    content, _, pipeline = rig
     git = _ScriptedGit()
     ctx = make_context(source_session=_session(git, sources={
         "app": {"protocol": "git", "url": GIT_URL, "ref": "main", "auth": "ci-token"},
@@ -931,7 +978,10 @@ def test_the_git_road_carries_the_auth_and_the_category_limit(rig):
     # refuses a member by DECLARED size against the category number, the
     # same vocabulary the URL road's transport enforces.
     assert decl.source.file_limit == 1 * 1024 * 1024
-    assert decl.auth() == "ci-token"
+    # The credential NAME rides the source, and it is what lands on the
+    # receipt when the caller asks this delivery to file its bytes.
+    decl.file(ctx, b"one-file", category="identity", entry_identity="x")
+    assert content.store_calls[-1]["credential_name"] == "ci-token"
 
 
 # --- the oss road carries a signing credential (defect D4) ------------------

--- a/src/backend/tests/community/core/bot_config_manifest/apply/test_entry_fetch.py
+++ b/src/backend/tests/community/core/bot_config_manifest/apply/test_entry_fetch.py
@@ -9,7 +9,8 @@ and that a secret cannot ride out through an error.
 W2's guarded HTTPS transport is no longer one of them. It served the
 bare-string ``source:`` road, which had one caller left (``cli_tools``, whose
 management API now takes an upload) and no way to be declared; the road and its
-entry point are gone, and the policy above lives on ``acquire_object``.
+entry point are gone, and the policy above lives on the object road's own
+fetcher, reached here through the front door the way production reaches it.
 """
 from __future__ import annotations
 
@@ -31,6 +32,7 @@ from agentclaw.community.core.bot_config_manifest.apply.entry_fetch import (
     EntryFetcher,
 )
 from agentclaw.community.core.bot_config_manifest.apply.source_fetchers import (
+    ObjectStoreFetcher,
     object_receipt_url,
 )
 from agentclaw.community.core.bot_config_manifest.support_matrix import SourceKind
@@ -114,18 +116,16 @@ def rig():
     return content, credentials, EntryFetcher(content, credentials, FakeObjectStore())
 
 
-#: The object road's coordinates, and the address a receipt for them is filed
-#: under. The endpoint and the key pair come off the credential in production;
-#: the tests that go through ``fetch_declared`` prove that, and the ones that
-#: call :meth:`EntryFetcher.acquire_object` directly are past the point where
-#: it was resolved.
-_TARGET = ObjectStoreTarget(
-    endpoint=_OBJ_ENDPOINT,
-    bucket="b",
-    access_key_id=_OBJ_AK,
-    secret_access_key="the-secret-half",
-    region="cn-shanghai",
-)
+#: The object road's coordinates, as a document declares them, and the address
+#: a receipt for them is filed under. The endpoint and the key pair are absent
+#: on purpose: they come off the credential in production, which is what
+#: driving these tests through the front door proves.
+_OSS_SOURCE = {
+    "protocol": "oss",
+    "bucket": "b",
+    "key": "k",
+    "auth": "oss-cred",
+}
 _ADDRESS = object_receipt_url("b", "k")
 
 
@@ -139,17 +139,33 @@ def _store_holding(content: FakeManifestContent, body: bytes = BODY) -> None:
     content.store_calls.clear()
 
 
-def _acquire(pipeline, *, ctx=None, digest=None, keep_last=False, auth="oss-cred"):
-    return pipeline.acquire_object(
-        ctx if ctx is not None else make_context(),
-        target=_TARGET,
-        key="k",
-        digest=digest,
-        auth=auth,
-        category="identity",
-        keep_last=keep_last,
-        entry_identity="data/faq.csv",
+def _oss_ctx(**kwargs):
+    """A context whose session declares :data:`_OSS_SOURCE` as ``"s"``."""
+    return make_context(
+        source_session=_session(_ScriptedGit(), sources={"s": _OSS_SOURCE}),
+        **kwargs,
     )
+
+
+def _acquire(pipeline, *, ctx=None, digest=None, keep_last=False):
+    """One object-road fetch, driven the way production reaches it.
+
+    Through the front door with a declared ``oss`` source — so the credential
+    resolves the target, exactly as it does in an apply — and unwrapped back to
+    the :class:`FetchedEntry` these tests make their statements about. The road
+    itself lives on ``source_fetchers.ObjectStoreFetcher``; reaching it through
+    the dispatcher is what keeps these tests pinned to the pipeline rather than
+    to one class's private method.
+    """
+    entry = {"from": "s", "on_fetch_failure": "keep_last" if keep_last else "fail"}
+    if digest is not None:
+        entry["digest"] = digest
+    return pipeline.fetch_declared(
+        ctx if ctx is not None else _oss_ctx(),
+        entry=entry,
+        category="identity",
+        entry_identity="data/faq.csv",
+    ).fetched
 
 
 # --- the store-first policy, on the road that still has a network ---------
@@ -386,7 +402,7 @@ def test_a_time_exhausted_budget_refuses_before_touching_the_network(
 
     objects.put("b", "k", BODY, access_key_id=_OBJ_AK)
     ctx = _with_budget(
-        make_context(), ApplyFetchBudget(deadline=0.0, total_bytes=10**9)
+        _oss_ctx(), ApplyFetchBudget(deadline=0.0, total_bytes=10**9)
     )
 
     with pytest.raises(EntryFetchError) as excinfo:
@@ -405,7 +421,7 @@ def test_a_byte_exhausted_budget_refuses_the_next_entry(objects_rig):
 
     objects.put("b", "k", BODY, access_key_id=_OBJ_AK)
     budget = ApplyFetchBudget(deadline=1e18, total_bytes=len(BODY), clock=lambda: 0.0)
-    ctx = _with_budget(make_context(), budget)
+    ctx = _with_budget(_oss_ctx(), budget)
 
     first = _acquire(pipeline, ctx=ctx)
     assert first.content == BODY  # the first read fits exactly
@@ -426,7 +442,7 @@ def test_the_funnel_requires_a_category_by_keyword():
     the PR's two blocking-level type issues)."""
     import inspect
 
-    for entry_point in (EntryFetcher.fetch_declared, EntryFetcher.acquire_object):
+    for entry_point in (EntryFetcher.fetch_declared, ObjectStoreFetcher._acquire):
         category = inspect.signature(entry_point).parameters["category"]
         assert category.kind is inspect.Parameter.KEYWORD_ONLY
         assert category.default is inspect.Parameter.empty

--- a/src/backend/tests/community/core/bot_config_manifest/apply/test_identity_materialiser.py
+++ b/src/backend/tests/community/core/bot_config_manifest/apply/test_identity_materialiser.py
@@ -18,8 +18,8 @@ import asyncio
 from pathlib import Path
 from types import SimpleNamespace
 
-from agentclaw.community.core.bot_config_manifest.apply.entry_fetch import (
-    EntryFetcher,
+from agentclaw.community.core.bot_config_manifest.apply.source_resolver import (
+    DeclaredSourceResolver,
 )
 from agentclaw.community.core.bot_config_manifest.apply.materialisers.identity import (
     IdentityMaterialiser,
@@ -216,7 +216,7 @@ def test_one_failed_fetch_aborts_the_whole_category_no_writes():
     objects.make_unavailable("down-bucket", "source answered 404")
     materialiser = IdentityMaterialiser(
         identity,
-        EntryFetcher(FakeManifestContent(), FakeObjectCredentials(), objects),
+        DeclaredSourceResolver(FakeManifestContent(), FakeObjectCredentials(), objects),
     )
 
     resolved = _run(
@@ -249,7 +249,7 @@ def test_keep_last_reuses_the_platform_copy_when_the_source_is_down():
     objects.make_unavailable(OSS_BUCKET, "source transport failed")
     materialiser = IdentityMaterialiser(
         identity,
-        EntryFetcher(content, FakeObjectCredentials(), objects),
+        DeclaredSourceResolver(content, FakeObjectCredentials(), objects),
     )
 
     result, plan, written = _run(
@@ -381,7 +381,7 @@ def test_an_omitted_on_fetch_failure_defaults_to_keep_last():
     objects.make_unavailable(OSS_BUCKET, "source transport failed")
     materialiser = IdentityMaterialiser(
         identity,
-        EntryFetcher(content, FakeObjectCredentials(), objects),
+        DeclaredSourceResolver(content, FakeObjectCredentials(), objects),
     )
 
     result, _, written = _run(

--- a/src/backend/tests/community/core/bot_config_manifest/apply/test_resources_materialiser.py
+++ b/src/backend/tests/community/core/bot_config_manifest/apply/test_resources_materialiser.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime
+from types import SimpleNamespace
 from typing import Any
 
 from agentclaw.community.core.bot_config_manifest.apply.entry_delivery import (
@@ -69,6 +70,41 @@ def _src(key: str, **extra) -> dict:
     return {"protocol": "oss", "bucket": _BUCKET, "key": key, "auth": "oss-cred", **extra}
 
 
+class _RecordingStore:
+    """The content store a :class:`GitDelivery` files through, recorded.
+
+    The git road's delivery now writes its own receipt, so the double that
+    used to record ``file_bytes`` records the store call instead — in the
+    store's own vocabulary, which is what the real one receives.
+    """
+
+    def __init__(self, filed: list[dict[str, Any]]) -> None:
+        self._filed = filed
+
+    def store(
+        self,
+        fetched,
+        *,
+        scope,
+        source_url,
+        credential_name=None,
+        modifier="",
+        apply_id=None,
+        category=None,
+        entry_identity=None,
+    ):
+        self._filed.append(
+            {
+                "content": fetched.bytes,
+                "source_url": source_url,
+                "category": category,
+                "entry_identity": entry_identity,
+                "credential_name": credential_name,
+            }
+        )
+        return SimpleNamespace(digest=fetched.sha256)
+
+
 class _StubEntryFetcher:
     """``EntryFetcher``'s test double, every call recorded.
 
@@ -95,8 +131,10 @@ class _StubEntryFetcher:
         self.git_trees = git_trees or {}
         self.moved_from = moved_from
         #: When set, ``fetch_declared`` answers with it verbatim — the way to
-        #: stand in for what ``_git_keep_last`` hands back.
+        #: stand in for what the git road's ``_keep_last`` hands back.
         self.declared_override = None
+        #: The store a git delivery files through, recording into ``filed``.
+        self.store = _RecordingStore(self.filed)
 
     def fetch(
         self,
@@ -187,7 +225,8 @@ class _StubEntryFetcher:
                     auth=decl.get("auth"),
                     url=key,
                     moved=self.moved_from,
-                )
+                ),
+                self.store,
             )
 
         url = decl.get("url") or f"oss://{decl.get('bucket')}/{decl.get('key')}"
@@ -205,28 +244,7 @@ class _StubEntryFetcher:
             )
         )
 
-    def file_bytes(
-        self,
-        ctx: Any,
-        *,
-        content: bytes,
-        source_url: str,
-        category: str,
-        entry_identity: str | None = None,
-        content_type: str | None = None,
-        credential_name: str | None = None,
-    ) -> str:
-        """Records the audit copy the git road files, exactly as the real one."""
-        self.filed.append(
-            {
-                "content": content,
-                "source_url": source_url,
-                "category": category,
-                "entry_identity": entry_identity,
-                "credential_name": credential_name,
-            }
-        )
-        return "sha256:filed"
+
 
 
 def _compose(source_subpath: str | None, entry_subpath: str | None) -> str | None:

--- a/src/backend/tests/community/core/bot_config_manifest/apply/test_resources_materialiser.py
+++ b/src/backend/tests/community/core/bot_config_manifest/apply/test_resources_materialiser.py
@@ -105,8 +105,8 @@ class _RecordingStore:
         return SimpleNamespace(digest=fetched.sha256)
 
 
-class _StubEntryFetcher:
-    """``EntryFetcher``'s test double, every call recorded.
+class _StubDeclaredSourceResolver:
+    """``DeclaredSourceResolver``'s test double, every call recorded.
 
     Addresses ending in ``gone`` stand in for unreachable sources. With
     ``fixed_body``, every address serves the same bytes (an archive); without
@@ -130,7 +130,7 @@ class _StubEntryFetcher:
         #: repository url → the whole tree it delivers, path → bytes.
         self.git_trees = git_trees or {}
         self.moved_from = moved_from
-        #: When set, ``fetch_declared`` answers with it verbatim — the way to
+        #: When set, ``resolve`` answers with it verbatim — the way to
         #: stand in for what the git road's ``_keep_last`` hands back.
         self.declared_override = None
         #: The store a git delivery files through, recording into ``filed``.
@@ -166,7 +166,7 @@ class _StubEntryFetcher:
         )
         return FetchedEntry(content=body, digest="sha256:stub", from_store=False)
 
-    def fetch_declared(
+    def resolve(
         self,
         ctx: Any,
         *,
@@ -248,7 +248,7 @@ class _StubEntryFetcher:
 
 
 def _compose(source_subpath: str | None, entry_subpath: str | None) -> str | None:
-    """The composition ``EntryFetcher`` performs, so the double addresses the
+    """The composition ``DeclaredSourceResolver`` performs, so the double addresses the
     same tree the real fetcher would."""
     if entry_subpath is None:
         return source_subpath
@@ -359,7 +359,7 @@ def test_fake_resource_service_records_uploads_and_deletes():
 
 def test_file_entry_from_a_declared_source_resolves_to_intent_bytes():
     svc = FakeResourceFileService()
-    stub = _StubEntryFetcher()
+    stub = _StubDeclaredSourceResolver()
     m = ResourcesMaterialiser(svc, stub)
     ctx = make_context(engine_type="claude_code")
     resolved = _run(
@@ -385,7 +385,7 @@ def test_file_entry_from_a_declared_source_resolves_to_intent_bytes():
 
 def test_file_entry_inline_content_never_fetches():
     svc = FakeResourceFileService()
-    stub = _StubEntryFetcher()
+    stub = _StubDeclaredSourceResolver()
     m = ResourcesMaterialiser(svc, stub)
     ctx = make_context(engine_type="claude_code")
     resolved = _run(m.resolve(ctx, [{"path": "notes/r.md", "content": "# rules"}]))
@@ -397,7 +397,7 @@ def test_file_entry_inline_content_never_fetches():
 
 def test_fetch_failure_aborts_whole_category():
     svc = FakeResourceFileService()
-    m = ResourcesMaterialiser(svc, _StubEntryFetcher())
+    m = ResourcesMaterialiser(svc, _StubDeclaredSourceResolver())
     ctx = make_context(engine_type="claude_code")
     resolved = _run(
         m.resolve(
@@ -414,7 +414,7 @@ def test_fetch_failure_aborts_whole_category():
 
 def test_bad_path_entry_is_a_resolve_failure():
     svc = FakeResourceFileService()
-    m = ResourcesMaterialiser(svc, _StubEntryFetcher())
+    m = ResourcesMaterialiser(svc, _StubDeclaredSourceResolver())
     ctx = make_context(engine_type="claude_code")
     resolved = _run(m.resolve(ctx, [{"path": 123}]))
     assert not resolved.ok
@@ -426,7 +426,7 @@ def test_bad_path_entry_is_a_resolve_failure():
 def test_dir_entry_expands_members_under_path():
     archive = _tgz({"top/a.txt": b"AAA", "top/sub/b.txt": b"BBB"})
     svc = FakeResourceFileService()
-    m = ResourcesMaterialiser(svc, _StubEntryFetcher(archive))
+    m = ResourcesMaterialiser(svc, _StubDeclaredSourceResolver(archive))
     ctx = make_context(engine_type="claude_code")
     resolved = _run(
         m.resolve(
@@ -457,7 +457,7 @@ def test_dir_entry_expands_members_under_path():
 
 def test_bad_archive_is_a_resolve_failure_and_nothing_reaches_the_bot():
     svc = FakeResourceFileService()
-    m = ResourcesMaterialiser(svc, _StubEntryFetcher(b"not-an-archive"))
+    m = ResourcesMaterialiser(svc, _StubDeclaredSourceResolver(b"not-an-archive"))
     ctx = make_context(engine_type="claude_code")
     resolved = _run(
         m.resolve(
@@ -472,7 +472,7 @@ def test_bad_archive_is_a_resolve_failure_and_nothing_reaches_the_bot():
 
 def test_dir_unpack_missing_is_rejected_at_resolve():
     svc = FakeResourceFileService()
-    m = ResourcesMaterialiser(svc, _StubEntryFetcher(_tgz({"a.txt": b"x"})))
+    m = ResourcesMaterialiser(svc, _StubDeclaredSourceResolver(_tgz({"a.txt": b"x"})))
     ctx = make_context(engine_type="claude_code")
     resolved = _run(
         m.resolve(ctx, [{"path": "wrap/", "source": _src("tree.tgz")}])
@@ -483,7 +483,7 @@ def test_dir_unpack_missing_is_rejected_at_resolve():
 
 def test_nested_paths_abort_category():
     svc = FakeResourceFileService()
-    m = ResourcesMaterialiser(svc, _StubEntryFetcher(_tgz({"a.txt": b"x"})))
+    m = ResourcesMaterialiser(svc, _StubDeclaredSourceResolver(_tgz({"a.txt": b"x"})))
     ctx = make_context(engine_type="claude_code")
     resolved = _run(
         m.resolve(
@@ -507,7 +507,7 @@ def test_nested_paths_abort_category():
 
 def test_plan_classifies_present_as_updated_and_new_as_created():
     svc = FakeResourceFileService(exists_paths={"data/a.md"})
-    m = ResourcesMaterialiser(svc, _StubEntryFetcher())
+    m = ResourcesMaterialiser(svc, _StubDeclaredSourceResolver())
     ctx = make_context(engine_type="claude_code")
     resolved = _run(
         m.resolve(
@@ -539,7 +539,7 @@ def test_plan_addresses_the_bot_owner_not_the_manifest_storage_key():
     derives. A test that left them equal would never catch the swap.
     """
     svc = FakeResourceFileService()
-    m = ResourcesMaterialiser(svc, _StubEntryFetcher())
+    m = ResourcesMaterialiser(svc, _StubDeclaredSourceResolver())
     ctx = make_context(
         bot_id="b_1",
         owner_id="u_owner",
@@ -575,7 +575,7 @@ def test_declared_trees_report_as_removals_not_member_rows():
     """
     archive = _tgz({"a.txt": b"AAA"})
     svc = FakeResourceFileService(exists_paths={"established/a.txt"})
-    m = ResourcesMaterialiser(svc, _StubEntryFetcher(archive))
+    m = ResourcesMaterialiser(svc, _StubDeclaredSourceResolver(archive))
     ctx = make_context(engine_type="claude_code")
     resolved = _run(
         m.resolve(
@@ -623,7 +623,7 @@ def _write_through(m, ctx, entries):
 def test_write_replaces_the_tree_then_uploads_every_member():
     svc = FakeResourceFileService(exists_paths={"wrap/old.txt"})
     archive = _tgz({"a.txt": b"AAA", "sub/b.txt": b"BBB"})
-    m = ResourcesMaterialiser(svc, _StubEntryFetcher(archive))
+    m = ResourcesMaterialiser(svc, _StubDeclaredSourceResolver(archive))
     ctx = make_context(engine_type="claude_code")
     plan, results = _write_through(
         m,
@@ -659,7 +659,7 @@ def test_write_deletes_the_declared_tree_without_the_trailing_slash():
     """
     svc = FakeResourceFileService(exists_paths={"wrap/old.txt"})
     archive = _tgz({"a.txt": b"AAA"})
-    m = ResourcesMaterialiser(svc, _StubEntryFetcher(archive))
+    m = ResourcesMaterialiser(svc, _StubDeclaredSourceResolver(archive))
     ctx = make_context(engine_type="claude_code")
     _write_through(
         m, ctx, [{"path": "wrap/", "unpack": "tar.gz", "source": _src("t")}]
@@ -679,7 +679,7 @@ def test_a_silently_failed_tree_delete_fails_its_members():
         exists_paths={"tools"}, fail_deletes={"tools"}
     )
     archive = _tgz({"a.md": b"A"})
-    m = ResourcesMaterialiser(svc, _StubEntryFetcher(archive))
+    m = ResourcesMaterialiser(svc, _StubDeclaredSourceResolver(archive))
     ctx = make_context(engine_type="claude_code")
     plan, results = _write_through(
         m,
@@ -707,7 +707,7 @@ def test_a_failed_delete_of_an_absent_tree_is_not_a_failure():
     """
     svc = FakeResourceFileService(fail_deletes={"tools"})
     archive = _tgz({"a.md": b"A"})
-    m = ResourcesMaterialiser(svc, _StubEntryFetcher(archive))
+    m = ResourcesMaterialiser(svc, _StubDeclaredSourceResolver(archive))
     ctx = make_context(engine_type="claude_code")
     plan, results = _write_through(
         m,
@@ -722,7 +722,7 @@ def test_write_addresses_the_bot_owner():
     """The write chain gets the owner's address, the router's own way."""
     svc = FakeResourceFileService()
     archive = _tgz({"a.txt": b"AAA"})
-    m = ResourcesMaterialiser(svc, _StubEntryFetcher(archive))
+    m = ResourcesMaterialiser(svc, _StubDeclaredSourceResolver(archive))
     ctx = make_context(
         bot_id="b_1",
         owner_id="u_owner",
@@ -763,7 +763,7 @@ def test_write_is_player_setup_convergent():
     archive = _tgz({"a.txt": b"AAA"})
     svc = FakeResourceFileService()
     for _ in range(2):
-        m = ResourcesMaterialiser(svc, _StubEntryFetcher(archive))
+        m = ResourcesMaterialiser(svc, _StubDeclaredSourceResolver(archive))
         ctx = make_context(engine_type="claude_code")
         _write_through(
             m,
@@ -783,7 +783,7 @@ def test_write_failure_yields_failed_entry_per_member():
 
     svc = _Buggy(exists_paths=set())
     archive = _tgz({"a.txt": b"A", "b.txt": "B".encode()})
-    m = ResourcesMaterialiser(svc, _StubEntryFetcher(archive))
+    m = ResourcesMaterialiser(svc, _StubDeclaredSourceResolver(archive))
     ctx = make_context(engine_type="claude_code")
     plan, results = _write_through(
         m,
@@ -867,7 +867,7 @@ def test_each_form_fetches_under_its_own_category():
     """
     archive = _tgz({"a.txt": b"x"})
     svc = FakeResourceFileService()
-    stub = _StubEntryFetcher(archive)
+    stub = _StubDeclaredSourceResolver(archive)
     m = ResourcesMaterialiser(svc, stub)
     ctx = make_context(engine_type="claude_code")
     resolved = _run(
@@ -900,7 +900,7 @@ def test_keep_last_fallback_surfaces_as_the_entries_note():
     the contract broken quietly.
     """
 
-    class _FallingBack(_StubEntryFetcher):
+    class _FallingBack(_StubDeclaredSourceResolver):
         def fetch(self, ctx, **kwargs):
             entry = super().fetch(ctx, **kwargs)
             return FetchedEntry(
@@ -930,7 +930,7 @@ def test_write_carries_the_note_onto_the_report_row():
     """The note reaches the report row — stating a keep_last fallback only in
     the log is §9.6 broken quietly."""
 
-    class _FallingBack(_StubEntryFetcher):
+    class _FallingBack(_StubDeclaredSourceResolver):
         def fetch(self, ctx, **kwargs):
             entry = super().fetch(ctx, **kwargs)
             return FetchedEntry(
@@ -964,7 +964,7 @@ def test_an_archive_member_the_chain_would_refuse_fails_at_resolve():
     """
     archive = _tgz({"a.md": b"ok", "run.sh": b"#!/bin/sh\n"})
     svc = FakeResourceFileService(exists_paths={"tools/old.md"})
-    m = ResourcesMaterialiser(svc, _StubEntryFetcher(archive))
+    m = ResourcesMaterialiser(svc, _StubDeclaredSourceResolver(archive))
     ctx = make_context(engine_type="claude_code")
     resolved = _run(
         m.resolve(
@@ -983,7 +983,7 @@ def test_an_archive_member_the_chain_would_refuse_fails_at_resolve():
 
 def test_an_extensionless_inline_file_fails_at_resolve():
     svc = FakeResourceFileService()
-    m = ResourcesMaterialiser(svc, _StubEntryFetcher())
+    m = ResourcesMaterialiser(svc, _StubDeclaredSourceResolver())
     ctx = make_context(engine_type="claude_code")
     resolved = _run(m.resolve(ctx, [{"path": "data/LICENSE", "content": "MIT"}]))
     assert not resolved.ok
@@ -1000,7 +1000,7 @@ def test_inline_content_over_the_size_cap_fails_at_resolve(
 
     monkeypatch.setattr(fs, "MAX_FILE_SIZE", 16)
     svc = FakeResourceFileService()
-    m = ResourcesMaterialiser(svc, _StubEntryFetcher())
+    m = ResourcesMaterialiser(svc, _StubDeclaredSourceResolver())
     ctx = make_context(engine_type="claude_code")
     resolved = _run(
         m.resolve(ctx, [{"path": "data/big.md", "content": "x" * 32}])
@@ -1016,7 +1016,7 @@ def test_strip_components_of_the_wrong_type_is_a_resolve_failure():
     may escape ``resolve`` — the orchestrator would abort the category with
     the exception's text in it."""
     svc = FakeResourceFileService()
-    m = ResourcesMaterialiser(svc, _StubEntryFetcher(_tgz({"a.md": b"x"})))
+    m = ResourcesMaterialiser(svc, _StubDeclaredSourceResolver(_tgz({"a.md": b"x"})))
     ctx = make_context(engine_type="claude_code")
     resolved = _run(
         m.resolve(
@@ -1050,7 +1050,7 @@ def test_a_failed_tree_replacement_fails_its_members_in_composed_words():
 
     archive = _tgz({"a.md": b"A"})
     svc = _BuggyTreeDelete(exists_paths=set())
-    m = ResourcesMaterialiser(svc, _StubEntryFetcher(archive))
+    m = ResourcesMaterialiser(svc, _StubDeclaredSourceResolver(archive))
     ctx = make_context(engine_type="claude_code")
     plan, results = _write_through(
         m,
@@ -1122,7 +1122,7 @@ def test_dry_run_and_apply_report_the_same_resources_shape():
     """
     archive = _tgz({"a.txt": b"AAA"})
     svc = FakeResourceFileService()
-    engine = _resources_engine(svc, _StubEntryFetcher(archive))
+    engine = _resources_engine(svc, _StubDeclaredSourceResolver(archive))
     ctx = make_context(engine_type="claude_code")
 
     dry = _run(
@@ -1161,7 +1161,7 @@ def test_an_empty_archive_still_audits_the_tree_removal():
     """
     archive = _tgz({})
     svc = FakeResourceFileService(exists_paths={"gone/old.md"})
-    engine = _resources_engine(svc, _StubEntryFetcher(archive))
+    engine = _resources_engine(svc, _StubDeclaredSourceResolver(archive))
     ctx = make_context(engine_type="claude_code")
 
     dry = _run(
@@ -1226,7 +1226,7 @@ def test_a_refused_member_blames_the_declared_entry_in_the_report():
     """
     archive = _tgz({"a.md": b"ok", "run.sh": b"#!/bin/sh\n"})
     svc = FakeResourceFileService(exists_paths={"tools/old.md"})
-    engine = _resources_engine(svc, _StubEntryFetcher(archive))
+    engine = _resources_engine(svc, _StubDeclaredSourceResolver(archive))
     ctx = make_context(engine_type="claude_code")
 
     report = _run(
@@ -1278,7 +1278,7 @@ def test_routed_bots_address_the_runtime_engine_workspace():
     """
     archive = _tgz({"a.txt": b"A"})
     svc = FakeResourceFileService()
-    m = ResourcesMaterialiser(svc, _StubEntryFetcher(archive))
+    m = ResourcesMaterialiser(svc, _StubDeclaredSourceResolver(archive))
     ctx = make_context(
         engine_type="claude_code", bot={"template_type": "applicationCoding"}
     )
@@ -1301,7 +1301,7 @@ def test_unrouted_bots_keep_the_active_engine():
     ]
     for overlay in cases:
         svc = FakeResourceFileService()
-        m = ResourcesMaterialiser(svc, _StubEntryFetcher(archive))
+        m = ResourcesMaterialiser(svc, _StubDeclaredSourceResolver(archive))
         ctx = make_context(engine_type="claude_code", bot=overlay)
         _write_through(
             m, ctx, [{"path": "wrap/", "unpack": "tar.gz", "source": _src("t")}]
@@ -1309,7 +1309,7 @@ def test_unrouted_bots_keep_the_active_engine():
         assert svc.delete_calls[0]["engine_type"] == "claude_code"
 
     svc = FakeResourceFileService()
-    m = ResourcesMaterialiser(svc, _StubEntryFetcher(archive))
+    m = ResourcesMaterialiser(svc, _StubDeclaredSourceResolver(archive))
     ctx = make_context(engine_type="openclaw")
     _write_through(
         m, ctx, [{"path": "wrap/", "unpack": "tar.gz", "source": _src("t")}]
@@ -1323,7 +1323,7 @@ def test_an_engineless_bot_record_falls_back_to_the_context_engine():
     factory would compose into the bot root instead of an engine dir."""
     archive = _tgz({"a.txt": b"A"})
     svc = FakeResourceFileService()
-    m = ResourcesMaterialiser(svc, _StubEntryFetcher(archive))
+    m = ResourcesMaterialiser(svc, _StubDeclaredSourceResolver(archive))
     ctx = make_context(engine_type="openclaw", bot={"active_engine": None})
     _write_through(
         m, ctx, [{"path": "wrap/", "unpack": "tar.gz", "source": _src("t")}]
@@ -1340,7 +1340,7 @@ def test_a_tilde_path_is_refused_at_resolve():
     "/" is, and the old belt (only "/", ".." segments) let it through to
     the write chain."""
     svc = FakeResourceFileService()
-    m = ResourcesMaterialiser(svc, _StubEntryFetcher())
+    m = ResourcesMaterialiser(svc, _StubDeclaredSourceResolver())
     ctx = make_context(engine_type="claude_code")
     resolved = _run(m.resolve(ctx, [{"path": "~/x.md", "content": "x"}]))
     assert not resolved.ok
@@ -1350,7 +1350,7 @@ def test_a_tilde_path_is_refused_at_resolve():
 
 def test_a_windows_drive_path_is_refused_at_resolve():
     svc = FakeResourceFileService()
-    m = ResourcesMaterialiser(svc, _StubEntryFetcher())
+    m = ResourcesMaterialiser(svc, _StubDeclaredSourceResolver())
     ctx = make_context(engine_type="claude_code")
     resolved = _run(m.resolve(ctx, [{"path": "C:evil.md", "content": "x"}]))
     assert not resolved.ok
@@ -1362,7 +1362,7 @@ def test_duplicate_declared_paths_abort_the_category():
     re-ask it, or two entries at one path produce two intents with one
     identity, two report rows, and a last-write-wins order no rule defines."""
     svc = FakeResourceFileService()
-    m = ResourcesMaterialiser(svc, _StubEntryFetcher())
+    m = ResourcesMaterialiser(svc, _StubDeclaredSourceResolver())
     ctx = make_context(engine_type="claude_code")
     resolved = _run(
         m.resolve(
@@ -1383,7 +1383,7 @@ def test_duplicate_declared_paths_abort_the_category():
 
 def test_an_unknown_unpack_kind_is_refused():
     svc = FakeResourceFileService()
-    m = ResourcesMaterialiser(svc, _StubEntryFetcher(_tgz({"a.md": b"x"})))
+    m = ResourcesMaterialiser(svc, _StubDeclaredSourceResolver(_tgz({"a.md": b"x"})))
     ctx = make_context(engine_type="claude_code")
     resolved = _run(
         m.resolve(
@@ -1409,7 +1409,7 @@ def test_refusals_quote_the_write_chains_own_words():
     about what they admit.
     """
     svc = FakeResourceFileService()
-    m = ResourcesMaterialiser(svc, _StubEntryFetcher())
+    m = ResourcesMaterialiser(svc, _StubDeclaredSourceResolver())
     ctx = make_context(engine_type="claude_code")
     resolved = _run(m.resolve(ctx, [{"path": "data/run.sh", "content": "#"}]))
     assert not resolved.ok
@@ -1470,7 +1470,7 @@ def test_an_unhashable_unpack_kind_is_refused_not_raised():
     path instead of the stage's own words.
     """
     svc = FakeResourceFileService()
-    m = ResourcesMaterialiser(svc, _StubEntryFetcher(_tgz({"a.md": b"x"})))
+    m = ResourcesMaterialiser(svc, _StubDeclaredSourceResolver(_tgz({"a.md": b"x"})))
     ctx = make_context(engine_type="claude_code")
     resolved = _run(
         m.resolve(
@@ -1520,7 +1520,7 @@ def _git_ctx(*, subpath=None, auth=None):
 def test_a_file_entry_reads_one_file_out_of_a_git_source():
     """D1's simplest half: ``from:`` resolves, and one file lands at ``path``."""
     svc = FakeResourceFileService()
-    stub = _StubEntryFetcher(git_trees={_REPO: _TREE})
+    stub = _StubDeclaredSourceResolver(git_trees={_REPO: _TREE})
     m = ResourcesMaterialiser(svc, stub)
     resolved = _run(
         m.resolve(
@@ -1543,7 +1543,7 @@ def test_a_directory_entry_over_git_takes_the_tree_recursively():
     and quietly truncate real trees.
     """
     svc = FakeResourceFileService()
-    stub = _StubEntryFetcher(git_trees={_REPO: _TREE})
+    stub = _StubDeclaredSourceResolver(git_trees={_REPO: _TREE})
     m = ResourcesMaterialiser(svc, stub)
     resolved = _run(
         m.resolve(
@@ -1568,7 +1568,7 @@ def test_a_directory_entry_over_git_declares_no_unpack():
     over a real tree, so requiring it here would be asking the caller to
     configure a packaging step that does not happen."""
     svc = FakeResourceFileService()
-    stub = _StubEntryFetcher(git_trees={_REPO: _TREE})
+    stub = _StubDeclaredSourceResolver(git_trees={_REPO: _TREE})
     m = ResourcesMaterialiser(svc, stub)
     resolved = _run(
         m.resolve(_git_ctx(subpath="kb"), [{"path": "data/kb/", "from": "content"}])
@@ -1580,14 +1580,14 @@ def test_a_file_removed_upstream_disappears_on_the_next_apply():
     """A directory entry owns its tree: the declared area is replaced wholesale,
     not merged. Modelled as two applies over a shrinking repository."""
     svc = FakeResourceFileService()
-    m = ResourcesMaterialiser(svc, _StubEntryFetcher(git_trees={_REPO: _TREE}))
+    m = ResourcesMaterialiser(svc, _StubDeclaredSourceResolver(git_trees={_REPO: _TREE}))
     first = _run(
         m.resolve(_git_ctx(subpath="kb"), [{"path": "data/kb/", "from": "content"}])
     )
     assert "data/kb/pricing.csv" in {i.identity for i in first.intents}
 
     shrunk = {k: v for k, v in _TREE.items() if k != "kb/pricing.csv"}
-    m2 = ResourcesMaterialiser(svc, _StubEntryFetcher(git_trees={_REPO: shrunk}))
+    m2 = ResourcesMaterialiser(svc, _StubDeclaredSourceResolver(git_trees={_REPO: shrunk}))
     second = _run(
         m2.resolve(_git_ctx(subpath="kb"), [{"path": "data/kb/", "from": "content"}])
     )
@@ -1604,7 +1604,7 @@ def test_a_member_refused_by_admission_aborts_with_the_tree_still_standing():
     deterministically deletes the tree and then fails to refill it."""
     svc = FakeResourceFileService()
     oversized = {"kb/ok.md": b"fine\n", "kb/bad.exe": b"\x00" * 8}
-    m = ResourcesMaterialiser(svc, _StubEntryFetcher(git_trees={_REPO: oversized}))
+    m = ResourcesMaterialiser(svc, _StubDeclaredSourceResolver(git_trees={_REPO: oversized}))
     resolved = _run(
         m.resolve(_git_ctx(subpath="kb"), [{"path": "data/kb/", "from": "content"}])
     )
@@ -1617,7 +1617,7 @@ def test_two_entries_share_one_declared_git_source():
     """The declare-once-reference-many mechanism, which ``resources`` was
     excluded from: one source block, two entries, two different subpaths."""
     svc = FakeResourceFileService()
-    stub = _StubEntryFetcher(git_trees={_REPO: _TREE})
+    stub = _StubDeclaredSourceResolver(git_trees={_REPO: _TREE})
     m = ResourcesMaterialiser(svc, stub)
     resolved = _run(
         m.resolve(
@@ -1644,7 +1644,7 @@ def test_a_git_sourced_entry_files_its_bytes_with_the_platform_store():
     bytes. The credential **name** rides with it — never a value — so the
     lineage answers "which credential distributed this" on both roads."""
     svc = FakeResourceFileService()
-    stub = _StubEntryFetcher(git_trees={_REPO: _TREE})
+    stub = _StubDeclaredSourceResolver(git_trees={_REPO: _TREE})
     m = ResourcesMaterialiser(svc, stub)
     _run(
         m.resolve(
@@ -1664,7 +1664,7 @@ def test_a_git_sourced_tree_files_one_receipt_not_one_per_member():
     """A 5000-file tree is one delivery. One receipt per member would make the
     audit log describe the transport instead of the entry."""
     svc = FakeResourceFileService()
-    stub = _StubEntryFetcher(git_trees={_REPO: _TREE})
+    stub = _StubDeclaredSourceResolver(git_trees={_REPO: _TREE})
     m = ResourcesMaterialiser(svc, stub)
     _run(
         m.resolve(_git_ctx(subpath="kb"), [{"path": "data/kb/", "from": "content"}])
@@ -1688,7 +1688,7 @@ def test_a_git_sourced_tree_files_one_receipt_not_one_per_member():
 def test_a_moved_ref_rides_into_the_entrys_note():
     """§9.6: a non-strict source that moved reports the move on the entry."""
     svc = FakeResourceFileService()
-    stub = _StubEntryFetcher(git_trees={_REPO: _TREE}, moved_from="deadbeef")
+    stub = _StubDeclaredSourceResolver(git_trees={_REPO: _TREE}, moved_from="deadbeef")
     m = ResourcesMaterialiser(svc, stub)
     resolved = _run(
         m.resolve(
@@ -1702,7 +1702,7 @@ def test_a_moved_ref_rides_into_the_entrys_note():
 
 def test_an_undeclared_from_fails_the_entry_not_the_process():
     svc = FakeResourceFileService()
-    m = ResourcesMaterialiser(svc, _StubEntryFetcher(git_trees={_REPO: _TREE}))
+    m = ResourcesMaterialiser(svc, _StubDeclaredSourceResolver(git_trees={_REPO: _TREE}))
     resolved = _run(
         m.resolve(_git_ctx(), [{"path": "data/x.md", "from": "nowhere"}])
     )
@@ -1762,7 +1762,7 @@ def test_keep_last_delivers_a_stored_git_tree_instead_of_failing():
 
     tree = [("faq.csv", b"q,a\n"), ("deep/notes.md", b"# nested\n")]
     svc = FakeResourceFileService()
-    stub = _StubEntryFetcher()
+    stub = _StubDeclaredSourceResolver()
     # What `_git_keep_last` hands back: the baseline receipt's bytes, carrying
     # the fallback reason the report must state (§9.6).
     stub.declared_override = FetchedEntry(
@@ -1793,7 +1793,7 @@ def test_a_real_archive_still_takes_the_unpack_road():
     """Recognising a stored tree must not swallow the archive case: an oss
     directory entry with a genuine zip goes on unpacking exactly as before."""
     svc = FakeResourceFileService()
-    stub = _StubEntryFetcher(_tgz({"kb/faq.csv": b"q,a\n"}))
+    stub = _StubDeclaredSourceResolver(_tgz({"kb/faq.csv": b"q,a\n"}))
     m = ResourcesMaterialiser(svc, stub)
     resolved = _run(
         m.resolve(
@@ -1816,7 +1816,7 @@ def test_an_oss_directory_entry_is_refused_before_the_network_is_touched():
     apply's byte budget and its lock TTL. An entry a missing `unpack`
     guarantees to reject must not spend one."""
     svc = FakeResourceFileService()
-    stub = _StubEntryFetcher()
+    stub = _StubDeclaredSourceResolver()
     m = ResourcesMaterialiser(svc, stub)
     resolved = _run(
         m.resolve(
@@ -1831,7 +1831,7 @@ def test_an_oss_directory_entry_is_refused_before_the_network_is_touched():
 
 def test_an_invalid_strip_components_is_also_refused_before_the_fetch():
     svc = FakeResourceFileService()
-    stub = _StubEntryFetcher()
+    stub = _StubDeclaredSourceResolver()
     m = ResourcesMaterialiser(svc, stub)
     resolved = _run(
         m.resolve(
@@ -1853,7 +1853,7 @@ def test_a_git_directory_entry_still_fetches_without_declaring_unpack():
     """The pre-fetch gate must not leak onto the git road, where `unpack` is
     refused at PUT and a tree needs no packaging at all."""
     svc = FakeResourceFileService()
-    stub = _StubEntryFetcher(git_trees={_REPO: _TREE})
+    stub = _StubDeclaredSourceResolver(git_trees={_REPO: _TREE})
     m = ResourcesMaterialiser(svc, stub)
     resolved = _run(
         m.resolve(_git_ctx(subpath="kb"), [{"path": "data/kb/", "from": "content"}])

--- a/src/backend/tests/community/core/bot_config_manifest/apply/test_skills_materialiser.py
+++ b/src/backend/tests/community/core/bot_config_manifest/apply/test_skills_materialiser.py
@@ -22,8 +22,8 @@ from pathlib import Path
 from types import SimpleNamespace
 
 
-from agentclaw.community.core.bot_config_manifest.apply.entry_fetch import (
-    EntryFetcher,
+from agentclaw.community.core.bot_config_manifest.apply.source_resolver import (
+    DeclaredSourceResolver,
 )
 from agentclaw.community.core.bot_config_manifest.apply.source_session import (
     SourceSession,
@@ -110,7 +110,7 @@ def skill_rig(
     reader = FakeCapabilityReader(assets=assets, member_ids=member_ids)
     objects = seeded_object_store(packages)
     content = FakeManifestContent()
-    pipeline = EntryFetcher(content, FakeObjectCredentials(), objects)
+    pipeline = DeclaredSourceResolver(content, FakeObjectCredentials(), objects)
     materialiser = SkillsMaterialiser(
         uploads, activation, reader, real_validator(), pipeline
     )

--- a/src/backend/tests/community/core/bot_config_manifest/apply/test_source_fetchers.py
+++ b/src/backend/tests/community/core/bot_config_manifest/apply/test_source_fetchers.py
@@ -50,10 +50,14 @@ def _session(sources=None) -> SourceSession:
 
 
 @pytest.fixture
-def pipeline() -> EntryFetcher:
-    return EntryFetcher(
-        FakeManifestContent(), FakeCredentials(), FakeObjectStore()
-    )
+def collaborators():
+    """The three a pipeline is composed over: store, credentials, objects."""
+    return FakeManifestContent(), FakeCredentials(), FakeObjectStore()
+
+
+@pytest.fixture
+def pipeline(collaborators) -> EntryFetcher:
+    return EntryFetcher(*collaborators)
 
 
 # ── the table ────────────────────────────────────────────────────────────────
@@ -93,21 +97,27 @@ def test_a_protocol_with_no_fetcher_is_refused_at_import():
     "kind,expected",
     [(SourceKind.OSS, ObjectStoreFetcher), (SourceKind.GIT, GitSourceFetcher)],
 )
-def test_the_bound_table_holds_one_fetcher_per_protocol(pipeline, kind, expected):
-    bound = build_fetchers(pipeline)
+def test_the_bound_table_holds_one_fetcher_per_protocol(
+    collaborators, kind, expected
+):
+    bound = build_fetchers(*collaborators)
     assert isinstance(bound[kind], expected)
     assert isinstance(bound[kind], SourceFetcher)
 
 
-def test_the_fetchers_share_the_pipelines_collaborators(pipeline):
-    """Strategies over one pipeline, not independent pipelines.
+def test_the_fetchers_share_the_pipelines_collaborators(collaborators):
+    """Strategies over one apply's collaborators, not independent pipelines.
 
     Two fetchers that each built their own content store would file receipts
     under two policies, and W11's lineage would answer "which credential
-    served this" differently depending on which road an entry took.
+    served this" differently depending on which road an entry took. They are
+    handed the collaborators now rather than an owner to reach through, so
+    what this asserts is that one call binds both roads to the same objects.
     """
-    bound = build_fetchers(pipeline)
-    assert all(f._owner is pipeline for f in bound.values())
+    content, credentials, _ = collaborators
+    bound = build_fetchers(*collaborators)
+    assert all(f._content is content for f in bound.values())
+    assert all(f._credentials is credentials for f in bound.values())
 
 
 # ── dispatch ─────────────────────────────────────────────────────────────────

--- a/src/backend/tests/community/core/bot_config_manifest/apply/test_source_fetchers.py
+++ b/src/backend/tests/community/core/bot_config_manifest/apply/test_source_fetchers.py
@@ -1,6 +1,6 @@
 """The protocol table: exhaustive, and consulted rather than branched on.
 
-The per-protocol *behaviour* is pinned by ``test_entry_fetch.py`` — those
+The per-protocol *behaviour* is pinned by ``test_source_resolver.py`` — those
 tests drive real declarations through the front door and assert what came
 back, and they did not change when the branch became a table, which is the
 strongest statement available that the refactor moved nothing.
@@ -13,8 +13,8 @@ from __future__ import annotations
 
 import pytest
 
-from agentclaw.community.core.bot_config_manifest.apply.entry_fetch import (
-    EntryFetcher,
+from agentclaw.community.core.bot_config_manifest.apply.source_resolver import (
+    DeclaredSourceResolver,
 )
 from agentclaw.community.core.bot_config_manifest.apply.source_session import (
     SourceSession,
@@ -56,8 +56,8 @@ def collaborators():
 
 
 @pytest.fixture
-def pipeline(collaborators) -> EntryFetcher:
-    return EntryFetcher(*collaborators)
+def pipeline(collaborators) -> DeclaredSourceResolver:
+    return DeclaredSourceResolver(*collaborators)
 
 
 # ── the table ────────────────────────────────────────────────────────────────
@@ -160,7 +160,7 @@ def test_dispatch_selects_the_fetcher_the_declaration_names(
     others = {k: _Recorder() for k in FETCHER_TYPES if k is not kind}
     pipeline._fetchers = {kind: recorder, **others}
 
-    result = pipeline.fetch_declared(
+    result = pipeline.resolve(
         make_context(source_session=_session()),
         entry={"source": source},
         category="resources_file",
@@ -179,7 +179,7 @@ def test_the_request_carries_what_the_front_door_resolved(pipeline):
     recorder = _Recorder()
     pipeline._fetchers = {SourceKind.OSS: recorder, SourceKind.GIT: _Recorder()}
 
-    pipeline.fetch_declared(
+    pipeline.resolve(
         make_context(source_session=_session()),
         entry={
             "source": {
@@ -219,7 +219,7 @@ def test_a_named_source_carries_its_name_for_the_report(pipeline):
         )
     )
 
-    pipeline.fetch_declared(
+    pipeline.resolve(
         ctx,
         entry={"from": "content"},
         category="resources_file",
@@ -269,7 +269,7 @@ def test_a_git_source_naming_an_object_store_credential_fails_one_entry():
         def binding(self, *, name):
             return _AksKBinding()
 
-    pipeline = EntryFetcher(
+    pipeline = DeclaredSourceResolver(
         FakeManifestContent(), _WrongTypeCredentials(), FakeObjectStore()
     )
     ctx = make_context(
@@ -288,6 +288,6 @@ def test_a_git_source_naming_an_object_store_credential_fails_one_entry():
     # EntryFetchError, not ValueError: the materialiser turns this into one
     # entry's ResolveFailure. Anything else aborts the category.
     with pytest.raises(EntryFetchError, match="oss-cred"):
-        pipeline.fetch_declared(
+        pipeline.resolve(
             ctx, entry={"from": "repo"}, category="identity", entry_identity="x"
         )

--- a/src/backend/tests/community/core/bot_config_manifest/apply/test_source_resolver.py
+++ b/src/backend/tests/community/core/bot_config_manifest/apply/test_source_resolver.py
@@ -1,4 +1,4 @@
-"""Tests for the per-entry fetch pipeline (``apply/entry_fetch.py``, W5).
+"""Tests for the per-entry fetch pipeline (``apply/source_resolver.py``, W5).
 
 The pipeline is where the fetch-side waves meet: the object store and git as
 transports, W3's named credentials, W11's platform copy. What these tests pin
@@ -26,10 +26,10 @@ from agentclaw.community.core.bot_config_manifest.fetch.object_store import (
     ObjectStoreTarget,
 )
 from tests.community.core.bot_config_manifest.apply._fakes import FakeObjectStore
-from agentclaw.community.core.bot_config_manifest.apply.entry_fetch import (
+from agentclaw.community.core.bot_config_manifest.apply.source_resolver import (
     declared_protocol,
     EntryFetchError,
-    EntryFetcher,
+    DeclaredSourceResolver,
 )
 from agentclaw.community.core.bot_config_manifest.apply.source_fetchers import (
     ObjectStoreFetcher,
@@ -105,7 +105,7 @@ def objects_rig():
     gives every ``ObjectFetchStatus`` a shape a consumer test can drive."""
     content = FakeManifestContent()
     objects = FakeObjectStore()
-    pipeline = EntryFetcher(content, _AksKCredentials(), objects)
+    pipeline = DeclaredSourceResolver(content, _AksKCredentials(), objects)
     return content, objects, pipeline
 
 
@@ -113,7 +113,7 @@ def objects_rig():
 def rig():
     content = FakeManifestContent()
     credentials = FakeCredentials()
-    return content, credentials, EntryFetcher(content, credentials, FakeObjectStore())
+    return content, credentials, DeclaredSourceResolver(content, credentials, FakeObjectStore())
 
 
 #: The object road's coordinates, as a document declares them, and the address
@@ -160,7 +160,7 @@ def _acquire(pipeline, *, ctx=None, digest=None, keep_last=False):
     entry = {"from": "s", "on_fetch_failure": "keep_last" if keep_last else "fail"}
     if digest is not None:
         entry["digest"] = digest
-    return pipeline.fetch_declared(
+    return pipeline.resolve(
         ctx if ctx is not None else _oss_ctx(),
         entry=entry,
         category="identity",
@@ -170,7 +170,7 @@ def _acquire(pipeline, *, ctx=None, digest=None, keep_last=False):
 
 # --- the store-first policy, on the road that still has a network ---------
 #
-# These cases used to drive ``EntryFetcher.fetch``, the HTTPS-GET road that no
+# These cases used to drive ``DeclaredSourceResolver.fetch``, the HTTPS-GET road that no
 # longer exists. The policy they pin is not the transport's — it is the
 # pipeline's, and ``acquire_object`` is where it lives now: pinned entries read
 # from the platform's copy, unpinned ones re-read, ``keep_last`` answers only
@@ -280,7 +280,7 @@ def test_a_missing_credential_fails_with_the_name_and_no_read(objects_rig):
     """The credential is resolved before the store is touched, and a name that
     no longer exists is configuration drift: loud, named, and never masked."""
     content, objects, _ = objects_rig
-    pipeline = EntryFetcher(
+    pipeline = DeclaredSourceResolver(
         content, FakeCredentials(missing={"ghost"}), objects
     )
     ctx = make_context(source_session=_session(_ScriptedGit(), sources={
@@ -288,7 +288,7 @@ def test_a_missing_credential_fails_with_the_name_and_no_read(objects_rig):
     }))
 
     with pytest.raises(EntryFetchError) as excinfo:
-        pipeline.fetch_declared(ctx, entry={"from": "s"}, category="identity")
+        pipeline.resolve(ctx, entry={"from": "s"}, category="identity")
     assert "ghost" in excinfo.value.reason
     assert objects.calls == []
 
@@ -442,13 +442,13 @@ def test_the_funnel_requires_a_category_by_keyword():
     the PR's two blocking-level type issues)."""
     import inspect
 
-    for entry_point in (EntryFetcher.fetch_declared, ObjectStoreFetcher._acquire):
+    for entry_point in (DeclaredSourceResolver.resolve, ObjectStoreFetcher._acquire):
         category = inspect.signature(entry_point).parameters["category"]
         assert category.kind is inspect.Parameter.KEYWORD_ONLY
         assert category.default is inspect.Parameter.empty
 
 
-# --- the W7 declared-source front door: fetch_declared ---
+# --- the W7 declared-source front door: resolve ---
 
 GIT_URL = "https://git.corp/repo.git"
 _FAKE_SHA = "a" * 40
@@ -499,7 +499,7 @@ def test_a_named_oss_source_reads_through_the_object_store(objects_rig):
             },
         })
     )
-    result = pipeline.fetch_declared(
+    result = pipeline.resolve(
         ctx, entry={"from": "cdn", "key": "logo.png"}, category="identity"
     )
     assert result.single() == BODY
@@ -525,7 +525,7 @@ def test_the_document_names_the_bucket_and_the_credential_names_the_host(
     ctx = make_context(source_session=_session(_ScriptedGit(), sources={
         "s": {"protocol": "oss", "bucket": "b", "key": "k", "auth": "oss-cred"},
     }))
-    pipeline.fetch_declared(ctx, entry={"from": "s"}, category="identity")
+    pipeline.resolve(ctx, entry={"from": "s"}, category="identity")
     assert objects.calls[0][0].endpoint == _OBJ_ENDPOINT
 
 
@@ -561,11 +561,11 @@ def test_a_refusal_is_never_masked_by_keep_last(objects_rig, break_it, expected)
     }))
     entry = {"from": "s", "on_fetch_failure": "keep_last"}
     # The first apply succeeds and files the receipt a fallback would read.
-    assert pipeline.fetch_declared(ctx, entry=entry, category="identity").single() == BODY
+    assert pipeline.resolve(ctx, entry=entry, category="identity").single() == BODY
 
     break_it(objects)
     with pytest.raises(EntryFetchError, match=expected):
-        pipeline.fetch_declared(ctx, entry=entry, category="identity")
+        pipeline.resolve(ctx, entry=entry, category="identity")
 
 
 def test_an_unreachable_store_is_a_failure_keep_last_may_answer(objects_rig):
@@ -576,10 +576,10 @@ def test_an_unreachable_store_is_a_failure_keep_last_may_answer(objects_rig):
         "s": {"protocol": "oss", "bucket": "b", "key": "k", "auth": "oss-cred"},
     }))
     # First apply files the receipt the second one falls back to.
-    pipeline.fetch_declared(ctx, entry={"from": "s"}, category="identity")
+    pipeline.resolve(ctx, entry={"from": "s"}, category="identity")
     objects.make_unavailable("b")
 
-    result = pipeline.fetch_declared(
+    result = pipeline.resolve(
         ctx,
         entry={"from": "s", "on_fetch_failure": "keep_last"},
         category="identity",
@@ -589,7 +589,7 @@ def test_an_unreachable_store_is_a_failure_keep_last_may_answer(objects_rig):
     assert result.note() and "keep_last" in result.note()
 
 
-def test_fetch_declared_gives_the_git_road_a_checkout(rig):
+def test_resolve_gives_the_git_road_a_checkout(rig):
     _, credentials, pipeline = rig
     git = _ScriptedGit()
     ctx = make_context(
@@ -597,7 +597,7 @@ def test_fetch_declared_gives_the_git_road_a_checkout(rig):
             "app": {"protocol": "git", "url": GIT_URL, "ref": "main", "subpath": "pkg"},
         })
     )
-    decl = pipeline.fetch_declared(
+    decl = pipeline.resolve(
         ctx, entry={"from": "app"}, category="skills", entry_identity="s1"
     )
     assert isinstance(decl, GitDelivery)
@@ -609,18 +609,18 @@ def test_fetch_declared_gives_the_git_road_a_checkout(rig):
     assert ctx.source_session.resolution_records()[0].resolved_sha == _FAKE_SHA
 
 
-def test_fetch_declared_refuses_a_from_that_names_nothing(rig):
+def test_resolve_refuses_a_from_that_names_nothing(rig):
     _, _, pipeline = rig
     ctx = make_context(source_session=_session(_ScriptedGit()))
     with pytest.raises(EntryFetchError, match="not declared"):
-        pipeline.fetch_declared(ctx, entry={"from": "ghost"}, category="skills")
+        pipeline.resolve(ctx, entry={"from": "ghost"}, category="skills")
 
 
-def test_fetch_declared_missing_session_is_loud(rig):
+def test_resolve_missing_session_is_loud(rig):
     _, _, pipeline = rig
     ctx = make_context()
     with pytest.raises(EntryFetchError, match="no source session"):
-        pipeline.fetch_declared(ctx, entry={"from": "x"}, category="skills")
+        pipeline.resolve(ctx, entry={"from": "x"}, category="skills")
 
 
 def test_strict_refuses_when_the_ref_moved(rig):
@@ -632,7 +632,7 @@ def test_strict_refuses_when_the_ref_moved(rig):
         source_session=_session(git, baselines={GIT_URL: "b" * 40})
     )
     with pytest.raises(EntryFetchError, match="moved"):
-        pipeline.fetch_declared(
+        pipeline.resolve(
             ctx,
             entry={"source": {"protocol": "git", "url": GIT_URL, "ref": "main", "mode": "strict"}},
             category="skills",
@@ -650,7 +650,7 @@ def test_non_strict_records_the_move_in_the_note(rig):
     ctx = make_context(
         source_session=_session(git, baselines={GIT_URL: "b" * 40})
     )
-    decl = pipeline.fetch_declared(
+    decl = pipeline.resolve(
         ctx,
         entry={"source": {"protocol": "git", "url": GIT_URL, "ref": "main"}},
         category="skills",
@@ -664,7 +664,7 @@ def test_strict_on_the_first_apply_has_no_opinion(rig):
     _, _, pipeline = rig
     git = _ScriptedGit()
     ctx = make_context(source_session=_session(git))  # no baselines
-    decl = pipeline.fetch_declared(
+    decl = pipeline.resolve(
         ctx,
         entry={"source": {"protocol": "git", "url": GIT_URL, "ref": "main", "mode": "strict"}},
         category="skills",
@@ -677,7 +677,7 @@ def test_digest_on_a_git_source_is_refused(rig):
     _, _, pipeline = rig
     ctx = make_context(source_session=_session(_ScriptedGit()))
     with pytest.raises(EntryFetchError, match="digest"):
-        pipeline.fetch_declared(
+        pipeline.resolve(
             ctx,
             entry={"source": {"protocol": "git", "url": GIT_URL, "ref": "main"},
                    "digest": "sha256:" + "0" * 64},
@@ -700,7 +700,7 @@ def test_git_keep_last_falls_back_to_the_baseline_receipt(rig):
         sources={"app": {"protocol": "git", "url": GIT_URL, "ref": "main", "subpath": "pkg"}},
         baselines={"app": old_sha},
     ))
-    result = pipeline.fetch_declared(
+    result = pipeline.resolve(
         ctx,
         entry={"from": "app", "on_fetch_failure": "keep_last"},
         category="skills",
@@ -718,7 +718,7 @@ def test_git_credentials_reach_the_transport_as_headers(rig):
     ctx = make_context(source_session=_session(git, sources={
         "app": {"protocol": "git", "url": GIT_URL, "ref": "main", "auth": "ci-token"},
     }))
-    pipeline.fetch_declared(ctx, entry={"from": "app"}, category="skills")
+    pipeline.resolve(ctx, entry={"from": "app"}, category="skills")
     assert credentials.binding_calls == ["ci-token"]
     assert git.headers == [{"X-Custom-Auth": "payload-of-ci-token"}]
 
@@ -730,7 +730,7 @@ def _git_delivery(pipeline, ctx, *, subpath="pkg", auth=None):
     through is the one the fetcher bound it to — which is the whole of what
     replaced the caller reaching for ``receipt_url`` and ``auth``.
     """
-    return pipeline.fetch_declared(
+    return pipeline.resolve(
         ctx, entry={"from": "app"}, category="skills", entry_identity="s1"
     )
 
@@ -787,7 +787,7 @@ def test_the_git_fetchs_declared_bytes_charge_the_apply_ledger_once(rig):
     # Two entries name the same source: one fetch, one charge — a cached
     # checkout answers a read, not a fetch, the URL road's fast-path ruling.
     for name in ("first", "second"):
-        pipeline.fetch_declared(
+        pipeline.resolve(
             ctx, entry={"from": "app", "name": name}, category="skills",
             entry_identity=name,
         )
@@ -808,7 +808,7 @@ def test_a_git_fetch_exhausting_the_byte_ledger_fails_the_entry(rig):
         ApplyFetchBudget(deadline=9e99, total_bytes=5),
     )
     with pytest.raises(EntryFetchError, match="exhausted \\(bytes\\)"):
-        pipeline.fetch_declared(
+        pipeline.resolve(
             ctx, entry={"from": "app"}, category="skills"
         )
 
@@ -827,7 +827,7 @@ def test_entry_subpath_composes_with_the_sources_on_the_git_road(rig):
     ctx = make_context(source_session=_session(git, sources={
         "app": {"protocol": "git", "url": GIT_URL, "ref": "main", "subpath": "pkg"},
     }))
-    decl = pipeline.fetch_declared(
+    decl = pipeline.resolve(
         ctx, entry={"from": "app", "subpath": "narrow/inner.md"},
         category="skills",
     )
@@ -842,7 +842,7 @@ def test_a_source_with_no_subpath_takes_the_entrys_whole(rig):
     ctx = make_context(source_session=_session(git, sources={
         "app": {"protocol": "git", "url": GIT_URL, "ref": "main"},
     }))
-    decl = pipeline.fetch_declared(
+    decl = pipeline.resolve(
         ctx, entry={"from": "app", "subpath": "kb/faq.csv"}, category="skills"
     )
     assert decl.source.subpath == "kb/faq.csv"
@@ -862,10 +862,10 @@ def test_two_entries_off_one_git_source_share_a_checkout_and_a_sha(rig):
         "app": {"protocol": "git", "url": GIT_URL, "ref": "main", "subpath": "kb"},
     })
     ctx = make_context(source_session=session)
-    first = pipeline.fetch_declared(
+    first = pipeline.resolve(
         ctx, entry={"from": "app", "subpath": "faq.csv"}, category="resources_file"
     )
-    second = pipeline.fetch_declared(
+    second = pipeline.resolve(
         ctx, entry={"from": "app", "subpath": "pricing.csv"},
         category="resources_file",
     )
@@ -887,7 +887,7 @@ def test_a_composed_subpath_that_escapes_the_tree_is_refused(rig):
         "app": {"protocol": "git", "url": GIT_URL, "ref": "main", "subpath": "pkg"},
     }))
     with pytest.raises(EntryFetchError, match="'..' segment"):
-        pipeline.fetch_declared(
+        pipeline.resolve(
             ctx, entry={"from": "app", "subpath": "../../etc/shadow"},
             category="skills",
         )
@@ -909,7 +909,7 @@ def test_an_entry_subpath_is_not_part_of_an_object_stores_address(objects_rig):
             "auth": "oss-cred",
         },
     }))
-    pipeline.fetch_declared(
+    pipeline.resolve(
         ctx,
         entry={"from": "cdn", "subpath": "inside/archive.md"},
         category="skills",
@@ -922,7 +922,7 @@ def test_entry_level_auth_on_an_inline_git_source_is_refused(rig):
     _, _, pipeline = rig
     ctx = make_context(source_session=_session(_ScriptedGit()))
     with pytest.raises(EntryFetchError, match="'auth' is not supported on a git"):
-        pipeline.fetch_declared(
+        pipeline.resolve(
             ctx,
             entry={"source": {"protocol": "git", "url": GIT_URL, "ref": "main"}, "auth": "ci-token"},
             category="skills",
@@ -954,7 +954,7 @@ def test_the_object_road_files_once_and_its_delivery_adds_nothing(objects_rig):
     objects.put("b", "k", BODY, access_key_id=_OBJ_AK)
     ctx = _oss_ctx()
 
-    delivery = pipeline.fetch_declared(
+    delivery = pipeline.resolve(
         ctx, entry={"from": "s"}, category="identity", entry_identity="soul"
     )
     assert len(content.store_calls) == 1
@@ -972,7 +972,7 @@ def test_the_git_road_carries_the_auth_and_the_category_limit(rig):
     ctx = make_context(source_session=_session(git, sources={
         "app": {"protocol": "git", "url": GIT_URL, "ref": "main", "auth": "ci-token"},
     }))
-    decl = pipeline.fetch_declared(ctx, entry={"from": "app"}, category="identity")
+    decl = pipeline.resolve(ctx, entry={"from": "app"}, category="identity")
     assert isinstance(decl, GitDelivery)
     # The identity category's per-entry cap rides the source: its reader
     # refuses a member by DECLARED size against the category number, the
@@ -1001,7 +1001,7 @@ def test_an_oss_source_without_auth_is_refused_before_any_read(objects_rig):
         "cdn": {"protocol": "oss", "bucket": "b", "key": "k"},
     }))
     with pytest.raises(EntryFetchError, match="auth"):
-        pipeline.fetch_declared(ctx, entry={"from": "cdn"}, category="identity")
+        pipeline.resolve(ctx, entry={"from": "cdn"}, category="identity")
     assert objects.calls == []  # refused before the store was touched
 
 
@@ -1024,7 +1024,7 @@ def test_a_source_written_as_a_plain_url_string_is_refused(rig):
     _, _, pipeline = rig
     ctx = make_context(source_session=_session(_ScriptedGit()))
     with pytest.raises(EntryFetchError) as raised:
-        pipeline.fetch_declared(
+        pipeline.resolve(
             ctx,
             entry={"source": "https://example.com/x.zip"},
             category="skills",

--- a/src/backend/tests/community/core/bot_config_manifest/cli_tools/_fakes.py
+++ b/src/backend/tests/community/core/bot_config_manifest/cli_tools/_fakes.py
@@ -226,6 +226,41 @@ class FakeGitEntrySource(GitEntrySource):
         )
 
 
+class _RecordingStore:
+    """The content store a :class:`GitDelivery` files through, recorded.
+
+    The git road's delivery writes its own receipt now, so what used to be a
+    ``file_bytes`` recording on the fetcher is a store call here — in the
+    store's own vocabulary, which is what the real one receives.
+    """
+
+    def __init__(self, filed: list[dict]) -> None:
+        self._filed = filed
+
+    def store(
+        self,
+        fetched,
+        *,
+        scope,
+        source_url,
+        credential_name=None,
+        modifier="",
+        apply_id=None,
+        category=None,
+        entry_identity=None,
+    ):
+        self._filed.append(
+            {
+                "content": fetched.bytes,
+                "source_url": source_url,
+                "category": category,
+                "entry_identity": entry_identity,
+                "credential_name": credential_name,
+            }
+        )
+        return SimpleNamespace(digest=fetched.sha256)
+
+
 class FakeEntryFetcher:
     """Answers a declared entry with canned bytes; records what it resolved.
 
@@ -242,6 +277,8 @@ class FakeEntryFetcher:
         self.error = error
         self.calls: list[dict] = []
         self.filed: list[dict] = []
+        #: The store a git delivery files its own receipt through.
+        self.store = _RecordingStore(self.filed)
 
     def fetch_declared(self, ctx, *, entry, category, entry_identity=None):
         decl = None
@@ -281,16 +318,16 @@ class FakeEntryFetcher:
         if self.error is not None:
             raise self.error
         if decl.get("protocol") == "git":
-            return GitDelivery(FakeGitEntrySource(self.content, decl, entry))
+            return GitDelivery(
+                FakeGitEntrySource(self.content, decl, entry), self.store
+            )
         return BlobDelivery(
             FakeFetchedEntry(
                 self.content, self.digest or entry.get("digest") or ""
             )
         )
 
-    def file_bytes(self, ctx, **kwargs):
-        self.filed.append(kwargs)
-        return "sha256:filed"
+
 
 
 def code_of(module) -> str:

--- a/src/backend/tests/community/core/bot_config_manifest/cli_tools/_fakes.py
+++ b/src/backend/tests/community/core/bot_config_manifest/cli_tools/_fakes.py
@@ -8,7 +8,7 @@ from agentclaw.community.core.bot_config_manifest.apply.entry_delivery import (
     BlobDelivery,
     GitDelivery,
 )
-from agentclaw.community.core.bot_config_manifest.apply.entry_fetch import (
+from agentclaw.community.core.bot_config_manifest.apply.source_resolver import (
     EntryFetchError,
     GitEntrySource,
 )
@@ -261,10 +261,10 @@ class _RecordingStore:
         return SimpleNamespace(digest=fetched.sha256)
 
 
-class FakeEntryFetcher:
+class FakeDeclaredSourceResolver:
     """Answers a declared entry with canned bytes; records what it resolved.
 
-    It resolves the entry the way the real ``fetch_declared`` does — a ``from``
+    It resolves the entry the way the real ``resolve`` does — a ``from``
     name against the session's ``sources``, an inline declaration, a git source
     answering with a tree — and **refuses anything else**, including the bare
     URL string the grammar used to allow. A double that quietly served a string
@@ -280,7 +280,7 @@ class FakeEntryFetcher:
         #: The store a git delivery files its own receipt through.
         self.store = _RecordingStore(self.filed)
 
-    def fetch_declared(self, ctx, *, entry, category, entry_identity=None):
+    def resolve(self, ctx, *, entry, category, entry_identity=None):
         decl = None
         if isinstance(entry.get("from"), str):
             session = getattr(ctx, "source_session", None)

--- a/src/backend/tests/community/core/bot_config_manifest/cli_tools/test_service.py
+++ b/src/backend/tests/community/core/bot_config_manifest/cli_tools/test_service.py
@@ -14,7 +14,7 @@ import zipfile
 
 import pytest
 
-from agentclaw.community.core.bot_config_manifest.apply.entry_fetch import (
+from agentclaw.community.core.bot_config_manifest.apply.source_resolver import (
     EntryFetchError,
 )
 from agentclaw.community.core.bot_config_manifest.cli_tools import (
@@ -39,7 +39,7 @@ from ._fakes import (
     elf,
     FakeCliToolRepo,
     FakeDelivery,
-    FakeEntryFetcher,
+    FakeDeclaredSourceResolver,
     FakeObjectStorage,
     code_of,
 )
@@ -89,7 +89,7 @@ def _service(*, content=_TOOL, digest=_DIGEST, fetch_error=None, delivery=None, 
     oss = oss or FakeObjectStorage()
     repo = FakeCliToolRepo()
     delivery = delivery if delivery is not None else FakeDelivery()
-    fetcher = FakeEntryFetcher(content=content, digest=digest, error=fetch_error)
+    fetcher = FakeDeclaredSourceResolver(content=content, digest=digest, error=fetch_error)
     store = CliToolStore(object_storage=oss, store_base=lambda: _BASE)
     service = CliToolService(
         repo=repo, store=store, delivery=delivery, entry_fetcher=fetcher
@@ -635,7 +635,7 @@ def test_the_service_composes_no_filesystem_path_for_a_bot() -> None:
 def test_the_context_is_what_the_fetch_funnel_asks_for() -> None:
     """An HTTP-driven install and a manifest apply fetch through one funnel;
     the seam that makes that true is a declared protocol, not a coincidence."""
-    from agentclaw.community.core.bot_config_manifest.apply.entry_fetch import (
+    from agentclaw.community.core.bot_config_manifest.apply.source_resolver import (
         FetchContext,
     )
 
@@ -816,7 +816,7 @@ async def test_a_failed_replacement_leaves_the_installed_tools_bytes_intact() ->
     other = _elf(payload=b"\x02" * 64)
     other_digest = "sha256:" + hashlib.sha256(other).hexdigest()
     service._delivery.install_error = CliToolPlacementError("nope")
-    service._fetcher.content, service._fetcher.digest = other, other_digest
+    service._resolver.content, service._resolver.digest = other, other_digest
 
     outcome = await service.install(
         _CTX, _decl(digest=other_digest), installed_by="u2"
@@ -854,7 +854,7 @@ async def test_a_successful_replacement_collects_the_version_it_replaced() -> No
 
     other = _elf(payload=b"\x02" * 64)
     other_digest = "sha256:" + hashlib.sha256(other).hexdigest()
-    service._fetcher.content, service._fetcher.digest = other, other_digest
+    service._resolver.content, service._resolver.digest = other, other_digest
     outcome = await service.install(
         _CTX, _decl(digest=other_digest), installed_by="u2"
     )
@@ -1031,7 +1031,7 @@ async def test_a_manifest_apply_still_replaces_rather_than_conflicting() -> None
 
     other = _elf(payload=b"\x02" * 64)
     other_digest = "sha256:" + hashlib.sha256(other).hexdigest()
-    service._fetcher.content, service._fetcher.digest = other, other_digest
+    service._resolver.content, service._resolver.digest = other, other_digest
     outcomes = await service.replace_all(
         _CTX, [_decl(digest=other_digest)], installed_by="manifest"
     )
@@ -1118,7 +1118,7 @@ async def test_a_failed_record_leaves_the_previous_version_intact() -> None:
 
     other = _elf(payload=b"\x02" * 64)
     other_digest = "sha256:" + hashlib.sha256(other).hexdigest()
-    service._fetcher.content, service._fetcher.digest = other, other_digest
+    service._resolver.content, service._resolver.digest = other, other_digest
     repo.write_error = RuntimeError("connection reset")
 
     outcome = await service.install(
@@ -1165,7 +1165,7 @@ async def test_a_per_name_refusal_puts_that_tools_row_back() -> None:
 
     other = _elf(payload=b"\x02" * 64)
     other_digest = "sha256:" + hashlib.sha256(other).hexdigest()
-    service._fetcher.content, service._fetcher.digest = other, other_digest
+    service._resolver.content, service._resolver.digest = other, other_digest
     delivery.replace_failures = {"mycli": "not executable"}
 
     outcomes = await service.replace_all(
@@ -1190,7 +1190,7 @@ async def test_a_per_name_refusal_keeps_the_last_known_good_binary() -> None:
 
     other = _elf(payload=b"\x02" * 64)
     other_digest = "sha256:" + hashlib.sha256(other).hexdigest()
-    service._fetcher.content, service._fetcher.digest = other, other_digest
+    service._resolver.content, service._resolver.digest = other, other_digest
     delivery.replace_failures = {"mycli": "not executable"}
 
     await service.replace_all(_CTX, [_decl(digest=other_digest)], installed_by="manifest")

--- a/src/backend/tests/community/core/bot_config_manifest/creation/test_creation_ordering.py
+++ b/src/backend/tests/community/core/bot_config_manifest/creation/test_creation_ordering.py
@@ -55,8 +55,8 @@ from agentclaw.community.core.repository.implementations.bot.config_manifest_app
     BotConfigManifestApplyRepository,
 )
 
-from agentclaw.community.core.bot_config_manifest.apply.entry_fetch import (
-    EntryFetcher,
+from agentclaw.community.core.bot_config_manifest.apply.source_resolver import (
+    DeclaredSourceResolver,
 )
 from ..apply._fakes import (
     FakeActivationService,
@@ -218,7 +218,7 @@ def _build(db, *, scripts=None):
         upload_service_provider=lambda: FakeSkillUploadService(),
         capability_reader_provider=lambda: FakeCapabilityReader(),
         package_validator_provider=lambda: real_validator(),
-        entry_fetcher_provider=lambda: EntryFetcher(
+        entry_fetcher_provider=lambda: DeclaredSourceResolver(
             FakeManifestContent(), FakeCredentials(), FakeObjectStore()
         ),
         # W6's resources materialiser and W7's git transport: unreached by

--- a/src/backend/tests/community/core/bot_config_manifest/creation/test_creation_ordering_teclaw.py
+++ b/src/backend/tests/community/core/bot_config_manifest/creation/test_creation_ordering_teclaw.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import pytest
 
 from agentclaw.community.core.bot_config_manifest.apply.delivery import MaterialiserPorts
-from agentclaw.community.core.bot_config_manifest.apply.entry_fetch import EntryFetcher
+from agentclaw.community.core.bot_config_manifest.apply.source_resolver import DeclaredSourceResolver
 from agentclaw.community.core.bot_config_manifest.apply.outcomes import ApplyStatus
 from agentclaw.community.core.bot_config_manifest.create_job import (
     DEFAULT_CREATE_DEADLINE_SECONDS,
@@ -122,7 +122,7 @@ def _build(db):
     )
     queue = _InlineQueue()
     bots = _Bots()
-    fetcher = lambda: EntryFetcher(FakeManifestContent(), FakeCredentials(), FakeObjectStore())  # noqa: E731
+    fetcher = lambda: DeclaredSourceResolver(FakeManifestContent(), FakeCredentials(), FakeObjectStore())  # noqa: E731
 
     def platform_ports() -> MaterialiserPorts:
         return MaterialiserPorts(

--- a/src/backend/tests/community/core/bot_config_manifest/creation/test_creation_tenancy.py
+++ b/src/backend/tests/community/core/bot_config_manifest/creation/test_creation_tenancy.py
@@ -126,8 +126,8 @@ def _real_apply_service(manifests):
         BotConfigManifestApplyRepository,
     )
 
-    from agentclaw.community.core.bot_config_manifest.apply.entry_fetch import (
-        EntryFetcher,
+    from agentclaw.community.core.bot_config_manifest.apply.source_resolver import (
+        DeclaredSourceResolver,
     )
     from ..apply._fakes import (
         FakeActivationService,
@@ -181,7 +181,7 @@ def _real_apply_service(manifests):
         upload_service_provider=lambda: FakeSkillUploadService(),
         capability_reader_provider=lambda: FakeCapabilityReader(),
         package_validator_provider=lambda: real_validator(),
-        entry_fetcher_provider=lambda: EntryFetcher(
+        entry_fetcher_provider=lambda: DeclaredSourceResolver(
             FakeManifestContent(), FakeCredentials(), FakeObjectStore()
         ),
         # W6's resources materialiser and W7's git transport: unreached by

--- a/src/backend/tests/community/core/bot_config_manifest/creation/test_first_artifact.py
+++ b/src/backend/tests/community/core/bot_config_manifest/creation/test_first_artifact.py
@@ -20,7 +20,7 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
 from agentclaw.community.core.bot_config_manifest.apply.delivery import MaterialiserPorts
-from agentclaw.community.core.bot_config_manifest.apply.entry_fetch import EntryFetcher
+from agentclaw.community.core.bot_config_manifest.apply.source_resolver import DeclaredSourceResolver
 from agentclaw.community.core.bot_config_manifest.apply.order import ApplyPhase
 from agentclaw.community.core.bot_config_manifest.apply.outcomes import ApplyStatus
 from agentclaw.community.core.bot_config_manifest.apply.activation_delegates import (
@@ -188,7 +188,7 @@ def _build(db):
     validator = real_validator()
 
     def fetcher():
-        return EntryFetcher(FakeManifestContent(), FakeObjectCredentials(), seeded_object_store({_QC_KEY: _QZ}))
+        return DeclaredSourceResolver(FakeManifestContent(), FakeObjectCredentials(), seeded_object_store({_QC_KEY: _QZ}))
 
     def platform_ports() -> MaterialiserPorts:
         return MaterialiserPorts(

--- a/src/backend/tests/community/core/bot_config_manifest/managed_files/test_skill_port.py
+++ b/src/backend/tests/community/core/bot_config_manifest/managed_files/test_skill_port.py
@@ -13,7 +13,7 @@ import hashlib
 from types import SimpleNamespace
 from typing import Any
 
-from agentclaw.community.core.bot_config_manifest.apply.entry_fetch import EntryFetcher
+from agentclaw.community.core.bot_config_manifest.apply.source_resolver import DeclaredSourceResolver
 from agentclaw.community.core.bot_config_manifest.apply.materialisers.skills import (
     SkillsMaterialiser,
 )
@@ -124,7 +124,7 @@ def _rig(packages: dict[str, bytes]):
         skill_repository=skills,
     )
     objects = seeded_object_store(packages)
-    pipeline = EntryFetcher(FakeManifestContent(), FakeObjectCredentials(), objects)
+    pipeline = DeclaredSourceResolver(FakeManifestContent(), FakeObjectCredentials(), objects)
     materialiser = SkillsMaterialiser(
         port, activation, LiveCapabilityReader(skills, activation), real_validator(), pipeline
     )

--- a/src/backend/tests/community/core/bot_config_manifest/managed_files/test_store_ports.py
+++ b/src/backend/tests/community/core/bot_config_manifest/managed_files/test_store_ports.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import asyncio
 
-from agentclaw.community.core.bot_config_manifest.apply.entry_fetch import EntryFetcher
+from agentclaw.community.core.bot_config_manifest.apply.source_resolver import DeclaredSourceResolver
 from agentclaw.community.core.bot_config_manifest.apply.materialisers.identity import (
     IdentityMaterialiser,
 )
@@ -49,7 +49,7 @@ def _store():
 
 
 def _fetcher():
-    return EntryFetcher(FakeManifestContent(), FakeCredentials(), FakeObjectStore())
+    return DeclaredSourceResolver(FakeManifestContent(), FakeCredentials(), FakeObjectStore())
 
 
 async def _apply(materialiser, ctx, entries):

--- a/src/backend/tests/community/di/test_manifest_fetch_module_wiring.py
+++ b/src/backend/tests/community/di/test_manifest_fetch_module_wiring.py
@@ -43,7 +43,7 @@ def test_the_entry_fetcher_reads_the_oss_road_through_the_one_object_store(
 ) -> None:
     """The ``oss`` road has one implementation and one instance.
 
-    ``EntryFetcher`` is the funnel every fetch-consuming category shares, and
+    ``DeclaredSourceResolver`` is the funnel every fetch-consuming category shares, and
     it takes the object store by constructor — a plain core class since the
     plugin seam went, exactly as it takes ``GuardedFetcher``. Asserted on the
     wired instance rather than the module source: what matters is that the
@@ -51,8 +51,8 @@ def test_the_entry_fetcher_reads_the_oss_road_through_the_one_object_store(
     test that substitutes the store on the injector substitutes it for every
     apply.
     """
-    from agentclaw.community.core.bot_config_manifest.apply.entry_fetch import (
-        EntryFetcher,
+    from agentclaw.community.core.bot_config_manifest.apply.source_resolver import (
+        DeclaredSourceResolver,
     )
     from agentclaw.community.core.bot_config_manifest.fetch.object_store import (
         AliyunObjectStore,
@@ -61,4 +61,4 @@ def test_the_entry_fetcher_reads_the_oss_road_through_the_one_object_store(
     store = test_injector.get(AliyunObjectStore)
 
     assert isinstance(store, AliyunObjectStore)
-    assert test_injector.get(EntryFetcher)._objects is store
+    assert test_injector.get(DeclaredSourceResolver)._objects is store

--- a/src/backend/tests/community/di/test_manifest_fetch_module_wiring.py
+++ b/src/backend/tests/community/di/test_manifest_fetch_module_wiring.py
@@ -43,13 +43,13 @@ def test_the_entry_fetcher_reads_the_oss_road_through_the_one_object_store(
 ) -> None:
     """The ``oss`` road has one implementation and one instance.
 
-    ``DeclaredSourceResolver`` is the funnel every fetch-consuming category shares, and
-    it takes the object store by constructor — a plain core class since the
-    plugin seam went, exactly as it takes ``GuardedFetcher``. Asserted on the
-    wired instance rather than the module source: what matters is that the
-    singleton the injector binds is the one the funnel reads through, so a
-    test that substitutes the store on the injector substitutes it for every
-    apply.
+    ``DeclaredSourceResolver`` is the funnel every fetch-consuming category
+    shares, and it takes the object store by constructor — a plain core class
+    since the plugin seam went, exactly as it takes ``GuardedFetcher`` — then
+    hands it to the one road that reads through it. Asserted on the wired
+    instance rather than the module source: what matters is that the singleton
+    the injector binds is the one the funnel reads through, so a test that
+    substitutes the store on the injector substitutes it for every apply.
     """
     from agentclaw.community.core.bot_config_manifest.apply.source_resolver import (
         DeclaredSourceResolver,
@@ -57,8 +57,12 @@ def test_the_entry_fetcher_reads_the_oss_road_through_the_one_object_store(
     from agentclaw.community.core.bot_config_manifest.fetch.object_store import (
         AliyunObjectStore,
     )
+    from agentclaw.community.core.bot_config_manifest.support_matrix import (
+        SourceKind,
+    )
 
     store = test_injector.get(AliyunObjectStore)
 
     assert isinstance(store, AliyunObjectStore)
-    assert test_injector.get(DeclaredSourceResolver)._objects is store
+    resolver = test_injector.get(DeclaredSourceResolver)
+    assert resolver._fetchers[SourceKind.OSS]._objects is store


### PR DESCRIPTION
## Problem

`apply/entry_fetch.py` held three methods on `EntryFetcher` that did not belong
to a dispatcher:

- `_git_keep_last` — one caller, `source_fetchers.GitSourceFetcher.fetch`.
- `acquire_object` — one caller, `source_fetchers.ObjectStoreFetcher.fetch`.
- `file_bytes` — the git road's receipt, filed *on behalf of* the materialisers,
  always behind an `if delivery.needs_receipt():` the caller had to remember.

Both fetchers were constructed with their owner and reached back through it
(`self._owner._credentials`, `self._owner._objects`, `self._owner._content`),
which is why `source_fetchers.py` carried a `TYPE_CHECKING` import of the module
that imports it and why private attributes were read across module boundaries.
And `fetch_declared` and `declared_protocol` each spelled out the same "find the
raw declaration for this entry" lookup — two places for one rule to be true in,
where the second exists precisely to predict what the first will do.

## Solution

Each road gets one home, a delivery files its own receipt, and the class that is
left is a dispatcher named for what it does.

### Where each method lives

| Before | After |
| --- | --- |
| `EntryFetcher._git_keep_last` | `GitSourceFetcher._keep_last` (`apply/source_fetchers.py`) |
| `EntryFetcher.acquire_object` | `ObjectStoreFetcher._acquire` (`apply/source_fetchers.py`) |
| `EntryFetcher.file_bytes` | `GitDelivery.file` (writes) / `BlobDelivery.file` (no-op) (`apply/entry_delivery.py`) |
| `EntryFetcher.fetch_declared` | `DeclaredSourceResolver.resolve` (`apply/source_resolver.py`) |
| `FetchContext`, `scope_of` | `apply/fetch_context.py` (new) |
| the declaration lookup, inline in two functions | `source_resolver._raw_declaration`, read by both |

`ObjectStoreFetcher(content, credentials, objects)` and
`GitSourceFetcher(content, credentials)` now take their collaborators directly,
bound once by `build_fetchers(content, credentials, objects)`. Nothing reaches
through an owner, and `source_fetchers.py` has no `TYPE_CHECKING` block left.

`fetch_context.py` exists because the fetchers, the dispatcher **and** the
deliveries all read `FetchContext`/`scope_of`: with `scope_of` now called at
runtime from `source_fetchers.py` and `entry_delivery.py`, leaving it on the
dispatcher would close a real import cycle rather than a typing-only one.

### One behaviour-preserving fix, called out

`acquire_object` read its per-entry cap as

```python
limit = FETCH_ENTRY_LIMITS.get(category, FETCH_ENTRY_LIMITS["resources_file"])
```

a `.get` whose default would have silently narrowed an unrecognised category to
the 100 MiB file cap. `category` is the `FetchCategory` the front door already
coerced, and `fetch/limits.py` binds that enum to `FETCH_ENTRY_LIMITS` with its
own module-level assertion — so the lookup is now the total
`FETCH_ENTRY_LIMITS[category]`, and the parameter is annotated `FetchCategory`.
That is exactly how the git road's `file_limit=` line already read the table;
the two are now consistent. No reachable call changes value: every caller comes
through the front door's coercion.

### `receipt_url` / `auth` callers kept: none

Grepped `apply/`, `cli_tools/` and `services/`: the only callers of
`EntryDelivery.receipt_url()` and `EntryDelivery.auth()` were the five
`file_bytes` sites. All three of `needs_receipt()`, `receipt_url()` and `auth()`
are therefore gone from the protocol and from both implementations, and nothing
was kept. `GitEntrySource.receipt_url()` — the dataclass helper, not the
protocol member — stays: `GitDelivery.file` is now its one caller.

### The three renames, for grepping

`EntryFetcher` → `DeclaredSourceResolver`; `fetch_declared` → `resolve`; `apply/entry_fetch.py` → `apply/source_resolver.py`.

`EntryFetchError`, `FetchContext`, `scope_of` and `declared_protocol` keep their
names.

## Validation

```
cd src/backend
uv run --no-sync python -m pytest -q -o addopts="" -W ignore \
  tests/community/core/bot_config_manifest/ \
  tests/community/endpoints/test_openapi_cli_tools.py
```

**1063 passed** (1061 on the base commit; net +2 from the new
`BlobDelivery.file` test and the object-road "files once" test, against the
`file_bytes`/`needs_receipt` assertions that were converted rather than
duplicated). `ruff check` is clean on every file this PR touches.

Post-change greps, all empty as intended:

- `grep -rn "EntryFetcher\b\|fetch_declared\|entry_fetch\b" src tests --include=*.py`
- `grep -n "_owner\|TYPE_CHECKING" .../apply/source_fetchers.py`
- `grep -n "def acquire_object\|def _git_keep_last\|def file_bytes" .../apply/source_resolver.py`
- `grep -rn "needs_receipt\|receipt_url()\|\.auth()" .../apply/materialisers/ .../cli_tools/`

`git status --short` lists no `uv.lock`.

### Zero behaviour change

The same bytes reach the same store under the same receipt identity, credential
name, category, apply id and entry identity on both roads; the budget is charged
at the same points and for the same amounts; every error message is byte-for-byte
what it was, including the asymmetry `_raw_declaration` preserves (a `from`
naming a source that does not parse still gets the parser's reason, not "not
declared under 'sources'"). The one changed expression is the
`FETCH_ENTRY_LIMITS` lookup above, which no reachable call path evaluates
differently.

## Compatibility and risk

Internal refactor: no schema, config, receipt, or HTTP contract changes. All
renamed symbols are internal to `core/bot_config_manifest` and its DI wiring.

Two deliberate scope notes for reviewers:

- **Commits 1 and 2 are swapped** relative to the task's suggested order. The
  fetchers cannot stop reaching through an owner until the two road methods have
  moved onto them, so "move the roads" lands first and "take their collaborators"
  second — both commits build and test green on their own.
- **The wiring identifiers `entry_fetcher` are left alone** (the DI provider
  names, the `MaterialiserPorts` field, the `build_materialisers` keyword). They
  name a role in the object graph rather than the class, and renaming them would
  have spread this diff across another ~40 call sites for no reading gain.
  Materialisers' own constructor parameters and attributes *are* renamed
  (`self._fetcher` → `self._resolver`), as instructed.

`apply/__init__.py` needed no change: it is deliberately import-free and exports
nothing.

`source_resolver.py` lands at 353 lines rather than the ~250 the task estimated.
The difference is prose, not code: the module docstring (47), `resolve`'s
worked-example docstring (~65) and `declared_protocol`'s answer table (~45) are
~160 lines that the non-goals put out of scope for trimming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CDryq37fbyGZjCAE1B22dq


---
_Generated by [Claude Code](https://claude.ai/code/session_01CDryq37fbyGZjCAE1B22dq)_