### PR TITLE
fix(bcs): keep bot session views independent of human scope

### DIFF
--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/sessions.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/sessions.rs
@@ -1734,7 +1734,7 @@ pub async fn get_session_messages(
     };
 
     let resolved_view =
-        match resolve_session_history_view(&sess, &caller, query.view_bot_id.as_deref()) {
+        match resolve_session_history_view(&state, &sess, &caller, query.view_bot_id.as_deref()).await {
             Ok(view) => view,
             Err(response) => return response,
         };
@@ -1862,7 +1862,8 @@ struct ResolvedSessionHistoryView {
     human_view: Option<HumanMessageView>,
 }
 
-fn resolve_session_history_view(
+async fn resolve_session_history_view(
+    state: &HttpAppState,
     session: &bcs_service_api::Session,
     caller: &bcs_service_api::CallerContext,
     requested_view_actor_id: Option<&str>,
@@ -1880,6 +1881,25 @@ fn resolve_session_history_view(
 
     match caller {
         bcs_service_api::CallerContext::Human(human) => {
+            if let Some(requested) = requested_view_actor_id.filter(|id| *id != human.actor_id) {
+                // The authenticated Human authorizes the selected Bot; its
+                // own message scope applies only when viewing the Human tab.
+                if !session.participants.iter().any(|participant| {
+                    participant.bot_uuid == requested && participant.actor_kind == ActorKind::Bot
+                }) {
+                    return Err(forbidden());
+                }
+                let owned = state.services.bot_query.list_bots_by_creator(&human.staff_no)
+                    .await
+                    .map_err(|error| super::bots::bot_use_case_error_to_http(error).into_response())?;
+                if !owned.iter().any(|bot| bot.bot_uuid == requested) {
+                    return Err(forbidden());
+                }
+                return Ok(ResolvedSessionHistoryView {
+                    view_actor_id: Some(requested.to_string()),
+                    human_view: None,
+                });
+            }
             let participant_view = session
                 .participants
                 .iter()
@@ -1889,9 +1909,6 @@ fn resolve_session_history_view(
                         && participant.message_view_scope == MessageViewScope::Participant
                 });
             if let Some(participant) = participant_view {
-                if requested_view_actor_id.is_some_and(|requested| requested != human.actor_id) {
-                    return Err(forbidden());
-                }
                 return Ok(ResolvedSessionHistoryView {
                     view_actor_id: Some(human.actor_id.clone()),
                     human_view: Some(HumanMessageView {
@@ -1903,8 +1920,7 @@ fn resolve_session_history_view(
             }
 
             // Full is the compatibility mode. Preserve the pre-feature
-            // behavior exactly: do not infer a Human View Actor and leave an
-            // explicitly requested legacy view unchanged.
+            // behavior: do not infer a Human View Actor for an omitted view.
             Ok(ResolvedSessionHistoryView {
                 view_actor_id: requested_view_actor_id.map(str::to_string),
                 human_view: None,

--- a/src/bcs/crates/adapters/http/bcs-http/tests/group_messages_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/group_messages_contract.rs
@@ -870,6 +870,7 @@ async fn build_group_app_with_identity_and_session_status(
         Arc::new(NoopFriendCoreService),
     ));
     let services = Services::builder()
+        .bot_query(Arc::new(bcs_bot::Bot::new(registry.clone())))
         .registry(registry)
         .group(group_store.clone())
         .routing(routing.clone())
@@ -1522,6 +1523,111 @@ async fn participant_session_history_merges_own_legacy_one_shot_response_snapsho
     assert_eq!(views.len(), 1);
     assert_eq!(views[0].actor_id, "human_123");
     assert_eq!(views[0].scope, bcs_domain::MessageViewScope::Participant);
+}
+
+async fn scoped_session_history_app(
+    strategy: GroupStrategy,
+    scope: bcs_domain::MessageViewScope,
+) -> (
+    axum::Router,
+    Arc<RecordingGroupMessageHistory>,
+    Arc<RecordingStateMachineHistoryRuntime>,
+    TempDir,
+) {
+    let temp_dir = TempDir::new().unwrap();
+    let registry = Arc::new(BotCore::with_base_dir(temp_dir.path().to_path_buf()));
+    for (bot_id, owner) in [
+        ("owner-bot", "123"),
+        ("other-bot", "456"),
+        ("outside-bot", "123"),
+    ] {
+        registry.register(bot_id.to_string(), BotCapabilities::default()).await.unwrap();
+        registry.save_created_by(bot_id, owner, true).await.unwrap();
+    }
+    let mut human = Participant::human("human_123", ParticipantRole::Observer);
+    human.message_view_scope = scope;
+    let participants = vec![
+        Participant::bot("owner-bot", ParticipantRole::Driver),
+        Participant::bot("other-bot", ParticipantRole::Consultant),
+        human,
+        Participant::human("human_456", ParticipantRole::Observer),
+    ];
+    let mut group = Group::new("scoped-group", "owner-bot", participants.clone());
+    group.group_strategy = strategy;
+    group.status = GroupStatus::Active;
+    let group_store = Arc::new(GroupStore::new());
+    group_store.upsert(group).await.unwrap();
+    let session = test_session("scoped-group:abcdef12", "scoped-group", participants);
+    let history = Arc::new(RecordingGroupMessageHistory::default());
+    let runtime = Arc::new(RecordingStateMachineHistoryRuntime {
+        calls: Mutex::new(Vec::new()),
+        human_views: Mutex::new(Vec::new()),
+        result: SessionHistoryResult {
+            session_id: session.id.clone(),
+            messages: rich_session_messages(),
+            limit: 20,
+            before: None,
+            next_before: None,
+        },
+    });
+    let mut services = Services::noop();
+    services.bot_query = Arc::new(bcs_bot::Bot::new(registry.clone()));
+    services.registry = registry;
+    services.group = group_store;
+    services.session_management = Arc::new(StaticSessionManagement::new(session));
+    services.group_message_history = history.clone();
+    services.collaboration_runtime = runtime.clone();
+    let app = build_router(HttpAppState::new(services).with_user_identity(Arc::new(
+        ChainUserIdentityPort::new(static_auth_chain("123", "Owner")),
+    )));
+    (app, history, runtime, temp_dir)
+}
+
+#[tokio::test]
+async fn session_messages_bot_view_is_independent_of_human_scope() {
+    for strategy in [GroupStrategy::Chat, GroupStrategy::ManagerWorker, GroupStrategy::StateMachine] {
+        for scope in [bcs_domain::MessageViewScope::Full, bcs_domain::MessageViewScope::Participant] {
+            let (app, history, runtime, _temp_dir) = scoped_session_history_app(strategy, scope).await;
+            let response = app.oneshot(
+                Request::builder()
+                    .uri("/sessions/scoped-group:abcdef12/messages?view_bot_id=owner-bot&limit=20")
+                    .body(Body::empty()).unwrap(),
+            ).await.unwrap();
+            assert_eq!(response.status(), StatusCode::OK, "{strategy:?}, {scope:?}");
+            let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+            assert_eq!(serde_json::from_slice::<Value>(&body).unwrap(),
+                serde_json::to_value(rich_session_messages()).unwrap());
+            assert!(runtime.human_views.lock().await.is_empty(), "Bot tab must not use Human projection");
+            if strategy == GroupStrategy::StateMachine {
+                assert!(history.session_calls.lock().await.is_empty());
+                assert_eq!(runtime.calls.lock().await.len(), 1);
+            } else {
+                let calls = history.session_calls.lock().await;
+                assert_eq!(calls.len(), 1);
+                assert_eq!(calls[0].view_bot_id.as_deref(), Some("owner-bot"));
+                assert!(runtime.calls.lock().await.is_empty(), "Bot tab must not merge Human snapshots");
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn session_messages_explicit_view_requires_owned_session_bot() {
+    for strategy in [GroupStrategy::Chat, GroupStrategy::ManagerWorker, GroupStrategy::StateMachine] {
+        for scope in [bcs_domain::MessageViewScope::Full, bcs_domain::MessageViewScope::Participant] {
+            let (app, history, runtime, _temp_dir) = scoped_session_history_app(strategy, scope).await;
+            for actor in ["other-bot", "outside-bot", "missing-bot", "human_456"] {
+                let response = app.clone().oneshot(
+                    Request::builder()
+                        .uri(format!("/sessions/scoped-group:abcdef12/messages?view_bot_id={actor}&limit=20"))
+                        .body(Body::empty()).unwrap(),
+                ).await.unwrap();
+                assert_eq!(response.status(), StatusCode::FORBIDDEN, "{strategy:?}, {scope:?}, {actor}");
+            }
+            assert!(history.session_calls.lock().await.is_empty());
+            assert!(runtime.calls.lock().await.is_empty());
+        }
+    }
 }
 
 #[tokio::test]

--- a/src/bcs/docs/superpowers/specs/2026-09-01-bcs-human-participant-message-isolation-design.md
+++ b/src/bcs/docs/superpowers/specs/2026-09-01-bcs-human-participant-message-isolation-design.md
@@ -21,7 +21,8 @@ worker 或状态机节点的内部回复。
    `message_view_scope`，继续沿用各自已有的成员、受理人和运行权限规则。
 4. 本能力是产品视图降噪，不承诺机密性。Human 可通过有权限的状态机副屏查看流程
    信息；真正的秘密信息不能仅依赖本 scope 保护。
-5. bot owner 以 bot 视角查看不在本次范围内。
+5. Bot tab 按所选 Bot 的归属与 Session 成员关系授权，不受登录 Human 的
+   `message_view_scope` 影响；Human 投影仅用于 Human tab。
 
 ## 3. Scope 数据模型
 
@@ -102,6 +103,11 @@ scope。Leader Election 开启的多副本部署暂时只提供实例内的 best
 
 历史接口解析同一个 actor id 与有效 scope，并在分页语义确定后返回该 viewer 的投影。
 实时与历史必须复用同一判定函数及消息元数据。
+
+HTTP 登录身份与所选 View Actor 分开处理。Human 显式通过 `view_bot_id` 选择 Bot
+时，必须拥有该 Bot，且 Bot 必须是当前 Session 的参与者；通过校验后读取 Bot
+视角，不应用 Human 的 scope，也不合并 Human 专属的运行时快照。该规则适用于
+Chat、ManagerWorker 和 StateMachine Session，旧历史接口与 V1 接口保持一致。
 
 对于运行时快照补齐的 HumanInput 展示，只能用于 `participant` 投影，不能改变 `full`
 原有消息集合。补齐消息需要稳定 identity，防止与持久化消息重复。
@@ -190,6 +196,8 @@ API 默认值为 `full`。不应引入 `participant_view_unsupported` 之类由 
 - 未传 `view_actor_id` 的旧 Workbench 连接保持原授权与未投影消息行为。
 - `full` 的 WS 帧、历史消息集合、排序和副屏行为与基线一致。
 - 旧群、旧 session 可以继续创建运行、加入和查询状态机。
+- Human 为 `full` 或 `participant` 时，切到自有且已加入 Session 的 Bot tab
+  得到相同的 Bot 历史；他人的 Bot、未加入 Session 的 Bot 和其他 Human 视角均拒绝。
 
 ### participant 主消息流
 


### PR DESCRIPTION
## Problem

Human 在 Session 中设置 `message_view_scope=participant` 后，切换到自有 Bot tab 查看消息会返回 403，即使该 Bot 已是 Session 成员。

旧历史接口将登录 Human 的消息视野限制应用到了 Bot 视角，导致两个 tab 的行为耦合。

## Solution

- 显式选择 Bot 视角时，先校验 Bot 归属和当前 Session 成员关系。
- 校验通过后读取 Bot 视角，不应用 Human 的消息投影或合并 Human 专属快照。
- 保留 Human tab 原有的 `full` / `participant` 行为。
- 更新设计说明，补充普通聊天、主从协作和状态机 Session 的回归测试。

## Validation

- HTTP 模块全部 **509 个测试通过**。
- BCS 二进制构建成功。
- 重启本地 BCS 后，原报错 URL 从 **403 恢复为 200**；Human 保持 `participant`，自身消息接口仍返回 200。
- 未运行完整 BCS workspace 和 Singlebox E2E；本次验证聚焦 HTTP 模块及原始本地复现场景。

## Compatibility and risk

无接口结构、配置或数据库迁移变更。显式 Bot 视角统一执行归属和 Session 成员校验；他人的 Bot、未加入 Session 的 Bot及其他 Human 视角均返回 403，与 V1 接口规则一致。