### PR TITLE
feat(baas): propagate eval headers in WebSocket HTTP handshake

### DIFF
--- a/src/baas/src/secbaas/community/core/service/bot_run/_baas_service.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_baas_service.py
@@ -310,7 +310,9 @@ class BaasBotService(BotService):
             ) from e
 
         # Step 2: Get or create adapter session
-        session_client = self._create_session_client(conn_info, engine_type, metadata=metadata)
+        session_client = self._create_session_client(
+            conn_info, engine_type, metadata=metadata
+        )
 
         # 评测流量：eval_id 存在且调用方未传 session_id 时，
         # 用 consistency_key（结构化格式，含 evalId）作为 session_id 传给 adapter，
@@ -457,7 +459,14 @@ class BaasBotService(BotService):
             ) from e
 
         pool_key = conn_info.target
-        headers = {"x-proxypass-token": conn_info.token}
+        headers: dict[str, str] = {"x-proxypass-token": conn_info.token}
+        if chat_metadata:
+            eval_id = chat_metadata.get("eval_id")
+            if eval_id:
+                headers["X-Eval-Id"] = str(eval_id)
+            default_tag = chat_metadata.get("default_tag")
+            if default_tag:
+                headers["X-Agentclaw-Default-Tag"] = str(default_tag)
 
         client = await self._client_pool.get(pool_key, conn_info.ws_url, headers)
         try:
@@ -544,7 +553,14 @@ class BaasBotService(BotService):
             ) from e
 
         pool_key = conn_info.target
-        headers = {"x-proxypass-token": conn_info.token}
+        headers: dict[str, str] = {"x-proxypass-token": conn_info.token}
+        if chat_metadata:
+            eval_id = chat_metadata.get("eval_id")
+            if eval_id:
+                headers["X-Eval-Id"] = str(eval_id)
+            default_tag = chat_metadata.get("default_tag")
+            if default_tag:
+                headers["X-Agentclaw-Default-Tag"] = str(default_tag)
 
         client = await self._client_pool.get(pool_key, conn_info.ws_url, headers)
         auth_token = context.build_auth_token() if context else None


### PR DESCRIPTION
## Problem

- Eval identification tags (`X-Eval-Id`, `X-Agentclaw-Default-Tag`) were not propagated in WebSocket HTTP handshake headers. 
- The teclaw engine relies on `propagation` headers to extract eval context, but currently the WS connection only carried `x-proxypass-token`, causing eval-tagged traffic to be unrecognized on the WS channel.

This created an asymmetry: eval headers were already injected in the HTTP API path (`_create_session_client`, line ~977-984) and the WebSocket frame params body (`chat_metadata`), but missing from the WebSocket HTTP handshake headers.

## Solution

Inject eval headers from `chat_metadata` into the WebSocket connection HTTP handshake headers in `send_message` and `send_message_stream`, mirroring the existing pattern in `_create_session_client()`.

**Changes in `src/baas/src/secbaas/community/core/service/bot_run/_baas_service.py`:**

- `send_message` (line 459-467): Read `eval_id` and `default_tag` from `chat_metadata`, inject `X-Eval-Id` and `X-Agentclaw-Default-Tag` into the headers dict before creating the WS client.
- `send_message_stream` (line 553-561): Same injection for the streaming path.

No new dependencies or configuration changes. The headers are conditionally added only when `chat_metadata` is present and contains the relevant keys.

## Validation

- `src/baas/tests/unit/core/service/bot_run/` — 973 tests passed
- `test_baas_service.py` — 142 tests passed
- Ruff format and lint checks passed

## Compatibility and risk (optional)

**Risk:** Low. The change is additive — existing headers are preserved, and new headers are only added when eval context is present. Engine-side handlers that do not recognize these headers will ignore them.

**Rollback:** Revert the commit; no schema or config migration involved.