### PR TITLE
refactor(apply): ApplyStep carries construct and position only; the phase belongs to the delivery strategy

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/delivery.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/delivery.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, replace
 from enum import StrEnum
+from types import MappingProxyType
 from typing import Any, Awaitable, Callable, Mapping, Optional, Protocol
 
 from agentclaw.community.core.ports.activation_port import (
@@ -65,7 +66,10 @@ from agentclaw.community.core.bot_config_manifest.apply.order import (
     ApplyPhase,
     ApplyStep,
 )
-from agentclaw.community.core.bot_config_manifest.apply.outcomes import ApplyReport
+from agentclaw.community.core.bot_config_manifest.apply.outcomes import (
+    ApplyConstruct,
+    ApplyReport,
+)
 from agentclaw.community.core.bot_config_manifest.capabilities import ManifestSection
 
 #: The yaml key under ``user_config.bot_config_manifest``::
@@ -158,8 +162,8 @@ class DeliveryStrategy(Protocol):
     ``family``              ``"arca"``             ``"teclaw"``
     ``creation_sequence``   ``CREATE_BETWEEN_``    ``RECORD_APPLY_``
                             ``PHASES``             ``PROVISION``
-    ``phase_of(step)``      the table's own        ``PRE_CONTAINER`` for
-                            ``step.phase``         everything but ``script``
+    ``phase_of(step)``      :data:`_ARCA_PHASES`   ``PRE_CONTAINER`` for
+                                                   every construct
     ``needs_container()``   ``True``               ``False``
     ``ports()``             device-backed          store-backed
     ``finish()``            ``None``               one whole-artifact
@@ -197,7 +201,8 @@ class DeliveryStrategy(Protocol):
     def phase_of(self, step: ApplyStep) -> ApplyPhase:
         """Which phase this family delivers the step's construct in.
 
-        May disagree with ``step.phase``, which is the ARCA reading.
+        The phase table is the strategy's own — :data:`ApplyStep` carries no
+        phase, so the two families are free to disagree and routinely do.
         """
         ...
 
@@ -206,9 +211,11 @@ class DeliveryStrategy(Protocol):
     ) -> tuple[ApplyStep, ...]:
         """The steps in the requested phases, in position order.
 
-        Same contract as ``apply.order.steps_for``, but filtered through this
-        family's :meth:`phase_of` rather than the table's own column. This is
-        the callable handed to ``ApplyOrchestrator``.
+        :data:`~agentclaw.community.core.bot_config_manifest.apply.order.APPLY_ORDER`
+        sorted by position and filtered through this family's
+        :meth:`phase_of`. ``None`` means both phases, which is what an ordinary
+        apply on an existing bot wants; the creation job passes one at a time.
+        This is the callable handed to ``ApplyOrchestrator``.
         """
         ...
 
@@ -240,6 +247,28 @@ class DeliveryStrategy(Protocol):
         ...
 
 
+#: The container family's phase per construct. ``script`` is the only
+#: construct that needs no container; everything else lands after it is up.
+_ARCA_PHASES: Mapping[ApplyConstruct, ApplyPhase] = MappingProxyType({
+    ManifestSection.SCRIPT: ApplyPhase.PRE_CONTAINER,
+    ManifestCategory.IDENTITY: ApplyPhase.ON_CONTAINER,
+    ManifestCategory.RESOURCES: ApplyPhase.ON_CONTAINER,
+    ManifestCategory.SKILLS: ApplyPhase.ON_CONTAINER,
+    ManifestCategory.MCP: ApplyPhase.ON_CONTAINER,
+    ManifestCategory.ENGINE_CONFIG: ApplyPhase.ON_CONTAINER,
+    ManifestCategory.CLI_TOOLS: ApplyPhase.ON_CONTAINER,
+})
+
+# The no-drift assertion ``source_fetchers.FETCHER_TYPES`` and ``fetch/limits``
+# set the precedent for: adding a construct to APPLY_ORDER without giving this
+# family a phase for it would otherwise be a KeyError on the first apply that
+# walked it, on whichever bot happened to declare it first.
+assert set(_ARCA_PHASES) == {step.construct for step in APPLY_ORDER}, (
+    "_ARCA_PHASES and APPLY_ORDER must name the same set of constructs — a "
+    "construct in the order with no phase here has no ARCA delivery at all"
+)
+
+
 def _steps(
     phase_of: Callable[[ApplyStep], ApplyPhase],
     phases: frozenset[ApplyPhase] | None,
@@ -253,11 +282,11 @@ def _steps(
 
 
 class ArcaDelivery(DeliveryStrategy):
-    """The container family: the phase table is ``APPLY_ORDER``'s own.
+    """The container family: the phase table is :data:`_ARCA_PHASES`.
 
-    Every answer is the table's, unchanged — ``phase_of`` returns
-    ``step.phase``, ``needs_container`` is ``True``, and ``finish`` has
-    nothing to do because the owning services project as they write.
+    ``script`` before the container, every other construct after it;
+    ``needs_container`` is ``True``, and ``finish`` has nothing to do because
+    the owning services project as they write.
     """
 
     family = "arca"
@@ -267,7 +296,7 @@ class ArcaDelivery(DeliveryStrategy):
         self._ports = ports
 
     def phase_of(self, step: ApplyStep) -> ApplyPhase:
-        return step.phase
+        return _ARCA_PHASES[step.construct]
 
     def steps_for(
         self, phases: frozenset[ApplyPhase] | None = None
@@ -329,6 +358,10 @@ class TeclawPlatformBindings:
 class TeclawDelivery(DeliveryStrategy):
     """The artifact family.
 
+    Its phase table is not a literal like :data:`_ARCA_PHASES` but computed in
+    :meth:`phase_of` from the platform-managed switch plus the two per-construct
+    rules that ignore it (``script`` and ``cli_tools``).
+
     With ``platform_managed`` on, every non-script construct is
     ``PRE_CONTAINER``: it writes platform state and needs no container. The
     apply is closed by one redeliver. Off, the strategy reproduces the shape
@@ -383,9 +416,10 @@ class TeclawDelivery(DeliveryStrategy):
     def phase_of(self, step: ApplyStep) -> ApplyPhase:
         if step.construct == ManifestSection.SCRIPT:
             # Unsupported on teclaw (the capability resolver refuses it); the
-            # phase is kept as the table says so a declared script still walks
-            # the orchestrator's no-support path and is reported, not skipped.
-            return step.phase
+            # phase is stated anyway, and stated as the ARCA one, so a declared
+            # script still walks the orchestrator's no-support path and is
+            # reported, not skipped.
+            return ApplyPhase.PRE_CONTAINER
         if step.construct == ManifestCategory.CLI_TOOLS:
             # The artifact is teclaw's delivery and it is composed before
             # provisioning, so this category is PRE_CONTAINER whatever the

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/orchestrator.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/orchestrator.py
@@ -106,10 +106,10 @@ class ApplyOrchestrator:
     """Applies a parsed manifest to one bot, category by category.
 
     Constructed with the registry map (construct → materialiser) and a
-    ``steps`` callable, which is the engine family's phase table: ARCA passes
-    ``apply.order.steps_for``, teclaw passes its delivery strategy's re-phased
-    version. There is no default, so the table in use is always visible at the
-    call site.
+    ``steps`` callable, which is always a delivery strategy's ``steps_for`` —
+    the engine family's phase table applied to the shared order. There is no
+    table-level default, so the family whose phases are in use is always
+    visible at the call site.
 
     Holds no per-apply state: everything is passed in and the report comes back
     out. That is what lets the creation job call it twice — once per phase,
@@ -125,9 +125,9 @@ class ApplyOrchestrator:
         self._materialisers = dict(materialisers)
         # Which construct belongs to which phase is the engine family's to say
         # (``apply/delivery.py``, W8): every caller hands the strategy's
-        # ``steps_for`` in — there is no default, so the phase table in use is
-        # always visible at the call site. The order table's own reading,
-        # ``apply.order.steps_for``, is ARCA's.
+        # ``steps_for`` in. ``apply.order`` has no phase column and no
+        # ``steps_for`` of its own, so there is nothing to default to and the
+        # phase table in use is always visible at the call site.
         self._steps = steps
 
     async def apply(

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/order.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/order.py
@@ -1,4 +1,4 @@
-"""In what order the constructs are applied, and which phase each belongs to.
+"""In what order the constructs are applied, and the phase vocabulary.
 
 **This table is complete, and completeness is the point.** It names every
 construct the v1 vocabulary defines, including the ones no materialiser can act
@@ -7,6 +7,11 @@ a separate, sparse fact that lives in :mod:`.registry`. Walking a complete table
 and finding a sparse registry is what makes "no materialiser yet" an ordinary
 state the orchestrator handles once, rather than a branch naming three
 categories by hand.
+
+The table says *what* and *when relative to the others*; it does not say which
+half of the creation path a construct lands in. That is :class:`ApplyPhase`,
+defined here as shared vocabulary but **answered** per engine family by the
+delivery strategies in :mod:`.delivery`.
 """
 from __future__ import annotations
 
@@ -28,10 +33,10 @@ class ApplyPhase(StrEnum):
         ApplyPhase.PRE_CONTAINER.value == "pre_container"
         ApplyPhase.ON_CONTAINER.value  == "on_container"
 
-    Created by: this module's :data:`APPLY_ORDER` table, one phase per step.
-    Consumed by: :func:`steps_for` as the filter, the creation job (which
-    passes one at a time), and ``apply/delivery``, which re-phases every
-    non-script step to ``PRE_CONTAINER`` for teclaw.
+    Created by: each ``DeliveryStrategy.phase_of`` in ``apply/delivery`` —
+    the phase is the engine family's answer, not the order table's.
+    Consumed by: ``apply/delivery._steps`` as the filter, the creation job
+    (which passes one at a time), and the HTTP routes.
 
     The split is not organisational. The two halves have **opposite**
     delivery-time constraints, and an orchestrator that ignored that would be
@@ -59,22 +64,23 @@ class ApplyPhase(StrEnum):
 class ApplyStep:
     """One construct's place in the order::
 
-        ApplyStep(ManifestSection.SCRIPT, ApplyPhase.PRE_CONTAINER, 0)
-        ApplyStep(ManifestCategory.IDENTITY, ApplyPhase.ON_CONTAINER, 1)
+        ApplyStep(ManifestSection.SCRIPT, 0)
+        ApplyStep(ManifestCategory.IDENTITY, 1)
 
-    Created by: :data:`APPLY_ORDER`, and rebuilt with a swapped ``phase`` by
-    ``apply/delivery`` for the teclaw family.
-    Consumed by: :func:`steps_for` and ``apply/orchestrator``, which walks the
-    steps in order.
+    A pure ordering record: which construct, and where in the walk. The phase
+    it lands in is **not** here, because it is not a property of the step — it
+    is a function of the engine family, and each ``DeliveryStrategy`` in
+    ``apply/delivery`` owns its own phase table.
+
+    Created by: :data:`APPLY_ORDER`.
+    Consumed by: ``apply/delivery`` (which phases and filters the steps) and
+    ``apply/orchestrator``, which walks the steps in order.
     """
 
     #: Which construct this step applies.
     construct: ApplyConstruct
-    #: Which half of the creation path it belongs to. The **ARCA** family's
-    #: answer; teclaw's delivery strategy overrides it.
-    phase: ApplyPhase
-    #: The sort key, 0-6, unique across the table. Shared by both families —
-    #: only the phase is family-specific.
+    #: The sort key, 0-6, unique across the table. Shared by every family: the
+    #: order is the table's, only the phase is family-specific.
     position: int
 
 
@@ -83,10 +89,9 @@ class ApplyStep:
 #: **This REVERSES design §3.4**, which put ``script`` last. The reversal is
 #: work-items §2.12's, and the reason is the one :class:`ApplyPhase` states:
 #: ``script`` is the only construct needing no container, and on the creation
-#: path the row must exist before the start command is composed. Everything else
-#: is delivered after the container is up. A reader of the design who does not
-#: find this note here would reasonably implement the design's order and break
-#: the creation path.
+#: path the row must exist before the start command is composed. A reader of
+#: the design who does not find this note here would reasonably implement the
+#: design's order and break the creation path.
 #:
 #: The consequence, stated so nobody has to derive it: on a bot's first boot the
 #: script runs **before** any other category is delivered. That is why iteration
@@ -94,49 +99,16 @@ class ApplyStep:
 #: manifest declares (§2.12). #1508 removes the restriction in iteration 2 by
 #: delivering everything before the container starts.
 APPLY_ORDER: tuple[ApplyStep, ...] = (
-    ApplyStep(ManifestSection.SCRIPT, ApplyPhase.PRE_CONTAINER, 0),
-    ApplyStep(ManifestCategory.IDENTITY, ApplyPhase.ON_CONTAINER, 1),
-    ApplyStep(ManifestCategory.RESOURCES, ApplyPhase.ON_CONTAINER, 2),
-    ApplyStep(ManifestCategory.SKILLS, ApplyPhase.ON_CONTAINER, 3),
-    ApplyStep(ManifestCategory.MCP, ApplyPhase.ON_CONTAINER, 4),
-    ApplyStep(ManifestCategory.ENGINE_CONFIG, ApplyPhase.ON_CONTAINER, 5),
-    ApplyStep(ManifestCategory.CLI_TOOLS, ApplyPhase.ON_CONTAINER, 6),
+    ApplyStep(ManifestSection.SCRIPT, 0),
+    ApplyStep(ManifestCategory.IDENTITY, 1),
+    ApplyStep(ManifestCategory.RESOURCES, 2),
+    ApplyStep(ManifestCategory.SKILLS, 3),
+    ApplyStep(ManifestCategory.MCP, 4),
+    ApplyStep(ManifestCategory.ENGINE_CONFIG, 5),
+    ApplyStep(ManifestCategory.CLI_TOOLS, 6),
 )
 
 #: Both phases — what the HTTP route passes, and the default everywhere.
 ALL_PHASES: frozenset[ApplyPhase] = frozenset(ApplyPhase)
 
-# The ``phase`` column above is the **ARCA** family's table. teclaw delivers by
-# artifact and needs no container for any construct, so its strategy
-# (``apply/delivery.py``, W8) re-phases every non-script step to
-# ``PRE_CONTAINER`` when the platform-managed switch is on. The position column
-# is shared; the phase is the family's. ``steps_for`` below stays the ARCA
-# reading for callers that predate the seam.
-
-
-def steps_for(phases: frozenset[ApplyPhase] | None = None) -> tuple[ApplyStep, ...]:
-    """The steps in the requested phases, in position order::
-
-        steps_for()                                     # all seven, 0..6
-        steps_for(ALL_PHASES)                           # the same
-        steps_for(frozenset({ApplyPhase.PRE_CONTAINER}))
-        # -> (ApplyStep(ManifestSection.SCRIPT, PRE_CONTAINER, 0),)
-        steps_for(frozenset({ApplyPhase.ON_CONTAINER}))
-        # -> the other six, positions 1..6
-
-    Called by: ``apply/orchestrator`` and ``apply/delivery``.
-
-    ``None`` means both, which is what an ordinary apply on an existing bot
-    wants. The creation job passes one at a time — ``PRE_CONTAINER`` before the
-    start command is composed, ``ON_CONTAINER`` once the container is up — and
-    gets one report from each.
-    """
-    wanted = ALL_PHASES if phases is None else phases
-    return tuple(
-        step
-        for step in sorted(APPLY_ORDER, key=lambda s: s.position)
-        if step.phase in wanted
-    )
-
-
-__all__ = ["ALL_PHASES", "APPLY_ORDER", "ApplyPhase", "ApplyStep", "steps_for"]
+__all__ = ["ALL_PHASES", "APPLY_ORDER", "ApplyPhase", "ApplyStep"]

--- a/src/backend/tests/community/core/bot_config_manifest/apply/test_apply_engine.py
+++ b/src/backend/tests/community/core/bot_config_manifest/apply/test_apply_engine.py
@@ -13,7 +13,7 @@ import pytest
 import yaml
 
 from agentclaw.community.core.bot_config_manifest.apply.order import ApplyPhase
-from agentclaw.community.core.bot_config_manifest.apply.order import steps_for
+from agentclaw.community.core.bot_config_manifest.apply.delivery import ArcaDelivery
 from agentclaw.community.core.bot_config_manifest.apply.orchestrator import (
     ApplyOrchestrator,
 )
@@ -53,6 +53,13 @@ from ._fakes import (
 from tests.community.core.bot_config_manifest.apply._fakes import FakeObjectStore
 
 
+#: The orchestrator is always handed a delivery strategy's ``steps_for``; these
+#: tests exercise the ARCA family, so they hand it ARCA's. The ports callable is
+#: never reached — ``steps_for`` only phases and sorts ``APPLY_ORDER``.
+_arca_steps = ArcaDelivery(lambda: None).steps_for
+
+
+
 def _engine(scripts=None, activations=None, auth=None):
     """The W4-shaped engine: mcp + script over their fakes (these tests are
     the engine's contract, not the two fetch-consuming categories' — those
@@ -70,7 +77,7 @@ def _engine(scripts=None, activations=None, auth=None):
             resource_service=FakeResourceFileService(),
             cli_tool_service=object(),
         ),
-        steps=steps_for
+        steps=_arca_steps
     )
 
 
@@ -801,7 +808,7 @@ async def test_a_fetching_document_applies_all_four_categories_in_order():
             resource_service=FakeResourceFileService(),
             cli_tool_service=object(),
         ),
-        steps=steps_for
+        steps=_arca_steps
     )
 
     report = await _apply(

--- a/src/backend/tests/community/core/bot_config_manifest/apply/test_delivery_strategy.py
+++ b/src/backend/tests/community/core/bot_config_manifest/apply/test_delivery_strategy.py
@@ -1,7 +1,9 @@
 """The delivery seam (W8): what differs between engine families, and only that.
 
-Three configurations, three phase tables. ARCA is ``APPLY_ORDER`` verbatim.
-teclaw with the switch on puts every non-script construct before the container,
+Three configurations, three phase tables — and the tables live on the
+strategies, not on ``APPLY_ORDER``, which carries only construct and position.
+ARCA is ``_ARCA_PHASES``: ``script`` before the container, everything else
+after. teclaw with the switch on puts every non-script construct before it,
 because the artifact is the delivery; with it off, after, because that is the
 shape it ran before W8.
 """
@@ -10,6 +12,7 @@ from __future__ import annotations
 import pytest
 
 from agentclaw.community.core.bot_config_manifest.apply.delivery import (
+    _ARCA_PHASES,
     ArcaDelivery,
     CreationSequence,
     DeliveryStrategyFactory,
@@ -21,7 +24,6 @@ from agentclaw.community.core.bot_config_manifest.apply.order import (
     ALL_PHASES,
     APPLY_ORDER,
     ApplyPhase,
-    steps_for,
 )
 from agentclaw.community.core.bot_config_manifest.capabilities import (
     ManifestCategory,
@@ -39,16 +41,34 @@ _IS_TECLAW = lambda engine: (engine or "").lower() == "teclaw"  # noqa: E731
 # ── phase tables ──────────────────────────────────────────────────────────
 
 
-def test_arca_phases_are_the_order_tables_own() -> None:
+def test_arca_phases_are_the_strategys_own_table() -> None:
     arca = ArcaDelivery(lambda: _ports("arca"))
+    assert [(s.construct, arca.phase_of(s)) for s in APPLY_ORDER] == [
+        (ManifestSection.SCRIPT, ApplyPhase.PRE_CONTAINER),
+        (ManifestCategory.IDENTITY, ApplyPhase.ON_CONTAINER),
+        (ManifestCategory.RESOURCES, ApplyPhase.ON_CONTAINER),
+        (ManifestCategory.SKILLS, ApplyPhase.ON_CONTAINER),
+        (ManifestCategory.MCP, ApplyPhase.ON_CONTAINER),
+        (ManifestCategory.ENGINE_CONFIG, ApplyPhase.ON_CONTAINER),
+        (ManifestCategory.CLI_TOOLS, ApplyPhase.ON_CONTAINER),
+    ]
     for step in APPLY_ORDER:
-        assert arca.phase_of(step) is step.phase
-    assert arca.steps_for(None) == steps_for(None)
-    assert arca.steps_for(frozenset({ApplyPhase.PRE_CONTAINER})) == steps_for(
-        frozenset({ApplyPhase.PRE_CONTAINER})
+        assert arca.phase_of(step) is _ARCA_PHASES[step.construct]
+    assert arca.steps_for(None) == tuple(
+        sorted(APPLY_ORDER, key=lambda s: s.position)
     )
+    assert [s.construct for s in arca.steps_for(frozenset({ApplyPhase.PRE_CONTAINER}))] == [
+        ManifestSection.SCRIPT
+    ]
     assert arca.creation_sequence is CreationSequence.CREATE_BETWEEN_PHASES
     assert arca.needs_container()
+
+
+def test_the_arca_phase_table_names_every_construct_in_the_order() -> None:
+    """The import-time assertion in ``delivery.py``, named here too: adding a
+    construct to ``APPLY_ORDER`` without giving ARCA a phase for it is a
+    ``KeyError`` at the first apply that walks it."""
+    assert set(_ARCA_PHASES) == {step.construct for step in APPLY_ORDER}
 
 
 def test_teclaw_on_puts_every_non_script_construct_before_the_container() -> None:
@@ -101,8 +121,8 @@ def test_teclaw_off_is_the_pre_w8_shape() -> None:
 
 
 def test_cli_tools_is_on_container_on_arca() -> None:
-    """The order table's phase is the ARCA reading, and W9 did not change it:
-    an ARCA tool is a write into a live container."""
+    """W9 did not change the ARCA reading: an ARCA tool is a write into a live
+    container."""
     arca = ArcaDelivery(lambda: _ports("arca"))
     step = next(s for s in APPLY_ORDER if s.construct is ManifestCategory.CLI_TOOLS)
     assert arca.phase_of(step) is ApplyPhase.ON_CONTAINER
@@ -189,11 +209,34 @@ def test_a_teclaw_strategy_with_no_cli_service_bound_leaves_the_bundle_alone() -
     assert teclaw.ports() == _ports("device")
 
 
-def test_the_order_table_itself_is_untouched_by_w9() -> None:
-    """``order.py`` carries the ARCA reading; the per-family rule lives in the
-    strategy. A change here would silently re-phase ARCA too."""
+def test_the_arca_table_itself_is_untouched_by_w9() -> None:
+    """The per-family rule lives in ``TeclawDelivery``; ARCA's own table still
+    says ``ON_CONTAINER``, and the position is the shared one. A change here
+    would silently re-phase ARCA too."""
     step = next(s for s in APPLY_ORDER if s.construct is ManifestCategory.CLI_TOOLS)
-    assert (step.phase, step.position) == (ApplyPhase.ON_CONTAINER, 6)
+    assert (_ARCA_PHASES[step.construct], step.position) == (
+        ApplyPhase.ON_CONTAINER,
+        6,
+    )
+
+
+@pytest.mark.parametrize("switch", [True, False])
+def test_script_is_pre_container_on_teclaw_under_either_switch(switch) -> None:
+    """``script`` is unsupported on teclaw, but the phase is still answered —
+    and answered without consulting any shared table, since ``ApplyStep``
+    carries none. A step that fell out of both phases would be skipped
+    silently instead of walking the orchestrator's no-support path and being
+    reported."""
+    teclaw = TeclawDelivery(
+        platform_managed=switch,
+        platform_ports=lambda: _ports("store"),
+        device_ports=lambda: _ports("device"),
+    )
+    step = next(s for s in APPLY_ORDER if s.construct is ManifestSection.SCRIPT)
+    assert teclaw.phase_of(step) is ApplyPhase.PRE_CONTAINER
+    assert ManifestSection.SCRIPT in {
+        s.construct for s in teclaw.steps_for(frozenset({ApplyPhase.PRE_CONTAINER}))
+    }
 
 
 def test_both_phases_walk_every_construct_on_every_strategy() -> None:

--- a/src/backend/tests/community/core/bot_config_manifest/apply/test_orchestrator_stays_generic.py
+++ b/src/backend/tests/community/core/bot_config_manifest/apply/test_orchestrator_stays_generic.py
@@ -9,6 +9,7 @@ import inspect
 import re
 
 from agentclaw.community.core.bot_config_manifest.apply import (
+    delivery,
     order,
     orchestrator,
     registry,
@@ -126,11 +127,15 @@ def test_every_registered_materialiser_has_a_place_in_the_order():
 
 
 def test_script_is_alone_in_the_phase_that_needs_no_container():
-    """The property W13 depends on, pinned against a careless reordering."""
+    """The property W13 depends on, pinned against a careless reordering.
+
+    The phase is the delivery strategy's, not the order table's; this is the
+    ARCA family's table.
+    """
     pre = [
         step.construct
         for step in order.APPLY_ORDER
-        if step.phase is order.ApplyPhase.PRE_CONTAINER
+        if delivery._ARCA_PHASES[step.construct] is order.ApplyPhase.PRE_CONTAINER
     ]
     assert pre == [ManifestSection.SCRIPT]
 
@@ -140,7 +145,7 @@ def test_phase_b_keeps_the_declared_category_order():
     on_container = [
         step.construct
         for step in sorted(order.APPLY_ORDER, key=lambda s: s.position)
-        if step.phase is order.ApplyPhase.ON_CONTAINER
+        if delivery._ARCA_PHASES[step.construct] is order.ApplyPhase.ON_CONTAINER
     ]
     assert on_container[:4] == [
         ManifestCategory.IDENTITY,

--- a/src/backend/tests/community/core/bot_config_manifest/apply/test_resources_materialiser.py
+++ b/src/backend/tests/community/core/bot_config_manifest/apply/test_resources_materialiser.py
@@ -33,7 +33,7 @@ from agentclaw.community.core.bot_config_manifest.apply.materialisers.resources 
     _DECLARED_TREE,
     ResourcesMaterialiser,
 )
-from agentclaw.community.core.bot_config_manifest.apply.order import steps_for
+from agentclaw.community.core.bot_config_manifest.apply.delivery import ArcaDelivery
 from agentclaw.community.core.bot_config_manifest.apply.orchestrator import (
     ApplyOrchestrator,
 )
@@ -53,6 +53,13 @@ from ._fakes import (
     make_context,
     real_validator,
 )
+
+
+#: The orchestrator is always handed a delivery strategy's ``steps_for``; these
+#: tests exercise the ARCA family, so they hand it ARCA's. The ports callable is
+#: never reached — ``steps_for`` only phases and sorts ``APPLY_ORDER``.
+_arca_steps = ArcaDelivery(lambda: None).steps_for
+
 
 
 def _run(coro):
@@ -1091,7 +1098,7 @@ def _resources_engine(svc, fetcher):
             resource_service=svc,
             cli_tool_service=object(),
         ),
-        steps=steps_for
+        steps=_arca_steps
     )
 
 

--- a/src/backend/tests/community/core/bot_config_manifest/test_iteration1_ordering.py
+++ b/src/backend/tests/community/core/bot_config_manifest/test_iteration1_ordering.py
@@ -24,7 +24,6 @@ from agentclaw.community.core.bot_config_manifest.apply.delivery import (
 from agentclaw.community.core.bot_config_manifest.apply.order import (
     APPLY_ORDER,
     ApplyPhase,
-    steps_for,
 )
 from agentclaw.community.core.bot_config_manifest.apply.triggers import (
     ALL_TRIGGERS,
@@ -38,12 +37,13 @@ def _ports() -> MaterialiserPorts:
 
 
 def test_on_arca_the_script_is_the_only_pre_container_construct() -> None:
-    pre = steps_for(frozenset({ApplyPhase.PRE_CONTAINER}))
+    arca = ArcaDelivery(_ports)
+    pre = arca.steps_for(frozenset({ApplyPhase.PRE_CONTAINER}))
     assert [s.construct for s in pre] == [ManifestSection.SCRIPT]
-    on = steps_for(frozenset({ApplyPhase.ON_CONTAINER}))
+    on = arca.steps_for(frozenset({ApplyPhase.ON_CONTAINER}))
     assert ManifestSection.SCRIPT not in {s.construct for s in on}
-    # The strategy says the same thing the table does.
-    assert ArcaDelivery(_ports).steps_for(frozenset({ApplyPhase.PRE_CONTAINER})) == pre
+    # Between them the two phases walk the whole table, once each.
+    assert len(pre) + len(on) == len(APPLY_ORDER)
 
 
 def test_on_arca_the_script_runs_first() -> None:


### PR DESCRIPTION
## Problem

`ApplyStep` carried a `phase` column that no longer had an owner. A construct's phase is a function of `(delivery family, construct, platform-managed switch)` — not a property of the step — and the code already said so: `order.py` documented the column as "the **ARCA** family's answer; teclaw's delivery strategy overrides it", `TeclawDelivery.phase_of` ignored it for every construct except `SCRIPT`, and for `SCRIPT` the table value was the constant `PRE_CONTAINER` anyway. Meanwhile `order.steps_for`, the module-level function that filtered `APPLY_ORDER` by that column, had no production caller left: the orchestrator is handed `strategy.steps_for` (`services/config_manifest_apply_service.py:836`) and both strategies implement it via `delivery._steps(self.phase_of, phases)`. A phase column that only one family reads, through a function nobody calls, is a second source of truth waiting to drift from the one the orchestrator actually walks.

## Solution

Each strategy now owns its phase table, and `ApplyStep` is a pure ordering record.

Before / after:

```python
ApplyStep(ManifestSection.SCRIPT, ApplyPhase.PRE_CONTAINER, 0)   # construct, phase, position
ApplyStep(ManifestSection.SCRIPT, 0)                             # construct, position
```

- `apply/delivery.py` gains `_ARCA_PHASES`, a module-level `MappingProxyType` giving the container family's phase per construct (`script` pre-container, everything else on-container), guarded by an import-time assertion that its keys equal `{step.construct for step in APPLY_ORDER}` — the same no-drift discipline `source_fetchers.FETCHER_TYPES` and `fetch/limits.py` use, so adding a construct to the order without a phase fails at import rather than as a `KeyError` on the first apply that walks it. `ArcaDelivery.phase_of` reads it.
- `TeclawDelivery.phase_of`'s `SCRIPT` branch returns `ApplyPhase.PRE_CONTAINER` directly instead of `step.phase` — the same value, now stated rather than borrowed, so a declared script on teclaw still walks the orchestrator's no-support path and is reported instead of silently falling out of both phases. The `CLI_TOOLS` rule and the switch logic are untouched. Its table stays computed rather than a literal, because it genuinely is: the switch plus the two per-construct rules that ignore it.
- `apply/order.py` drops the `phase` field and `steps_for`. `ApplyPhase` and `ALL_PHASES` stay as shared vocabulary — `creation.py`, `create_job.py`, `apply_task.py`, the service, the protocol and the HTTP routes import only those two and are unaffected. Positions are unchanged.
- `apply/orchestrator.py`: docstring and comments no longer name `apply.order.steps_for` as a table-level default; the orchestrator is always handed a strategy's `steps_for`, and now there is nothing to default to.

`phase_of` and `steps_for` answer identically for all three configurations. Verified directly against the pre-refactor behaviour:

| construct | ARCA | teclaw, switch off | teclaw, switch on |
| --- | --- | --- | --- |
| `script` | `pre_container` | `pre_container` | `pre_container` |
| `identity`, `resources`, `skills`, `mcp`, `engine_config` | `on_container` | `on_container` | `pre_container` |
| `cli_tools` | `on_container` | `pre_container` | `pre_container` |

## Validation

```
uv run --no-sync python -m pytest -q -o addopts="" -W ignore \
  tests/community/core/bot_config_manifest/ \
  tests/community/adapters/http/openapi_v1/test_config_manifest_apply_bars.py
# 1087 passed
```

`git status --short` lists no `uv.lock` change. Both grep gates from the task are clean: no reads of a step's phase and no calls to a module-level `steps_for` anywhere in `src/agentclaw/community`, and no `def steps_for` left in `order.py`.

Tests changed:

- `apply/test_delivery_strategy.py` — the assertion against the deleted `order.steps_for` is replaced by a literal expected `(construct, phase)` tuple for ARCA plus a per-step check against `_ARCA_PHASES`; the iterations that read `step.phase` now read `strategy.phase_of(step)`; the module docstring and the W9 guard's wording follow the table's move. **Two new tests**: `_ARCA_PHASES` names exactly the constructs in `APPLY_ORDER` (the import-time assertion, named in the suite), and `TeclawDelivery.phase_of(script)` is `PRE_CONTAINER` under either switch position — it used to come from the table and must now hold on its own.
- `apply/test_orchestrator_stays_generic.py` — the two structural guards that read `step.phase` (`script` alone in the pre-container phase; phase B's declared category order) now read `delivery._ARCA_PHASES`, which is the ARCA reading they were always asserting.
- `test_iteration1_ordering.py` — reads both phases off `ArcaDelivery` instead of the module function, and pins that the two phases between them walk the whole table once.
- `apply/test_apply_engine.py`, `apply/test_resources_materialiser.py` — these passed `steps=steps_for` into `ApplyOrchestrator`; they now pass a module-level `_arca_steps = ArcaDelivery(...).steps_for`, matching how production wires it.

## Compatibility and risk

Internal refactor: no schema, wire-format, config or API change, and no change to which phases the creation job or the HTTP routes pass. `ApplyStep`'s constructor signature changes, but it is constructed in exactly one place (`APPLY_ORDER`). `order.steps_for` is removed from `__all__` and the module; nothing outside the deleted tests imported it. Rollback is a revert of the three commits.

## Spec

`specs/2026-09-02-manifest-lifecycle-apply-points/` (W8, #1476). The design's §3.4 ordering reversal and the reasoning for it stay documented on `APPLY_ORDER`, where they are about position, not phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CRh5PHfiWPN7MkJpLm8SKN

---
_Generated by [Claude Code](https://claude.ai/code/session_01CRh5PHfiWPN7MkJpLm8SKN)_